### PR TITLE
ci(e2e): update runner labels to match hetzner-vps

### DIFF
--- a/.github/workflows/e2e-trigger.yml
+++ b/.github/workflows/e2e-trigger.yml
@@ -1,4 +1,4 @@
-# Trigger E2E tests on push to main, PRs targeting main, and nightly schedule.
+# Trigger E2E tests on push to main and PRs targeting main.
 # Delegates to e2e.yml (workflow_call) with explicit default inputs.
 
 name: E2E Tests (CI)
@@ -8,9 +8,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    # Nightly at 03:00 UTC
-    - cron: "0 3 * * *"
+  # schedule:
+  #   # Nightly at 03:00 UTC — disabled to save resources.
+  #   # Re-enable if upstream container changes need regular validation.
+  #   - cron: "0 3 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-trigger.yml
+++ b/.github/workflows/e2e-trigger.yml
@@ -1,0 +1,24 @@
+# Trigger E2E tests on push to main, PRs targeting main, and nightly schedule.
+# Delegates to e2e.yml (workflow_call) with explicit default inputs.
+
+name: E2E Tests (CI)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly at 03:00 UTC
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E Tests
+    uses: ./.github/workflows/e2e.yml
+    with:
+      run-scan: false
+      clean: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@
 # exercises the rust-gvm client against a real gvmd instance.
 #
 # Trigger: manual dispatch or nightly schedule.
-# Runner: self-hosted (etterkal) — requires Docker or Podman with Compose.
+# Runner: self-hosted (hetzner-vps) — requires Docker or Podman with Compose.
 
 name: E2E Tests
 
@@ -67,7 +67,7 @@ jobs:
   e2e:
     name: GVM Community E2E
     needs: build-runner
-    runs-on: [self-hosted, fedora]
+    runs-on: [self-hosted, docker]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       run-scan:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,10 @@
 # E2E Tests — GVM Community container stack on self-hosted runner
-# Runs the full Greenbone Community stack via Docker/Podman Compose and
+# Runs the full Greenbone Community stack via Docker Compose and
 # exercises the rust-gvm client against a real gvmd instance.
 #
-# Trigger: manual dispatch or nightly schedule.
-# Runner: self-hosted (hetzner-vps) — requires Docker or Podman with Compose.
+# The runner is permanent (hetzner-vps). Docker volumes are kept between
+# runs so that GVM feed data (VTs, SCAP, CERT, scan configs) persists.
+# First run: full feed sync (~20 min). Subsequent runs: delta only (~2-3 min).
 
 name: E2E Tests
 
@@ -19,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      clean:
+        description: "Force clean environment (destroy all volumes)"
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Nightly at 03:00 UTC
     - cron: "0 3 * * *"
@@ -29,90 +35,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   COMPOSE_FILE: tests/e2e/gvm-community/docker-compose.yml
-  RUNNER_IMAGE_NAME: rust-gvm-e2e-runner
-  RUNNER_IMAGE_TAG: ci
 
 jobs:
-  # ──────────────────────────────────────────────
-  # Job 1: Build the test runner container image
-  # ──────────────────────────────────────────────
-  build-runner:
-    name: Build E2E Runner Image
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Build and export runner image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: tests/e2e/gvm-community/Dockerfile.runner
-          tags: ${{ env.RUNNER_IMAGE_NAME }}:${{ env.RUNNER_IMAGE_TAG }}
-          outputs: type=docker,dest=runner-image.tar
-
-      - name: Upload runner image artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: e2e-runner-image
-          path: runner-image.tar
-          retention-days: 1
-
-  # ──────────────────────────────────────────────
-  # Job 2: Pre-pull GVM images (skip if present)
-  # ──────────────────────────────────────────────
-  pull-images:
-    name: Pre-pull GVM Images
-    runs-on: [self-hosted, docker]
-    timeout-minutes: 60
-    steps:
-      - name: Pull GVM Community images (skip cached)
-        run: |
-          set -euo pipefail
-          REGISTRY="registry.community.greenbone.net/community"
-          declare -A IMAGES=(
-            [vulnerability-tests]=latest
-            [notus-data]=latest
-            [scap-data]=latest
-            [cert-bund-data]=latest
-            [dfn-cert-data]=latest
-            [data-objects]=latest
-            [report-formats]=latest
-            [gpg-data]=stable
-            [redis-server]=stable
-            [pg-gvm-migrator]=stable
-            [pg-gvm]=stable
-            [openvas-scanner]=stable
-            [ospd-openvas]=stable
-            [gvmd]=stable
-            [gsad]=stable
-          )
-          pulled=0
-          skipped=0
-          for img in "${!IMAGES[@]}"; do
-            tag="${IMAGES[$img]}"
-            full="${REGISTRY}/${img}:${tag}"
-            if docker image inspect "$full" &>/dev/null; then
-              echo "✓ ${img}:${tag} already cached"
-              skipped=$((skipped + 1))
-            else
-              echo "::group::Pulling ${img}:${tag}"
-              docker pull "$full"
-              echo "::endgroup::"
-              pulled=$((pulled + 1))
-            fi
-          done
-          echo "Done: ${pulled} pulled, ${skipped} cached"
-
-  # ──────────────────────────────────────────────
-  # Job 3: Run E2E tests on self-hosted runner
-  # ──────────────────────────────────────────────
   e2e:
     name: GVM Community E2E
-    needs: [build-runner, pull-images]
     runs-on: [self-hosted, docker]
     timeout-minutes: 45
     steps:
@@ -120,58 +46,41 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Detect compose backend
-        id: compose
+      - name: Clean environment (if requested)
+        if: ${{ inputs.clean == true }}
         run: |
-          if command -v podman-compose &>/dev/null; then
-            echo "cmd=podman-compose" >> "$GITHUB_OUTPUT"
-            echo "runtime=podman" >> "$GITHUB_OUTPUT"
-            echo "Using podman-compose"
-          elif command -v docker && docker compose version &>/dev/null; then
-            echo "cmd=docker compose" >> "$GITHUB_OUTPUT"
-            echo "runtime=docker" >> "$GITHUB_OUTPUT"
-            echo "Using docker compose"
-          else
-            echo "::error::Neither podman-compose nor docker compose found"
-            exit 1
-          fi
+          echo "Cleaning all containers and volumes..."
+          docker compose -f ${{ env.COMPOSE_FILE }} down -v --remove-orphans 2>/dev/null || true
 
-      - name: Download runner image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: e2e-runner-image
+      - name: Pull container images
+        run: docker compose -f ${{ env.COMPOSE_FILE }} pull
 
-      - name: Load runner image
+      - name: Build E2E runner image
         run: |
-          if [[ "${{ steps.compose.outputs.runtime }}" == "podman" ]]; then
-            podman load -i runner-image.tar
-            podman tag ${{ env.RUNNER_IMAGE_NAME }}:${{ env.RUNNER_IMAGE_TAG }} \
-              localhost/${{ env.RUNNER_IMAGE_NAME }}:${{ env.RUNNER_IMAGE_TAG }}
-          else
-            docker load -i runner-image.tar
-          fi
-          rm -f runner-image.tar
+          docker build \
+            -t rust-gvm-e2e-runner:ci \
+            -f tests/e2e/gvm-community/Dockerfile.runner \
+            .
 
       - name: Start GVM stack
-        run: ${{ steps.compose.outputs.cmd }} -f ${{ env.COMPOSE_FILE }} up -d
+        run: docker compose -f ${{ env.COMPOSE_FILE }} up -d
 
       - name: Wait for gvmd readiness
-        run: |
-          bash tests/e2e/gvm-community/scripts/wait-ready.sh
+        run: bash tests/e2e/gvm-community/scripts/wait-ready.sh
         timeout-minutes: 20
 
       - name: Run smoke tests
         run: |
-          ${{ steps.compose.outputs.cmd }} -f ${{ env.COMPOSE_FILE }} --profile runner run \
+          docker compose -f ${{ env.COMPOSE_FILE }} --profile runner run \
             -e E2E_RUN_SCAN=${{ inputs.run-scan && '1' || '0' }} \
             --rm rust-gvm-e2e
 
       - name: Collect logs on failure
         if: failure()
         run: |
-          ${{ steps.compose.outputs.cmd }} -f ${{ env.COMPOSE_FILE }} logs --tail=100 gvmd
-          ${{ steps.compose.outputs.cmd }} -f ${{ env.COMPOSE_FILE }} logs --tail=50 ospd-openvas
+          docker compose -f ${{ env.COMPOSE_FILE }} logs --tail=200 gvmd
+          docker compose -f ${{ env.COMPOSE_FILE }} logs --tail=50 ospd-openvas
 
-      - name: Teardown
+      - name: Stop containers (keep volumes)
         if: always()
-        run: ${{ steps.compose.outputs.cmd }} -f ${{ env.COMPOSE_FILE }} down -v
+        run: docker compose -f ${{ env.COMPOSE_FILE }} down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,11 +25,6 @@ on:
         required: false
         type: boolean
         default: false
-      validate:
-        description: "Run differential validation against gvm-tools"
-        required: false
-        type: boolean
-        default: false
   schedule:
     # Nightly at 03:00 UTC
     - cron: "0 3 * * *"
@@ -80,15 +75,16 @@ jobs:
             -e E2E_RUN_SCAN=${{ inputs.run-scan && '1' || '0' }} \
             --rm rust-gvm-e2e
 
-      - name: Validate against gvm-tools (differential test)
-        if: ${{ success() && inputs.validate == true }}
+      - name: Cross-check with gvm-tools (fault isolation)
+        if: failure()
         run: |
+          echo "rust-gvm failed — cross-checking with gvm-tools..."
           docker compose -f ${{ env.COMPOSE_FILE }} --profile runner run --rm -T \
             -e GVM_ADMIN_USER=admin \
             -e GVM_ADMIN_PASS=admin \
             -e GVM_SOCKET_PATH=/run/gvmd/gvmd.sock \
             rust-gvm-e2e \
-            python3 tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
+            python3 tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py --check all || true
 
       - name: Collect logs on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,6 +71,7 @@ jobs:
     steps:
       - name: Pull GVM Community images (skip cached)
         run: |
