### PR TITLE
docs: Extract and refine proxy concept from gvmd proxy analysis

### DIFF
--- a/docs/gmp-api-proxy-analysis.md
+++ b/docs/gmp-api-proxy-analysis.md
@@ -1,0 +1,326 @@
+# GMP API Proxy Analysis
+
+## 1. Scope
+
+This document focuses on exposing an API proxy in front of `gvmd`.
+
+The direct transport between `rust-gvm` and `gvmd` is covered in [gvmd Transport Analysis for rust-gvm](gvmd-transport-analysis.md).
+
+## 2. Why a Proxy Exists at All
+
+gvmd exposes GMP as a raw XML stream over a persistent Unix socket or TLS connection. There is no native HTTP or gRPC interface.
+
+That makes a proxy attractive for consumers that want:
+
+- standard API contracts
+- generated clients
+- browser and script-friendly access
+- simpler integration than raw GMP XML
+- better handling for large responses and cross-service communication
+
+## 3. Proxy Built on rust-gvm
+
+Rather than waiting for Greenbone to change gvmd itself, we can build a gateway on top of `rust-gvm` that:
+
+- talks GMP over Unix socket, SSH, or TLS to gvmd on the backend
+- exposes REST and gRPC on the frontend
+
+```text
+┌──────────────┐       REST / gRPC        ┌──────────────────┐      GMP/XML       ┌────────┐
+│ Web UI       │◄────────────────────────►│ gvm-gateway      │◄──────────────────►│ gvmd   │
+│ Scripts      │   HTTP/JSON or Protobuf  │ (rust-gvm based) │   Unix socket      │        │
+│ Automation   │                          │                  │   or SSH/TLS       │        │
+│ MCP Server   │                          │                  │                    │        │
+└──────────────┘                          └──────────────────┘                    └────────┘
+```
+
+### Why this is viable
+
+`rust-gvm` already provides the main backend building blocks:
+
+- `gvm-connection`: Unix socket and SSH transports, with TLS planned
+- `gvm-client`: async client with version negotiation and authentication
+- `gvm-gmp`: typed GMP command builders
+- `gvm-protocol`: response parsing and XML extraction
+
+A proxy service can stay relatively thin:
+
+1. Accept REST or gRPC requests.
+2. Map them to `gvm-gmp` command builders.
+3. Send them via `gvm-client` and `gvm-connection` to gvmd.
+4. Parse the XML response.
+5. Return structured JSON or Protobuf to the caller.
+
+## 4. API Frontend Options
+
+### Option A: REST/JSON proxy
+
+Typical stack:
+
+- `axum` or `actix-web`
+- session bootstrap endpoint that accepts gvmd credentials and returns a proxy session token
+- OpenAPI 3.1 for documentation and client generation
+
+Example endpoints:
+
+- `GET /api/v1/version`
+- `POST /api/v1/sessions`
+- `DELETE /api/v1/sessions/{token}`
+- `GET /api/v1/tasks`
+- `POST /api/v1/tasks`
+- `GET /api/v1/tasks/{id}`
+- `PUT /api/v1/tasks/{id}`
+- `DELETE /api/v1/tasks/{id}`
+- `POST /api/v1/tasks/{id}/start`
+- `POST /api/v1/tasks/{id}/stop`
+- `GET /api/v1/reports/{id}`
+- `GET /api/v1/targets`
+
+Strengths:
+
+- accessible from `curl`, Postman, browsers, and any HTTP client
+- OpenAPI can generate docs and SDKs
+- easy to deploy beside gvmd
+- good fit for simple automation and human-driven integrations
+
+Weaknesses:
+
+- GMP actions do not map perfectly to REST resources
+- XML to JSON translation adds latency and complexity
+- large reports need pagination, chunked responses, or a secondary streaming mechanism
+
+### Option B: gRPC proxy
+
+Typical stack:
+
+- `tonic`
+- `.proto` schemas as the contract
+- HTTP/2 and TLS by default
+
+Service sketch:
+
+```proto
+service GmpService {
+  rpc GetVersion(Empty) returns (VersionResponse);
+  rpc Authenticate(AuthRequest) returns (AuthResponse);
+  rpc GetTasks(GetTasksRequest) returns (GetTasksResponse);
+  rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
+  rpc StartTask(TaskIdRequest) returns (TaskActionResponse);
+  rpc GetReport(GetReportRequest) returns (stream ReportChunk);
+}
+```
+
+Strengths:
+
+- strongly typed contracts
+- efficient Protobuf serialization
+- server-side streaming for large reports
+- better fit for service-to-service integrations
+- auto-generated typed clients for many languages
+
+Weaknesses:
+
+- more upfront schema design work
+- not browser-friendly without `grpc-web`
+- harder to inspect manually than REST
+- consumers need Protobuf and gRPC tooling
+
+### Option C: Hybrid REST + gRPC
+
+Expose both from one service:
+
+- `REST` as the initial and most accessible interface for scripts, `curl`, Postman, and lightweight automation
+- `gRPC` as a later addition for full-featured clients, large report retrieval, and service-to-service use
+- a shared backend built on `gvm-client -> gvmd`
+
+This is the preferred long-term model because it avoids forcing one style onto every consumer while allowing the project to start with the simpler interface first.
+
+## 5. Recommended Hybrid Architecture
+
+The gateway should have four layers:
+
+1. REST adapter for simple integrations
+2. gRPC adapter for full integrations
+3. shared application core for session bootstrap, request validation, mapping, error normalization, and auditing
+4. pooled gvmd session manager backed by `rust-gvm`
+
+In practice:
+
+- start with REST as the first public surface and cover the highest-value operations for scripts and human-operated tooling
+- require clients to create a proxy session by submitting gvmd credentials to the proxy once
+- return a session token that the client includes on every subsequent API call
+- add gRPC later for complete GMP coverage, typed contracts, and streaming-heavy workflows
+- route both through the same execution core so command mapping and gvmd behavior stay consistent
+
+## 6. Connection Pooling and Session Management
+
+This is the critical design constraint.
+
+gvmd forks per client and the connection has session state, but this needs to be interpreted correctly.
+
+GMP is not "conversation stateful" in the sense that most resource-oriented commands carry their own parameters and do not build up a multi-step transaction context across requests.
+
+However, the connection is still stateful in operational terms because it retains:
+
+- authentication state
+- current user identity
+- user-specific settings
+- database session variables
+- XML parser and stream state
+
+That means the proxy cannot treat gvmd connections as stateless request pipes. It should:
+
+- create an explicit proxy session per authenticated client workflow
+- accept gvmd credentials only during session creation
+- establish a gvmd connection, authenticate immediately, and validate the credentials up front
+- store the authenticated live connection in the pool keyed by the proxy session token
+- require the session token on every subsequent REST or gRPC request
+- serialize work per gvmd connection because GMP is synchronous per session
+- expire, close, and remove idle or revoked sessions cleanly
+- apply request queuing, rate limiting, and backpressure
+
+```text
+Client A ──┐
+Client B ──┤──► gvm-gateway ──► connection pool ──► gvmd
+Client C ──┘       │
+                   └── auth cache, rate limiting, request queuing
+```
+
+### Recommended session model
+
+The proxy should expose an explicit session bootstrap flow.
+
+#### Session creation
+
+1. The client calls `POST /api/v1/sessions` or `CreateSession`.
+2. The request contains the gvmd username and password for the target backend.
+3. The proxy opens a new gvmd connection through `rust-gvm`.
+4. The proxy sends GMP `<authenticate>` immediately.
+5. If authentication succeeds, the proxy stores the authenticated connection in the pool.
+6. The proxy returns a session token that refers to that pooled authenticated connection.
+
+Example bootstrap response:
+
+```json
+{
+  "session_token": "gvm_sess_9e6b2d...",
+  "expires_in": 1800,
+  "gmp_version": "22.7"
+}
+```
+
+#### Subsequent requests
+
+Every later REST or gRPC call must present the session token.
+
+- REST should carry it as `Authorization: Bearer <session-token>`
+- gRPC can carry it in request metadata
+- the proxy uses the token to look up the corresponding authenticated gvmd connection
+- all commands for that token execute on that session's bound connection
+
+#### Session teardown
+
+The proxy should support both explicit and automatic cleanup:
+
+- client-driven logout or close via `DELETE /api/v1/sessions/{token}`
+- idle timeout for abandoned sessions
+- immediate removal on authentication failure, disconnect, or token revocation
+- backend disconnect when the proxy session ends
+
+### Why this model fits gvmd better
+
+This design aligns with gvmd's stateful connection model:
+
+- authentication is validated exactly once during session creation
+- each proxy token maps to one authenticated gvmd session
+- session-local gvmd state stays isolated to one client session
+- request routing is deterministic because the token selects the connection directly
+- the security boundary becomes possession of the proxy session token
+
+### Operational tradeoffs
+
+Pros:
+
+- clear one-token-to-one-session mapping
+- no ambiguity about which gvmd identity a request uses
+- stronger isolation between clients, even when they use the same gvmd username at different times
+- simpler auditing because each API request can be tied to one explicit proxy session
+- avoids hidden session reuse across unrelated clients
+
+Cons:
+
+- clients must manage session creation and token lifecycle
+- each active proxy session usually consumes a dedicated gvmd connection
+- capacity planning must account for active sessions, not only request rate
+- the session token must be treated as a bearer secret
+- reconnect behavior needs policy: either fail the session or transparently re-authenticate using retained credentials
+
+#### Recommendation
+
+For the initial proxy design, adopt the explicit session-token model as the default and only supported mode.
+
+This keeps the contract concrete:
+
+- credentials are submitted once to start a session
+- the proxy validates them by authenticating to gvmd immediately
+- the returned token identifies the correct pooled authenticated connection for every later call
+- session cleanup is explicit and observable
+
+## 7. Deployment Model
+
+The proxy should run as a standalone binary or container alongside gvmd.
+
+```yaml
+services:
+  gvmd:
+    image: greenbone/gvmd
+    volumes:
+      - gvmd-socket:/run/gvmd
+
+  gvm-gateway:
+    image: ghcr.io/clawosiris/gvm-gateway:latest
+    depends_on: [gvmd]
+    volumes:
+      - gvmd-socket:/run/gvmd:ro
+    ports:
+      - "8080:8080"
+      - "50051:50051"
+    environment:
+      - GVM_SOCKET=/run/gvmd/gvmd.sock
+```
+
+Default deployment should prefer the gvmd Unix socket. SSH and TLS backends can be added for remote routing scenarios.
+
+## 8. Impact on Consumers
+
+| Consumer | Current | With proxy |
+|----------|---------|------------|
+| `openvas-mcp-server` | Talks GMP/XML directly | Create a proxy session once, then reuse the session token; prefer gRPC for fuller integration |
+| `gvm-tools` / CLI automation | Talks GMP/XML directly | Start a session with gvmd credentials, then use REST with the returned token |
+| GSA or other web UIs | Talks GMP/XML through existing components | Browser-facing flows can use REST if the proxy handles secure session bootstrap carefully |
+| Custom services | Need GMP expertise or a GMP client library | Use session bootstrap plus REST or gRPC with a stable token-based contract |
+| Ad hoc automation | `python-gvm` or raw XML | One login call yields a token, removing the need to manage raw GMP sessions directly |
+
+## 9. Recommendation
+
+Adopt the hybrid model in phases:
+
+- start with `REST` because it is the fastest path to a usable public interface for scripts, `curl`, and low-friction automation
+- make `POST /api/v1/sessions` the mandatory entry point so the proxy can authenticate to gvmd, validate credentials, and bind a live connection to a returned token
+- define the shared execution core so the gateway is ready to support multiple frontends from the beginning
+- add `gRPC` later for complete command coverage, typed clients, and streaming-heavy use cases such as large reports
+
+This gives the project a pragmatic path forward: immediate value through REST, a concrete session model that matches gvmd's stateful behavior, and a clear upgrade path to a richer gRPC interface without changing gvmd itself.
+
+## 10. Gateway Extension
+
+The proxy can later grow into a broader access-control gateway for:
+
+- multi-endpoint routing across Unix, SSH, and TLS gvmd backends
+- RBAC and policy enforcement
+- credential isolation
+- audit logging
+- cross-endpoint aggregation
+- multi-tenant or MSP-style deployments
+
+See [Proxy Access Control Analysis](proxy-access-control-analysis.md) for that extension.

