### PR TITLE
fix(ci): skip Scorecard on private repos

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,9 @@ jobs:
   scorecard:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # Scorecard requires public repo access; skip on private repos
+    # Remove this condition when the repo becomes public
+    if: ${{ github.event.repository.visibility == 'public' }}
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
## Problem

OpenSSF Scorecard workflow fails on private repos with:
```
Resource not accessible by integration
```

Scorecard uses GraphQL queries that require public repo access.

## Fix

Added `if: ${{ github.event.repository.visibility == 'public' }}` condition to skip the job on private repos.

## When to Remove

Remove the condition when the repo becomes public — Scorecard will then run automatically.