+          set -euo pipefail
           REGISTRY="registry.community.greenbone.net/community"
           declare -A IMAGES=(
             [vulnerability-tests]=latest
@@ -96,12 +97,12 @@ jobs:
             full="${REGISTRY}/${img}:${tag}"
             if docker image inspect "$full" &>/dev/null; then
               echo "✓ ${img}:${tag} already cached"
-              ((skipped++))
+              skipped=$((skipped + 1))
             else
               echo "::group::Pulling ${img}:${tag}"
               docker pull "$full"
               echo "::endgroup::"
-              ((pulled++))
+              pulled=$((pulled + 1))
             fi
           done
           echo "Done: ${pulled} pulled, ${skipped} cached"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@
 # The runner is permanent (hetzner-vps). Docker volumes are kept between
 # runs so that GVM feed data (VTs, SCAP, CERT, scan configs) persists.
 # First run: full feed sync (~20 min). Subsequent runs: delta only (~2-3 min).
+#
+# Called by e2e-trigger.yml for push/PR/schedule events.
+# Can also be invoked manually via workflow_dispatch.
 
 name: E2E Tests
 
@@ -13,10 +16,18 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
+    inputs:
+      run-scan:
+        description: "Run extended scan test (slow, ~10min+)"
+        required: false
+        type: boolean
+        default: false
+      clean:
+        description: "Force clean environment (destroy all volumes)"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       run-scan:
@@ -29,9 +40,6 @@ on:
         required: false
         type: boolean
         default: false
-  schedule:
-    # Nightly at 03:00 UTC
-    - cron: "0 3 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,11 +62,53 @@ jobs:
           retention-days: 1
 
   # ──────────────────────────────────────────────
-  # Job 2: Run E2E tests on self-hosted runner
+  # Job 2: Pre-pull GVM container images
+  # ──────────────────────────────────────────────
+  pull-images:
+    name: Pre-pull GVM Images
+    runs-on: [self-hosted, docker]
+    timeout-minutes: 60
+    steps:
+      - name: Pull all GVM Community images
+        run: |
+          REGISTRY="registry.community.greenbone.net/community"
+          IMAGES_LATEST=(
+            vulnerability-tests
+            notus-data
+            scap-data
+            cert-bund-data
+            dfn-cert-data
+            data-objects
+            report-formats
+          )
+          IMAGES_STABLE=(
+            gpg-data
+            redis-server
+            pg-gvm-migrator
+            pg-gvm
+            openvas-scanner
+            ospd-openvas
+            gvmd
+            gsad
+          )
+          for img in "${IMAGES_LATEST[@]}"; do
+            echo "::group::Pulling ${img}:latest"
+            docker pull "${REGISTRY}/${img}:latest"
+            echo "::endgroup::"
+          done
+          for img in "${IMAGES_STABLE[@]}"; do
+            echo "::group::Pulling ${img}:stable"
+            docker pull "${REGISTRY}/${img}:stable"
+            echo "::endgroup::"
+          done
+          echo "All images pulled successfully"
+
+  # ──────────────────────────────────────────────
+  # Job 3: Run E2E tests on self-hosted runner
   # ──────────────────────────────────────────────
   e2e:
     name: GVM Community E2E
-    needs: build-runner
+    needs: [build-runner, pull-images]
     runs-on: [self-hosted, docker]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           echo "rust-gvm failed — cross-checking with gvm-tools..."
           docker compose -f ${{ env.COMPOSE_FILE }} --profile runner run --rm -T \
+            --entrypoint "" \
             -e GVM_ADMIN_USER=admin \
             -e GVM_ADMIN_PASS=admin \
             -e GVM_SOCKET_PATH=/run/gvmd/gvmd.sock \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      validate:
+        description: "Run differential validation against gvm-tools"
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Nightly at 03:00 UTC
     - cron: "0 3 * * *"
@@ -76,7 +81,7 @@ jobs:
             --rm rust-gvm-e2e
 
       - name: Validate against gvm-tools (differential test)
-        if: success()
+        if: ${{ success() && inputs.validate == true }}
         run: |
           docker compose -f ${{ env.COMPOSE_FILE }} --profile runner run --rm -T \
             -e GVM_ADMIN_USER=admin \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
   e2e:
     name: GVM Community E2E
     runs-on: [self-hosted, docker]
-    timeout-minutes: 45
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Wait for gvmd readiness
         run: bash tests/e2e/gvm-community/scripts/wait-ready.sh
-        timeout-minutes: 20
+        timeout-minutes: 150
 
       - name: Run smoke tests
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,7 +114,7 @@ jobs:
     name: GVM Community E2E
     needs: [build-runner, pull-images]
     runs-on: [self-hosted, docker]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -158,7 +158,7 @@ jobs:
       - name: Wait for gvmd readiness
         run: |
           bash tests/e2e/gvm-community/scripts/wait-ready.sh
-        timeout-minutes: 15
+        timeout-minutes: 20
 
       - name: Run smoke tests
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,16 @@ jobs:
             -e E2E_RUN_SCAN=${{ inputs.run-scan && '1' || '0' }} \
             --rm rust-gvm-e2e
 
+      - name: Validate against gvm-tools (differential test)
+        if: success()
+        run: |
+          docker compose -f ${{ env.COMPOSE_FILE }} --profile runner run --rm -T \
+            -e GVM_ADMIN_USER=admin \
+            -e GVM_ADMIN_PASS=admin \
+            -e GVM_SOCKET_PATH=/run/gvmd/gvmd.sock \
+            rust-gvm-e2e \
+            python3 tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
+
       - name: Collect logs on failure
         if: failure()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,46 +62,49 @@ jobs:
           retention-days: 1
 
   # ──────────────────────────────────────────────
-  # Job 2: Pre-pull GVM container images
+  # Job 2: Pre-pull GVM images (skip if present)
   # ──────────────────────────────────────────────
   pull-images:
     name: Pre-pull GVM Images
     runs-on: [self-hosted, docker]
     timeout-minutes: 60
     steps:
-      - name: Pull all GVM Community images
+      - name: Pull GVM Community images (skip cached)
         run: |
           REGISTRY="registry.community.greenbone.net/community"
-          IMAGES_LATEST=(
-            vulnerability-tests
-            notus-data
-            scap-data
-            cert-bund-data
-            dfn-cert-data
-            data-objects
-            report-formats
+          declare -A IMAGES=(
+            [vulnerability-tests]=latest
+            [notus-data]=latest
+            [scap-data]=latest
+            [cert-bund-data]=latest
+            [dfn-cert-data]=latest
+            [data-objects]=latest
+            [report-formats]=latest
+            [gpg-data]=stable
+            [redis-server]=stable
+            [pg-gvm-migrator]=stable
+            [pg-gvm]=stable
+            [openvas-scanner]=stable
+            [ospd-openvas]=stable
+            [gvmd]=stable
+            [gsad]=stable
           )
-          IMAGES_STABLE=(
-            gpg-data
-            redis-server
-            pg-gvm-migrator
-            pg-gvm
-            openvas-scanner
-            ospd-openvas
-            gvmd
-            gsad
-          )
-          for img in "${IMAGES_LATEST[@]}"; do
-            echo "::group::Pulling ${img}:latest"
-            docker pull "${REGISTRY}/${img}:latest"
-            echo "::endgroup::"
+          pulled=0
+          skipped=0
+          for img in "${!IMAGES[@]}"; do
+            tag="${IMAGES[$img]}"
+            full="${REGISTRY}/${img}:${tag}"
+            if docker image inspect "$full" &>/dev/null; then
+              echo "✓ ${img}:${tag} already cached"
+              ((skipped++))
+            else
+              echo "::group::Pulling ${img}:${tag}"
+              docker pull "$full"
+              echo "::endgroup::"
+              ((pulled++))
+            fi
           done
-          for img in "${IMAGES_STABLE[@]}"; do
-            echo "::group::Pulling ${img}:stable"
-            docker pull "${REGISTRY}/${img}:stable"
-            echo "::endgroup::"
-          done
-          echo "All images pulled successfully"
+          echo "Done: ${pulled} pulled, ${skipped} cached"
 
   # ──────────────────────────────────────────────
   # Job 3: Run E2E tests on self-hosted runner
@@ -141,7 +144,6 @@ jobs:
         run: |
           if [[ "${{ steps.compose.outputs.runtime }}" == "podman" ]]; then
             podman load -i runner-image.tar
-            # Tag to match compose service image reference
             podman tag ${{ env.RUNNER_IMAGE_NAME }}:${{ env.RUNNER_IMAGE_TAG }} \
               localhost/${{ env.RUNNER_IMAGE_NAME }}:${{ env.RUNNER_IMAGE_TAG }}
           else
@@ -155,7 +157,7 @@ jobs:
       - name: Wait for gvmd readiness
         run: |
           bash tests/e2e/gvm-community/scripts/wait-ready.sh
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       - name: Run smoke tests
         run: |

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -415,15 +415,25 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
     log_line("Authentication successful");
 
     // Phase 2: Wait for feeds to finish syncing
+    // IMPORTANT: reconnect on each poll — gvmd can return stale data on
+    // long-lived connections during feed sync.
+    client.disconnect().await?;
     log_line("Waiting for feed sync to complete...");
     for poll in 1..=360 {
-        let feeds_response = client
+        let mut poll_client = connect_client(config).await?;
+        let auth = poll_client
+            .call(authenticate(&config.username, &config.password))
+            .await?;
+        assert_status(&auth, 200, "authenticate")?;
+
+        let feeds_response = poll_client
             .send(get_feeds(GetFeedsOpts::default()))
             .await?;
         assert_status(&feeds_response, 200, "get_feeds")?;
 
         let feeds_xml = feeds_response.as_str().unwrap_or("");
         let syncing = feeds_xml.matches("<currently_syncing>").count();
+        poll_client.disconnect().await?;
 
         if syncing == 0 {
             log_line(&format!("Feed sync complete (poll {poll})"));
@@ -441,18 +451,24 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
     // Phase 3: Wait for scan configs to exist
     log_line("Waiting for scan configs...");
     for poll in 1..=120 {
-        let configs_response = client
+        let mut poll_client = connect_client(config).await?;
+        let auth = poll_client
+            .call(authenticate(&config.username, &config.password))
+            .await?;
+        assert_status(&auth, 200, "authenticate")?;
+
+        let configs_response = poll_client
             .call(get_scan_configs(GetScanConfigsOpts::default()))
             .await?;
         assert_status(&configs_response, 200, "get_scan_configs")?;
 
         let config_count = count_elements(&configs_response, "config")?;
+        poll_client.disconnect().await?;
+
         if config_count > 0 {
             log_line(&format!("Found {config_count} scan config(s) (poll {poll})"));
-            // Grace period for gvmd to finish loading
             log_line("Allowing 30s grace period...");
             sleep(Duration::from_secs(30)).await;
-            client.disconnect().await?;
             return Ok(());
         }
         if poll % 6 == 0 {
@@ -461,7 +477,6 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
         sleep(Duration::from_secs(5)).await;
     }
 
-    client.disconnect().await?;
     Err(AppError::Assertion("no scan configs found after 10 minutes of polling".to_string()))
 }
 

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -518,11 +518,21 @@ async fn run_smoke_suite(config: &EnvConfig, tracker: &mut CleanupTracker) -> Re
     ensure(port_list_count >= 1, "expected at least one port list")?;
     log_pass("06", &format!("list port lists ({port_list_count})"));
 
+    // Pick the first port list for target creation (GMP requires PORT_LIST or PORT_RANGE)
+    let port_list_id = {
+        let pl_xml = port_lists_response.as_str().unwrap_or("");
+        let ids = extract_attribute_values(pl_xml, "port_list", "id");
+        let id_str = ids.first()
+            .ok_or_else(|| AppError::Assertion("no port lists available for target creation".to_string()))?;
+        parse_entity_id(id_str)?
+    };
+
     let target_response = client
         .call(create_target(
             SMOKE_TARGET_NAME,
             CreateTargetOpts {
                 hosts: vec!["127.0.0.1".to_string()],
+                port_list_id: Some(port_list_id),
                 ..CreateTargetOpts::default()
             },
         ))

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -420,7 +420,7 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
     // Reconnect each poll to avoid stale responses on long-lived connections.
     client.disconnect().await?;
     log_line("Waiting for scan configs (feed loading into DB)...");
-    for poll in 1..=360 {
+    for poll in 1..=1800 {
         match connect_client(config).await {
             Ok(mut poll_client) => {
                 let auth = poll_client
@@ -451,12 +451,12 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
             }
         }
         if poll % 12 == 0 {
-            log_line(&format!("No scan configs yet (poll {poll}/360, ~{}s elapsed)", poll * 5));
+            log_line(&format!("No scan configs yet (poll {poll}/1800, ~{}s elapsed)", poll * 5));
         }
         sleep(Duration::from_secs(5)).await;
     }
 
-    Err(AppError::Assertion("no scan configs found after 30 minutes of polling".to_string()))
+    Err(AppError::Assertion("no scan configs found after 150 minutes of polling".to_string()))
 }
 
 async fn run_smoke_suite(config: &EnvConfig, tracker: &mut CleanupTracker) -> Result<(), AppError> {

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -70,6 +70,9 @@ async fn async_main() -> Result<(), AppError> {
             tracker.cleanup_now().await?;
             log_line("E2E smoke suite passed");
         }
+        Mode::Validate => {
+            run_validate(&config).await?;
+        }
     }
 
     Ok(())
@@ -103,6 +106,7 @@ impl EnvConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Mode {
     Smoke,
+    Validate,
     WaitReady,
 }
 
@@ -116,15 +120,16 @@ impl Mode {
         if values.len() == 2 && values[0] == "--mode" {
             return match values[1].as_str() {
                 "smoke" => Ok(Self::Smoke),
+                "validate" => Ok(Self::Validate),
                 "wait-ready" => Ok(Self::WaitReady),
                 other => Err(AppError::Usage(format!(
-                    "unsupported mode `{other}`; expected `smoke` or `wait-ready`"
+                    "unsupported mode `{other}`; expected `smoke`, `validate`, or `wait-ready`"
                 ))),
             };
         }
 
         Err(AppError::Usage(
-            "usage: cargo run --example e2e_gvm_community -- --mode <smoke|wait-ready>".to_string(),
+            "usage: cargo run --example e2e_gvm_community -- --mode <smoke|validate|wait-ready>".to_string(),
         ))
     }
 }
@@ -234,6 +239,163 @@ enum AppError {
     Xml(#[from] quick_xml::Error),
     #[error(transparent)]
     Client(#[from] GvmError),
+}
+
+async fn run_validate(config: &EnvConfig) -> Result<(), AppError> {
+    use gvm_gmp::commands::report_formats::{get_report_formats, GetReportFormatsOpts};
+
+    let mut client = connect_client(config).await?;
+
+    // Version
+    let version_response = client
+        .send(gvm_gmp::commands::version::get_version())
+        .await?;
+    assert_status(&version_response, 200, "get_version")?;
+    let version = version_response
+        .child_text("version")
+        .unwrap_or_default();
+
+    // Authenticate
+    let auth_response = client
+        .call(authenticate(&config.username, &config.password))
+        .await?;
+    assert_status(&auth_response, 200, "authenticate")?;
+
+    // Scan configs
+    let configs_response = client
+        .call(get_scan_configs(GetScanConfigsOpts::default()))
+        .await?;
+    assert_status(&configs_response, 200, "get_scan_configs")?;
+    let configs_xml = configs_response.as_str().unwrap_or("");
+    let config_names = extract_child_texts(configs_xml, "config", "name");
+    let config_ids = extract_attribute_values(configs_xml, "config", "id");
+
+    // Scanners
+    let scanners_response = client
+        .call(get_scanners(GetScannersOpts::default()))
+        .await?;
+    assert_status(&scanners_response, 200, "get_scanners")?;
+    let scanners_xml = scanners_response.as_str().unwrap_or("");
+    let scanner_names = extract_child_texts(scanners_xml, "scanner", "name");
+
+    // Port lists
+    let port_lists_response = client
+        .call(get_port_lists(GetPortListsOpts::default()))
+        .await?;
+    assert_status(&port_lists_response, 200, "get_port_lists")?;
+    let port_lists_xml = port_lists_response.as_str().unwrap_or("");
+    let port_list_names = extract_child_texts(port_lists_xml, "port_list", "name");
+
+    // Feeds
+    let feeds_response = client
+        .send(get_feeds(GetFeedsOpts::default()))
+        .await?;
+    assert_status(&feeds_response, 200, "get_feeds")?;
+    let feeds_xml = feeds_response.as_str().unwrap_or("");
+    let feed_types = extract_child_texts(feeds_xml, "feed", "type");
+    let feeds_syncing = feeds_xml.matches("<currently_syncing>").count();
+
+    // Report formats
+    let formats_response = client
+        .call(get_report_formats(GetReportFormatsOpts::default()))
+        .await?;
+    assert_status(&formats_response, 200, "get_report_formats")?;
+    let format_count = count_elements(&formats_response, "report_format")?;
+
+    client.disconnect().await?;
+
+    // Output as JSON for comparison with gvm-tools
+    let json = format!(
+        r#"{{"version":"{}","scan_config_count":{},"scan_config_names":{},"scan_config_ids":{},"scanner_count":{},"scanner_names":{},"port_list_count":{},"port_list_names":{},"feed_count":{},"feed_types":{},"feeds_syncing":{},"report_format_count":{}}}"#,
+        version,
+        config_names.len(),
+        to_json_array(&config_names),
+        to_json_array(&config_ids),
+        scanner_names.len(),
+        to_json_array(&scanner_names),
+        port_list_names.len(),
+        to_json_array(&port_list_names),
+        feed_types.len(),
+        to_json_array(&feed_types),
+        feeds_syncing,
+        format_count,
+    );
+    println!("{json}");
+    Ok(())
+}
+
+/// Extract text content of child elements matching `<parent><child_tag>text</child_tag>...`.
+fn extract_child_texts(xml: &str, parent_tag: &str, child_tag: &str) -> Vec<String> {
+    let mut results = Vec::new();
+    let mut reader = Reader::from_str(xml);
+    let mut buf = Vec::new();
+    let mut in_parent = false;
+    let mut in_child = false;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let local = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+                if local == parent_tag {
+                    in_parent = true;
+                } else if in_parent && local == child_tag {
+                    in_child = true;
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let local = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+                if local == parent_tag {
+                    in_parent = false;
+                } else if local == child_tag {
+                    in_child = false;
+                }
+            }
+            Ok(Event::Text(ref e)) if in_child => {
+                results.push(String::from_utf8_lossy(e.as_ref()).to_string());
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    results.sort();
+    results
+}
+
+/// Extract attribute values from elements: `<tag attr="value">`.
+fn extract_attribute_values(xml: &str, tag: &str, attr: &str) -> Vec<String> {
+    let mut results = Vec::new();
+    let mut reader = Reader::from_str(xml);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
+                if local == tag {
+                    for a in e.attributes().flatten() {
+                        if String::from_utf8_lossy(a.key.as_ref()) == attr {
+                            results.push(
+                                String::from_utf8_lossy(a.value.as_ref()).to_string()
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+    results.sort();
+    results
+}
+
+fn to_json_array(items: &[String]) -> String {
+    let escaped: Vec<String> = items.iter().map(|s| format!("\"{}\"", s.replace('"', "\\\""))).collect();
+    format!("[{}]", escaped.join(","))
 }
 
 async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -414,70 +414,49 @@ async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
     assert_status(&auth_response, 200, "authenticate")?;
     log_line("Authentication successful");
 
-    // Phase 2: Wait for feeds to finish syncing
-    // IMPORTANT: reconnect on each poll — gvmd can return stale data on
-    // long-lived connections during feed sync.
+    // Phase 2: Wait for scan configs to exist
+    // Skip feed sync polling — scan configs are the actual gate.
+    // gvmd creates them from data-objects feed; once they exist, we're ready.
+    // Reconnect each poll to avoid stale responses on long-lived connections.
     client.disconnect().await?;
-    log_line("Waiting for feed sync to complete...");
+    log_line("Waiting for scan configs (feed loading into DB)...");
     for poll in 1..=360 {
-        let mut poll_client = connect_client(config).await?;
-        let auth = poll_client
-            .call(authenticate(&config.username, &config.password))
-            .await?;
-        assert_status(&auth, 200, "authenticate")?;
-
-        let feeds_response = poll_client
-            .send(get_feeds(GetFeedsOpts::default()))
-            .await?;
-        assert_status(&feeds_response, 200, "get_feeds")?;
-
-        let feeds_xml = feeds_response.as_str().unwrap_or("");
-        let syncing = feeds_xml.matches("<currently_syncing>").count();
-        poll_client.disconnect().await?;
-
-        if syncing == 0 {
-            log_line(&format!("Feed sync complete (poll {poll})"));
-            break;
+        match connect_client(config).await {
+            Ok(mut poll_client) => {
+                let auth = poll_client
+                    .call(authenticate(&config.username, &config.password))
+                    .await;
+                if let Ok(auth_resp) = auth {
+                    if auth_resp.is_success() {
+                        let configs_response = poll_client
+                            .call(get_scan_configs(GetScanConfigsOpts::default()))
+                            .await;
+                        if let Ok(ref resp) = configs_response {
+                            if let Ok(config_count) = count_elements(resp, "config") {
+                                if config_count > 0 {
+                                    log_line(&format!("Found {config_count} scan config(s) (poll {poll}, ~{}s)", poll * 5));
+                                    let _ = poll_client.disconnect().await;
+                                    log_line("Allowing 30s grace period...");
+                                    sleep(Duration::from_secs(30)).await;
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+                let _ = poll_client.disconnect().await;
+            }
+            Err(_) => {
+                // Connection failed, gvmd might be restarting
+            }
         }
-        if poll % 10 == 0 {
-            log_line(&format!("Feeds still syncing ({syncing} active, poll {poll}/360)"));
-        }
-        if poll == 360 {
-            log_line("WARNING: feeds still syncing after 30 minutes");
-        }
-        sleep(Duration::from_secs(5)).await;
-    }
-
-    // Phase 3: Wait for scan configs to exist
-    log_line("Waiting for scan configs...");
-    for poll in 1..=120 {
-        let mut poll_client = connect_client(config).await?;
-        let auth = poll_client
-            .call(authenticate(&config.username, &config.password))
-            .await?;
-        assert_status(&auth, 200, "authenticate")?;
-
-        let configs_response = poll_client
-            .call(get_scan_configs(GetScanConfigsOpts::default()))
-            .await?;
-        assert_status(&configs_response, 200, "get_scan_configs")?;
-
-        let config_count = count_elements(&configs_response, "config")?;
-        poll_client.disconnect().await?;
-
-        if config_count > 0 {
-            log_line(&format!("Found {config_count} scan config(s) (poll {poll})"));
-            log_line("Allowing 30s grace period...");
-            sleep(Duration::from_secs(30)).await;
-            return Ok(());
-        }
-        if poll % 6 == 0 {
-            log_line(&format!("No scan configs yet (poll {poll}/120, ~{}s)", poll * 5));
+        if poll % 12 == 0 {
+            log_line(&format!("No scan configs yet (poll {poll}/360, ~{}s elapsed)", poll * 5));
         }
         sleep(Duration::from_secs(5)).await;
     }
 
-    Err(AppError::Assertion("no scan configs found after 10 minutes of polling".to_string()))
+    Err(AppError::Assertion("no scan configs found after 30 minutes of polling".to_string()))
 }
 
 async fn run_smoke_suite(config: &EnvConfig, tracker: &mut CleanupTracker) -> Result<(), AppError> {

--- a/examples/e2e_gvm_community.rs
+++ b/examples/e2e_gvm_community.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use gvm_client::{parse_version_text, GmpClient, GvmError};
 use gvm_connection::UnixSocketConnection;
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::system::{get_feeds, GetFeedsOpts};
 use gvm_gmp::commands::port_lists::{get_port_lists, GetPortListsOpts};
 use gvm_gmp::commands::report_formats::{get_report_formats, GetReportFormatsOpts};
 use gvm_gmp::commands::reports::get_report;
@@ -236,13 +237,70 @@ enum AppError {
 }
 
 async fn wait_ready(config: &EnvConfig) -> Result<(), AppError> {
+    // Phase 1: Connect and verify GMP version
     let mut client = connect_client(config).await?;
     let response = client
         .send(gvm_gmp::commands::version::get_version())
         .await?;
     assert_status(&response, 200, "get_version")?;
+    log_line("GMP version check passed");
+
+    // Authenticate for feed/config queries
+    let auth_response = client
+        .call(authenticate(&config.username, &config.password))
+        .await?;
+    assert_status(&auth_response, 200, "authenticate")?;
+    log_line("Authentication successful");
+
+    // Phase 2: Wait for feeds to finish syncing
+    log_line("Waiting for feed sync to complete...");
+    for poll in 1..=360 {
+        let feeds_response = client
+            .send(get_feeds(GetFeedsOpts::default()))
+            .await?;
+        assert_status(&feeds_response, 200, "get_feeds")?;
+
+        let feeds_xml = feeds_response.as_str().unwrap_or("");
+        let syncing = feeds_xml.matches("<currently_syncing>").count();
+
+        if syncing == 0 {
+            log_line(&format!("Feed sync complete (poll {poll})"));
+            break;
+        }
+        if poll % 10 == 0 {
+            log_line(&format!("Feeds still syncing ({syncing} active, poll {poll}/360)"));
+        }
+        if poll == 360 {
+            log_line("WARNING: feeds still syncing after 30 minutes");
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+
+    // Phase 3: Wait for scan configs to exist
+    log_line("Waiting for scan configs...");
+    for poll in 1..=120 {
+        let configs_response = client
+            .call(get_scan_configs(GetScanConfigsOpts::default()))
+            .await?;
+        assert_status(&configs_response, 200, "get_scan_configs")?;
+
+        let config_count = count_elements(&configs_response, "config")?;
+        if config_count > 0 {
+            log_line(&format!("Found {config_count} scan config(s) (poll {poll})"));
+            // Grace period for gvmd to finish loading
+            log_line("Allowing 30s grace period...");
+            sleep(Duration::from_secs(30)).await;
+            client.disconnect().await?;
+            return Ok(());
+        }
+        if poll % 6 == 0 {
+            log_line(&format!("No scan configs yet (poll {poll}/120, ~{}s)", poll * 5));
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+
     client.disconnect().await?;
-    Ok(())
+    Err(AppError::Assertion("no scan configs found after 10 minutes of polling".to_string()))
 }
 
 async fn run_smoke_suite(config: &EnvConfig, tracker: &mut CleanupTracker) -> Result<(), AppError> {

--- a/tests/e2e/gvm-community/Dockerfile.runner
+++ b/tests/e2e/gvm-community/Dockerfile.runner
@@ -2,8 +2,13 @@ FROM rust:1.75
 
 WORKDIR /workspace
 
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates bash pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Ensure cargo is on PATH for login shells too
+RUN echo 'export PATH="/usr/local/cargo/bin:${PATH}"' >> /etc/profile.d/cargo.sh
 
 CMD ["/bin/bash"]

--- a/tests/e2e/gvm-community/Dockerfile.runner
+++ b/tests/e2e/gvm-community/Dockerfile.runner
@@ -5,10 +5,12 @@ WORKDIR /workspace
 ENV PATH="/usr/local/cargo/bin:${PATH}"
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates bash pkg-config libssl-dev \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates bash pkg-config libssl-dev python3 python3-pip \
+    && pip3 install --break-system-packages gvm-tools \
     && rm -rf /var/lib/apt/lists/*
 
-# Ensure cargo is on PATH for login shells too
+# Ensure cargo is on PATH for login shells
 RUN echo 'export PATH="/usr/local/cargo/bin:${PATH}"' >> /etc/profile.d/cargo.sh
 
 CMD ["/bin/bash"]

--- a/tests/e2e/gvm-community/docker-compose.yml
+++ b/tests/e2e/gvm-community/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       - gvmd-data:/var/lib/gvm
       - scap-data:/var/lib/gvm/scap-data
       - cert-data:/var/lib/gvm/cert-data
-      - data-objects:/var/lib/gvm/data-objects/gvmd
+      - data-objects:/var/lib/gvm/data-objects
       - vt-data:/var/lib/openvas/plugins
       - psql-data:/var/lib/postgresql
       - gvmd-socket:/run/gvmd

--- a/tests/e2e/gvm-community/docker-compose.yml
+++ b/tests/e2e/gvm-community/docker-compose.yml
@@ -1,76 +1,76 @@
+# E2E test stack — aligned with upstream Greenbone Community Edition compose.
+# Key difference from upstream: adds rust-gvm-e2e runner service (profile: runner).
 name: rust-gvm-e2e
 
 services:
   vulnerability-tests:
-    image: registry.community.greenbone.net/community/vulnerability-tests:latest
+    image: registry.community.greenbone.net/community/vulnerability-tests
     environment:
       FEED_RELEASE: "24.10"
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - vt-data:/mnt
 
   notus-data:
-    image: registry.community.greenbone.net/community/notus-data:latest
+    image: registry.community.greenbone.net/community/notus-data
     environment:
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - notus-data:/mnt
 
   scap-data:
-    image: registry.community.greenbone.net/community/scap-data:latest
+    image: registry.community.greenbone.net/community/scap-data
     environment:
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - scap-data:/mnt
 
   cert-bund-data:
-    image: registry.community.greenbone.net/community/cert-bund-data:latest
+    image: registry.community.greenbone.net/community/cert-bund-data
     environment:
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - cert-data:/mnt
 
   dfn-cert-data:
-    image: registry.community.greenbone.net/community/dfn-cert-data:latest
+    image: registry.community.greenbone.net/community/dfn-cert-data
     environment:
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - cert-data:/mnt
     depends_on:
       cert-bund-data:
-        condition: service_started
+        condition: service_healthy
 
   data-objects:
-    image: registry.community.greenbone.net/community/data-objects:latest
+    image: registry.community.greenbone.net/community/data-objects
     environment:
       FEED_RELEASE: "24.10"
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - data-objects:/mnt
 
   report-formats:
-    image: registry.community.greenbone.net/community/report-formats:latest
+    image: registry.community.greenbone.net/community/report-formats
     environment:
       FEED_RELEASE: "24.10"
-      KEEP_ALIVE: "1"
+      KEEP_ALIVE: 1
     volumes:
       - data-objects:/mnt
     depends_on:
       data-objects:
-        condition: service_started
+        condition: service_healthy
 
   gpg-data:
-    image: registry.community.greenbone.net/community/gpg-data:stable
-    environment:
-      KEEP_ALIVE: "1"
+    image: registry.community.greenbone.net/community/gpg-data
     volumes:
       - gpg-data:/mnt
 
   redis-server:
-    image: registry.community.greenbone.net/community/redis-server:stable
+    image: registry.community.greenbone.net/community/redis-server
     restart: on-failure
     volumes:
-      - redis-socket:/run/redis
+      - redis-socket:/run/redis/
 
   pg-gvm-migrator:
     image: registry.community.greenbone.net/community/pg-gvm-migrator:stable
@@ -171,9 +171,9 @@ services:
     restart: on-failure
     volumes:
       - gvmd-data:/var/lib/gvm
-      - scap-data:/var/lib/gvm/scap-data
+      - scap-data:/var/lib/gvm/scap-data/
       - cert-data:/var/lib/gvm/cert-data
-      - data-objects:/var/lib/gvm/data-objects
+      - data-objects:/var/lib/gvm/data-objects/gvmd
       - vt-data:/var/lib/openvas/plugins
       - psql-data:/var/lib/postgresql
       - gvmd-socket:/run/gvmd
@@ -183,15 +183,15 @@ services:
       pg-gvm:
         condition: service_started
       scap-data:
-        condition: service_started
+        condition: service_healthy
       cert-bund-data:
-        condition: service_started
+        condition: service_healthy
       dfn-cert-data:
-        condition: service_started
+        condition: service_healthy
       data-objects:
-        condition: service_started
+        condition: service_healthy
       report-formats:
-        condition: service_started
+        condition: service_healthy
       ospd-openvas:
         condition: service_started
 
@@ -206,6 +206,7 @@ services:
       gvmd:
         condition: service_started
 
+  # ── E2E test runner (only started with --profile runner) ──
   rust-gvm-e2e:
     image: ${RUNNER_IMAGE:-rust-gvm-e2e-runner:ci}
     profiles:
@@ -232,10 +233,10 @@ services:
     command: ./tests/e2e/gvm-community/scripts/run-smoke.sh
 
 volumes:
-  cert-data:
   cargo-git:
   cargo-registry:
   cargo-target:
+  cert-data:
   data-objects:
   gpg-data:
   gvmd-data:

--- a/tests/e2e/gvm-community/scripts/run-smoke.sh
+++ b/tests/e2e/gvm-community/scripts/run-smoke.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PATH="/usr/local/cargo/bin:${PATH}"
 cd /workspace
 cargo run --example e2e_gvm_community -- --mode smoke

--- a/tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
+++ b/tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
 """
-Differential validation: compare rust-gvm GMP responses against gvm-tools (reference).
+gvm-tools fallback diagnostic: when rust-gvm reports a failure, re-run
+the same GMP query via gvm-tools to determine fault location.
 
-Runs both implementations against the same live gvmd instance and
-checks that they agree on key facts (counts, IDs, structures).
+Usage:
+  python3 validate-against-gvm-tools.py --check <check_name>
+
+Checks: get_version, get_scan_configs, get_scanners, get_port_lists,
+        get_feeds, get_report_formats, authenticate
+
+Exit codes:
+  0 = gvm-tools also succeeds (bug likely in rust-gvm)
+  1 = gvm-tools also fails (problem in GVM stack)
+  2 = usage error
 """
 
+import argparse
 import json
 import os
-import subprocess
 import sys
-import xml.etree.ElementTree as ET
 
 from gvm.connections import UnixSocketConnection
 from gvm.protocols.gmp import Gmp
@@ -20,140 +28,106 @@ SOCKET_PATH = os.environ.get("GVM_SOCKET_PATH", "/run/gvmd/gvmd.sock")
 USERNAME = os.environ.get("GVM_ADMIN_USER", "admin")
 PASSWORD = os.environ.get("GVM_ADMIN_PASS", "admin")
 
+CHECKS = {
+    "get_version": lambda gmp: gmp.get_version(),
+    "get_scan_configs": lambda gmp: gmp.get_scan_configs(),
+    "get_scanners": lambda gmp: gmp.get_scanners(),
+    "get_port_lists": lambda gmp: gmp.get_port_lists(),
+    "get_feeds": lambda gmp: gmp.get_feeds(),
+    "get_report_formats": lambda gmp: gmp.get_report_formats(),
+}
 
-def gvm_tools_query():
-    """Query gvmd via gvm-tools (Python reference implementation)."""
+
+def run_check(check_name):
     connection = UnixSocketConnection(path=SOCKET_PATH)
     transform = EtreeCheckCommandTransform()
 
     with Gmp(connection=connection, transform=transform) as gmp:
         gmp.authenticate(USERNAME, PASSWORD)
 
-        results = {}
+        if check_name == "all":
+            results = {}
+            for name, fn in CHECKS.items():
+                try:
+                    resp = fn(gmp)
+                    results[name] = {"status": "ok", "element_count": len(list(resp))}
+                except Exception as e:
+                    results[name] = {"status": "error", "error": str(e)}
+            return results
 
-        # Version
-        version_resp = gmp.get_version()
-        results["version"] = version_resp.find("version").text
+        if check_name not in CHECKS:
+            print(f"Unknown check: {check_name}", file=sys.stderr)
+            print(f"Available: {', '.join(CHECKS.keys())}, all", file=sys.stderr)
+            sys.exit(2)
 
-        # Scan configs
-        configs_resp = gmp.get_scan_configs()
-        configs = configs_resp.findall("config")
-        results["scan_config_count"] = len(configs)
-        results["scan_config_names"] = sorted([c.find("name").text for c in configs])
-        results["scan_config_ids"] = sorted([c.get("id") for c in configs])
+        resp = CHECKS[check_name](gmp)
+        children = list(resp)
+        result = {
+            "check": check_name,
+            "status": "ok",
+            "element_count": len(children),
+        }
 
-        # Scanners
-        scanners_resp = gmp.get_scanners()
-        scanners = scanners_resp.findall("scanner")
-        results["scanner_count"] = len(scanners)
-        results["scanner_names"] = sorted([s.find("name").text for s in scanners])
+        # Add detail for key checks
+        if check_name == "get_scan_configs":
+            configs = resp.findall("config")
+            result["configs"] = [
+                {"name": c.find("name").text, "id": c.get("id")} for c in configs
+            ]
+        elif check_name == "get_scanners":
+            scanners = resp.findall("scanner")
+            result["scanners"] = [
+                {"name": s.find("name").text, "id": s.get("id")} for s in scanners
+            ]
+        elif check_name == "get_feeds":
+            feeds = resp.findall("feed")
+            result["feeds"] = []
+            for f in feeds:
+                feed_info = {"type": f.find("type").text}
+                syncing = f.find("currently_syncing")
+                if syncing is not None:
+                    feed_info["syncing"] = True
+                result["feeds"].append(feed_info)
 
-        # Port lists
-        port_lists_resp = gmp.get_port_lists()
-        port_lists = port_lists_resp.findall("port_list")
-        results["port_list_count"] = len(port_lists)
-        results["port_list_names"] = sorted([p.find("name").text for p in port_lists])
-
-        # Feeds
-        feeds_resp = gmp.get_feeds()
-        feeds = feeds_resp.findall("feed")
-        results["feed_count"] = len(feeds)
-        results["feed_types"] = sorted([f.find("type").text for f in feeds])
-        results["feeds_syncing"] = sum(
-            1 for f in feeds if f.find("currently_syncing") is not None
-        )
-
-        # Report formats
-        formats_resp = gmp.get_report_formats()
-        formats = formats_resp.findall("report_format")
-        results["report_format_count"] = len(formats)
-
-    return results
-
-
-def rust_gvm_query():
-    """Query gvmd via rust-gvm e2e binary and parse its output."""
-    # Run the smoke suite which prints pass/fail for each check
-    # We'll parse the XML responses directly via a dedicated validation mode
-    # For now, use raw GMP XML via the Rust binary
-    result = subprocess.run(
-        [
-            "cargo", "run", "--quiet", "--example", "e2e_gvm_community",
-            "--", "--mode", "validate"
-        ],
-        capture_output=True, text=True, cwd="/workspace",
-        timeout=120,
-    )
-
-    if result.returncode != 0:
-        print(f"rust-gvm validate failed: {result.stderr}", file=sys.stderr)
-        # If validate mode doesn't exist yet, fall back to counting from smoke output
-        return None
-
-    # Parse JSON output from validate mode
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        print(f"Failed to parse rust-gvm output: {result.stdout[:500]}", file=sys.stderr)
-        return None
-
-
-def compare(ref_results, test_results):
-    """Compare reference (gvm-tools) against test (rust-gvm) results."""
-    passed = 0
-    failed = 0
-    total = 0
-
-    def check(name, ref_val, test_val):
-        nonlocal passed, failed, total
-        total += 1
-        if ref_val == test_val:
-            print(f"  [PASS] {name}: {ref_val}")
-            passed += 1
-        else:
-            print(f"  [FAIL] {name}: gvm-tools={ref_val}, rust-gvm={test_val}")
-            failed += 1
-
-    print("\n=== Differential Validation: gvm-tools vs rust-gvm ===\n")
-
-    check("GMP version", ref_results["version"], test_results.get("version"))
-    check("Scan config count", ref_results["scan_config_count"], test_results.get("scan_config_count"))
-    check("Scan config names", ref_results["scan_config_names"], test_results.get("scan_config_names"))
-    check("Scan config IDs", ref_results["scan_config_ids"], test_results.get("scan_config_ids"))
-    check("Scanner count", ref_results["scanner_count"], test_results.get("scanner_count"))
-    check("Scanner names", ref_results["scanner_names"], test_results.get("scanner_names"))
-    check("Port list count", ref_results["port_list_count"], test_results.get("port_list_count"))
-    check("Port list names", ref_results["port_list_names"], test_results.get("port_list_names"))
-    check("Feed count", ref_results["feed_count"], test_results.get("feed_count"))
-    check("Feed types", ref_results["feed_types"], test_results.get("feed_types"))
-    check("Report format count", ref_results["report_format_count"], test_results.get("report_format_count"))
-
-    print(f"\nResults: {passed}/{total} passed, {failed} failed")
-    return failed == 0
+        return result
 
 
 def main():
-    print("Querying gvm-tools (Python reference)...")
-    ref = gvm_tools_query()
-    print(f"  Got {ref['scan_config_count']} configs, {ref['scanner_count']} scanners, "
-          f"{ref['port_list_count']} port lists, {ref['feed_count']} feeds")
+    parser = argparse.ArgumentParser(description="gvm-tools fallback diagnostic")
+    parser.add_argument(
+        "--check", required=True,
+        help="GMP check to run (get_version, get_scan_configs, etc., or 'all')"
+    )
+    args = parser.parse_args()
 
-    print("Querying rust-gvm...")
-    test = rust_gvm_query()
+    try:
+        result = run_check(args.check)
+        print(json.dumps(result, indent=2))
 
-    if test is None:
-        print("\nrust-gvm validate mode not available yet.")
-        print("Falling back to reference-only report:\n")
-        print(json.dumps(ref, indent=2))
-        print("\nValidation: SKIPPED (rust-gvm validate mode needed)")
-        # Don't fail — this is informational until validate mode is added
-        return 0
+        # Determine if gvm-tools succeeded
+        if isinstance(result, dict) and "status" in result:
+            if result["status"] == "ok":
+                print(f"\n→ gvm-tools: {args.check} SUCCEEDED", file=sys.stderr)
+                print("→ Fault likely in rust-gvm implementation", file=sys.stderr)
+                return 0
+            else:
+                print(f"\n→ gvm-tools: {args.check} FAILED", file=sys.stderr)
+                print("→ Problem in GVM stack, not rust-gvm", file=sys.stderr)
+                return 1
+        elif isinstance(result, dict):
+            # "all" mode — check if any failed
+            failures = [k for k, v in result.items() if v.get("status") != "ok"]
+            if failures:
+                print(f"\n→ gvm-tools failures: {failures}", file=sys.stderr)
+                print("→ Problem in GVM stack", file=sys.stderr)
+                return 1
+            print("\n→ gvm-tools: all checks SUCCEEDED", file=sys.stderr)
+            print("→ Fault likely in rust-gvm implementation", file=sys.stderr)
+            return 0
 
-    if compare(ref, test):
-        print("\n✓ All checks passed — rust-gvm matches gvm-tools")
-        return 0
-    else:
-        print("\n✗ Mismatches detected — rust-gvm differs from gvm-tools")
+    except Exception as e:
+        print(f"gvm-tools error: {e}", file=sys.stderr)
+        print("→ gvm-tools also failed — problem in GVM stack", file=sys.stderr)
         return 1
 
 

--- a/tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
+++ b/tests/e2e/gvm-community/scripts/validate-against-gvm-tools.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Differential validation: compare rust-gvm GMP responses against gvm-tools (reference).
+
+Runs both implementations against the same live gvmd instance and
+checks that they agree on key facts (counts, IDs, structures).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+from gvm.connections import UnixSocketConnection
+from gvm.protocols.gmp import Gmp
+from gvm.transforms import EtreeCheckCommandTransform
+
+SOCKET_PATH = os.environ.get("GVM_SOCKET_PATH", "/run/gvmd/gvmd.sock")
+USERNAME = os.environ.get("GVM_ADMIN_USER", "admin")
+PASSWORD = os.environ.get("GVM_ADMIN_PASS", "admin")
+
+
+def gvm_tools_query():
+    """Query gvmd via gvm-tools (Python reference implementation)."""
+    connection = UnixSocketConnection(path=SOCKET_PATH)
+    transform = EtreeCheckCommandTransform()
+
+    with Gmp(connection=connection, transform=transform) as gmp:
+        gmp.authenticate(USERNAME, PASSWORD)
+
+        results = {}
+
+        # Version
+        version_resp = gmp.get_version()
+        results["version"] = version_resp.find("version").text
+
+        # Scan configs
+        configs_resp = gmp.get_scan_configs()
+        configs = configs_resp.findall("config")
+        results["scan_config_count"] = len(configs)
+        results["scan_config_names"] = sorted([c.find("name").text for c in configs])
+        results["scan_config_ids"] = sorted([c.get("id") for c in configs])
+
+        # Scanners
+        scanners_resp = gmp.get_scanners()
+        scanners = scanners_resp.findall("scanner")
+        results["scanner_count"] = len(scanners)
+        results["scanner_names"] = sorted([s.find("name").text for s in scanners])
+
+        # Port lists
+        port_lists_resp = gmp.get_port_lists()
+        port_lists = port_lists_resp.findall("port_list")
+        results["port_list_count"] = len(port_lists)
+        results["port_list_names"] = sorted([p.find("name").text for p in port_lists])
+
+        # Feeds
+        feeds_resp = gmp.get_feeds()
+        feeds = feeds_resp.findall("feed")
+        results["feed_count"] = len(feeds)
+        results["feed_types"] = sorted([f.find("type").text for f in feeds])
+        results["feeds_syncing"] = sum(
+            1 for f in feeds if f.find("currently_syncing") is not None
+        )
+
+        # Report formats
+        formats_resp = gmp.get_report_formats()
+        formats = formats_resp.findall("report_format")
+        results["report_format_count"] = len(formats)
+
+    return results
+
+
+def rust_gvm_query():
+    """Query gvmd via rust-gvm e2e binary and parse its output."""
+    # Run the smoke suite which prints pass/fail for each check
+    # We'll parse the XML responses directly via a dedicated validation mode
+    # For now, use raw GMP XML via the Rust binary
+    result = subprocess.run(
+        [
+            "cargo", "run", "--quiet", "--example", "e2e_gvm_community",
+            "--", "--mode", "validate"
+        ],
+        capture_output=True, text=True, cwd="/workspace",
+        timeout=120,
+    )
+
+    if result.returncode != 0:
+        print(f"rust-gvm validate failed: {result.stderr}", file=sys.stderr)
+        # If validate mode doesn't exist yet, fall back to counting from smoke output
+        return None
+
+    # Parse JSON output from validate mode
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"Failed to parse rust-gvm output: {result.stdout[:500]}", file=sys.stderr)
+        return None
+
+
+def compare(ref_results, test_results):
+    """Compare reference (gvm-tools) against test (rust-gvm) results."""
+    passed = 0
+    failed = 0
+    total = 0
+
+    def check(name, ref_val, test_val):
+        nonlocal passed, failed, total
+        total += 1
+        if ref_val == test_val:
+            print(f"  [PASS] {name}: {ref_val}")
+            passed += 1
+        else:
+            print(f"  [FAIL] {name}: gvm-tools={ref_val}, rust-gvm={test_val}")
+            failed += 1
+
+    print("\n=== Differential Validation: gvm-tools vs rust-gvm ===\n")
+
+    check("GMP version", ref_results["version"], test_results.get("version"))
+    check("Scan config count", ref_results["scan_config_count"], test_results.get("scan_config_count"))
+    check("Scan config names", ref_results["scan_config_names"], test_results.get("scan_config_names"))
+    check("Scan config IDs", ref_results["scan_config_ids"], test_results.get("scan_config_ids"))
+    check("Scanner count", ref_results["scanner_count"], test_results.get("scanner_count"))
+    check("Scanner names", ref_results["scanner_names"], test_results.get("scanner_names"))
+    check("Port list count", ref_results["port_list_count"], test_results.get("port_list_count"))
+    check("Port list names", ref_results["port_list_names"], test_results.get("port_list_names"))
+    check("Feed count", ref_results["feed_count"], test_results.get("feed_count"))
+    check("Feed types", ref_results["feed_types"], test_results.get("feed_types"))
+    check("Report format count", ref_results["report_format_count"], test_results.get("report_format_count"))
+
+    print(f"\nResults: {passed}/{total} passed, {failed} failed")
+    return failed == 0
+
+
+def main():
+    print("Querying gvm-tools (Python reference)...")
+    ref = gvm_tools_query()
+    print(f"  Got {ref['scan_config_count']} configs, {ref['scanner_count']} scanners, "
+          f"{ref['port_list_count']} port lists, {ref['feed_count']} feeds")
+
+    print("Querying rust-gvm...")
+    test = rust_gvm_query()
+
+    if test is None:
+        print("\nrust-gvm validate mode not available yet.")
+        print("Falling back to reference-only report:\n")
+        print(json.dumps(ref, indent=2))
+        print("\nValidation: SKIPPED (rust-gvm validate mode needed)")
+        # Don't fail — this is informational until validate mode is added
+        return 0
+
+    if compare(ref, test):
+        print("\n✓ All checks passed — rust-gvm matches gvm-tools")
+        return 0
+    else:
+        print("\n✗ Mismatches detected — rust-gvm differs from gvm-tools")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
-# Wait for gvmd to be fully ready:
-#   1. Socket exists inside container
-#   2. GMP connection responds
-#   3. Scan configs exist (feed sync complete)
+# Wait for gvmd to be fully ready.
+# With upstream healthchecks on feed containers, gvmd won't start until
+# feed data is copied. We just need to wait for gvmd to finish its own
+# initialization (socket + GMP ready + feed sync).
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
 SOCKET_PATH="/run/gvmd/gvmd.sock"
-GVM_USER="${GVM_ADMIN_USER:-admin}"
-GVM_PASS="${GVM_ADMIN_PASS:-admin}"
 
 echo "=== Phase 1: Waiting for gvmd socket ==="
 for i in $(seq 1 300); do
@@ -24,79 +22,44 @@ done
 
 if ! docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
   echo "gvmd did not start: socket not found after 300s" >&2
+  docker compose -f "$COMPOSE_FILE" logs --tail=30 gvmd 2>&1 || true
   exit 1
 fi
 
 echo "=== Phase 2: Waiting for GMP readiness ==="
-for i in $(seq 1 60); do
+for i in $(seq 1 120); do
   if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "ready to accept GMP connections"; then
     echo "gvmd accepting GMP connections"
     break
   fi
-  echo "Waiting for GMP readiness... (${i}/60)"
+  if (( i % 20 == 0 )); then
+    echo "Waiting for GMP readiness... (${i}/120)"
+  fi
   sleep 2
 done
 
-echo "=== Phase 3: Waiting for scan configs ==="
-# Query scan configs via GMP over the Unix socket using Python inside gvmd container
-GMP_QUERY_SCRIPT=$(cat << 'PYEOF'
-import socket, ssl, sys, time
-
-sock_path = sys.argv[1]
-user = sys.argv[2]
-passwd = sys.argv[3]
-
-auth_xml = f'<authenticate><credentials><username>{user}</username><password>{passwd}</password></credentials></authenticate>'
-configs_xml = '<get_configs/>'
-
-try:
-    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.settimeout(10)
-    s.connect(sock_path)
-    s.sendall((auth_xml + configs_xml).encode())
-    data = b''
-    while True:
-        try:
-            chunk = s.recv(65536)
-            if not chunk:
-                break
-            data += chunk
-            # Check if we have complete response (ends with </get_configs_response>)
-            if b'</get_configs_response>' in data:
-                break
-        except socket.timeout:
-            break
-    s.close()
-    count = data.count(b'<config ')
-    print(count)
-except Exception as e:
-    print(f'0', file=sys.stdout)
-    print(f'Error: {e}', file=sys.stderr)
-PYEOF
-)
-
+echo "=== Phase 3: Waiting for feed sync ==="
+# Wait for VT update and scan config creation.
+# On a fresh environment this takes ~15 min; with persistent volumes it's fast.
 for i in $(seq 1 180); do
-  RESULT=$(docker compose -f "$COMPOSE_FILE" exec -T gvmd \
-    python3 -c "$GMP_QUERY_SCRIPT" "$SOCKET_PATH" "$GVM_USER" "$GVM_PASS" 2>/dev/null || echo "0")
-  RESULT=$(echo "$RESULT" | tr -d '[:space:]')
+  # Check for scan config creation in logs (gvmd logs "Scan config ... has been created")
+  # OR check for the sync completion markers
+  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -qE "scan_config.*created|Updating VTs in database.*done"; then
+    echo "Feed sync indicators found after ${i} polls (~$((i * 5))s)"
 
-  if [[ "$RESULT" =~ ^[0-9]+$ ]] && (( RESULT > 0 )); then
-    echo "Found ${RESULT} scan config(s) after ${i} polls (~$((i * 5))s)"
-    echo "=== gvmd readiness check complete ==="
-    exit 0
+    # If VTs are done but configs might still be syncing, wait a bit more
+    if ! docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "scan_config.*created"; then
+      echo "VTs synced but scan configs not yet visible. Waiting 60s for data-objects sync..."
+      sleep 60
+    fi
+    break
   fi
 
-  if (( i % 10 == 0 )); then
-    echo "Waiting for scan configs... (poll ${i}/180, ~$((i * 5))s elapsed)"
-    # Show recent gvmd feed sync activity
-    docker compose -f "$COMPOSE_FILE" logs --tail=5 gvmd 2>&1 | tail -3 || true
+  if (( i % 12 == 0 )); then
+    echo "Waiting for feed sync... ($((i * 5))s elapsed)"
+    docker compose -f "$COMPOSE_FILE" logs --tail=3 gvmd 2>&1 | tail -3 || true
   fi
   sleep 5
 done
 
-echo "WARNING: No scan configs found after 15 minutes."
-echo "Last gvmd log lines:"
-docker compose -f "$COMPOSE_FILE" logs --tail=10 gvmd 2>&1 | tail -10 || true
-echo "=== gvmd readiness check complete (no configs) ==="
-# Exit 0 to let the smoke test provide its own error message
-exit 0
+echo "=== gvmd readiness check complete ==="

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,30 +1,39 @@
 #!/usr/bin/env bash
+# Wait for gvmd to be ready by checking for the socket inside the gvmd container
 set -euo pipefail
 
-ROOT_DIR="/workspace"
-SOCKET_PATH="${GVM_SOCKET_PATH:-/run/gvmd/gvmd.sock}"
+COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
+SOCKET_PATH="/run/gvmd/gvmd.sock"
+MAX_WAIT=300  # 5 minutes
 
-echo "Waiting for gvmd socket at ${SOCKET_PATH}"
-for _ in $(seq 1 120); do
-  if [[ -S "${SOCKET_PATH}" ]]; then
+echo "Waiting for gvmd socket inside container..."
+for i in $(seq 1 $MAX_WAIT); do
+  if docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
+    echo "Socket detected after ${i}s"
     break
+  fi
+  if (( i % 30 == 0 )); then
+    echo "Still waiting... (${i}s)"
   fi
   sleep 1
 done
 
-if [[ ! -S "${SOCKET_PATH}" ]]; then
-  echo "gvmd did not start: socket ${SOCKET_PATH} not found after 120 seconds" >&2
+# Verify socket exists
+if ! docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
+  echo "gvmd did not start: socket ${SOCKET_PATH} not found after ${MAX_WAIT} seconds" >&2
   exit 1
 fi
 
-echo "Socket detected. Polling get_version response"
-for _ in $(seq 1 60); do
-  if cargo run --quiet --example e2e_gvm_community -- --mode wait-ready; then
-    echo "gvmd is responsive"
+# Check for "ready to accept" message in gvmd logs
+echo "Checking gvmd logs for readiness message..."
+for i in $(seq 1 60); do
+  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "ready to accept GMP connections"; then
+    echo "gvmd is ready to accept GMP connections"
     exit 0
   fi
+  echo "Poll ${i}/60: waiting for ready message..."
   sleep 2
 done
 
-echo "gvmd not responsive after 60 polls" >&2
-exit 1
+echo "Warning: ready message not found in logs, but socket exists. Proceeding anyway."
+exit 0

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,39 +1,60 @@
 #!/usr/bin/env bash
-# Wait for gvmd to be ready by checking for the socket inside the gvmd container
+# Wait for gvmd to be fully ready (socket + GMP responsive + scan configs loaded)
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
 SOCKET_PATH="/run/gvmd/gvmd.sock"
-MAX_WAIT=300  # 5 minutes
 
-echo "Waiting for gvmd socket inside container..."
-for i in $(seq 1 $MAX_WAIT); do
+echo "=== Phase 1: Waiting for gvmd socket ==="
+for i in $(seq 1 300); do
   if docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
     echo "Socket detected after ${i}s"
     break
   fi
   if (( i % 30 == 0 )); then
-    echo "Still waiting... (${i}s)"
+    echo "Still waiting for socket... (${i}s)"
   fi
   sleep 1
 done
 
-# Verify socket exists
 if ! docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
-  echo "gvmd did not start: socket ${SOCKET_PATH} not found after ${MAX_WAIT} seconds" >&2
+  echo "gvmd did not start: socket not found after 300s" >&2
   exit 1
 fi
 
-# Check for "ready to accept" message in gvmd logs
-echo "Checking gvmd logs for readiness message..."
+echo "=== Phase 2: Waiting for GMP readiness ==="
 for i in $(seq 1 60); do
   if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "ready to accept GMP connections"; then
-    echo "gvmd is ready to accept GMP connections"
-    exit 0
+    echo "gvmd accepting GMP connections"
+    break
   fi
-  echo "Poll ${i}/60: waiting for ready message..."
+  echo "Waiting for GMP readiness... (${i}/60)"
   sleep 2
 done
 
-echo "Warning: ready message not found in logs, but socket exists. Proceeding anyway."
-exit 0
+echo "=== Phase 3: Waiting for scan configs (feed sync) ==="
+# gvmd needs time to process feed data and create default scan configs.
+# We check by running gvm-cli get_configs or checking gvmd logs for config creation.
+for i in $(seq 1 120); do
+  # Check if scan configs exist by looking for config creation events in gvmd logs
+  if docker compose -f "$COMPOSE_FILE" exec -T gvmd \
+      gvmd --get-scanners 2>/dev/null | grep -q "Scanner"; then
+    echo "Scanners available after ${i} polls"
+    break
+  fi
+  # Alternative: check logs for scan config creation
+  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "scan_config.*has been created"; then
+    echo "Scan configs detected in logs after ${i} polls"
+    break
+  fi
+  if (( i % 10 == 0 )); then
+    echo "Waiting for feed sync to create scan configs... (${i}/120)"
+  fi
+  sleep 5
+done
+
+# Final grace period — let the feed sync settle
+echo "Allowing 30s grace period for remaining feed sync..."
+sleep 30
+
+echo "=== gvmd readiness check complete ==="

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-# Wait for gvmd to be fully ready (socket + GMP responsive + scan configs loaded)
+# Wait for gvmd to be fully ready:
+#   1. Socket exists inside container
+#   2. GMP connection responds
+#   3. Scan configs exist (feed sync complete)
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
 SOCKET_PATH="/run/gvmd/gvmd.sock"
+GVM_USER="${GVM_ADMIN_USER:-admin}"
+GVM_PASS="${GVM_ADMIN_PASS:-admin}"
 
 echo "=== Phase 1: Waiting for gvmd socket ==="
 for i in $(seq 1 300); do
@@ -32,29 +37,66 @@ for i in $(seq 1 60); do
   sleep 2
 done
 
-echo "=== Phase 3: Waiting for scan configs (feed sync) ==="
-# gvmd needs time to process feed data and create default scan configs.
-# We check by running gvm-cli get_configs or checking gvmd logs for config creation.
-for i in $(seq 1 120); do
-  # Check if scan configs exist by looking for config creation events in gvmd logs
-  if docker compose -f "$COMPOSE_FILE" exec -T gvmd \
-      gvmd --get-scanners 2>/dev/null | grep -q "Scanner"; then
-    echo "Scanners available after ${i} polls"
-    break
+echo "=== Phase 3: Waiting for scan configs ==="
+# Query scan configs via GMP over the Unix socket using Python inside gvmd container
+GMP_QUERY_SCRIPT=$(cat << 'PYEOF'
+import socket, ssl, sys, time
+
+sock_path = sys.argv[1]
+user = sys.argv[2]
+passwd = sys.argv[3]
+
+auth_xml = f'<authenticate><credentials><username>{user}</username><password>{passwd}</password></credentials></authenticate>'
+configs_xml = '<get_configs/>'
+
+try:
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(10)
+    s.connect(sock_path)
+    s.sendall((auth_xml + configs_xml).encode())
+    data = b''
+    while True:
+        try:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+            # Check if we have complete response (ends with </get_configs_response>)
+            if b'</get_configs_response>' in data:
+                break
+        except socket.timeout:
+            break
+    s.close()
+    count = data.count(b'<config ')
+    print(count)
+except Exception as e:
+    print(f'0', file=sys.stdout)
+    print(f'Error: {e}', file=sys.stderr)
+PYEOF
+)
+
+for i in $(seq 1 180); do
+  RESULT=$(docker compose -f "$COMPOSE_FILE" exec -T gvmd \
+    python3 -c "$GMP_QUERY_SCRIPT" "$SOCKET_PATH" "$GVM_USER" "$GVM_PASS" 2>/dev/null || echo "0")
+  RESULT=$(echo "$RESULT" | tr -d '[:space:]')
+
+  if [[ "$RESULT" =~ ^[0-9]+$ ]] && (( RESULT > 0 )); then
+    echo "Found ${RESULT} scan config(s) after ${i} polls (~$((i * 5))s)"
+    echo "=== gvmd readiness check complete ==="
+    exit 0
   fi
-  # Alternative: check logs for scan config creation
-  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "scan_config.*has been created"; then
-    echo "Scan configs detected in logs after ${i} polls"
-    break
-  fi
+
   if (( i % 10 == 0 )); then
-    echo "Waiting for feed sync to create scan configs... (${i}/120)"
+    echo "Waiting for scan configs... (poll ${i}/180, ~$((i * 5))s elapsed)"
+    # Show recent gvmd feed sync activity
+    docker compose -f "$COMPOSE_FILE" logs --tail=5 gvmd 2>&1 | tail -3 || true
   fi
   sleep 5
 done
 
-# Final grace period — let the feed sync settle
-echo "Allowing 30s grace period for remaining feed sync..."
-sleep 30
-
-echo "=== gvmd readiness check complete ==="
+echo "WARNING: No scan configs found after 15 minutes."
+echo "Last gvmd log lines:"
+docker compose -f "$COMPOSE_FILE" logs --tail=10 gvmd 2>&1 | tail -10 || true
+echo "=== gvmd readiness check complete (no configs) ==="
+# Exit 0 to let the smoke test provide its own error message
+exit 0

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -27,10 +27,11 @@ fi
 
 echo "=== Running GMP readiness check via rust-gvm ==="
 docker compose -f "$COMPOSE_FILE" --profile runner run --rm -T \
+  --entrypoint "" \
   -e GVM_ADMIN_USER="${GVM_ADMIN_USER:-admin}" \
   -e GVM_ADMIN_PASS="${GVM_ADMIN_PASS:-admin}" \
   -e GVM_SOCKET_PATH="${GVM_SOCKET_PATH:-/run/gvmd/gvmd.sock}" \
   rust-gvm-e2e \
-  cargo run --example e2e_gvm_community -- --mode wait-ready
+  bash -c 'export PATH="/usr/local/cargo/bin:$PATH" && cargo run --example e2e_gvm_community -- --mode wait-ready'
 
 echo "=== gvmd is ready ==="

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# Wait for gvmd to be fully ready.
-# With upstream healthchecks on feed containers, gvmd won't start until
-# feed data is copied. We just need to wait for gvmd to finish its own
-# initialization (socket + GMP ready + feed sync).
+# Wait for gvmd readiness using the rust-gvm E2E binary.
+# Phase 1 (bash): Wait for gvmd socket inside container
+# Phase 2-3 (rust): Poll feeds + scan configs via GMP
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
 SOCKET_PATH="/run/gvmd/gvmd.sock"
 
-echo "=== Phase 1: Waiting for gvmd socket ==="
+echo "=== Waiting for gvmd socket ==="
 for i in $(seq 1 300); do
   if docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
     echo "Socket detected after ${i}s"
@@ -26,40 +25,12 @@ if ! docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/de
   exit 1
 fi
 
-echo "=== Phase 2: Waiting for GMP readiness ==="
-for i in $(seq 1 120); do
-  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "ready to accept GMP connections"; then
-    echo "gvmd accepting GMP connections"
-    break
-  fi
-  if (( i % 20 == 0 )); then
-    echo "Waiting for GMP readiness... (${i}/120)"
-  fi
-  sleep 2
-done
+echo "=== Running GMP readiness check via rust-gvm ==="
+docker compose -f "$COMPOSE_FILE" --profile runner run --rm -T \
+  -e GVM_ADMIN_USER="${GVM_ADMIN_USER:-admin}" \
+  -e GVM_ADMIN_PASS="${GVM_ADMIN_PASS:-admin}" \
+  -e GVM_SOCKET_PATH="${GVM_SOCKET_PATH:-/run/gvmd/gvmd.sock}" \
+  rust-gvm-e2e \
+  cargo run --example e2e_gvm_community -- --mode wait-ready
 
-echo "=== Phase 3: Waiting for feed sync ==="
-# Wait for VT update and scan config creation.
-# On a fresh environment this takes ~15 min; with persistent volumes it's fast.
-for i in $(seq 1 180); do
-  # Check for scan config creation in logs (gvmd logs "Scan config ... has been created")
-  # OR check for the sync completion markers
-  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -qE "scan_config.*created|Updating VTs in database.*done"; then
-    echo "Feed sync indicators found after ${i} polls (~$((i * 5))s)"
-
-    # If VTs are done but configs might still be syncing, wait a bit more
-    if ! docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "scan_config.*created"; then
-      echo "VTs synced but scan configs not yet visible. Waiting 60s for data-objects sync..."
-      sleep 60
-    fi
-    break
-  fi
-
-  if (( i % 12 == 0 )); then
-    echo "Waiting for feed sync... ($((i * 5))s elapsed)"
-    docker compose -f "$COMPOSE_FILE" logs --tail=3 gvmd 2>&1 | tail -3 || true
-  fi
-  sleep 5
-done
-
-echo "=== gvmd readiness check complete ==="
+echo "=== gvmd is ready ==="

--- a/tests/e2e/gvm-community/scripts/wait-ready.sh
+++ b/tests/e2e/gvm-community/scripts/wait-ready.sh
@@ -1,29 +1,35 @@
 #!/usr/bin/env bash
 # Wait for gvmd readiness using the rust-gvm E2E binary.
-# Phase 1 (bash): Wait for gvmd socket inside container
+# Phase 1 (bash): Wait for gvmd to accept connections on socket
 # Phase 2-3 (rust): Poll feeds + scan configs via GMP
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-tests/e2e/gvm-community/docker-compose.yml}"
 SOCKET_PATH="/run/gvmd/gvmd.sock"
 
-echo "=== Waiting for gvmd socket ==="
+echo "=== Waiting for gvmd to accept connections ==="
 for i in $(seq 1 300); do
-  if docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
-    echo "Socket detected after ${i}s"
+  # Check that gvmd is actually listening, not just that the socket file exists
+  # (socket file may persist from previous run with persistent volumes)
+  if docker compose -f "$COMPOSE_FILE" exec -T gvmd \
+      bash -c "echo '<get_version/>' | socat - UNIX-CONNECT:${SOCKET_PATH} 2>/dev/null | grep -q 'get_version_response'" 2>/dev/null; then
+    echo "gvmd responding on socket after ${i}s"
     break
   fi
+  # Fallback: if socat isn't available, check logs for ready message
+  if docker compose -f "$COMPOSE_FILE" logs gvmd 2>&1 | grep -q "ready to accept GMP connections"; then
+    # Verify socket actually works
+    if docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
+      echo "gvmd ready (from logs) after ${i}s"
+      break
+    fi
+  fi
   if (( i % 30 == 0 )); then
-    echo "Still waiting for socket... (${i}s)"
+    echo "Still waiting for gvmd... (${i}s)"
+    docker compose -f "$COMPOSE_FILE" logs --tail=3 gvmd 2>&1 | tail -3 || true
   fi
   sleep 1
 done
-
-if ! docker compose -f "$COMPOSE_FILE" exec -T gvmd test -S "$SOCKET_PATH" 2>/dev/null; then
-  echo "gvmd did not start: socket not found after 300s" >&2
-  docker compose -f "$COMPOSE_FILE" logs --tail=30 gvmd 2>&1 || true
-  exit 1
-fi
 
 echo "=== Running GMP readiness check via rust-gvm ==="
 docker compose -f "$COMPOSE_FILE" --profile runner run --rm -T \


### PR DESCRIPTION
The new self-hosted runner `hetzner-vps` uses labels `[self-hosted, Linux, X64, docker]`.

This updates `runs-on` from `[self-hosted, fedora]` to `[self-hosted, docker]` so the E2E workflow gets picked up by the new runner.

**Based on:** `feat/e2e-gvm-community` (contains the E2E infrastructure)

---
Closes #49
Closes #22