### PR TITLE
ci(fuzz): add cargo-fuzz infrastructure and initial targets

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+corpus/
+artifacts/
+target/

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "gvm-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+license = "AGPL-3.0-or-later"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+
+[dependencies.gvm-protocol]
+path = "../crates/gvm-protocol"
+
+[dependencies.gvm-gmp]
+path = "../crates/gvm-gmp"
+features = ["serde"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_xml_parser"
+path = "fuzz_targets/fuzz_xml_parser.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_response_parser"
+path = "fuzz_targets/fuzz_response_parser.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,52 @@
+# Fuzz Testing for rust-gvm
+
+This directory contains fuzz targets for testing rust-gvm's XML and response parsing.
+
+## Prerequisites
+
+Install `cargo-fuzz`:
+
+```bash
+cargo install cargo-fuzz
+```
+
+Requires nightly Rust:
+
+```bash
+rustup install nightly
+```
+
+## Running Fuzz Targets
+
+From the repository root:
+
+```bash
+# Fuzz the low-level XML parser
+cargo +nightly fuzz run fuzz_xml_parser
+
+# Fuzz the high-level response model parsers
+cargo +nightly fuzz run fuzz_response_parser
+```
+
+## Fuzz Targets
+
+| Target | Description |
+|--------|-------------|
+| `fuzz_xml_parser` | Tests `gvm-protocol::Response` construction from arbitrary bytes |
+| `fuzz_response_parser` | Tests typed response parsers in `gvm-gmp::responses` |
+
+## Corpus
+
+Fuzz corpus is stored in `fuzz/corpus/<target>/`. Seed inputs can be added manually.
+
+## Artifacts
+
+Crash inputs are saved to `fuzz/artifacts/<target>/`. These should be converted to regression tests.
+
+## CI Integration
+
+Fuzzing is not run in CI by default (it's time-unbounded). For CI smoke tests, use:
+
+```bash
+cargo +nightly fuzz run fuzz_xml_parser -- -max_total_time=60
+```

--- a/fuzz/fuzz_targets/fuzz_response_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_response_parser.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Fuzz target for high-level GMP response model parsing.
+//!
+//! Tests the typed response parsers in `gvm-gmp::responses`.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Try to interpret bytes as UTF-8 XML
+    if let Ok(s) = std::str::from_utf8(data) {
+        let response = gvm_protocol::Response::from(s);
+
+        // Try parsing as various response types — all should handle malformed input gracefully
+        let _ = gvm_gmp::responses::version::GetVersionResponse::from_response(&response);
+        let _ = gvm_gmp::responses::auth::AuthenticateResponse::from_response(&response);
+        let _ = gvm_gmp::responses::target::GetTargetsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::task::GetTasksResponse::from_response(&response);
+        let _ = gvm_gmp::responses::report::GetReportsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::result::GetResultsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::nvt::GetNvtsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::feed::GetFeedsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::scanner::GetScannersResponse::from_response(&response);
+        let _ = gvm_gmp::responses::scan_config::GetScanConfigsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::port_list::GetPortListsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::secinfo::GetCvesResponse::from_response(&response);
+        let _ = gvm_gmp::responses::secinfo::GetCpesResponse::from_response(&response);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_xml_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_xml_parser.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Fuzz target for low-level XML response parsing.
+//!
+//! Tests the `gvm-protocol` Response type which wraps raw XML data.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Try to interpret bytes as UTF-8 XML
+    if let Ok(s) = std::str::from_utf8(data) {
+        // Construct a Response from the string data
+        let response = gvm_protocol::Response::from(s);
+        // Access data to ensure no panics
+        let _ = response.data();
+        let _ = response.status();
+        let _ = response.status_text();
+    }
+});


### PR DESCRIPTION
## Summary
Sets up the cargo-fuzz infrastructure for rust-gvm fuzzing.

## What's included
- `fuzz/Cargo.toml`: standalone fuzz crate with libfuzzer-sys + arbitrary
- `fuzz_xml_parser`: fuzzes `gvm-protocol::Response` construction from arbitrary bytes
- `fuzz_response_parser`: fuzzes typed response model parsers in `gvm-gmp::responses`
- `fuzz/README.md`: usage instructions

## Usage
```bash
cargo +nightly fuzz run fuzz_xml_parser
cargo +nightly fuzz run fuzz_response_parser
```

## Next steps
Detailed harness design and coverage targets documented in a separate OpenSpec (to follow).

Part of #72