--- a/docs/gvmd-transport-analysis.md
+++ b/docs/gvmd-transport-analysis.md
@@ -1,346 +1,91 @@
-# gvmd Transport & Protocol Analysis
+# gvmd Transport Analysis for rust-gvm
 
-## 1. How gvmd Implements GMP Today
+## 1. Scope
+
+This document focuses on the transport and protocol boundary between `rust-gvm` and `gvmd` as it exists today.
+
+It does not cover exposing a new API in front of `gvmd`. That analysis now lives in [GMP API Proxy Analysis](gmp-api-proxy-analysis.md).
+
+## 2. How gvmd Implements GMP Today
 
 ### Transport architecture
 
-gvmd exposes GMP as a **raw XML stream over a persistent TCP/Unix socket connection**, optionally wrapped in TLS. There is no HTTP layer.
+gvmd exposes GMP as a raw XML stream over a persistent TCP or Unix socket connection, optionally wrapped in TLS. There is no HTTP layer.
 
-```
-Client ──[ XML bytes ]──▶ [ Unix socket | TLS+TCP :9390 ] ──▶ gvmd
-       ◀── [ XML bytes ] ─────────────────────────────────────◀
+```text
+rust-gvm client ──[ XML bytes ]──▶ [ Unix socket | TLS+TCP :9390 ] ──▶ gvmd
+                ◀── [ XML bytes ]─────────────────────────────────────◀
 ```
 
-### Connection types (from gvmd source)
+### Connection types
 
 | Listener | Mechanism | Auth | Notes |
 |----------|-----------|------|-------|
-| **Unix socket** | `AF_UNIX` / `SOCK_STREAM` | Filesystem permissions + GMP `<authenticate>` | Default in container deployments. Owner/group/mode configurable via `--listen-owner`, `--listen-group`, `--listen-mode`. |
-| **TLS over TCP** | `AF_INET`/`AF_INET6` on port 9390 (default) | GnuTLS mutual TLS + GMP `<authenticate>` | Enabled via `--listen <address>` + `--port <port>`. Supports DH params (`--dh-params`), priority strings (`--gnutls-priorities`). Client cert optional. |
-| **SSH tunnel** | Not native to gvmd | SSH handles transport; gvmd sees Unix socket | python-gvm's `SSHConnection` tunnels via `direct-streamlocal@openssh.com` to the remote Unix socket. |
+| Unix socket | `AF_UNIX` / `SOCK_STREAM` | Filesystem permissions + GMP `<authenticate>` | Default in container deployments. Owner, group, and mode are configurable via `--listen-owner`, `--listen-group`, `--listen-mode`. |
+| TLS over TCP | `AF_INET`/`AF_INET6` on port 9390 by default | GnuTLS mutual TLS + GMP `<authenticate>` | Enabled via `--listen <address>` and `--port <port>`. Supports DH params via `--dh-params` and priority strings via `--gnutls-priorities`. Client cert is optional. |
+| SSH tunnel | Not native to gvmd | SSH handles transport; gvmd still sees a Unix socket | `python-gvm` uses `direct-streamlocal@openssh.com` to tunnel to the remote Unix socket. |
 
-gvmd can listen on **two sockets simultaneously** (`--listen` + `--listen2`), e.g., one Unix + one TLS.
+gvmd can listen on two sockets simultaneously via `--listen` and `--listen2`, for example one Unix socket and one TLS listener.
 
 ### Protocol flow
 
-1. Client connects (Unix or TLS).
-2. Client sends `<get_version/>` (pre-auth, always allowed).
+1. Client connects over Unix socket or TLS.
+2. Client sends `<get_version/>`, which is available before authentication.
 3. Client sends `<authenticate><credentials>...</credentials></authenticate>`.
 4. Client sends GMP commands as XML elements; gvmd responds with XML elements.
-5. Connection persists (stateful session) until client disconnects.
+5. The connection persists until the client disconnects.
 
-**Key characteristics:**
-- **Stateful sessions**: gvmd forks a child process per client connection. Session state (authenticated user, permissions) lives in that process.
-- **XML stream framing**: No length prefix or delimiter — the client must parse XML to detect where one response ends and the next begins. This is what `XmlReader` in rust-gvm handles.
-- **Synchronous request/response**: One command at a time per connection. No multiplexing, no pipelining (except `<commands>` wrapper for batching).
-- **No HTTP**: GMP is **not** HTTP-based. There are no HTTP headers, no Content-Length, no chunked encoding. It's raw XML over a byte stream.
+### Key characteristics
+
+- Stateful sessions: gvmd forks a child process per client connection. Authenticated user state and permissions live in that process.
+- XML stream framing: there is no length prefix or record delimiter. Clients must parse XML to detect message boundaries. This is what `XmlReader` in `rust-gvm` handles.
+- Synchronous request and response: one command at a time per connection. There is no multiplexing or pipelining beyond the GMP `<commands>` wrapper for batching.
+- No HTTP: GMP is not HTTP-based. There are no HTTP headers, no `Content-Length`, and no chunked transfer encoding.
 
 ### The `manage_http_scanner.c` file
 
-This is **not** an HTTP interface for GMP. It's gvmd's internal client for connecting to **HTTP-based scanners** (a newer scanner type introduced in 2025). gvmd itself acts as an HTTP *client* to talk to scanners — it does not expose GMP over HTTP.
+This is not an HTTP interface for GMP. It is gvmd's internal client for connecting to HTTP-based scanners. gvmd itself acts as an HTTP client there; it does not expose GMP over HTTP.
 
----
+## 3. Transport Implications for rust-gvm
 
-## 2. Comparison: GMP-over-XML-stream vs REST vs gRPC
+`rust-gvm` currently implements the correct transport model for gvmd as it exists today:
 
-### Current: GMP over raw XML stream (TLS/Unix)
+- `UnixSocketConnection` for primary containerized deployments
+- `SshConnection` for remote access via SSH tunnel
+- `TlsConnection` as the remaining planned parity item for direct TLS+TCP on port 9390
 
-**Strengths:**
-- Simple, mature, battle-tested (15+ years)
-- Low overhead — no HTTP framing, headers, or content negotiation
-- Stateful sessions — natural for long-lived management connections
-- Works over Unix sockets (zero network exposure in container deployments)
-- TLS with mutual auth provides strong transport security
-- The `<commands>` wrapper allows batching multiple operations in one round-trip
+There is no native HTTP or gRPC transport to implement in `rust-gvm` today because gvmd does not expose either interface.
 
-**Weaknesses:**
-- **No standard framing** — clients must implement XML stream parsing to detect message boundaries (error-prone, hard to implement correctly in many languages)
-- **No multiplexing** — one request at a time per connection; concurrent operations require multiple connections
-- **XML verbosity** — large responses (reports with thousands of results) produce enormous XML payloads with no built-in compression or pagination beyond filter params
-- **No streaming** — entire response must be assembled before the client can process it (problematic for 100MB+ reports)
-- **Stateful sessions** — client must manage connection lifecycle; reconnection requires re-authentication
-- **Limited tooling** — no Swagger/OpenAPI, no auto-generated clients, no standard HTTP debugging tools (curl, Postman, browser dev tools)
-- **No standard error model** — errors are XML elements with status codes that don't map to HTTP semantics
+## 4. Strengths and Constraints of the Current Transport
 
-### Alternative A: REST API (HTTP/JSON)
+### Strengths
 
-**Strengths:**
-- Universal client support (curl, fetch, any HTTP library in any language)
-- Standard framing (Content-Length / chunked encoding) — no custom parser needed
-- Stateless requests — each request carries auth (token/API key), no session management
-- Mature ecosystem: OpenAPI spec → auto-generated clients, documentation, testing tools
-- HTTP/2 multiplexing for concurrent requests
-- Built-in caching (ETags, conditional requests)
-- Pagination via standard patterns (Link headers, cursor params)
-- JSON is more compact than XML for most payloads
-- Easy to put behind load balancers, API gateways, rate limiters
+- Mature and battle-tested transport model
+- Low framing overhead
+- Natural fit for long-lived management sessions
+- Works well with Unix sockets in local and containerized deployments
+- TLS with mutual authentication provides strong transport security
+- GMP supports batching through the `<commands>` wrapper
 
-**Weaknesses:**
-- Would require a **complete API redesign** — GMP's command surface doesn't map 1:1 to REST resources (e.g., `start_task` is an action, not a CRUD operation)
-- Loss of session statefulness (could be a strength or weakness depending on use case)
-- HTTP overhead per request (headers, connection setup if not keep-alive)
-- No built-in server-push for long-running operations (would need polling or webhooks)
-- Breaking change for all existing clients (python-gvm, gvm-tools, rust-gvm, GSA)
+### Constraints
 
-### Alternative B: gRPC (HTTP/2 + Protobuf)
+- No standard framing; clients need XML stream parsing
+- No multiplexing; concurrency requires multiple connections
+- XML is verbose for large payloads such as reports
+- Responses are typically processed as full XML documents unless the client implements incremental parsing
+- Reconnection requires re-authentication because sessions are stateful
+- Tooling is limited compared to HTTP-based APIs
+- Error handling is encoded in GMP XML rather than a standard transport error model
 
-**Strengths:**
-- Strongly typed contracts via `.proto` files → auto-generated clients in many languages
-- Efficient binary serialization (Protobuf is 3–10× smaller than XML for structured data)
-- **Streaming support** — server-side streaming (ideal for large reports), client-side streaming, bidirectional streaming
-- HTTP/2 multiplexing — multiple concurrent RPCs on one connection
-- Built-in deadline/timeout propagation
-- TLS by default
-- Excellent for internal service-to-service communication
+## 5. Practical Recommendations
 
-**Weaknesses:**
-- Requires Protobuf toolchain for client generation
-- Not browser-friendly without grpc-web proxy
-- Harder to debug than REST (binary protocol, needs grpcurl or similar)
-- Would require defining a complete `.proto` schema for all GMP entities
-- Less mature ecosystem for security tooling compared to REST
-- Same breaking-change problem as REST
+1. Complete `TlsConnection` support to reach parity with existing gvmd connection modes.
+2. Improve incremental or streaming XML reads so large report responses do not need to be buffered fully in memory.
+3. Keep the transport abstraction centered on gvmd's real interfaces: Unix socket, SSH tunnel, and TLS.
+4. Watch upstream changes in gvmd, especially around newer HTTP-based scanner integrations, but do not assume that implies a client-facing HTTP API.
+5. Treat any REST or gRPC exposure as a separate proxy or gateway concern rather than part of the direct `rust-gvm` transport layer.
 
-### Alternative C: GMP over WebSocket (hybrid)
+## 6. Related Documents
 
-**Strengths:**
-- Keeps the XML command/response model (minimal protocol change)
-- Adds standard framing (WebSocket frames have length headers)
-- Works through HTTP proxies and load balancers
-- Browser-compatible (GSA could use it directly)
-- Can be upgraded from HTTP, enabling a REST+WS hybrid
-
-**Weaknesses:**
-- Still XML-verbose
-- Adds WebSocket handshake overhead
-- Less ecosystem tooling than pure REST
-- Not a standard pattern for management APIs
-
----
-
-## 3. Summary Matrix
-
-| Dimension | GMP/XML stream | REST/JSON | gRPC/Protobuf | GMP/WebSocket |
-|-----------|---------------|-----------|---------------|---------------|
-| **Client effort** | High (custom XML framing) | Low (any HTTP lib) | Medium (codegen) | Medium (WS + XML) |
-| **Payload size** | Large (XML) | Medium (JSON) | Small (Protobuf) | Large (XML) |
-| **Streaming** | ❌ | ❌ (needs polling/SSE) | ✅ Native | ✅ Possible |
-| **Multiplexing** | ❌ | ✅ (HTTP/2) | ✅ | ✅ |
-| **Tooling** | Minimal | Excellent (OpenAPI) | Good (proto + grpcurl) | Moderate |
-| **Breaking change** | N/A (current) | 🔴 Full redesign | 🔴 Full redesign | 🟡 Moderate |
-| **Browser compat** | ❌ | ✅ | ❌ (needs proxy) | ✅ |
-| **Session model** | Stateful | Stateless | Either | Either |
-| **Maturity** | 15+ years | Would be new | Would be new | Would be new |
-
----
-
-## 4. Implications for rust-gvm
-
-rust-gvm currently implements the **correct** transport model for gvmd as it exists today:
-
-- `UnixSocketConnection` — primary, containerized deployments
-- `SshConnection` — remote access via SSH tunnel
-- `TlsConnection` — planned (#7), for direct TLS+TCP on port 9390
-
-There's no HTTP or gRPC interface to implement because **gvmd doesn't offer one**. If Greenbone ever adds a REST/gRPC/WebSocket interface, we'd add corresponding transport implementations.
-
-### Practical recommendations
-
-1. **Complete TLS transport** (#7) — this is the remaining gap for full parity with python-gvm's connection options.
-2. **Implement streaming reads** (#4) — even without a protocol change, we can stream-parse large XML responses incrementally rather than buffering entire responses in memory.
-3. **Watch for upstream changes** — the `manage_http_scanner.c` addition signals Greenbone is exploring HTTP-based protocols for scanner communication. If they extend this to the client-facing GMP interface, we should be ready to adapt.
-4. **Consider a REST/gRPC proxy** — see Section 5 below.
-
----
-
-## 5. REST/gRPC Proxy Built on rust-gvm
-
-### The idea
-
-Rather than waiting for Greenbone to modernize gvmd's protocol, we could build a **proxy/gateway service** on top of rust-gvm that:
-
-- Talks GMP over Unix socket (or SSH/TLS) to gvmd on the backend
-- Exposes a **REST API** or **gRPC service** to consumers on the frontend
-
-```
-┌──────────────┐       REST / gRPC        ┌──────────────────┐      GMP/XML       ┌────────┐
-│  Web UI      │◄────────────────────────►│  gvm-gateway     │◄──────────────────►│  gvmd  │
-│  Scripts     │   HTTP/JSON or Protobuf   │  (rust-gvm based)│   Unix socket      │        │
-│  Automation  │                           │                  │   or SSH/TLS       │        │
-│  MCP Server  │                           │                  │                    │        │
-└──────────────┘                           └──────────────────┘                    └────────┘
-```
-
-### Why this is viable
-
-rust-gvm already provides the complete backend stack:
-- **gvm-connection**: Unix socket + SSH transports (TLS coming)
-- **gvm-client**: Async client with version negotiation + auth
-- **gvm-gmp**: Typed command builders for all GMP operations
-- **gvm-protocol**: Response parsing (status codes, XML extraction)
-
-A proxy service would be a relatively thin layer that:
-1. Accepts HTTP/JSON or gRPC requests
-2. Maps them to `gvm-gmp` command builders
-3. Sends via `gvm-client` → `gvm-connection` → gvmd
-4. Parses the XML response
-5. Returns structured JSON or Protobuf
-
-### Architecture options
-
-#### Option A: REST/JSON proxy (recommended first step)
-
-```
-Technology: axum or actix-web
-Auth: Bearer token / API key → maps to gvmd user credentials
-Schema: OpenAPI 3.1 spec → auto-generated docs + client SDKs
-
-Endpoints (examples):
-  GET    /api/v1/version
-  POST   /api/v1/auth/login          → authenticate, returns session token
-  GET    /api/v1/tasks                → get_tasks
-  POST   /api/v1/tasks                → create_task
-  GET    /api/v1/tasks/{id}           → get_tasks task_id=...
-  PUT    /api/v1/tasks/{id}           → modify_task
-  DELETE /api/v1/tasks/{id}           → delete_task
-  POST   /api/v1/tasks/{id}/start     → start_task
-  POST   /api/v1/tasks/{id}/stop      → stop_task
-  GET    /api/v1/reports/{id}         → get_reports report_id=...
-  GET    /api/v1/targets              → get_targets
-  ...
-```
-
-**Strengths:**
-- Instantly accessible from any HTTP client (curl, browser, Postman, any language)
-- OpenAPI spec enables auto-generated SDKs (TypeScript, Python, Go, Java, ...)
-- Stateless requests — no session management burden on clients
-- Easy to deploy as a sidecar container alongside gvmd
-- Could replace GSA's backend (GSA currently talks GMP directly)
-- Natural fit for the MCP server (openvas-mcp-server could use REST instead of raw GMP)
-
-**Weaknesses:**
-- REST doesn't map perfectly to all GMP operations (e.g., `start_task` is an action, not a resource)
-- Response translation: XML → JSON adds latency and complexity
-- Large reports: need pagination or streaming (SSE / chunked responses)
-
-**Estimated effort:** Medium. The command mapping is mechanical; the real work is auth management (session pooling to gvmd) and large-response handling.
-
-#### Option B: gRPC proxy
-
-```
-Technology: tonic (Rust gRPC framework)
-Schema: .proto files → auto-generated clients in 10+ languages
-Transport: HTTP/2, TLS built-in
-
-Service definition (sketch):
-  service GmpService {
-    rpc GetVersion(Empty) returns (VersionResponse);
-    rpc Authenticate(AuthRequest) returns (AuthResponse);
-    rpc GetTasks(GetTasksRequest) returns (GetTasksResponse);
-    rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
-    rpc StartTask(TaskIdRequest) returns (TaskActionResponse);
-    rpc GetReport(GetReportRequest) returns (stream ReportChunk);  // server streaming!
-    ...
-  }
-```
-
-**Strengths:**
-- **Server-side streaming** for large reports — the killer feature. Clients receive report chunks as they're parsed from the gvmd XML response, without buffering the entire thing.
-- Strongly typed contracts — `.proto` is the single source of truth
-- Binary serialization — 3–10× smaller than JSON for structured vulnerability data
-- Auto-generated clients with full type safety
-- Built-in deadline propagation, metadata, interceptors
-- Excellent for service-to-service (e.g., MCP server → gRPC proxy → gvmd)
-
-**Weaknesses:**
-- Not browser-friendly without grpc-web proxy
-- Requires Protobuf toolchain for consumers
-- Harder to debug/inspect than REST
-- More upfront design work (defining all message types in `.proto`)
-
-**Estimated effort:** Medium-High. Proto schema design is significant, but tonic makes the Rust implementation straightforward.
-
-#### Option C: Hybrid (REST + gRPC)
-
-Expose **both** from the same service:
-- REST for human/script consumers (curl, Postman, simple automation)
-- gRPC for programmatic/service consumers (MCP server, custom integrations)
-- Share the same backend: gvm-client → gvmd
-
-This is a common pattern (e.g., Google APIs expose both REST and gRPC from the same service).
-
-### Connection pooling
-
-A critical design consideration: gvmd forks per client and sessions are stateful. The proxy should:
-
-- Maintain a **pool of authenticated gvmd connections** (one per gvmd user)
-- Multiplex incoming REST/gRPC requests onto pooled connections
-- Handle reconnection transparently
-- This transforms gvmd's "one connection = one session" model into a scalable multi-client service
-
-```
-Client A ──┐
-Client B ──┤──► gvm-gateway ──► connection pool ──► gvmd (2-3 forked processes)
-Client C ──┘       │
-                   └── auth cache, rate limiting, request queuing
-```
-
-### Deployment model
-
-The proxy would be a standalone binary (or Docker image) that runs alongside gvmd:
-
-```yaml
-# docker-compose example
-services:
-  gvmd:
-    image: greenbone/gvmd
-    volumes:
-      - gvmd-socket:/run/gvmd
-
-  gvm-gateway:
-    image: ghcr.io/clawosiris/gvm-gateway:latest
-    depends_on: [gvmd]
-    volumes:
-      - gvmd-socket:/run/gvmd:ro
-    ports:
-      - "8080:8080"   # REST
-      - "50051:50051"  # gRPC (optional)
-    environment:
-      - GVM_SOCKET=/run/gvmd/gvmd.sock
-```
-
-### Impact on existing projects
-
-| Consumer | Current | With proxy |
-|----------|---------|------------|
-| openvas-mcp-server | Talks GMP/XML directly | Could use REST or gRPC — much simpler integration |
-| gvm-rools (gvm-cli) | Talks GMP/XML directly | Could add `--rest` transport option |
-| GSA (web UI) | Talks GMP/XML via gsad | Could talk REST directly — removes gsad dependency |
-| Custom automation | python-gvm or raw XML | Standard HTTP/JSON — any language, no GMP library needed |
-| AI/LLM tool use | Needs GMP expertise | OpenAPI spec enables native tool calling |
-
-### Recommendation
-
-**Start with REST** (Option A):
-1. It's the fastest to deliver value (any HTTP client can use it immediately)
-2. OpenAPI spec is a force multiplier (auto-docs, auto-clients)
-3. Add gRPC later for streaming (large reports) and service-to-service efficiency
-4. The proxy architecture decouples consumers from gvmd's protocol — if Greenbone changes GMP, only the proxy needs updating
-
-This could be a new repo (`gvm-gateway`) or a new crate in the rust-gvm workspace.
-
----
-
-## 6. Access Control Gateway Extension
-
-The proxy concept extends naturally into a **multi-endpoint access control gateway** — managing which clients can reach which gvmd instances and what operations they can perform. This transforms the proxy from a protocol translator into an authorization plane.
-
-See [Proxy Access Control Analysis](proxy-access-control-analysis.md) for the full design covering:
-- Multi-endpoint routing (Unix/SSH/TLS heterogeneous backends)
-- RBAC policy engine (role → endpoint × operations)
-- Connection pooling per endpoint
-- Audit trail for compliance (SOC 2, ISO 27001)
-- Credential isolation (clients never see gvmd passwords)
-- Cross-endpoint aggregation (single pane of glass)
-- MSP multi-tenant deployment model
-- Phased implementation roadmap
+- [GMP API Proxy Analysis](gmp-api-proxy-analysis.md)
+- [Proxy Access Control Analysis](proxy-access-control-analysis.md)


### PR DESCRIPTION
## Description

- Extract gmp proxy concept from transport analysis
- Refine connection pooling approach to connection per session
- Propose approach implementing a REST api as first, but relying on grpc for full feature set
