### PR TITLE
ci: publish gvm-mock-server GHCR image on main + manual trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+  workflow_dispatch:
+    # No inputs — builds from the selected branch (default: main)
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build & Push GHCR Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/clawosiris/gvm-mock-server
+          tags: |
+            # On tag push: use the tag name (e.g. v0.2.0)
+            type=ref,event=tag
+            # On main push: rolling "main" tag
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            # On workflow_dispatch: branch name
+            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
+          labels: |
+            org.opencontainers.image.title=gvm-mock-server
+            org.opencontainers.image.description=Programmable mock GMP server for testing
+            org.opencontainers.image.vendor=clawosiris
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+


### PR DESCRIPTION
Follow-up to merged PR #26.

Adds a dedicated Docker workflow to publish the `gvm-mock-server` GHCR image:

Triggers:
- **push to `main`** → updates rolling tag `ghcr.io/clawosiris/gvm-mock-server:main`
- **push tag `v*`** → publishes immutable version tag (e.g. `:v0.2.0`)
- **workflow_dispatch** → manual run (default branch main; can run on any selected branch)

This matches the desired behavior for downstream CI consumers:
- pin to `:<version>` for stability
- optionally test against `:main` for bleeding-edge behavior

Refs: rust-gvm #25
