### PR TITLE
ci(security): temporarily ignore RUSTSEC-2026-0074 (tracked)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run cargo-audit
-        run: cargo audit
+        run: cargo audit --ignore RUSTSEC-2026-0074
 
   # Check for unused dependencies
   cargo-machete:

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,9 @@ ignore = [
     "RUSTSEC-2023-0071",
     # rustls-pemfile unmaintained — workspace dep for TLS feature; will migrate when rustls ecosystem settles
     "RUSTSEC-2025-0134",
+    # libcrux-sha3 vulnerability via russh; tracking: https://github.com/clawosiris/rust-gvm/issues/59
+    # upstream: https://github.com/Eugeny/russh/pull/680
+    "RUSTSEC-2026-0074",
 ]
 
 [licenses]


### PR DESCRIPTION
This restores green Security/Cargo checks while we track and wait for upstream fixes.

Changes:
- security.yml: run cargo audit with ignore RUSTSEC-2026-0074
- deny.toml: add RUSTSEC-2026-0074 to advisories.ignore

Tracking:
- rust-gvm issue #59: https://github.com/clawosiris/rust-gvm/issues/59
- upstream russh PR: https://github.com/Eugeny/russh/pull/680