### PR TITLE
fix(ci): send client_payload as JSON object in E2E dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,5 +138,12 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh api repos/clawosiris/rust-gvm-e2e-tests/dispatches \
-            -f event_type=component-updated \
-            -f 'client_payload={"component":"rust-gvm","ref":"${{ github.sha }}"}'
+            --method POST --input - <<EOF
+          {
+            "event_type": "component-updated",
+            "client_payload": {
+              "component": "rust-gvm",
+              "ref": "${{ github.sha }}"
+            }
+          }
+          EOF


### PR DESCRIPTION
The `repository_dispatch` API requires `client_payload` to be a JSON object, not a string. Using `-f` passed it as a string, causing HTTP 422:

```
For 'properties/client_payload', "{...}" is not an object. (HTTP 422)
```

Switch to `--method POST --input` to send the entire request body as properly structured JSON.

Fixes the cross-repo trigger from rust-gvm CI → rust-gvm-e2e-tests.