### PR TITLE
ci: trigger standalone E2E tests on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,17 @@ jobs:
           toolchain: "1.75.0"
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       - run: cargo check --workspace --all-features
+
+  trigger-e2e:
+    name: Trigger E2E Tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rust-gvm-e2e-tests
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh api repos/clawosiris/rust-gvm-e2e-tests/dispatches \
+            -f event_type=component-updated \
+            -f 'client_payload={"component":"rust-gvm","ref":"${{ github.sha }}"}'


### PR DESCRIPTION
After CI tests pass on push to main, dispatch to `clawosiris/rust-gvm-e2e-tests` with the current SHA so E2E tests run against this commit.

Uses `repository_dispatch` with `client_payload={"component":"rust-gvm","ref":"<sha>"}`.

Part of the E2E migration plan: [rust-gvm-e2e-tests#5](https://github.com/clawosiris/rust-gvm-e2e-tests/pull/5)