### PR TITLE
ci: add sbomqs quality gate to SBOM generation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -135,6 +135,28 @@ jobs:
           find . -name '*.cdx.xml' -not -path '*/target/*' -exec cp {} sbom-artifacts/ \;
           ls -la sbom-artifacts/
 
+      - name: Install sbomqs
+        run: go install github.com/interlynk-io/sbomqs@latest
+
+      - name: Score SBOMs (quality gate ≥ 7.0)
+        shell: bash
+        run: |
+          PASS=true
+          for f in sbom-artifacts/*.cdx.json; do
+            echo "--- Scoring: $(basename $f) ---"
+            SCORE=$(~/go/bin/sbomqs score "$f" 2>&1 | head -1 | grep -oP 'Score:\K[0-9.]+')
+            echo "Score: $SCORE"
+            if [ "$(echo "$SCORE < 7.0" | bc -l)" -eq 1 ]; then
+              echo "::error::SBOM quality score $SCORE for $(basename $f) is below threshold 7.0"
+              PASS=false
+            fi
+          done
+          if [ "$PASS" = false ]; then
+            echo "::error::One or more SBOMs failed the quality gate"
+            exit 1
+          fi
+          echo "✅ All SBOMs pass quality gate (≥ 7.0)"
+
       - name: Package SBOMs
         run: |
           cd sbom-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,28 @@ jobs:
           find . -name '*.cdx.xml' -not -path '*/target/*' -exec cp {} sbom-artifacts/ \;
           ls -la sbom-artifacts/
 
+      - name: Install sbomqs
+        run: go install github.com/interlynk-io/sbomqs@latest
+
+      - name: Score SBOMs (quality gate ≥ 7.0)
+        shell: bash
+        run: |
+          PASS=true
+          for f in sbom-artifacts/*.cdx.json; do
+            echo "--- Scoring: $(basename $f) ---"
+            SCORE=$(~/go/bin/sbomqs score "$f" 2>&1 | head -1 | grep -oP 'Score:\K[0-9.]+')
+            echo "Score: $SCORE"
+            if [ "$(echo "$SCORE < 7.0" | bc -l)" -eq 1 ]; then
+              echo "::error::SBOM quality score $SCORE for $(basename $f) is below threshold 7.0"
+              PASS=false
+            fi
+          done
+          if [ "$PASS" = false ]; then
+            echo "::error::One or more SBOMs failed the quality gate"
+            exit 1
+          fi
+          echo "✅ All SBOMs pass quality gate (≥ 7.0)"
+
       - name: Package SBOMs
         run: |
           cd sbom-artifacts


### PR DESCRIPTION
Adds [sbomqs](https://github.com/interlynk-io/sbomqs) scoring as a quality gate in both **release** and **nightly** workflows. Fails if any per-crate SBOM scores below **7.0/10**.

### Current Scores (nightly 2026-03-17)

| Crate | Score |
|-------|-------|
| gvm-mock-server | 7.7 |
| gvm-client | 7.6 |
| gvm-connection | 7.6 |
| gvm-gmp | 7.5 |
| gvm-protocol | 7.5 |

### How it works
1. Generates SBOMs via `cargo-cyclonedx` (existing step)
2. Installs `sbomqs` via `go install`
3. Scores each `.cdx.json` file
4. Fails with `::error::` annotations if any score < 7.0

See issue for improvement suggestions to raise scores toward 9.0+.