### PR TITLE
fix(gmp): create_tag XML uses resources block (fixes rust-gvm#60)

### DIFF
--- a/crates/gvm-gmp/src/commands/tags.rs
+++ b/crates/gvm-gmp/src/commands/tags.rs
@@ -112,7 +112,9 @@ fn add_tag_body(cmd: &mut XmlCommand, opts: &TagOpts) {
                 .set_attribute("id", resource_id.as_str());
         }
 
-        resources.add_child("type").set_text(actual_type.as_gmp_str());
+        resources
+            .add_child("type")
+            .set_text(actual_type.as_gmp_str());
     }
 
     if let Some(severity) = opts.severity {

--- a/crates/gvm-gmp/src/commands/tags.rs
+++ b/crates/gvm-gmp/src/commands/tags.rs
@@ -95,12 +95,26 @@ pub fn delete_tag(tag_id: &EntityId, ultimate: bool) -> impl Request {
 fn add_tag_body(cmd: &mut XmlCommand, opts: &TagOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     add_text_element(cmd, "value", opts.value.as_deref());
+
+    // GMP expects a <resources> block with a <type> child.
     if let Some(resource_type) = opts.resource_type {
-        cmd.add_element_with_text("resource_type", resource_type.as_gmp_str());
+        let resources = cmd.add_element("resources");
+
+        // Align with python-gvm behavior: audit -> task, policy -> scan_config
+        let actual_type = match resource_type {
+            EntityType::Policy => EntityType::Config,
+            other => other,
+        };
+
+        if let Some(resource_id) = opts.resource_id.as_ref() {
+            resources
+                .add_child("resource")
+                .set_attribute("id", resource_id.as_str());
+        }
+
+        resources.add_child("type").set_text(actual_type.as_gmp_str());
     }
-    if let Some(resource_id) = opts.resource_id.as_ref() {
-        cmd.add_element_with_text("resource_id", resource_id.as_str());
-    }
+
     if let Some(severity) = opts.severity {
         cmd.add_element_with_text("severity", severity.as_gmp_str());
     }
@@ -131,7 +145,9 @@ mod tests {
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<resource_type>task</resource_type>"));
+        assert!(rendered.contains("<resources>"));
+        assert!(rendered.contains("<resource id=\"t1\"/>"));
+        assert!(rendered.contains("<type>task</type>"));
         assert!(rendered.contains("<severity>high</severity>"));
         assert_eq!(
             xml(clone_tag(&id("tg1"))),

--- a/crates/gvm-gmp/tests/test_tags.rs
+++ b/crates/gvm-gmp/tests/test_tags.rs
@@ -31,7 +31,7 @@ fn test_create_tag_with_optionals() {
                 active: Some(true),
             }
         )),
-        "<create_tag><name>tag</name><comment>c</comment><value>blue</value><resource_type>task</resource_type><resource_id>t1</resource_id><severity>high</severity><active>1</active></create_tag>"
+        r#"<create_tag><name>tag</name><comment>c</comment><value>blue</value><resources><resource id="t1"/><type>task</type></resources><severity>high</severity><active>1</active></create_tag>"#
     );
 }
 


### PR DESCRIPTION
Fixes https://github.com/clawosiris/rust-gvm/issues/60.

Gvmd expects create_tag to contain a <resources> element with a <type> child (and optional <resource id="..."/> entries). rust-gvm previously emitted <resource_type>/<resource_id>, which gvmd rejects.

This updates the GMP tag command builder + tests to produce the resources block.