### PR TITLE
ci: add OpenSSF Scorecard for security posture assessment

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly on Sunday at 03:00 UTC
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds OpenSSF Scorecard to CI for automated security health assessment.

## What This Does

- Runs on main branch pushes and weekly (Sunday 03:00 UTC)
- Publishes results to GitHub Security tab via SARIF upload
- Uses **SHA-pinned actions** (not tag-based) for supply chain security

## Scorecard Checks

OpenSSF Scorecard audits project-level security practices:

| Check | What It Measures |
|-------|-----------------|
| Branch-Protection | Are branch rules enforced? |
| Code-Review | PR-based workflow? |
| CI-Tests | Comprehensive CI? |
| Dependency-Update | Dependabot active? |
| Pinned-Dependencies | SHA-pinned actions? |
| Token-Permissions | Minimal permissions? |
| SAST | Static analysis beyond clippy? |
| Fuzzing | Fuzz testing for parsers? |
| Signed-Releases | Artifact signing? |
| Vulnerabilities | Known CVEs addressed? |

## Why Now

Per #72, this provides:
- Concrete checklist for hardening (instead of guessing)
- Visibility into SAST and fuzzing gaps
- Supply chain security baseline

## Action Pinning

All actions use SHA references (not tags like `@v4`):
```yaml
actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186  # v2.4.1
github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f  # v3.28.18
```

This prevents supply chain attacks on CI (recommended by Scorecard itself).

Refs #72