### PR TITLE
journal: 2026-03-28 — Fuzz harnesses, Semgrep SAST, OpenSSF Scorecard

### DIFF
--- a/journal/2026-03-28.md
+++ b/journal/2026-03-28.md
@@ -1,0 +1,46 @@
+# 2026-03-28 — Fuzz Harnesses, Semgrep SAST, OpenSSF Scorecard, Security Fixes
+
+## Security Tooling
+
+### Semgrep SAST (PR #77)
+- Added Semgrep static analysis with SARIF upload to CI
+- README badge added for security scan status
+- Follow-up fixes for private repo compatibility:
+  - PR #82 — Added `contents:read` permission and `GITHUB_TOKEN` passthrough for Semgrep checkout
+  - PR #83 — Added `actions:read` permission for SARIF upload
+  - Made SARIF upload non-blocking until code scanning is enabled on the repo
+
+### Semgrep Findings Remediation (PR #87)
+- Addressed Semgrep findings in gvm-mock-server
+- Security issues filed and closed:
+  - #84 — Insecure `temp_dir` usage in gvm-mock-server (closed)
+  - #85 — Insecure SHA-1 hash usage in gvm-mock-server (closed)
+
+### OpenSSF Scorecard (PRs #81, #88)
+- Added OpenSSF Scorecard workflow for security posture assessment (PR #81, closes #72)
+- Follow-up fix: skip Scorecard on private repos where token scopes are insufficient (PR #88)
+
+## Fuzzing Infrastructure
+
+### Fuzz OpenSpec (PR #79)
+- Added specification for fuzz harness design covering P1 and P2 targets
+- Defines corpus seeding strategy, coverage goals, and CI integration plan
+
+### P1 Fuzz Harnesses (PR #80)
+- Implemented priority-1 fuzz targets using cargo-fuzz:
+  - GMP XML parsing harnesses
+  - Protocol message handling
+- CI infrastructure for cargo-fuzz added (PR #78)
+
+## Documentation
+- Response models RFC merged (PR #65) — encapsulation design for typed GMP responses
+- E2E openspec removed from this repo (PR #86) — moved to rust-gvm-e2e-tests where it belongs
+
+## Issues
+- **Opened:** #76 (comma-separated list properties as vectors in responses)
+- **Closed:** #72 (OpenSSF Scorecard — done), #84 (temp_dir — done), #85 (SHA-1 — done)
+
+## CI Health
+- **Main branch**: ✅ Green
+- **Security scans**: ✅ Semgrep SAST active, OpenSSF Scorecard configured
+- **Fuzzing**: ✅ P1 harnesses in CI

--- a/journal/2026-03-28.md
+++ b/journal/2026-03-28.md
@@ -36,8 +36,12 @@
 - Response models RFC merged (PR #65) — encapsulation design for typed GMP responses
 - E2E openspec removed from this repo (PR #86) — moved to rust-gvm-e2e-tests where it belongs
 
+## In Progress
+- **PR #90** — Security: harden GitHub Actions workflows (open)
+  - Addresses workflow security posture identified by Scorecard analysis
+
 ## Issues
-- **Opened:** #76 (comma-separated list properties as vectors in responses)
+- **Opened:** #76 (comma-separated list properties as vectors in responses), #91 (OpenSSF Scorecard analysis of external actions), #92 (code review of external GitHub Actions), #93 (audit GitHub Actions with OpenSSF Scorecard)
 - **Closed:** #72 (OpenSSF Scorecard — done), #84 (temp_dir — done), #85 (SHA-1 — done)
 
 ## CI Health


### PR DESCRIPTION
Daily journal entry covering:
- P1 fuzz harnesses and cargo-fuzz CI infrastructure (PRs #78-#80)
- Semgrep SAST integration with SARIF upload (PRs #77, #82, #83, #87)
- OpenSSF Scorecard workflow (PRs #81, #88)
- Security findings remediation (#84, #85)
- Response models RFC merged (#65)
- E2E openspec relocated to rust-gvm-e2e-tests (#86)