### PR TITLE
docs(journal): update rust-gvm entries for Mar 25-26

### DIFF
--- a/journal/2026-03-25.md
+++ b/journal/2026-03-25.md
@@ -1,0 +1,20 @@
+# 2026-03-25 — Response Models RFC and Implementation Kickoff
+
+## Architecture / Design
+- Opened RFC PR for typed response models encapsulation:
+  - **PR #65** — https://github.com/clawosiris/rust-gvm/pull/65
+- RFC proposes moving consumer-side XML parsing into `gvm-gmp` response modules (`responses/*`) with additive, non-breaking API evolution.
+
+## Key Decisions Captured in RFC
+- Keep implementation in `gvm-gmp` (not a new crate) for now.
+- Use hand-written XML parsing with shared helpers.
+- Use optional serde derives behind feature flag.
+- Roll out in phases (core domains → tasks/reports/results → feeds/secinfo/NVTs → remaining entities).
+
+## Releases / CI
+- Nightly pre-release cadence continued.
+- Existing v0.3.0 / v0.3.1 pipeline remained stable.
+
+## Next Steps
+- Start Phase 1 implementation after review alignment.
+- Keep OpenSpec updated in the same PR as each phase implementation.

--- a/journal/2026-03-26.md
+++ b/journal/2026-03-26.md
@@ -48,3 +48,26 @@
 ## CI Health
 - **Main branch**: ✅ Green (nightly 2026-03-25 passing)
 - **Security**: ⚠️ RUSTSEC-2026-0074 ignored (tracked)
+
+---
+
+## Addendum (later updates on 2026-03-26)
+
+### Response Models Progress
+- **Phase 1 merged** — PR #67:
+  - https://github.com/clawosiris/rust-gvm/pull/67
+  - Added typed response models for version/auth/target/scan_config/scanner/port_list.
+- **Phase 2 merged** — PR #68:
+  - https://github.com/clawosiris/rust-gvm/pull/68
+  - Added typed response models for task/report/result domains.
+- OpenSpec was updated in-line with implementation PRs, including detailed test inventory per phase.
+
+### Security Process Work (issues filed + implementation started)
+- Filed assessment-driven issues:
+  - #69 cargo-vet: https://github.com/clawosiris/rust-gvm/issues/69
+  - #70 cargo-geiger: https://github.com/clawosiris/rust-gvm/issues/70
+  - #71 cargo-crev (deferred): https://github.com/clawosiris/rust-gvm/issues/71
+  - #72 OpenSSF Scorecard: https://github.com/clawosiris/rust-gvm/issues/72
+- Implementation PR opened for #69 + #70:
+  - **PR #73** — https://github.com/clawosiris/rust-gvm/pull/73
+  - Adds cargo-vet (`supply-chain/`) + cargo-geiger reporting + workspace unsafe gate.

--- a/journal/2026-03-26.md
+++ b/journal/2026-03-26.md
@@ -1,0 +1,50 @@
+# 2026-03-26 — GMP Bug Fixes, E2E Integration, v0.3.0/v0.3.1 Releases
+
+## Releases
+- **v0.3.0** (2026-03-24) — Major release: E2E cross-repo dispatch, release pipeline overhaul, russh 0.58.0
+- **v0.3.1** (2026-03-24) — Patch release: GMP bug fixes for schedules and tags (from E2E findings)
+- Several alpha pre-releases (v0.3.0-alpha.8 through v0.3.0-alpha.10) during pipeline stabilization
+
+## GMP Protocol Fixes (from E2E test findings)
+
+### iCalendar Schedule Support (PR #64, fixes #61)
+- `create_schedule` was using legacy `first_time`/`period` XML fields
+- GMP 22.4+ requires iCalendar (`VCALENDAR`/`VEVENT` with `RRULE`) format
+- Replaced legacy parameters with proper iCalendar support
+
+### Tag Resource Block Fix (PR #63, fixes #60)
+- `create_tag` XML was not wrapping resources in a `<resources>` block
+- E2E tests against live gvmd exposed the malformed XML
+- Both issues discovered via rust-gvm-e2e-tests#6 (CRUD test suites)
+
+## CI/CD Changes
+
+### E2E Cross-Repo Dispatch (PRs #54, #55, #56)
+- Push to main now triggers E2E tests in `clawosiris/rust-gvm-e2e-tests` via `repository_dispatch`
+- Fixed `client_payload` JSON serialization (#55)
+- Migrated to `greenbone/trigger-workflow` action, removed old in-repo `e2e.yml` (#56)
+
+### Security Advisory Handling (PR #62)
+- RUSTSEC-2026-0074 (via russh → libcrux) temporarily ignored in cargo-audit/deny
+- Tracked in issue #59 — waiting on upstream fix
+
+### Dependency Updates
+- russh 0.57.1 → 0.58.0 (PR #50)
+- Actions group bumped with 8 updates (PR #51, Dependabot)
+- Release workflow consolidated: independent release.yml removed, inlined into orchestrated (#46)
+
+## Issues
+- **Opened:** #59 (RUSTSEC-2026-0074 tracking), #60 (tag XML — closed), #61 (schedule iCalendar — closed)
+- **Closed:** #22 (E2E harness), #23 (python-gvm gaps), #24 (large-response generator), #49 (persistent volumes), #52 (upstream python-gvm v26.11.1 review), #60, #61
+
+## Open Issues
+- [#59](https://github.com/clawosiris/rust-gvm/issues/59) — RUSTSEC-2026-0074 via russh/libcrux
+- [#38](https://github.com/clawosiris/rust-gvm/issues/38) — Architecture: gvm-gateway concept
+- [#20](https://github.com/clawosiris/rust-gvm/issues/20) — SBOM quality improvements
+- [#9](https://github.com/clawosiris/rust-gvm/issues/9) — Record-and-replay support
+- [#7](https://github.com/clawosiris/rust-gvm/issues/7) — TLS client cert authentication
+- [#4](https://github.com/clawosiris/rust-gvm/issues/4) — Large-response streaming strategy
+
+## CI Health
+- **Main branch**: ✅ Green (nightly 2026-03-25 passing)
+- **Security**: ⚠️ RUSTSEC-2026-0074 ignored (tracked)


### PR DESCRIPTION
Adds/updates journal entries for the last couple of days:

- new `journal/2026-03-25.md` (Response Models RFC kickoff)
- addendum in `journal/2026-03-26.md` (Phase 1/2 merges, security issues #69-#72, and implementation PR #73)

References:
- https://github.com/clawosiris/rust-gvm/pull/65
- https://github.com/clawosiris/rust-gvm/pull/67
- https://github.com/clawosiris/rust-gvm/pull/68
- https://github.com/clawosiris/rust-gvm/pull/73
- https://github.com/clawosiris/rust-gvm/issues/69
- https://github.com/clawosiris/rust-gvm/issues/70
- https://github.com/clawosiris/rust-gvm/issues/71
- https://github.com/clawosiris/rust-gvm/issues/72
