### PR TITLE
fix(ci): fix Semgrep checkout on private repo

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -137,11 +137,14 @@ jobs:
     name: Semgrep SAST
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run Semgrep
         uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config: >-
             p/rust


### PR DESCRIPTION
## Problem

Semgrep SAST job was failing with:
```
fatal: repository 'https://github.com/clawosiris/rust-gvm/' not found
```

The Semgrep action container attempts its own checkout but doesn't inherit proper credentials for private repos.

## Fix

1. Add `contents: read` permission to allow GITHUB_TOKEN to access private repo
2. Explicitly pass `GITHUB_TOKEN` to Semgrep action via env var

## Testing

This PR itself will validate the fix — if Semgrep passes, the fix works.