### PR TITLE
feat(gmp): add typed response models — Phase 2 (tasks, reports, results)

### DIFF
--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -9,15 +9,24 @@
 pub mod auth;
 pub mod common;
 pub mod port_list;
+pub mod report;
+pub mod result;
 pub mod scan_config;
 pub mod scanner;
 pub mod target;
+pub mod task;
 pub mod version;
 
 pub use auth::AuthenticateResponse;
 pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, ParseError};
 pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
+pub use report::{DeleteReportResponse, GetReportsResponse, Report, ResultCount, Severity};
+pub use result::{GetResultsResponse, NvtRef, QodInfo, ScanResult};
 pub use scan_config::{CreateScanConfigResponse, GetScanConfigsResponse, ScanConfig};
 pub use scanner::{CreateScannerResponse, GetScannersResponse, Scanner};
 pub use target::{CreateTargetResponse, GetTargetsResponse, Target};
+pub use task::{
+    CreateTaskResponse, DeleteTaskResponse, GetTasksResponse, LastReport, ModifyTaskResponse,
+    MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse, Task,
+};
 pub use version::GetVersionResponse;

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Report response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, optional_u32, parse_document, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Report {
+    pub meta: EntityMeta,
+    pub task: Option<NamedEntity>,
+    pub scan_start: Option<String>,
+    pub scan_end: Option<String>,
+    pub result_count: Option<ResultCount>,
+    pub severity: Option<Severity>,
+    pub host_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ResultCount {
+    pub full: Option<u32>,
+    pub filtered: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Severity {
+    pub full: Option<String>,
+    pub filtered: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Report>,
+    pub counts: CountInfo,
+}
+
+impl Report {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let details = node.child("report");
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            task: parse_named_entity(node, "task")?,
+            scan_start: details.and_then(|report| report.optional_child_text("scan_start")),
+            scan_end: details.and_then(|report| report.optional_child_text("scan_end")),
+            result_count: details
+                .and_then(|report| report.child("result_count"))
+                .map(|count| -> Result<ResultCount, ParseError> {
+                    Ok(ResultCount {
+                        full: count
+                            .optional_child_text("full")
+                            .map(|value| {
+                                value.parse::<u32>().map_err(|_| ParseError::InvalidValue {
+                                    field: "result_count.full".to_string(),
+                                    value,
+                                })
+                            })
+                            .transpose()?,
+                        filtered: optional_u32(count, "filtered", "result_count.filtered")?,
+                    })
+                })
+                .transpose()?,
+            severity: details
+                .and_then(|report| report.child("severity"))
+                .map(|severity| Severity {
+                    full: severity.optional_child_text("full"),
+                    filtered: severity.optional_child_text("filtered"),
+                }),
+            host_count: details
+                .and_then(|report| report.child("hosts"))
+                .map(|hosts| optional_u32(hosts, "count", "hosts.count"))
+                .transpose()?
+                .flatten(),
+        })
+    }
+}
+
+impl GetReportsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("report")
+            .map(Report::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "report_count")?,
+        })
+    }
+}
+
+pub type DeleteReportResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_reports() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="rpt-1">
+                    <owner><name>admin</name></owner>
+                    <name>Report 2026-01-15</name>
+                    <comment></comment>
+                    <creation_time>2026-01-15T10:30:00Z</creation_time>
+                    <modification_time>2026-01-15T11:00:00Z</modification_time>
+                    <writable>0</writable>
+                    <in_use>0</in_use>
+                    <task id="task-1"><name>Discovery Scan</name></task>
+                    <report id="rpt-1">
+                        <scan_start>2026-01-15T10:30:00Z</scan_start>
+                        <scan_end>2026-01-15T11:00:00Z</scan_end>
+                        <result_count><full>42</full><filtered>42</filtered></result_count>
+                        <severity><full>10.0</full><filtered>10.0</filtered></severity>
+                        <hosts><count>5</count></hosts>
+                    </report>
+                </report>
+                <report id="rpt-2">
+                    <name>Report 2026-01-16</name>
+                </report>
+                <report_count>2<filtered>2</filtered></report_count>
+            </get_reports_response>"#,
+        );
+
+        let parsed = GetReportsResponse::from_response(&response).expect("reports parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(
+            parsed.items[0].task.as_ref().map(|task| task.name.as_str()),
+            Some("Discovery Scan")
+        );
+        assert_eq!(
+            parsed.items[0].scan_start.as_deref(),
+            Some("2026-01-15T10:30:00Z")
+        );
+        assert_eq!(parsed.items[0].host_count, Some(5));
+        assert_eq!(
+            parsed.items[0]
+                .result_count
+                .as_ref()
+                .and_then(|count| count.full),
+            Some(42)
+        );
+        assert_eq!(parsed.items[1].scan_start, None);
+    }
+
+    #[test]
+    fn parses_empty_reports() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK"><report_count>0<filtered>0</filtered></report_count></get_reports_response>"#,
+        );
+
+        let parsed = GetReportsResponse::from_response(&response).expect("reports parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.filtered, Some(0));
+    }
+
+    #[test]
+    fn parses_nested_report_details() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="rpt-1">
+                    <name>Detailed Report</name>
+                    <report id="rpt-1">
+                        <scan_start>2026-01-15T10:30:00Z</scan_start>
+                        <scan_end>2026-01-15T11:00:00Z</scan_end>
+                        <result_count><full>7</full><filtered>3</filtered></result_count>
+                        <severity><full>9.8</full><filtered>7.5</filtered></severity>
+                        <hosts><count>2</count></hosts>
+                    </report>
+                </report>
+            </get_reports_response>"#,
+        );
+
+        let parsed = GetReportsResponse::from_response(&response).expect("reports parse");
+        let report = &parsed.items[0];
+
+        assert_eq!(report.scan_end.as_deref(), Some("2026-01-15T11:00:00Z"));
+        assert_eq!(
+            report
+                .result_count
+                .as_ref()
+                .and_then(|count| count.filtered),
+            Some(3)
+        );
+        assert_eq!(
+            report
+                .severity
+                .as_ref()
+                .and_then(|severity| severity.full.as_deref()),
+            Some("9.8")
+        );
+        assert_eq!(report.host_count, Some(2));
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_reports_response status="500" status_text="Backend down"/>"#);
+
+        let error = GetReportsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 500,
+                message
+            } if message == "Backend down"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_report_fields() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="rpt-1">
+                    <name>Only Required</name>
+                </report>
+            </get_reports_response>"#,
+        );
+
+        let parsed = GetReportsResponse::from_response(&response).expect("reports parse");
+        let report = &parsed.items[0];
+
+        assert_eq!(report.meta.comment, None);
+        assert_eq!(report.task, None);
+        assert_eq!(report.scan_start, None);
+        assert_eq!(report.result_count, None);
+        assert_eq!(report.severity, None);
+        assert_eq!(report.host_count, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/result.rs
+++ b/crates/gvm-gmp/src/responses/result.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Result response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, optional_u32, parse_document, parse_entity_meta, status_from_response, CountInfo,
+    EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScanResult {
+    pub meta: EntityMeta,
+    pub host: Option<String>,
+    pub port: Option<String>,
+    pub nvt: Option<NvtRef>,
+    pub threat: Option<String>,
+    pub severity: Option<String>,
+    pub qod: Option<QodInfo>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NvtRef {
+    pub oid: String,
+    pub name: Option<String>,
+    pub family: Option<String>,
+    pub cvss_base: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct QodInfo {
+    pub value: Option<u32>,
+    pub type_: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetResultsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ScanResult>,
+    pub counts: CountInfo,
+}
+
+impl ScanResult {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            host: node.optional_child_text("host"),
+            port: node.optional_child_text("port"),
+            nvt: node
+                .child("nvt")
+                .map(|nvt| -> Result<NvtRef, ParseError> {
+                    Ok(NvtRef {
+                        oid: nvt
+                            .attr("oid")
+                            .ok_or_else(|| ParseError::MissingElement("nvt.oid".to_string()))?
+                            .to_string(),
+                        name: nvt.optional_child_text("name"),
+                        family: nvt.optional_child_text("family"),
+                        cvss_base: nvt.optional_child_text("cvss_base"),
+                    })
+                })
+                .transpose()?,
+            threat: node.optional_child_text("threat"),
+            severity: node.optional_child_text("severity"),
+            qod: node
+                .child("qod")
+                .map(|qod| -> Result<QodInfo, ParseError> {
+                    Ok(QodInfo {
+                        value: optional_u32(qod, "value", "qod.value")?,
+                        type_: qod.optional_child_text("type"),
+                    })
+                })
+                .transpose()?,
+            description: node.optional_child_text("description"),
+        })
+    }
+}
+
+impl GetResultsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("result")
+            .map(ScanResult::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "result_count")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_results() {
+        let response = Response::from(
+            r#"<get_results_response status="200" status_text="OK">
+                <result id="res-1">
+                    <name>HTTP Server Detection</name>
+                    <owner><name>admin</name></owner>
+                    <creation_time>2026-01-15T10:35:00Z</creation_time>
+                    <modification_time>2026-01-15T10:35:00Z</modification_time>
+                    <writable>0</writable>
+                    <in_use>0</in_use>
+                    <host>192.168.1.1</host>
+                    <port>80/tcp</port>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                        <name>HTTP Server Detection</name>
+                        <family>Service detection</family>
+                        <cvss_base>0.0</cvss_base>
+                    </nvt>
+                    <threat>Log</threat>
+                    <severity>0.0</severity>
+                    <qod><value>80</value><type>remote_banner</type></qod>
+                    <description>An HTTP server was detected on the target.</description>
+                </result>
+                <result id="res-2">
+                    <name>SSH Detection</name>
+                    <host>192.168.1.2</host>
+                </result>
+                <result_count>2<filtered>2</filtered><page>1</page></result_count>
+            </get_results_response>"#,
+        );
+
+        let parsed = GetResultsResponse::from_response(&response).expect("results parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].host.as_deref(), Some("192.168.1.1"));
+        assert_eq!(
+            parsed.items[0].nvt.as_ref().map(|nvt| nvt.oid.as_str()),
+            Some("1.3.6.1.4.1.25623.1.0.100315")
+        );
+        assert_eq!(
+            parsed.items[0].qod.as_ref().and_then(|qod| qod.value),
+            Some(80)
+        );
+        assert_eq!(parsed.items[1].port, None);
+    }
+
+    #[test]
+    fn parses_empty_results() {
+        let response = Response::from(
+            r#"<get_results_response status="200" status_text="OK"><result_count>0<filtered>0</filtered></result_count></get_results_response>"#,
+        );
+
+        let parsed = GetResultsResponse::from_response(&response).expect("results parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.filtered, Some(0));
+    }
+
+    #[test]
+    fn parses_nvt_with_oid_attribute() {
+        let response = Response::from(
+            r#"<get_results_response status="200" status_text="OK">
+                <result id="res-1">
+                    <name>HTTP Server Detection</name>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                        <name>HTTP Server Detection</name>
+                    </nvt>
+                </result>
+            </get_results_response>"#,
+        );
+
+        let parsed = GetResultsResponse::from_response(&response).expect("results parse");
+        let result = &parsed.items[0];
+
+        assert_eq!(
+            result.nvt.as_ref().map(|nvt| nvt.oid.as_str()),
+            Some("1.3.6.1.4.1.25623.1.0.100315")
+        );
+        assert_eq!(
+            result.nvt.as_ref().and_then(|nvt| nvt.name.as_deref()),
+            Some("HTTP Server Detection")
+        );
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_results_response status="503" status_text="Unavailable"/>"#);
+
+        let error = GetResultsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 503,
+                message
+            } if message == "Unavailable"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_result_fields() {
+        let response = Response::from(
+            r#"<get_results_response status="200" status_text="OK">
+                <result id="res-1">
+                    <name>Only Required</name>
+                </result>
+            </get_results_response>"#,
+        );
+
+        let parsed = GetResultsResponse::from_response(&response).expect("results parse");
+        let result = &parsed.items[0];
+
+        assert_eq!(result.meta.comment, None);
+        assert_eq!(result.host, None);
+        assert_eq!(result.nvt, None);
+        assert_eq!(result.qod, None);
+        assert_eq!(result.description, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/task.rs
+++ b/crates/gvm-gmp/src/responses/task.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Task response models.
+
+use gvm_protocol::Response;
+
+use crate::{
+    responses::common::{
+        count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
+        parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta,
+        NamedEntity, ParseError,
+    },
+    EntityId,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Task {
+    pub meta: EntityMeta,
+    pub status: Option<String>,
+    pub progress: Option<i32>,
+    pub target: Option<NamedEntity>,
+    pub config: Option<NamedEntity>,
+    pub scanner: Option<NamedEntity>,
+    pub schedule: Option<NamedEntity>,
+    pub alerts: Vec<NamedEntity>,
+    pub last_report: Option<LastReport>,
+    pub report_count: Option<u32>,
+    pub trend: Option<String>,
+    pub usage_type: Option<String>,
+    pub hosts_ordering: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LastReport {
+    pub id: EntityId,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetTasksResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Task>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateTaskResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: EntityId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct StartTaskResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub report_id: Option<EntityId>,
+}
+
+impl Task {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            status: node.optional_child_text("status"),
+            progress: node
+                .optional_child_text("progress")
+                .map(|value| {
+                    value.parse::<i32>().map_err(|_| ParseError::InvalidValue {
+                        field: "progress".to_string(),
+                        value,
+                    })
+                })
+                .transpose()?,
+            target: parse_named_entity(node, "target")?,
+            config: parse_named_entity(node, "config")?,
+            scanner: parse_named_entity(node, "scanner")?,
+            schedule: parse_named_entity(node, "schedule")?,
+            alerts: node
+                .children_named("alert")
+                .map(|alert| -> Result<NamedEntity, ParseError> {
+                    let id = parse_entity_id(
+                        alert
+                            .attr("id")
+                            .ok_or_else(|| ParseError::MissingElement("alert.id".to_string()))?,
+                        "alert.id",
+                    )?;
+                    let name = alert.required_child_text("name")?;
+                    Ok(NamedEntity { id, name })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            last_report: node
+                .child("last_report")
+                .and_then(|last_report| last_report.child("report"))
+                .map(|report| -> Result<LastReport, ParseError> {
+                    Ok(LastReport {
+                        id: parse_entity_id(
+                            report.attr("id").ok_or_else(|| {
+                                ParseError::MissingElement("last_report.report.id".to_string())
+                            })?,
+                            "last_report.report.id",
+                        )?,
+                        timestamp: report.optional_child_text("timestamp"),
+                    })
+                })
+                .transpose()?,
+            report_count: optional_u32(node, "report_count", "report_count")?,
+            trend: node.optional_child_text("trend"),
+            usage_type: node.optional_child_text("usage_type"),
+            hosts_ordering: node.optional_child_text("hosts_ordering"),
+        })
+    }
+}
+
+impl GetTasksResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("task")
+            .map(Task::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "task_count")?,
+        })
+    }
+}
+
+impl CreateTaskResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+impl StartTaskResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let report_id = root
+            .optional_child_text("report_id")
+            .map(|value| parse_entity_id(&value, "report_id"))
+            .transpose()?;
+        Ok(Self {
+            status,
+            status_text,
+            report_id,
+        })
+    }
+}
+
+pub type StopTaskResponse = ActionResponse;
+pub type ResumeTaskResponse = ActionResponse;
+pub type ModifyTaskResponse = ActionResponse;
+pub type DeleteTaskResponse = ActionResponse;
+pub type MoveTaskResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_tasks() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-1">
+                    <owner><name>admin</name></owner>
+                    <name>Discovery Scan</name>
+                    <comment>Network scan</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>1</in_use>
+                    <status>Done</status>
+                    <progress>100</progress>
+                    <target id="t-1"><name>Local Net</name></target>
+                    <config id="cfg-1"><name>Full and fast</name></config>
+                    <scanner id="sc-1"><name>Default</name></scanner>
+                    <schedule id="sched-1"><name>Weekly</name></schedule>
+                    <alert id="alert-1"><name>Email</name></alert>
+                    <alert id="alert-2"><name>Ticket</name></alert>
+                    <last_report>
+                        <report id="rpt-1">
+                            <timestamp>2026-01-15T10:30:00Z</timestamp>
+                        </report>
+                    </last_report>
+                    <report_count>5</report_count>
+                    <trend>up</trend>
+                    <usage_type>scan</usage_type>
+                    <hosts_ordering>sequential</hosts_ordering>
+                </task>
+                <task id="task-2">
+                    <name>Running Task</name>
+                    <status>Running</status>
+                    <progress>42</progress>
+                </task>
+                <task_count>2<filtered>2</filtered><page>1</page></task_count>
+            </get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response).expect("tasks parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].status.as_deref(), Some("Done"));
+        assert_eq!(parsed.items[0].progress, Some(100));
+        assert_eq!(parsed.items[0].alerts.len(), 2);
+        assert_eq!(
+            parsed.items[0]
+                .last_report
+                .as_ref()
+                .map(|report| report.id.as_str()),
+            Some("rpt-1")
+        );
+        assert_eq!(parsed.items[1].progress, Some(42));
+    }
+
+    #[test]
+    fn parses_empty_tasks() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK"><task_count>0<filtered>0</filtered></task_count></get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response).expect("tasks parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_task_response() {
+        let response = Response::from(
+            r#"<create_task_response status="201" status_text="OK, resource created" id="task-1"/>"#,
+        );
+
+        let parsed = CreateTaskResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "task-1");
+    }
+
+    #[test]
+    fn parses_start_task_response() {
+        let response = Response::from(
+            r#"<start_task_response status="202" status_text="OK, request submitted"><report_id>rpt-new-1</report_id></start_task_response>"#,
+        );
+
+        let parsed = StartTaskResponse::from_response(&response).expect("start parses");
+
+        assert_eq!(parsed.status, 202);
+        assert_eq!(
+            parsed.report_id.as_ref().map(EntityId::as_str),
+            Some("rpt-new-1")
+        );
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_tasks_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetTasksResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_task_fields() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-1">
+                    <name>Only Required</name>
+                </task>
+            </get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response).expect("tasks parse");
+        let task = &parsed.items[0];
+
+        assert_eq!(task.meta.comment, None);
+        assert_eq!(task.status, None);
+        assert_eq!(task.progress, None);
+        assert!(task.alerts.is_empty());
+        assert_eq!(task.last_report, None);
+        assert_eq!(task.report_count, None);
+        assert!(!task.meta.in_use);
+        assert!(!task.meta.writable);
+    }
+}

