### PR TITLE
feat(mock-server): large-response generator + integration tests (refs #24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ name = "gvm-connection"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "gvm-gmp",
  "gvm-mock-server",
  "gvm-protocol",
  "pretty_assertions",
@@ -1017,6 +1018,7 @@ dependencies = [
  "russh",
  "rustls",
  "rustls-pemfile",
+ "sha1 0.10.6",
  "tempfile",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 
 # UUID
 uuid = { version = "1", features = ["v4"] }
+sha1 = "0.10"
 
 # TLS (feature-gated)
 tokio-rustls = "0.26"

--- a/crates/gvm-connection/Cargo.toml
+++ b/crates/gvm-connection/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 default = ["unix"]
 unix = []
 unix-socket-tests = []
+large-response-tests = ["unix-socket-tests"]
 tls = ["dep:tokio-rustls", "dep:rustls", "dep:rustls-pemfile"]
 ssh = ["dep:russh"]
 
@@ -36,6 +37,7 @@ ignored = ["rustls", "rustls-pemfile", "tokio-rustls"]  # TLS feature-gated, not
 pretty_assertions.workspace = true
 tempfile.workspace = true
 tokio-test.workspace = true
+gvm-gmp.workspace = true
 gvm-mock-server = { workspace = true, features = ["ssh"] }
 
 [lints]

--- a/crates/gvm-connection/tests/large_response.rs
+++ b/crates/gvm-connection/tests/large_response.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![cfg(feature = "large-response-tests")]
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use gvm_connection::{GvmConnection, UnixSocketConfig, UnixSocketConnection};
+use gvm_gmp::commands::reports::get_report;
+use gvm_gmp::commands::scan_configs::{get_scan_configs, GetScanConfigsOpts};
+use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
+use gvm_gmp::commands::tasks::{create_task, start_task, CreateTaskOpts};
+use gvm_gmp::types::EntityId;
+use gvm_mock_server::{GmpVersion, LargeReportConfig, MockGmpServer, ServerMode};
+use gvm_protocol::{Request, Response};
+
+async fn start_mock(config: LargeReportConfig) -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .large_report(config)
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("mock server start failed: {error}"),
+    }
+}
+
+async fn send(conn: &mut UnixSocketConnection, request: impl Request) -> Response {
+    conn.send(&request.to_bytes())
+        .await
+        .expect("send should succeed");
+    Response::new(conn.read().await.expect("read should succeed"))
+}
+
+async fn authenticate(conn: &mut UnixSocketConnection) {
+    let response = send(
+        conn,
+        b"<authenticate><credentials><username>admin</username><password>admin</password></credentials></authenticate>"
+            .as_slice(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+}
+
+fn extract_first_config_id(xml: &str) -> EntityId {
+    let marker = "<config id=\"";
+    let start = xml
+        .find(marker)
+        .expect("scan config response should contain a config id")
+        + marker.len();
+    let end = xml[start..]
+        .find('"')
+        .expect("config id should terminate with a quote");
+    xml[start..start + end].parse().expect("valid entity id")
+}
+
+async fn create_large_report(conn: &mut UnixSocketConnection) -> (EntityId, Vec<u8>) {
+    authenticate(conn).await;
+
+    let target_response = send(
+        conn,
+        create_target(
+            "large-test",
+            CreateTargetOpts {
+                hosts: vec!["10.0.0.0/24".to_string()],
+                ..CreateTargetOpts::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(target_response.status_code(), Some(201));
+    let target_id: EntityId = target_response
+        .id()
+        .expect("target id")
+        .parse()
+        .expect("valid target id");
+
+    let scanner_response = send(
+        conn,
+        b"<create_scanner><name>large-response-scanner</name></create_scanner>".as_slice(),
+    )
+    .await;
+    assert_eq!(scanner_response.status_code(), Some(201));
+    let scanner_id: EntityId = scanner_response
+        .id()
+        .expect("scanner id")
+        .parse()
+        .expect("valid scanner id");
+
+    let config_create_response = send(
+        conn,
+        b"<create_config><name>large-response-config</name></create_config>".as_slice(),
+    )
+    .await;
+    assert_eq!(config_create_response.status_code(), Some(201));
+
+    let config_response = send(conn, get_scan_configs(GetScanConfigsOpts::default())).await;
+    assert_eq!(config_response.status_code(), Some(200));
+    let config_id = extract_first_config_id(
+        config_response
+            .as_str()
+            .expect("get_scan_configs response should be utf8"),
+    );
+
+    let task_response = send(
+        conn,
+        create_task(
+            "large-response-task",
+            &config_id,
+            &target_id,
+            &scanner_id,
+            CreateTaskOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(task_response.status_code(), Some(201));
+    let task_id: EntityId = task_response
+        .id()
+        .expect("task id")
+        .parse()
+        .expect("entity id");
+
+    let start_response = send(conn, start_task(&task_id)).await;
+    assert_eq!(start_response.status_code(), Some(202));
+    let report_id: EntityId = start_response
+        .child_text("report_id")
+        .expect("report_id")
+        .parse()
+        .expect("entity id");
+
+    conn.send(&get_report(&report_id).to_bytes())
+        .await
+        .expect("get_report send should succeed");
+    let bytes = conn.read().await.expect("get_report read should succeed");
+    (report_id, bytes)
+}
+
+#[tokio::test]
+async fn test_large_report_10mb() {
+    let server = start_mock(LargeReportConfig {
+        result_count: 5_000,
+        result_payload_bytes: 2_048,
+    })
+    .await;
+    let Some(server) = server else {
+        return;
+    };
+
+    let config = UnixSocketConfig::new(server.socket_path().expect("socket path"))
+        .with_max_response_bytes(Some(32 * 1024 * 1024));
+    let mut conn = UnixSocketConnection::new(config);
+    conn.connect().await.expect("connect should succeed");
+
+    let (_, bytes) = create_large_report(&mut conn).await;
+    let text = std::str::from_utf8(&bytes).expect("response should be utf8");
+
+    assert!(
+        bytes.len() >= 10 * 1024 * 1024,
+        "response too small: {}",
+        bytes.len()
+    );
+    assert!(text.contains("<get_reports_response status=\"200\""));
+    assert!(text.contains("<results"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_large_report_deterministic() {
+    let server = start_mock(LargeReportConfig {
+        result_count: 100,
+        result_payload_bytes: 512,
+    })
+    .await;
+    let Some(server) = server else {
+        return;
+    };
+
+    let config = UnixSocketConfig::new(server.socket_path().expect("socket path"));
+    let mut conn = UnixSocketConnection::new(config);
+    conn.connect().await.expect("connect should succeed");
+
+    let (report_id, first) = create_large_report(&mut conn).await;
+    let second = send(&mut conn, get_report(&report_id))
+        .await
+        .data()
+        .to_vec();
+
+    assert_eq!(first, second);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_large_report_result_count() {
+    let server = start_mock(LargeReportConfig {
+        result_count: 1_000,
+        result_payload_bytes: 512,
+    })
+    .await;
+    let Some(server) = server else {
+        return;
+    };
+
+    let config = UnixSocketConfig::new(server.socket_path().expect("socket path"));
+    let mut conn = UnixSocketConnection::new(config);
+    conn.connect().await.expect("connect should succeed");
+
+    let (_, bytes) = create_large_report(&mut conn).await;
+    let text = std::str::from_utf8(&bytes).expect("response should be utf8");
+    assert!(
+        text.contains("<result_count><full>1000</full><filtered>1000</filtered></result_count>")
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn test_large_report_parseable() {
+    let server = start_mock(LargeReportConfig {
+        result_count: 500,
+        result_payload_bytes: 512,
+    })
+    .await;
+    let Some(server) = server else {
+        return;
+    };
+
+    let config = UnixSocketConfig::new(server.socket_path().expect("socket path"));
+    let mut conn = UnixSocketConnection::new(config);
+    conn.connect().await.expect("connect should succeed");
+
+    let (_, bytes) = create_large_report(&mut conn).await;
+    let response = Response::new(bytes);
+    assert!(response.is_success());
+    assert_eq!(response.status_code(), Some(200));
+
+    server.shutdown().await;
+}

--- a/crates/gvm-mock-server/Cargo.toml
+++ b/crates/gvm-mock-server/Cargo.toml
@@ -26,6 +26,7 @@ quick-xml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+sha1.workspace = true
 clap.workspace = true
 
 # Feature-gated

--- a/crates/gvm-mock-server/src/builder.rs
+++ b/crates/gvm-mock-server/src/builder.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::fault::{Fault, FaultEngine};
 use crate::fixtures::FixtureStore;
+use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
 use crate::server::MockGmpServer;
 use crate::store::ResourceStore;
@@ -23,6 +24,7 @@ pub struct MockGmpServerBuilder {
     seed_fn: Option<Box<dyn FnOnce(&ResourceStore) + Send>>,
     faults: Vec<Fault>,
     scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+    large_report: Option<LargeReportConfig>,
 }
 
 enum Transport {
@@ -46,6 +48,7 @@ impl MockGmpServerBuilder {
             seed_fn: None,
             faults: Vec::new(),
             scenario_config: None,
+            large_report: None,
         }
     }
 
@@ -129,6 +132,29 @@ impl MockGmpServerBuilder {
         self
     }
 
+    /// Enable large synthetic report generation for reports created via `start_task`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use gvm_mock_server::{LargeReportConfig, MockGmpServer, ServerMode};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let server = MockGmpServer::builder()
+    ///     .mode(ServerMode::Stateful)
+    ///     .large_report(LargeReportConfig::default())
+    ///     .unix_socket_auto()
+    ///     .build()
+    ///     .await?;
+    /// server.shutdown().await;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn large_report(mut self, config: LargeReportConfig) -> Self {
+        self.large_report = Some(config);
+        self
+    }
+
     /// Build and start the mock server.
     ///
     /// # Errors
@@ -143,6 +169,7 @@ impl MockGmpServerBuilder {
             seed_fn,
             faults,
             scenario_config,
+            large_report,
         } = self;
 
         let fixtures = if mode == ServerMode::Fixture || !fixture_overrides.is_empty() {
@@ -189,6 +216,7 @@ impl MockGmpServerBuilder {
                     store,
                     fault_engine,
                     scenario_config,
+                    large_report,
                 )
                 .await
             }
@@ -206,6 +234,7 @@ impl MockGmpServerBuilder {
                     store,
                     fault_engine,
                     scenario_config,
+                    large_report,
                 )
                 .await
             }
@@ -218,6 +247,7 @@ impl MockGmpServerBuilder {
                     store,
                     fault_engine,
                     scenario_config,
+                    large_report,
                 )
                 .await
             }
@@ -231,6 +261,7 @@ impl MockGmpServerBuilder {
                     store,
                     fault_engine,
                     scenario_config,
+                    large_report,
                 )
                 .await
             }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -13,7 +13,9 @@ use crate::command_parser::{parse_command, parse_element_text, ParsedCommand};
 use crate::fault::{FaultAction, FaultEngine};
 use crate::fixtures::FixtureStore;
 use crate::history::CommandHistory;
-use crate::response_gen::{echo_response, error_response};
+use crate::response_gen::{
+    echo_response, error_response, generate_large_report, LargeReportConfig,
+};
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 use crate::store::{Resource, ResourceStore, TaskStatus};
 use crate::util::xml_escape;
@@ -29,6 +31,7 @@ pub struct SessionHandler {
     fixtures: Option<FixtureStore>,
     store: Option<ResourceStore>,
     scenario_engine: Option<Mutex<ScenarioEngine>>,
+    large_report: Option<LargeReportConfig>,
     fault_engine: FaultEngine,
     command_count: AtomicUsize,
 }
@@ -48,6 +51,7 @@ pub enum HandleResult {
 
 impl SessionHandler {
     /// Create a new session handler.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mode: ServerMode,
         version: GmpVersion,
@@ -56,6 +60,7 @@ impl SessionHandler {
         fixtures: Option<FixtureStore>,
         store: Option<ResourceStore>,
         scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+        large_report: Option<LargeReportConfig>,
         fault_engine: FaultEngine,
     ) -> Self {
         Self {
@@ -67,6 +72,7 @@ impl SessionHandler {
             store,
             scenario_engine: scenario_config
                 .map(|(mode, steps)| Mutex::new(ScenarioEngine::new(mode, steps))),
+            large_report,
             fault_engine,
             command_count: AtomicUsize::new(0),
         }
@@ -642,6 +648,12 @@ impl SessionHandler {
         report: &Resource,
         store: &ResourceStore,
     ) -> Vec<u8> {
+        if let Some(config) = self.large_report {
+            if report.attr("task_id").is_some() {
+                return generate_large_report(report.id, &config).into_bytes();
+            }
+        }
+
         let report_id = report.id.to_string();
         let results: Vec<Resource> = store
             .list("result")

--- a/crates/gvm-mock-server/src/lib.rs
+++ b/crates/gvm-mock-server/src/lib.rs
@@ -60,6 +60,7 @@ pub mod version;
 pub use builder::MockGmpServerBuilder;
 pub use fault::{Fault, FaultEngine, FaultKind};
 pub use history::CommandRecord;
+pub use response_gen::LargeReportConfig;
 pub use scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 pub use server::MockGmpServer;
 pub use store::{Resource, ResourceStore};

--- a/crates/gvm-mock-server/src/listener.rs
+++ b/crates/gvm-mock-server/src/listener.rs
@@ -14,6 +14,7 @@ use crate::fault::FaultEngine;
 use crate::fixtures::FixtureStore;
 use crate::handler::{HandleResult, SessionHandler};
 use crate::history::CommandHistory;
+use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
 use crate::store::ResourceStore;
 use crate::version::GmpVersion;
@@ -35,6 +36,8 @@ pub struct ListenerState {
     pub(crate) store: Option<ResourceStore>,
     /// Scenario configuration (if using Scenario mode).
     pub(crate) scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+    /// Large synthetic report configuration.
+    pub(crate) large_report: Option<LargeReportConfig>,
     /// Fault injection engine.
     pub(crate) fault_engine: FaultEngine,
     /// Shutdown signal.
@@ -112,6 +115,7 @@ where
         state.fixtures.clone(),
         state.store.clone(),
         state.scenario_config.clone(),
+        state.large_report,
         state.fault_engine.fork(),
     );
 

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -19,9 +19,9 @@ const DESCRIPTION_SENTENCE: &str =
 /// Configuration for synthetic large report generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LargeReportConfig {
-    /// Number of <result> elements to generate.
+    /// Number of `<result>` elements to generate.
     pub result_count: usize,
-    /// Approximate bytes of filler text per result's <description>.
+    /// Approximate bytes of filler text per result's `<description>`.
     pub result_payload_bytes: usize,
 }
 

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -3,9 +3,36 @@
 
 //! GMP response XML generation.
 
+use std::fmt::Write;
+
+use sha1::{Digest, Sha1};
 use uuid::Uuid;
 
 use crate::util::xml_escape_attr;
+
+const LARGE_REPORT_FORMAT_ID: Uuid = Uuid::from_u128(0xc402cc3e_b531_11e1_9163_406186ea4fc5);
+const PORTS: [u16; 5] = [22, 80, 443, 8080, 8443];
+const SEVERITIES: [&str; 7] = ["2.1", "4.3", "5.0", "6.5", "7.5", "8.1", "9.8"];
+const DESCRIPTION_SENTENCE: &str =
+    "Synthetic result payload generated for large-response integration testing. ";
+
+/// Configuration for synthetic large report generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LargeReportConfig {
+    /// Number of <result> elements to generate.
+    pub result_count: usize,
+    /// Approximate bytes of filler text per result's <description>.
+    pub result_payload_bytes: usize,
+}
+
+impl Default for LargeReportConfig {
+    fn default() -> Self {
+        Self {
+            result_count: 1_000,
+            result_payload_bytes: 512,
+        }
+    }
+}
 
 /// Known GMP commands that the mock server recognizes.
 pub static KNOWN_COMMANDS: &[&str] = &[
@@ -201,9 +228,135 @@ pub fn version_response(version: &str) -> Vec<u8> {
     .into_bytes()
 }
 
+/// Generate a deterministic synthetic `get_reports_response`.
+#[must_use]
+pub fn generate_large_report(report_id: Uuid, config: &LargeReportConfig) -> String {
+    let per_result_estimate = config.result_payload_bytes.saturating_add(320);
+    let estimated_len = config
+        .result_count
+        .saturating_mul(per_result_estimate)
+        .saturating_add(512);
+    let description = build_description_payload(config.result_payload_bytes);
+    let mut xml = String::with_capacity(estimated_len);
+
+    write!(
+        xml,
+        "<get_reports_response status=\"200\" status_text=\"OK\">\
+         <report id=\"{report_id}\" format_id=\"{format_id}\" content_type=\"text/xml\">\
+         <report id=\"{report_id}\">\
+         <results max=\"{count}\" start=\"1\">",
+        format_id = LARGE_REPORT_FORMAT_ID,
+        count = config.result_count,
+    )
+    .expect("writing XML into String should not fail");
+
+    for i in 0..config.result_count {
+        let result_id = uuid_v5(report_id, &(i as u64).to_le_bytes());
+        let host_octet = (i % 254) + 1;
+        let port = PORTS[i % PORTS.len()];
+        let severity = SEVERITIES[i % SEVERITIES.len()];
+        let threat = threat_for_severity(severity);
+        let oid = 10_000 + i;
+
+        write!(
+            xml,
+            "<result id=\"{result_id}\">\
+             <host>10.0.0.{host_octet}</host>\
+             <port>{port}/tcp</port>\
+             <nvt oid=\"1.3.6.1.4.1.25623.1.0.{oid}\">\
+             <name>Test NVT {i}</name>\
+             <type>nvt</type>\
+             </nvt>\
+             <severity>{severity}</severity>\
+             <threat>{threat}</threat>\
+             <description>{description}</description>\
+             </result>",
+        )
+        .expect("writing XML into String should not fail");
+    }
+
+    write!(
+        xml,
+        "</results>\
+         <result_count><full>{count}</full><filtered>{count}</filtered></result_count>\
+         </report>\
+         </report>\
+         </get_reports_response>",
+        count = config.result_count,
+    )
+    .expect("writing XML into String should not fail");
+
+    xml
+}
+
+fn build_description_payload(target_bytes: usize) -> String {
+    let mut description = String::with_capacity(target_bytes);
+    while description.len() < target_bytes {
+        let remaining = target_bytes - description.len();
+        if remaining >= DESCRIPTION_SENTENCE.len() {
+            description.push_str(DESCRIPTION_SENTENCE);
+        } else {
+            description.push_str(&DESCRIPTION_SENTENCE[..remaining]);
+        }
+    }
+    description
+}
+
+fn threat_for_severity(severity: &str) -> &'static str {
+    match severity {
+        "2.1" | "4.3" => "Low",
+        "5.0" | "6.5" => "Medium",
+        _ => "High",
+    }
+}
+
+fn uuid_v5(namespace: Uuid, name: &[u8]) -> Uuid {
+    let mut hasher = Sha1::new();
+    hasher.update(namespace.as_bytes());
+    hasher.update(name);
+
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&hasher.finalize()[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x50;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    Uuid::from_bytes(bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quick_xml::events::Event;
+    use quick_xml::Reader;
+
+    fn extract_descriptions(xml: &str) -> Vec<String> {
+        let mut reader = Reader::from_str(xml);
+        let mut descriptions = Vec::new();
+        let mut in_description = false;
+
+        loop {
+            match reader.read_event() {
+                Ok(Event::Start(ref e)) if e.name().as_ref() == b"description" => {
+                    in_description = true;
+                }
+                Ok(Event::Text(text)) if in_description => {
+                    descriptions.push(
+                        text.xml_content()
+                            .expect("description text should decode")
+                            .into_owned(),
+                    );
+                }
+                Ok(Event::End(ref e)) if e.name().as_ref() == b"description" => {
+                    in_description = false;
+                }
+                Ok(Event::Eof) => break,
+                Ok(_) => {}
+                Err(error) => panic!("unexpected xml parse failure: {error}"),
+            }
+        }
+
+        descriptions
+    }
 
     #[test]
     fn test_known_commands() {
@@ -250,5 +403,73 @@ mod tests {
         let text = std::str::from_utf8(&resp).expect("valid utf8");
         assert!(text.contains("status=\"404\""));
         assert!(text.contains("Not Found"));
+    }
+
+    #[test]
+    fn large_report_config_defaults_match_spec() {
+        let config = LargeReportConfig::default();
+        assert_eq!(config.result_count, 1_000);
+        assert_eq!(config.result_payload_bytes, 512);
+    }
+
+    #[test]
+    fn generate_large_report_small_payload_is_valid_xml() {
+        let xml = generate_large_report(
+            Uuid::parse_str("11111111-1111-1111-1111-111111111111").expect("valid uuid"),
+            &LargeReportConfig {
+                result_count: 10,
+                result_payload_bytes: 64,
+            },
+        );
+
+        let mut reader = Reader::from_str(&xml);
+        loop {
+            match reader.read_event() {
+                Ok(Event::Eof) => break,
+                Ok(_) => {}
+                Err(error) => panic!("large report should be valid xml: {error}"),
+            }
+        }
+
+        assert!(xml.contains("<get_reports_response"));
+        assert!(xml.contains("<results max=\"10\" start=\"1\">"));
+        assert!(xml.contains("<result_count><full>10</full><filtered>10</filtered></result_count>"));
+    }
+
+    #[test]
+    fn generate_large_report_is_deterministic() {
+        let report_id =
+            Uuid::parse_str("22222222-2222-2222-2222-222222222222").expect("valid uuid");
+        let config = LargeReportConfig {
+            result_count: 10,
+            result_payload_bytes: 32,
+        };
+
+        let first = generate_large_report(report_id, &config);
+        let second = generate_large_report(report_id, &config);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn generate_large_report_payload_size_is_approximate() {
+        let config = LargeReportConfig {
+            result_count: 10,
+            result_payload_bytes: 256,
+        };
+        let xml = generate_large_report(
+            Uuid::parse_str("33333333-3333-3333-3333-333333333333").expect("valid uuid"),
+            &config,
+        );
+        let descriptions = extract_descriptions(&xml);
+        let total_description_bytes: usize = descriptions.iter().map(String::len).sum();
+        let expected = config.result_count * config.result_payload_bytes;
+        let lower_bound = expected * 9 / 10;
+        let upper_bound = expected * 11 / 10;
+
+        assert_eq!(descriptions.len(), config.result_count);
+        assert!(
+            (lower_bound..=upper_bound).contains(&total_description_bytes),
+            "description payload bytes {total_description_bytes} not within 10% of {expected}"
+        );
     }
 }

--- a/crates/gvm-mock-server/src/server.rs
+++ b/crates/gvm-mock-server/src/server.rs
@@ -15,6 +15,7 @@ use crate::fault::FaultEngine;
 use crate::fixtures::FixtureStore;
 use crate::history::{CommandHistory, CommandRecord};
 use crate::listener::{run_tcp_listener, run_unix_listener, ListenerState};
+use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
 #[cfg(feature = "ssh")]
 use crate::ssh_listener::{generate_host_key, host_key_fingerprint, run_ssh_listener};
@@ -57,6 +58,7 @@ impl MockGmpServer {
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
         scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+        large_report: Option<LargeReportConfig>,
     ) -> Result<Self, std::io::Error> {
         // Remove existing socket if present
         if socket_path.exists() {
@@ -75,6 +77,7 @@ impl MockGmpServer {
             fixtures,
             store,
             scenario_config,
+            large_report,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });
@@ -105,6 +108,7 @@ impl MockGmpServer {
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
         scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+        large_report: Option<LargeReportConfig>,
     ) -> Result<Self, std::io::Error> {
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
@@ -119,6 +123,7 @@ impl MockGmpServer {
             fixtures,
             store,
             scenario_config,
+            large_report,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });
@@ -150,6 +155,7 @@ impl MockGmpServer {
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
         scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+        large_report: Option<LargeReportConfig>,
     ) -> Result<Self, std::io::Error> {
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
@@ -166,6 +172,7 @@ impl MockGmpServer {
             fixtures,
             store,
             scenario_config,
+            large_report,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });

--- a/crates/gvm-mock-server/src/ssh_listener.rs
+++ b/crates/gvm-mock-server/src/ssh_listener.rs
@@ -90,6 +90,7 @@ impl server::Handler for MockSshHandler {
             state.fixtures.clone(),
             state.store.clone(),
             state.scenario_config.clone(),
+            state.large_report,
             state.fault_engine.fork(),
         );
 


### PR DESCRIPTION
## Summary

Implements the large-response generator per OpenSpec (`spec/large-response-generator/openspec.md`).

### What's included

**`LargeReportConfig`** — configurable synthetic report generation:
- `result_count`: number of `<result>` elements (default: 1,000)
- `result_payload_bytes`: filler text per result's `<description>` (default: 512)

**Deterministic generator** — same config produces identical output:
- Result UUIDs: UUID v5 derived from report UUID + index
- Hosts: `10.0.0.{(i % 254) + 1}`
- Ports: cycle `[22, 80, 443, 8080, 8443]`
- NVT OIDs: `1.3.6.1.4.1.25623.1.0.{10000 + i}`
- Severities: cycle `[2.1, 4.3, 5.0, 6.5, 7.5, 8.1, 9.8]`

**Builder integration**: `MockGmpServer::builder().large_report(config)`

**Handler hookup**: `start_task → get_reports(report_id)` returns synthetic large report when config is set

**Feature-gated integration tests** (`--features large-response-tests`):
| Test | Config | Assertion |
|------|--------|-----------|
| `test_large_report_10mb` | 5,000 × 2KB | Response ≥ 10MB, status 200, contains `<results>` |
| `test_large_report_deterministic` | 100 × 512B | Two reads produce identical responses |
| `test_large_report_result_count` | 1,000 | `<result_count><full>1000</full>` present |
| `test_large_report_parseable` | 500 | `Response::new()` succeeds, `is_success()` true |

**Unit tests** for generator determinism, payload sizing, XML validity

### Stats
- 12 files changed, +527 lines
- Default `cargo test` unaffected (feature-gated)
- All existing tests pass

Refs #24
