### PR TITLE
fix: address Semgrep findings in gvm-mock-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,6 @@ dependencies = [
  "russh",
  "rustls",
  "rustls-pemfile",
- "sha1 0.10.6",
  "tempfile",
  "tokio",
  "tokio-rustls",
@@ -2321,6 +2320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2792,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # UUID
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v5"] }
 sha1 = "0.10"
 
 # TLS (feature-gated)

--- a/crates/gvm-mock-server/Cargo.toml
+++ b/crates/gvm-mock-server/Cargo.toml
@@ -26,7 +26,7 @@ quick-xml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sha1.workspace = true
+tempfile.workspace = true
 clap.workspace = true
 
 # Feature-gated
@@ -39,7 +39,6 @@ russh = { workspace = true, optional = true }
 gvm-gmp.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
-tempfile.workspace = true
 tokio-test.workspace = true
 
 [package.metadata.cargo-machete]

--- a/crates/gvm-mock-server/src/builder.rs
+++ b/crates/gvm-mock-server/src/builder.rs
@@ -5,11 +5,13 @@
 
 use std::path::PathBuf;
 
+use tempfile::Builder;
+
 use crate::fault::{Fault, FaultEngine};
 use crate::fixtures::FixtureStore;
 use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
-use crate::server::MockGmpServer;
+use crate::server::{MockGmpServer, UnixSocketBinding};
 use crate::store::ResourceStore;
 use crate::version::GmpVersion;
 use crate::ServerMode;
@@ -209,7 +211,10 @@ impl MockGmpServerBuilder {
         match transport {
             Transport::UnixSocket(path) => {
                 MockGmpServer::start_unix(
-                    path,
+                    UnixSocketBinding {
+                        path,
+                        temp_dir: None,
+                    },
                     mode,
                     version,
                     fixtures,
@@ -224,10 +229,14 @@ impl MockGmpServerBuilder {
                 use std::sync::atomic::{AtomicU64, Ordering};
                 static COUNTER: AtomicU64 = AtomicU64::new(0);
                 let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-                let dir = std::env::temp_dir();
-                let path = dir.join(format!("gvmd-test-{}-{id}.sock", std::process::id()));
+                // Keep the socket under /tmp so Unix domain path length stays well below SUN_LEN.
+                let dir = Builder::new().prefix("gvmd-test").tempdir_in("/tmp")?;
+                let path = dir.path().join(format!("{id}.sock"));
                 MockGmpServer::start_unix(
-                    path,
+                    UnixSocketBinding {
+                        path,
+                        temp_dir: Some(dir),
+                    },
                     mode,
                     version,
                     fixtures,

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -5,7 +5,6 @@
 
 use std::fmt::Write;
 
-use sha1::{Digest, Sha1};
 use uuid::Uuid;
 
 use crate::util::xml_escape_attr;
@@ -251,7 +250,7 @@ pub fn generate_large_report(report_id: Uuid, config: &LargeReportConfig) -> Str
     .expect("writing XML into String should not fail");
 
     for i in 0..config.result_count {
-        let result_id = uuid_v5(report_id, &(i as u64).to_le_bytes());
+        let result_id = Uuid::new_v5(&report_id, &(i as u64).to_le_bytes());
         let host_octet = (i % 254) + 1;
         let port = PORTS[i % PORTS.len()];
         let severity = SEVERITIES[i % SEVERITIES.len()];
@@ -308,19 +307,6 @@ fn threat_for_severity(severity: &str) -> &'static str {
         "5.0" | "6.5" => "Medium",
         _ => "High",
     }
-}
-
-fn uuid_v5(namespace: Uuid, name: &[u8]) -> Uuid {
-    let mut hasher = Sha1::new();
-    hasher.update(namespace.as_bytes());
-    hasher.update(name);
-
-    let mut bytes = [0_u8; 16];
-    bytes.copy_from_slice(&hasher.finalize()[..16]);
-    bytes[6] = (bytes[6] & 0x0f) | 0x50;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-
-    Uuid::from_bytes(bytes)
 }
 
 #[cfg(test)]

--- a/crates/gvm-mock-server/src/server.rs
+++ b/crates/gvm-mock-server/src/server.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
+use tempfile::TempDir;
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
@@ -23,10 +24,17 @@ use crate::store::ResourceStore;
 use crate::version::GmpVersion;
 use crate::ServerMode;
 
+pub(crate) struct UnixSocketBinding {
+    pub(crate) path: PathBuf,
+    pub(crate) temp_dir: Option<TempDir>,
+}
+
 /// A running mock GMP server.
 pub struct MockGmpServer {
     /// The Unix socket path (if using Unix transport).
     socket_path: Option<PathBuf>,
+    /// Keeps the auto-generated Unix socket directory alive for the server lifetime.
+    _socket_dir: Option<TempDir>,
     /// The TCP address (if using TCP transport).
     tcp_addr: Option<std::net::SocketAddr>,
     /// The SSH address (if using SSH transport).
@@ -51,7 +59,7 @@ impl MockGmpServer {
 
     /// Create and start a new mock server from components.
     pub(crate) async fn start_unix(
-        socket_path: PathBuf,
+        binding: UnixSocketBinding,
         mode: ServerMode,
         version: GmpVersion,
         fixtures: Option<FixtureStore>,
@@ -60,6 +68,11 @@ impl MockGmpServer {
         scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
         large_report: Option<LargeReportConfig>,
     ) -> Result<Self, std::io::Error> {
+        let UnixSocketBinding {
+            path: socket_path,
+            temp_dir,
+        } = binding;
+
         // Remove existing socket if present
         if socket_path.exists() {
             std::fs::remove_file(&socket_path)?;
@@ -88,6 +101,7 @@ impl MockGmpServer {
 
         Ok(Self {
             socket_path: Some(socket_path),
+            _socket_dir: temp_dir,
             tcp_addr: None,
             #[cfg(feature = "ssh")]
             ssh_addr: None,
@@ -134,6 +148,7 @@ impl MockGmpServer {
 
         Ok(Self {
             socket_path: None,
+            _socket_dir: None,
             tcp_addr: Some(local_addr),
             #[cfg(feature = "ssh")]
             ssh_addr: None,
@@ -185,6 +200,7 @@ impl MockGmpServer {
 
         Ok(Self {
             socket_path: None,
+            _socket_dir: None,
             tcp_addr: None,
             ssh_addr: Some(local_addr),
             ssh_host_key_fingerprint: Some(fingerprint),

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -288,7 +288,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
 version = "2.3.0"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
 version = "0.13.1"
@@ -500,7 +500,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.lock_api]]
 version = "0.4.14"
@@ -744,7 +744,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustix]]
 version = "1.1.4"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
 version = "0.23.37"
@@ -818,6 +818,10 @@ criteria = "safe-to-deploy"
 version = "0.11.0-rc.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.sha1_smol]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.sha2]]
 version = "0.10.9"
 criteria = "safe-to-deploy"
@@ -888,7 +892,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.27.0"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
 version = "1.0.69"


### PR DESCRIPTION
## Summary
- replace insecure auto Unix socket temp path generation with a private  directory retained for the mock server lifetime
- replace the manual UUID v5 SHA-1 implementation with 
- enable UUID v5 support in the workspace and move  into normal dependencies for 

## Verification
- 
- 
- 
running 8 tests
test version::tests::maps_known_supported_versions ... ok
test version::tests::parses_major_minor ... ok
test version::tests::maps_newer_minor_to_next_compatible_version ... ok
test version::tests::rejects_invalid_versions ... ok
test version::tests::parses_major_minor_with_patch_suffix ... ok
test version::tests::rejects_malformed_version_strings ... ok
test version::tests::rejects_unsupported_versions ... ok
test version::tests::trims_whitespace ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 10 tests
test create_target_and_get_targets_succeed ... FAILED
test connect_negotiates_supported_versions ... FAILED
test authenticate_succeeds ... FAILED
test full_crud_lifecycle_succeeds ... FAILED
test send_after_disconnect_returns_connection_error ... FAILED
test disconnect_leaves_transport_disconnected ... FAILED
test server_error_maps_to_gvm_error ... FAILED
test unsupported_version_returns_error ... FAILED
test connect_negotiates_version_22_5 ... FAILED
test versioned_enum_returns_v225_for_default_mock_server ... FAILED

failures:

---- create_target_and_get_targets_succeed stdout ----

thread 'create_target_and_get_targets_succeed' (2985143) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- connect_negotiates_supported_versions stdout ----

thread 'connect_negotiates_supported_versions' (2985141) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- authenticate_succeeds stdout ----

thread 'authenticate_succeeds' (2985140) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- full_crud_lifecycle_succeeds stdout ----

thread 'full_crud_lifecycle_succeeds' (2985146) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- send_after_disconnect_returns_connection_error stdout ----

thread 'send_after_disconnect_returns_connection_error' (2985147) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- disconnect_leaves_transport_disconnected stdout ----

thread 'disconnect_leaves_transport_disconnected' (2985145) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- server_error_maps_to_gvm_error stdout ----

thread 'server_error_maps_to_gvm_error' (2985148) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- unsupported_version_returns_error stdout ----

thread 'unsupported_version_returns_error' (2985149) panicked at crates/gvm-client/tests/client_integration.rs:62:23:
server should start: path must be shorter than SUN_LEN

---- connect_negotiates_version_22_5 stdout ----

thread 'connect_negotiates_version_22_5' (2985142) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN

---- versioned_enum_returns_v225_for_default_mock_server stdout ----

thread 'versioned_enum_returns_v225_for_default_mock_server' (2985150) panicked at crates/gvm-client/tests/client_integration.rs:43:23:
server should start: path must be shorter than SUN_LEN


failures:
    authenticate_succeeds
    connect_negotiates_supported_versions
    connect_negotiates_version_22_5
    create_target_and_get_targets_succeed
    disconnect_leaves_transport_disconnected
    full_crud_lifecycle_succeeds
    send_after_disconnect_returns_connection_error
    server_error_maps_to_gvm_error
    unsupported_version_returns_error
    versioned_enum_returns_v225_for_default_mock_server

test result: FAILED. 0 passed; 10 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

Closes #84
Closes #85