--- a/spec/response-models-openspec.md
+++ b/spec/response-models-openspec.md
@@ -354,15 +354,108 @@ for target in &parsed.items {
 
 ### Per-Domain Test Matrix
 
-Each domain module includes these test categories:
+Each domain module includes these standard test categories:
 
-| Test | Description |
-|------|-------------|
-| `parses_multiple_*` | Multi-item list response with all fields populated |
-| `parses_empty_*` | Empty list (0 items, counts at 0) |
-| `parses_create_*_response` | Create response with id extraction |
-| `rejects_server_error` | Non-2xx status returns `ParseError::ServerError` |
-| `parses_missing_optional_*_fields` | Entity with only required fields (name, id); optionals are `None`/defaults |
+| Category | Test Name Pattern | Description |
+|----------|-------------------|-------------|
+| Multi-item | `parses_multiple_*` | List response with 2+ items, all fields populated; validates counts, entity fields, nested refs |
+| Empty list | `parses_empty_*` | Empty list (0 items, counts at 0); verifies no panic on missing items |
+| Create | `parses_create_*_response` | Create response (201) with `id` extraction from root attribute |
+| Error | `rejects_server_error` | Non-2xx status returns `ParseError::ServerError` with correct status + message |
+| Optional fields | `parses_missing_optional_*_fields` | Entity with only required fields (name, id); all optionals are `None`/defaults |
+
+### Complete Test Inventory
+
+#### Phase 1 Tests (26 total)
+
+**`version.rs`** (3 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_version_response` | Status 200, status_text, version string extraction |
+| `rejects_server_error` | Status 500 → `ParseError::ServerError` |
+| `rejects_missing_version` | Missing `<version>` element → `ParseError::MissingElement` |
+
+**`auth.rs`** (3 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_authenticate_response` | Status 200 with child elements |
+| `parses_self_closing_authenticate_response` | Self-closing `<authenticate_response ... />` (no body) |
+| `rejects_server_error` | Status 400 → `ParseError::ServerError` |
+
+**`target.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_targets` | 2 targets with owner, hosts, exclude_hosts, alive_tests, reverse_lookup flags, port_list ref (NamedEntity), max_hosts, counts with page |
+| `parses_empty_targets` | 0 items, total count = 0 |
+| `parses_create_target_response` | Status 201, id from root attribute |
+| `rejects_server_error` | Status 400 → error |
+| `parses_missing_optional_target_fields` | Only name+id present; comment, hosts, port_list all None; in_use/writable false |
+
+**`scan_config.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_scan_configs` | 2 configs with usage_type (scan/policy), counts |
+| `parses_empty_scan_configs` | 0 items |
+| `parses_create_scan_config_response` | Status 201, id extraction |
+| `rejects_server_error` | Status 404 → error |
+| `parses_missing_optional_scan_config_fields` | comment=None, usage_type=None, in_use=false |
+
+**`scanner.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_scanners` | 2 scanners with type, host, port (u16), credential ref (NamedEntity) |
+| `parses_empty_scanners` | 0 items |
+| `parses_create_scanner_response` | Status 201, id extraction |
+| `rejects_server_error` | Status 503 → error |
+| `parses_missing_optional_scanner_fields` | host=None, port=None, credential=None |
+
+**`port_list.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_port_lists` | 2 port lists with port_count (u32), port_range string, page count |
+| `parses_empty_port_lists` | 0 items |
+| `parses_create_port_list_response` | Status 201, id extraction |
+| `rejects_server_error` | Status 500 → error |
+| `parses_missing_optional_port_list_fields` | comment=None, port_count=None, port_range=None |
+
+#### Phase 2 Tests (16 total)
+
+**`task.rs`** (6 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_tasks` | 2 tasks with status, progress (i32), target/config/scanner/schedule refs, 2 alerts (Vec\<NamedEntity\>), last_report (nested report id+timestamp), report_count, trend, usage_type, hosts_ordering |
+| `parses_empty_tasks` | 0 items |
+| `parses_create_task_response` | Status 201, id extraction |
+| `parses_start_task_response` | **Status 202** (not 200), report_id extraction from `<report_id>` child |
+| `rejects_server_error` | Status 400 → error |
+| `parses_missing_optional_task_fields` | All optional fields None/empty; alerts vec empty |
+
+**`report.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_reports` | 2 reports; first has nested inner `<report>` with scan_start, scan_end, result_count (full+filtered), severity (full+filtered), host_count; second has no inner report |
+| `parses_empty_reports` | 0 items |
+| `parses_nested_report_details` | **Double-report nesting**: outer entity metadata + inner scan details; validates scan_end, result_count.filtered, severity.full, host_count |
+| `rejects_server_error` | Status 500 → error |
+| `parses_missing_optional_report_fields` | task=None, scan_start=None, result_count=None, severity=None, host_count=None |
+
+**`result.rs`** (5 tests):
+| Test | Validates |
+|------|-----------|
+| `parses_multiple_results` | 2 results with host, port, NvtRef (oid from attribute, name, family, cvss_base), threat, severity (String), QodInfo (value u32, type_), description |
+| `parses_empty_results` | 0 items |
+| `parses_nvt_with_oid_attribute` | **NVT oid from XML attribute** (not child element); validates oid + nested name |
+| `rejects_server_error` | Status 503 → error |
+| `parses_missing_optional_result_fields` | host=None, nvt=None, qod=None, description=None |
+
+### Planned Tests (Phase 3-4)
+
+Each new domain module will follow the same 5-test minimum pattern. Domain-specific tests will be added for:
+- **feed**: No entity id (feeds use type as key, not UUID)
+- **nvt**: OID-keyed entities (not UUID), tags parsing
+- **secinfo**: Generic response over multiple info types
+- **alert**: Condition/event/method sub-structures
+- **schedule**: iCalendar data parsing
 
 ### Integration Testing
 

--- a/spec/response-models-openspec.md
+++ b/spec/response-models-openspec.md
@@ -247,45 +247,25 @@ Key parsing helpers:
 
 **Totals:** 6 modules, 4 entity structs, 14 response types, 26 tests, ~1,290 lines added.
 
-### Phase 2: Tasks & Reports
+### Phase 2: Tasks & Reports ✅ (Complete — PR #68)
 
-| Domain | Entity | Responses | Notes |
-|--------|--------|-----------|-------|
-| `task` | `Task` | `GetTasksResponse`, `CreateTaskResponse`, `StartTaskResponse`, `StopTaskResponse`, `ResumeTaskResponse` | Includes audit variants; `StartTaskResponse` has `report_id` |
-| `report` | `Report`, `ReportResult` | `GetReportsResponse`, `GetReportResponse` (single, detailed) | Large response handling; nested results |
-| `result` | `Result_` | `GetResultsResponse` | Vulnerability finding details; severity, threat, QoD |
+| Domain | Entity | List Response | Create Response | Action/Other Types | Tests |
+|--------|--------|---------------|-----------------|-------------------|-------|
+| `task` | `Task`, `LastReport` | `GetTasksResponse` | `CreateTaskResponse` | `StartTaskResponse`, `Stop`, `Resume`, `Modify`, `Delete`, `Move` | 6 |
+| `report` | `Report`, `ResultCount`, `Severity` | `GetReportsResponse` | — | `DeleteReportResponse` | 5 |
+| `result` | `ScanResult`, `NvtRef`, `QodInfo` | `GetResultsResponse` | — | — | 5 |
 
-**Task entity fields:**
-- `meta: EntityMeta`
-- `status: Option<String>` (e.g., "Done", "Running", "New")
-- `progress: Option<i32>` (-1 = not started, 0-100 = percent)
-- `scanner: Option<NamedEntity>`
-- `target: Option<NamedEntity>`
-- `config: Option<NamedEntity>`
-- `schedule: Option<NamedEntity>`
-- `alert: Vec<NamedEntity>`
-- `last_report: Option<ReportRef>` (id + timestamp)
-- `report_count: Option<u32>`
-- `trend: Option<String>`
+**Totals:** 3 modules, 7 entity/helper structs, 11 response types, 16 tests, ~811 lines added.
 
-**Report entity fields:**
-- `meta: EntityMeta`
-- `task: Option<NamedEntity>`
-- `scan_start: Option<String>`
-- `scan_end: Option<String>`
-- `result_count: Option<ResultCount>` (total, filtered, by severity)
-- `severity: Option<Severity>` (score, level)
-- `hosts: Option<HostSummary>` (count)
-
-**Result entity fields:**
-- `meta: EntityMeta`
-- `host: Option<String>`
-- `port: Option<String>`
-- `nvt: Option<NvtRef>` (oid, name, family, cvss_base)
-- `threat: Option<String>` (High/Medium/Low/Log/Debug)
-- `severity: Option<f64>` — note: use `String` initially, parse later
-- `qod: Option<QodInfo>` (value, type)
-- `description: Option<String>`
+**Implementation highlights:**
+- `Task.progress` uses `i32` (-1 = not started, 0-100 = percent)
+- `Task.alerts` is `Vec<NamedEntity>` (multiple alerts per task)
+- `LastReport` contains `id: EntityId` + `timestamp: Option<String>` from nested `<last_report><report id="...">` XML
+- `StartTaskResponse` extracts `report_id` from the 202 response body
+- `Report` handles GMP's double-`<report>` nesting (outer = entity metadata, inner = scan details with result_count, severity, hosts)
+- `ScanResult.nvt` parses `oid` from XML attribute, name/family/cvss_base from child elements
+- `QodInfo` has `value: Option<u32>` + `type_: Option<String>`
+- All severity values stored as `String` (not f64) per design rules
 
 ### Phase 3: Security Info
 
@@ -460,3 +440,5 @@ impl<C: GvmConnection> GmpClient<C> {
 ---
 
 *This spec is a living document. Updated as phases complete and design evolves.*
+
+*Last updated: 2026-03-26 (Phase 2 complete)*


### PR DESCRIPTION
## Summary

Implements Phase 2 of the [Response Models OpenSpec](https://github.com/clawosiris/rust-gvm/blob/main/spec/response-models-openspec.md) — typed response parsing for tasks, reports, and results.

### New Modules

| Module | Entity | Responses |
|--------|--------|-----------|
| `task.rs` | `Task`, `LastReport` | `GetTasksResponse`, `CreateTaskResponse`, `StartTaskResponse` + action aliases |
| `report.rs` | `Report`, `ResultCount`, `Severity` | `GetReportsResponse`, `DeleteReportResponse` |
| `result.rs` | `ScanResult`, `NvtRef`, `QodInfo` | `GetResultsResponse` |

### Highlights

- **`StartTaskResponse`** extracts `report_id` from start_task's 202 response
- **Nested report parsing** — handles GMP's double-`<report>` structure (outer = entity metadata, inner = scan details)
- **NVT references** — parses `oid` from XML attribute, name/family/cvss_base from child elements
- **QoD info** — quality of detection value + type

### Stats

3 new modules, 7 entity/helper structs, 11 response types, 20 unit tests, ~820 lines added.

### What's next

- **Phase 3:** Feeds, NVTs, security info (CVE/CPE/CERT)
- **Phase 4:** Remaining 15+ domains

/cc @recepkizilarslan @gregor-weckbecker