### PR TITLE
feat(gmp): add typed response models — Phase 4 (remaining entities)

### DIFF
--- a/PHASE4_SPEC.md
+++ b/PHASE4_SPEC.md
@@ -1,0 +1,389 @@
+# Phase 4: Response Models Implementation Spec
+
+## Task
+
+Implement Phase 4 of the response models OpenSpec for rust-gvm. This adds typed response models for all remaining GMP entities.
+
+**Reference the existing pattern exactly.** Look at `crates/gvm-gmp/src/responses/target.rs` as the canonical template. Every new module MUST follow this pattern precisely.
+
+## Architecture Rules
+
+1. All files go in `crates/gvm-gmp/src/responses/`
+2. Every public struct gets `#[derive(Debug, Clone, PartialEq, Eq)]`, `#[non_exhaustive]`, and `#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]`
+3. Use helpers from `common.rs`: `parse_entity_meta`, `parse_named_entity`, `count_info`, `optional_u32`, `parse_bool`, `status_from_response`, `parse_document`, `parse_entity_id`, `ActionResponse`, etc.
+4. SPDX header: `// SPDX-License-Identifier: AGPL-3.0-or-later` + `// SPDX-FileCopyrightText: 2026 Greenbone AG`
+5. Each domain has: Entity struct, GetXxxResponse (list), CreateXxxResponse, type aliases for Modify/Delete
+6. `from_response(&Response) -> Result<Self, ParseError>` on all response types
+7. Entity parsing via `fn from_node(node: &XmlNode) -> Result<Self, ParseError>` (crate-private)
+8. Timestamps as `Option<String>` (ISO 8601)
+9. Booleans from `"1"/"0"` via `parse_bool`
+10. Optional fields → `Option<T>`, missing = `None`
+
+## Modules to Create (17 files)
+
+### 1. `alert.rs`
+```rust
+pub struct Alert {
+    pub meta: EntityMeta,
+    pub event: Option<String>,        // e.g. "task_run_status_changed"
+    pub condition: Option<String>,     // e.g. "always"
+    pub method: Option<String>,        // e.g. "email"
+    pub filter: Option<NamedEntity>,   // filter ref
+    pub active: bool,                  // "1"/"0"
+}
+pub struct GetAlertsResponse { status, status_text, items: Vec<Alert>, counts: CountInfo }
+pub struct CreateAlertResponse { status, status_text, id: EntityId }
+pub type ModifyAlertResponse = ActionResponse;
+pub type DeleteAlertResponse = ActionResponse;
+```
+Count element: `alert_count`
+
+### 2. `credential.rs`
+```rust
+pub struct Credential {
+    pub meta: EntityMeta,
+    pub type_: Option<String>,         // "up", "usk", "cc", "snmp", etc.
+    pub login: Option<String>,
+    pub full_type: Option<String>,     // human-readable type
+    pub allow_insecure: bool,
+}
+pub struct GetCredentialsResponse { ... items: Vec<Credential>, counts }
+pub struct CreateCredentialResponse { ... id }
+pub type ModifyCredentialResponse = ActionResponse;
+pub type DeleteCredentialResponse = ActionResponse;
+```
+Count element: `credential_count`
+
+### 3. `filter.rs`
+```rust
+pub struct Filter {
+    pub meta: EntityMeta,
+    pub type_: Option<String>,         // filter type (e.g. "task", "alert")
+    pub term: Option<String>,          // filter expression
+}
+pub struct GetFiltersResponse { ... }
+pub struct CreateFilterResponse { ... }
+pub type ModifyFilterResponse = ActionResponse;
+pub type DeleteFilterResponse = ActionResponse;
+```
+Count element: `filter_count`
+
+### 4. `note.rs`
+```rust
+pub struct Note {
+    pub meta: EntityMeta,
+    pub text: Option<String>,
+    pub nvt_oid: Option<String>,       // from <nvt oid="..."> attribute
+    pub hosts: Option<String>,
+    pub port: Option<String>,
+    pub severity: Option<String>,
+    pub task: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub active: bool,
+    pub end_time: Option<String>,
+}
+pub struct GetNotesResponse { ... }
+pub struct CreateNoteResponse { ... }
+pub type ModifyNoteResponse = ActionResponse;
+pub type DeleteNoteResponse = ActionResponse;
+```
+Count element: `note_count`
+Note: `nvt_oid` is parsed from `<nvt oid="...">` attribute (child element named "nvt", get its "oid" attribute).
+
+### 5. `override_.rs`
+```rust
+pub struct Override {
+    pub meta: EntityMeta,
+    pub text: Option<String>,
+    pub nvt_oid: Option<String>,       // from <nvt oid="..."> attribute
+    pub hosts: Option<String>,
+    pub port: Option<String>,
+    pub severity: Option<String>,
+    pub new_severity: Option<String>,
+    pub task: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub active: bool,
+    pub end_time: Option<String>,
+}
+pub struct GetOverridesResponse { ... }
+pub struct CreateOverrideResponse { ... }
+pub type ModifyOverrideResponse = ActionResponse;
+pub type DeleteOverrideResponse = ActionResponse;
+```
+Count element: `override_count`
+
+### 6. `schedule.rs`
+```rust
+pub struct Schedule {
+    pub meta: EntityMeta,
+    pub icalendar: Option<String>,     // iCalendar data
+    pub timezone: Option<String>,
+    pub duration: Option<String>,
+}
+pub struct GetSchedulesResponse { ... }
+pub struct CreateScheduleResponse { ... }
+pub type ModifyScheduleResponse = ActionResponse;
+pub type DeleteScheduleResponse = ActionResponse;
+```
+Count element: `schedule_count`
+
+### 7. `tag.rs`
+```rust
+pub struct Tag {
+    pub meta: EntityMeta,
+    pub value: Option<String>,
+    pub resource_type: Option<String>,
+    pub resource_count: Option<u32>,   // from <resources><type>X</type><count><total>N</total></count></resources>
+    pub active: bool,
+}
+pub struct GetTagsResponse { ... }
+pub struct CreateTagResponse { ... }
+pub type ModifyTagResponse = ActionResponse;
+pub type DeleteTagResponse = ActionResponse;
+```
+Count element: `tag_count`
+For resource_type/resource_count, parse from `<resources>` child: `<type>` text and `<count><total>` text.
+
+### 8. `ticket.rs`
+```rust
+pub struct Ticket {
+    pub meta: EntityMeta,
+    pub status: Option<String>,         // "Open", "Fixed", "Closed"
+    pub assigned_to: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub task: Option<NamedEntity>,
+    pub open_note: Option<String>,
+    pub fixed_note: Option<String>,
+    pub closed_note: Option<String>,
+}
+pub struct GetTicketsResponse { ... }
+pub struct CreateTicketResponse { ... }
+pub type ModifyTicketResponse = ActionResponse;
+pub type DeleteTicketResponse = ActionResponse;
+```
+Count element: `ticket_count`
+
+### 9. `user.rs`
+```rust
+pub struct User {
+    pub meta: EntityMeta,
+    pub roles: Vec<NamedEntity>,        // multiple <role> children
+    pub groups: Vec<NamedEntity>,       // multiple <group> children (note: groups is parent, group is child — parse <groups><group id=...><name>...</name></group></groups>)
+    pub hosts_allow: Option<String>,    // "0" or "1"
+    pub hosts: Option<String>,
+}
+pub struct GetUsersResponse { ... }
+pub struct CreateUserResponse { ... }
+pub type ModifyUserResponse = ActionResponse;
+pub type DeleteUserResponse = ActionResponse;
+```
+Count element: `user_count`
+Roles: iterate `node.children_named("role")` and parse each as NamedEntity (id attr + name child).
+Groups: find `<groups>` child, then iterate its `<group>` children.
+
+### 10. `group.rs`
+```rust
+pub struct Group {
+    pub meta: EntityMeta,
+    pub users: Option<String>,          // comma-separated user names
+}
+pub struct GetGroupsResponse { ... }
+pub struct CreateGroupResponse { ... }
+pub type ModifyGroupResponse = ActionResponse;
+pub type DeleteGroupResponse = ActionResponse;
+```
+Count element: `group_count`
+
+### 11. `role.rs`
+```rust
+pub struct Role {
+    pub meta: EntityMeta,
+    pub users: Option<String>,          // comma-separated user names
+}
+pub struct GetRolesResponse { ... }
+pub struct CreateRoleResponse { ... }
+pub type ModifyRoleResponse = ActionResponse;
+pub type DeleteRoleResponse = ActionResponse;
+```
+Count element: `role_count`
+
+### 12. `permission.rs`
+```rust
+pub struct Permission {
+    pub meta: EntityMeta,
+    pub subject_type: Option<String>,   // from <subject><type>...</type></subject>
+    pub subject: Option<NamedEntity>,   // <subject id="..."><name>...</name></subject> — id from attr, name from child
+    pub resource_type: Option<String>,  // from <resource><type>...</type></resource>
+    pub resource: Option<NamedEntity>,  // <resource id="..."><name>...</name></resource>
+}
+pub struct GetPermissionsResponse { ... }
+pub struct CreatePermissionResponse { ... }
+pub type ModifyPermissionResponse = ActionResponse;
+pub type DeletePermissionResponse = ActionResponse;
+```
+Count element: `permission_count`
+For subject/resource: parse the child element, extract id from attribute, name from `<name>` child, type from `<type>` child.
+
+### 13. `host.rs`
+```rust
+pub struct Host {
+    pub meta: EntityMeta,
+    pub ip: Option<String>,             // from <identifiers><identifier><name>ip</name><value>...</value></identifier></identifiers> OR direct <ip> child if present
+    pub hostname: Option<String>,
+    pub severity: Option<String>,       // from <host><severity><value>...</value></severity></host> or direct <severity> child text
+    pub os: Option<String>,             // <os> child text
+}
+pub struct GetHostsResponse { ... }
+pub struct CreateHostResponse { ... }
+pub type ModifyHostResponse = ActionResponse;
+pub type DeleteHostResponse = ActionResponse;
+```
+Count element: `asset_count` (hosts use the asset endpoint, count element is `asset_count`)
+IMPORTANT: GMP hosts come from `get_assets` response, so the list tag is `<asset>` not `<host>`. The entity nodes are named `asset`, with type=host. Parse items from `node.children_named("asset")`.
+
+Actually, looking more carefully at GMP, `get_hosts` returns a `get_assets_response` with `<asset>` children. Let me simplify: keep the entity as `Host` but the response parses `<asset>` nodes and uses `asset_count`.
+
+### 14. `tls_certificate.rs`
+```rust
+pub struct TlsCertificate {
+    pub meta: EntityMeta,
+    pub certificate: Option<String>,    // base64 cert data
+    pub issuer_dn: Option<String>,
+    pub activation_time: Option<String>,
+    pub expiration_time: Option<String>,
+    pub md5_fingerprint: Option<String>,
+    pub sha256_fingerprint: Option<String>,
+    pub subject_dn: Option<String>,
+    pub valid: bool,
+}
+pub struct GetTlsCertificatesResponse { ... }
+pub struct CreateTlsCertificateResponse { ... }
+pub type ModifyTlsCertificateResponse = ActionResponse;
+pub type DeleteTlsCertificateResponse = ActionResponse;
+```
+Count element: `tls_certificate_count`
+
+### 15. `system.rs`
+```rust
+pub struct Setting {
+    pub id: EntityId,                   // from id attribute
+    pub name: String,
+    pub comment: Option<String>,
+    pub value: Option<String>,
+}
+pub struct GetSettingsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Setting>,
+    // no counts for settings typically
+}
+
+pub struct HelpResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub help_text: String,              // body text of the response
+}
+
+pub struct DescribeAuthResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub groups: Vec<AuthGroup>,         // <group name="..."><auth_conf_setting>...</auth_conf_setting></group>
+}
+pub struct AuthGroup {
+    pub name: String,
+    pub settings: Vec<AuthConfSetting>,
+}
+pub struct AuthConfSetting {
+    pub key: Option<String>,
+    pub value: Option<String>,
+}
+```
+Note: Settings don't have EntityMeta (no owner, in_use, writable, etc.) — they have a simpler structure. Parse `<setting id="..."><name>...</name><comment>...</comment><value>...</value></setting>`.
+
+### 16. `report_format.rs`
+```rust
+pub struct ReportFormat {
+    pub meta: EntityMeta,
+    pub content_type: Option<String>,
+    pub extension: Option<String>,
+    pub summary: Option<String>,
+    pub trust: Option<String>,          // "yes"/"no"
+    pub active: bool,
+    pub predefined: bool,
+}
+pub struct GetReportFormatsResponse { ... }
+pub struct CreateReportFormatResponse { ... }
+pub type ModifyReportFormatResponse = ActionResponse;
+pub type DeleteReportFormatResponse = ActionResponse;
+```
+Count element: `report_format_count`
+
+### 17. `report_config.rs`
+```rust
+pub struct ReportConfig {
+    pub meta: EntityMeta,
+    pub report_format: Option<NamedEntity>,  // ref to report format
+}
+pub struct GetReportConfigsResponse { ... }
+pub struct CreateReportConfigResponse { ... }
+pub type ModifyReportConfigResponse = ActionResponse;
+pub type DeleteReportConfigResponse = ActionResponse;
+```
+Count element: `report_config_count`
+
+## mod.rs Updates
+
+Add all 17 new modules to `crates/gvm-gmp/src/responses/mod.rs`:
+```rust
+pub mod alert;
+pub mod credential;
+pub mod filter;
+pub mod group;
+pub mod host;
+pub mod note;
+pub mod override_;
+pub mod permission;
+pub mod report_config;
+pub mod report_format;
+pub mod role;
+pub mod schedule;
+pub mod system;
+pub mod tag;
+pub mod ticket;
+pub mod tls_certificate;
+pub mod user;
+```
+
+Add re-exports for all public types following the existing pattern.
+
+## Testing
+
+Each module MUST have these 5 standard tests (matching Phase 1-3 pattern):
+
+1. `parses_multiple_*` — 2 items with all fields populated, validate counts + fields
+2. `parses_empty_*` — 0 items, counts = 0
+3. `parses_create_*_response` — status 201, id extraction (skip for system.rs)
+4. `rejects_server_error` — non-2xx → ParseError::ServerError
+5. `parses_missing_optional_*_fields` — only required fields, all optionals None
+
+For `system.rs`, adapt tests:
+- `parses_multiple_settings` — 2 settings
+- `parses_empty_settings` — 0 settings
+- `parses_help_response` — help text extraction
+- `parses_describe_auth_response` — auth groups + settings
+- `rejects_server_error` — error case
+
+Test XML format: use `Response::from(r#"<get_xxx_response status="200" ...>...</get_xxx_response>"#)`
+
+## Build Verification
+
+After implementation:
+1. `cargo check --all-features -p gvm-gmp` must pass
+2. `cargo test -p gvm-gmp` must pass (all new + existing tests)
+3. `cargo clippy --all-features -p gvm-gmp` must pass
+4. No modifications to existing files except `mod.rs` (add modules + re-exports)
+
+## Branch
+
+Create a feature branch: `feat/response-models-phase4`
+Commit message: `feat(gmp): add typed response models — Phase 4 (remaining entities)`

--- a/crates/gvm-gmp/src/responses/alert.rs
+++ b/crates/gvm-gmp/src/responses/alert.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Alert response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Alert {
+    pub meta: EntityMeta,
+    pub event: Option<String>,
+    pub condition: Option<String>,
+    pub method: Option<String>,
+    pub filter: Option<NamedEntity>,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAlertsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Alert>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateAlertResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Alert {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            event: node.optional_child_text("event"),
+            condition: node.optional_child_text("condition"),
+            method: node.optional_child_text("method"),
+            filter: parse_named_entity(node, "filter")?,
+            active: node
+                .optional_child_text("active")
+                .map(|value| parse_bool(&value, "active"))
+                .transpose()?
+                .unwrap_or(false),
+        })
+    }
+}
+
+impl GetAlertsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("alert")
+            .map(Alert::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "alert_count")?,
+        })
+    }
+}
+
+impl CreateAlertResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyAlertResponse = ActionResponse;
+pub type DeleteAlertResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_alerts() {
+        let response = Response::from(
+            r#"<get_alerts_response status="200" status_text="OK">
+                <alert id="a-1">
+                    <owner><name>admin</name></owner>
+                    <name>Alert One</name>
+                    <comment>first alert</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <event>task_run_status_changed</event>
+                    <condition>always</condition>
+                    <method>email</method>
+                    <filter id="f-1"><name>My Filter</name></filter>
+                    <active>1</active>
+                </alert>
+                <alert id="a-2">
+                    <name>Alert Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <active>0</active>
+                </alert>
+                <alert_count>2<filtered>2</filtered><page>1</page></alert_count>
+            </get_alerts_response>"#,
+        );
+
+        let parsed = GetAlertsResponse::from_response(&response).expect("alerts parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(
+            parsed.items[0].event.as_deref(),
+            Some("task_run_status_changed")
+        );
+        assert_eq!(parsed.items[0].condition.as_deref(), Some("always"));
+        assert_eq!(parsed.items[0].method.as_deref(), Some("email"));
+        assert_eq!(
+            parsed.items[0].filter.as_ref().map(|f| f.name.as_str()),
+            Some("My Filter")
+        );
+        assert!(parsed.items[0].active);
+        assert!(!parsed.items[1].active);
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_alerts() {
+        let response = Response::from(
+            r#"<get_alerts_response status="200" status_text="OK"><alert_count>0<filtered>0</filtered></alert_count></get_alerts_response>"#,
+        );
+
+        let parsed = GetAlertsResponse::from_response(&response).expect("alerts parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_alert_response() {
+        let response = Response::from(
+            r#"<create_alert_response status="201" status_text="OK, resource created" id="a-1"/>"#,
+        );
+
+        let parsed = CreateAlertResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "a-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_alerts_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetAlertsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_alert_fields() {
+        let response = Response::from(
+            r#"<get_alerts_response status="200" status_text="OK">
+                <alert id="a-1">
+                    <name>Only Required</name>
+                </alert>
+            </get_alerts_response>"#,
+        );
+
+        let parsed = GetAlertsResponse::from_response(&response).expect("alerts parse");
+        let alert = &parsed.items[0];
+
+        assert_eq!(alert.meta.comment, None);
+        assert_eq!(alert.event, None);
+        assert_eq!(alert.condition, None);
+        assert_eq!(alert.method, None);
+        assert_eq!(alert.filter, None);
+        assert!(!alert.active);
+    }
+}

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Credential response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Credential {
+    pub meta: EntityMeta,
+    pub type_: Option<String>,
+    pub login: Option<String>,
+    pub full_type: Option<String>,
+    pub allow_insecure: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetCredentialsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Credential>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateCredentialResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Credential {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            type_: node.optional_child_text("type"),
+            login: node.optional_child_text("login"),
+            full_type: node.optional_child_text("full_type"),
+            allow_insecure: node
+                .optional_child_text("allow_insecure")
+                .map(|value| parse_bool(&value, "allow_insecure"))
+                .transpose()?
+                .unwrap_or(false),
+        })
+    }
+}
+
+impl GetCredentialsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("credential")
+            .map(Credential::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "credential_count")?,
+        })
+    }
+}
+
+impl CreateCredentialResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyCredentialResponse = ActionResponse;
+pub type DeleteCredentialResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_credentials() {
+        let response = Response::from(
+            r#"<get_credentials_response status="200" status_text="OK">
+                <credential id="c-1">
+                    <owner><name>admin</name></owner>
+                    <name>Cred One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <type>up</type>
+                    <login>admin</login>
+                    <full_type>Username + Password</full_type>
+                    <allow_insecure>1</allow_insecure>
+                </credential>
+                <credential id="c-2">
+                    <name>Cred Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <allow_insecure>0</allow_insecure>
+                </credential>
+                <credential_count>2<filtered>2</filtered><page>1</page></credential_count>
+            </get_credentials_response>"#,
+        );
+
+        let parsed = GetCredentialsResponse::from_response(&response).expect("credentials parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].type_.as_deref(), Some("up"));
+        assert_eq!(parsed.items[0].login.as_deref(), Some("admin"));
+        assert_eq!(
+            parsed.items[0].full_type.as_deref(),
+            Some("Username + Password")
+        );
+        assert!(parsed.items[0].allow_insecure);
+        assert!(!parsed.items[1].allow_insecure);
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_credentials() {
+        let response = Response::from(
+            r#"<get_credentials_response status="200" status_text="OK"><credential_count>0<filtered>0</filtered></credential_count></get_credentials_response>"#,
+        );
+
+        let parsed = GetCredentialsResponse::from_response(&response).expect("credentials parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_credential_response() {
+        let response = Response::from(
+            r#"<create_credential_response status="201" status_text="OK, resource created" id="c-1"/>"#,
+        );
+
+        let parsed = CreateCredentialResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "c-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_credentials_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetCredentialsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_credential_fields() {
+        let response = Response::from(
+            r#"<get_credentials_response status="200" status_text="OK">
+                <credential id="c-1">
+                    <name>Only Required</name>
+                </credential>
+            </get_credentials_response>"#,
+        );
+
+        let parsed = GetCredentialsResponse::from_response(&response).expect("credentials parse");
+        let cred = &parsed.items[0];
+
+        assert_eq!(cred.meta.comment, None);
+        assert_eq!(cred.type_, None);
+        assert_eq!(cred.login, None);
+        assert_eq!(cred.full_type, None);
+        assert!(!cred.allow_insecure);
+    }
+}

--- a/crates/gvm-gmp/src/responses/filter.rs
+++ b/crates/gvm-gmp/src/responses/filter.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Filter response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Filter {
+    pub meta: EntityMeta,
+    pub type_: Option<String>,
+    pub term: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetFiltersResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Filter>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateFilterResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Filter {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            type_: node.optional_child_text("type"),
+            term: node.optional_child_text("term"),
+        })
+    }
+}
+
+impl GetFiltersResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("filter")
+            .map(Filter::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "filter_count")?,
+        })
+    }
+}
+
+impl CreateFilterResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyFilterResponse = ActionResponse;
+pub type DeleteFilterResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_filters() {
+        let response = Response::from(
+            r#"<get_filters_response status="200" status_text="OK">
+                <filter id="f-1">
+                    <owner><name>admin</name></owner>
+                    <name>Filter One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <type>task</type>
+                    <term>rows=10 first=1 sort=name</term>
+                </filter>
+                <filter id="f-2">
+                    <name>Filter Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <type>alert</type>
+                </filter>
+                <filter_count>2<filtered>2</filtered><page>1</page></filter_count>
+            </get_filters_response>"#,
+        );
+
+        let parsed = GetFiltersResponse::from_response(&response).expect("filters parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].type_.as_deref(), Some("task"));
+        assert_eq!(
+            parsed.items[0].term.as_deref(),
+            Some("rows=10 first=1 sort=name")
+        );
+        assert_eq!(parsed.items[1].type_.as_deref(), Some("alert"));
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_filters() {
+        let response = Response::from(
+            r#"<get_filters_response status="200" status_text="OK"><filter_count>0<filtered>0</filtered></filter_count></get_filters_response>"#,
+        );
+
+        let parsed = GetFiltersResponse::from_response(&response).expect("filters parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_filter_response() {
+        let response = Response::from(
+            r#"<create_filter_response status="201" status_text="OK, resource created" id="f-1"/>"#,
+        );
+
+        let parsed = CreateFilterResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "f-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_filters_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetFiltersResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_filter_fields() {
+        let response = Response::from(
+            r#"<get_filters_response status="200" status_text="OK">
+                <filter id="f-1">
+                    <name>Only Required</name>
+                </filter>
+            </get_filters_response>"#,
+        );
+
+        let parsed = GetFiltersResponse::from_response(&response).expect("filters parse");
+        let filter = &parsed.items[0];
+
+        assert_eq!(filter.meta.comment, None);
+        assert_eq!(filter.type_, None);
+        assert_eq!(filter.term, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/group.rs
+++ b/crates/gvm-gmp/src/responses/group.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Group response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Group {
+    pub meta: EntityMeta,
+    pub users: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetGroupsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Group>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateGroupResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Group {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            users: node.optional_child_text("users"),
+        })
+    }
+}
+
+impl GetGroupsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("group")
+            .map(Group::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "group_count")?,
+        })
+    }
+}
+
+impl CreateGroupResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyGroupResponse = ActionResponse;
+pub type DeleteGroupResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_groups() {
+        let response = Response::from(
+            r#"<get_groups_response status="200" status_text="OK">
+                <group id="g-1">
+                    <owner><name>admin</name></owner>
+                    <name>Group One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <users>alice, bob</users>
+                </group>
+                <group id="g-2">
+                    <name>Group Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </group>
+                <group_count>2<filtered>2</filtered><page>1</page></group_count>
+            </get_groups_response>"#,
+        );
+
+        let parsed = GetGroupsResponse::from_response(&response).expect("groups parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].users.as_deref(), Some("alice, bob"));
+        assert_eq!(
+            parsed.items[0].meta.owner.as_ref().map(|o| o.name.as_str()),
+            Some("admin")
+        );
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_groups() {
+        let response = Response::from(
+            r#"<get_groups_response status="200" status_text="OK"><group_count>0<filtered>0</filtered></group_count></get_groups_response>"#,
+        );
+
+        let parsed = GetGroupsResponse::from_response(&response).expect("groups parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_group_response() {
+        let response = Response::from(
+            r#"<create_group_response status="201" status_text="OK, resource created" id="g-1"/>"#,
+        );
+
+        let parsed = CreateGroupResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "g-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_groups_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetGroupsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_group_fields() {
+        let response = Response::from(
+            r#"<get_groups_response status="200" status_text="OK">
+                <group id="g-1">
+                    <name>Only Required</name>
+                </group>
+            </get_groups_response>"#,
+        );
+
+        let parsed = GetGroupsResponse::from_response(&response).expect("groups parse");
+        let group = &parsed.items[0];
+
+        assert_eq!(group.meta.comment, None);
+        assert_eq!(group.users, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/host.rs
+++ b/crates/gvm-gmp/src/responses/host.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Host (asset) response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Host {
+    pub meta: EntityMeta,
+    pub ip: Option<String>,
+    pub hostname: Option<String>,
+    pub severity: Option<String>,
+    pub os: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetHostsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Host>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateHostResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Host {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let ip = node
+            .child("identifiers")
+            .and_then(|ids| {
+                ids.children_named("identifier")
+                    .find(|id| id.child_text("name").as_deref() == Some("ip"))
+                    .and_then(|id| id.optional_child_text("value"))
+            })
+            .or_else(|| node.optional_child_text("ip"));
+
+        let hostname = node
+            .child("identifiers")
+            .and_then(|ids| {
+                ids.children_named("identifier")
+                    .find(|id| id.child_text("name").as_deref() == Some("hostname"))
+                    .and_then(|id| id.optional_child_text("value"))
+            })
+            .or_else(|| node.optional_child_text("hostname"));
+
+        let severity = node
+            .child("severity")
+            .and_then(|s| {
+                s.optional_child_text("value")
+                    .or_else(|| (!s.text.is_empty()).then_some(s.text.clone()))
+            })
+            .or_else(|| node.optional_child_text("severity"));
+
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            ip,
+            hostname,
+            severity,
+            os: node.optional_child_text("os"),
+        })
+    }
+}
+
+impl GetHostsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("asset")
+            .map(Host::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "asset_count")?,
+        })
+    }
+}
+
+impl CreateHostResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyHostResponse = ActionResponse;
+pub type DeleteHostResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_hosts() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset id="h-1">
+                    <owner><name>admin</name></owner>
+                    <name>Host One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <identifiers>
+                        <identifier>
+                            <name>ip</name>
+                            <value>192.168.1.1</value>
+                        </identifier>
+                        <identifier>
+                            <name>hostname</name>
+                            <value>host1.example.com</value>
+                        </identifier>
+                    </identifiers>
+                    <severity><value>7.5</value></severity>
+                    <os>Linux</os>
+                </asset>
+                <asset id="h-2">
+                    <name>Host Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <ip>10.0.0.1</ip>
+                </asset>
+                <asset_count>2<filtered>2</filtered><page>1</page></asset_count>
+            </get_assets_response>"#,
+        );
+
+        let parsed = GetHostsResponse::from_response(&response).expect("hosts parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].ip.as_deref(), Some("192.168.1.1"));
+        assert_eq!(
+            parsed.items[0].hostname.as_deref(),
+            Some("host1.example.com")
+        );
+        assert_eq!(parsed.items[0].severity.as_deref(), Some("7.5"));
+        assert_eq!(parsed.items[0].os.as_deref(), Some("Linux"));
+        assert_eq!(parsed.items[1].ip.as_deref(), Some("10.0.0.1"));
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_hosts() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK"><asset_count>0<filtered>0</filtered></asset_count></get_assets_response>"#,
+        );
+
+        let parsed = GetHostsResponse::from_response(&response).expect("hosts parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_host_response() {
+        let response = Response::from(
+            r#"<create_asset_response status="201" status_text="OK, resource created" id="h-1"/>"#,
+        );
+
+        let parsed = CreateHostResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "h-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_assets_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetHostsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_host_fields() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset id="h-1">
+                    <name>Only Required</name>
+                </asset>
+            </get_assets_response>"#,
+        );
+
+        let parsed = GetHostsResponse::from_response(&response).expect("hosts parse");
+        let host = &parsed.items[0];
+
+        assert_eq!(host.meta.comment, None);
+        assert_eq!(host.ip, None);
+        assert_eq!(host.hostname, None);
+        assert_eq!(host.severity, None);
+        assert_eq!(host.os, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -6,36 +6,109 @@
 #![allow(missing_docs)]
 #![allow(clippy::missing_errors_doc)]
 
+pub mod alert;
 pub mod auth;
 pub mod common;
+pub mod credential;
 pub mod feed;
+pub mod filter;
+pub mod group;
+pub mod host;
+pub mod note;
 pub mod nvt;
+pub mod override_;
+pub mod permission;
 pub mod port_list;
 pub mod report;
+pub mod report_config;
+pub mod report_format;
 pub mod result;
+pub mod role;
 pub mod scan_config;
 pub mod scanner;
+pub mod schedule;
 pub mod secinfo;
+pub mod system;
+pub mod tag;
 pub mod target;
 pub mod task;
+pub mod ticket;
+pub mod tls_certificate;
+pub mod user;
 pub mod version;
 
+pub use alert::{
+    Alert, CreateAlertResponse, DeleteAlertResponse, GetAlertsResponse, ModifyAlertResponse,
+};
 pub use auth::AuthenticateResponse;
 pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, ParseError};
+pub use credential::{
+    CreateCredentialResponse, Credential, DeleteCredentialResponse, GetCredentialsResponse,
+    ModifyCredentialResponse,
+};
 pub use feed::{Feed, GetFeedsResponse};
+pub use filter::{
+    CreateFilterResponse, DeleteFilterResponse, Filter, GetFiltersResponse, ModifyFilterResponse,
+};
+pub use group::{
+    CreateGroupResponse, DeleteGroupResponse, GetGroupsResponse, Group, ModifyGroupResponse,
+};
+pub use host::{
+    CreateHostResponse, DeleteHostResponse, GetHostsResponse, Host, ModifyHostResponse,
+};
+pub use note::{
+    CreateNoteResponse, DeleteNoteResponse, GetNotesResponse, ModifyNoteResponse, Note,
+};
 pub use nvt::{GetNvtFamiliesResponse, GetNvtsResponse, Nvt, NvtFamily};
+pub use override_::{
+    CreateOverrideResponse, DeleteOverrideResponse, GetOverridesResponse, ModifyOverrideResponse,
+    Override,
+};
+pub use permission::{
+    CreatePermissionResponse, DeletePermissionResponse, GetPermissionsResponse,
+    ModifyPermissionResponse, Permission,
+};
 pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
 pub use report::{DeleteReportResponse, GetReportsResponse, Report, ResultCount, Severity};
+pub use report_config::{
+    CreateReportConfigResponse, DeleteReportConfigResponse, GetReportConfigsResponse,
+    ModifyReportConfigResponse, ReportConfig,
+};
+pub use report_format::{
+    CreateReportFormatResponse, DeleteReportFormatResponse, GetReportFormatsResponse,
+    ModifyReportFormatResponse, ReportFormat,
+};
 pub use result::{GetResultsResponse, NvtRef, QodInfo, ScanResult};
+pub use role::{
+    CreateRoleResponse, DeleteRoleResponse, GetRolesResponse, ModifyRoleResponse, Role,
+};
 pub use scan_config::{CreateScanConfigResponse, GetScanConfigsResponse, ScanConfig};
 pub use scanner::{CreateScannerResponse, GetScannersResponse, Scanner};
+pub use schedule::{
+    CreateScheduleResponse, DeleteScheduleResponse, GetSchedulesResponse, ModifyScheduleResponse,
+    Schedule,
+};
 pub use secinfo::{
     CertBundAdvisory, Cpe, Cve, DfnCertAdvisory, GetCertBundAdvisoriesResponse, GetCpesResponse,
     GetCvesResponse, GetDfnCertAdvisoriesResponse,
 };
+pub use system::{
+    AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, HelpResponse, Setting,
+};
+pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};
 pub use target::{CreateTargetResponse, GetTargetsResponse, Target};
 pub use task::{
     CreateTaskResponse, DeleteTaskResponse, GetTasksResponse, LastReport, ModifyTaskResponse,
     MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse, Task,
+};
+pub use ticket::{
+    CreateTicketResponse, DeleteTicketResponse, GetTicketsResponse, ModifyTicketResponse, Ticket,
+};
+pub use tls_certificate::{
+    CreateTlsCertificateResponse, DeleteTlsCertificateResponse, GetTlsCertificatesResponse,
+    ModifyTlsCertificateResponse, TlsCertificate,
+};
+pub use user::{
+    CreateUserResponse, DeleteUserResponse, GetUsersResponse, ModifyUserResponse, User,
 };
 pub use version::GetVersionResponse;

--- a/crates/gvm-gmp/src/responses/note.rs
+++ b/crates/gvm-gmp/src/responses/note.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Note response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Note {
+    pub meta: EntityMeta,
+    pub text: Option<String>,
+    pub nvt_oid: Option<String>,
+    pub hosts: Option<String>,
+    pub port: Option<String>,
+    pub severity: Option<String>,
+    pub task: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub active: bool,
+    pub end_time: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetNotesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Note>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateNoteResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Note {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            text: node.optional_child_text("text"),
+            nvt_oid: node
+                .child("nvt")
+                .and_then(|n| n.attr("oid"))
+                .map(String::from),
+            hosts: node.optional_child_text("hosts"),
+            port: node.optional_child_text("port"),
+            severity: node.optional_child_text("severity"),
+            task: parse_named_entity(node, "task")?,
+            result: parse_named_entity(node, "result")?,
+            active: node
+                .optional_child_text("active")
+                .map(|value| parse_bool(&value, "active"))
+                .transpose()?
+                .unwrap_or(false),
+            end_time: node.optional_child_text("end_time"),
+        })
+    }
+}
+
+impl GetNotesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("note")
+            .map(Note::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "note_count")?,
+        })
+    }
+}
+
+impl CreateNoteResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyNoteResponse = ActionResponse;
+pub type DeleteNoteResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_notes() {
+        let response = Response::from(
+            r#"<get_notes_response status="200" status_text="OK">
+                <note id="n-1">
+                    <owner><name>admin</name></owner>
+                    <name>Note One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <text>This is a note</text>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.12345"><name>Some NVT</name></nvt>
+                    <hosts>192.168.1.1</hosts>
+                    <port>80/tcp</port>
+                    <severity>5.0</severity>
+                    <task id="t-1"><name>Task One</name></task>
+                    <result id="r-1"><name>Result One</name></result>
+                    <active>1</active>
+                    <end_time>2027-01-01T00:00:00Z</end_time>
+                </note>
+                <note id="n-2">
+                    <name>Note Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <active>0</active>
+                </note>
+                <note_count>2<filtered>2</filtered><page>1</page></note_count>
+            </get_notes_response>"#,
+        );
+
+        let parsed = GetNotesResponse::from_response(&response).expect("notes parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].text.as_deref(), Some("This is a note"));
+        assert_eq!(
+            parsed.items[0].nvt_oid.as_deref(),
+            Some("1.3.6.1.4.1.25623.1.0.12345")
+        );
+        assert_eq!(parsed.items[0].hosts.as_deref(), Some("192.168.1.1"));
+        assert_eq!(parsed.items[0].port.as_deref(), Some("80/tcp"));
+        assert_eq!(
+            parsed.items[0].task.as_ref().map(|t| t.name.as_str()),
+            Some("Task One")
+        );
+        assert!(parsed.items[0].active);
+        assert!(!parsed.items[1].active);
+    }
+
+    #[test]
+    fn parses_empty_notes() {
+        let response = Response::from(
+            r#"<get_notes_response status="200" status_text="OK"><note_count>0<filtered>0</filtered></note_count></get_notes_response>"#,
+        );
+
+        let parsed = GetNotesResponse::from_response(&response).expect("notes parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_note_response() {
+        let response = Response::from(
+            r#"<create_note_response status="201" status_text="OK, resource created" id="n-1"/>"#,
+        );
+
+        let parsed = CreateNoteResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "n-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_notes_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetNotesResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_note_fields() {
+        let response = Response::from(
+            r#"<get_notes_response status="200" status_text="OK">
+                <note id="n-1">
+                    <name>Only Required</name>
+                </note>
+            </get_notes_response>"#,
+        );
+
+        let parsed = GetNotesResponse::from_response(&response).expect("notes parse");
+        let note = &parsed.items[0];
+
+        assert_eq!(note.meta.comment, None);
+        assert_eq!(note.text, None);
+        assert_eq!(note.nvt_oid, None);
+        assert_eq!(note.hosts, None);
+        assert_eq!(note.task, None);
+        assert!(!note.active);
+    }
+}

--- a/crates/gvm-gmp/src/responses/override_.rs
+++ b/crates/gvm-gmp/src/responses/override_.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Override response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Override {
+    pub meta: EntityMeta,
+    pub text: Option<String>,
+    pub nvt_oid: Option<String>,
+    pub hosts: Option<String>,
+    pub port: Option<String>,
+    pub severity: Option<String>,
+    pub new_severity: Option<String>,
+    pub task: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub active: bool,
+    pub end_time: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetOverridesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Override>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateOverrideResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Override {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            text: node.optional_child_text("text"),
+            nvt_oid: node
+                .child("nvt")
+                .and_then(|n| n.attr("oid"))
+                .map(String::from),
+            hosts: node.optional_child_text("hosts"),
+            port: node.optional_child_text("port"),
+            severity: node.optional_child_text("severity"),
+            new_severity: node.optional_child_text("new_severity"),
+            task: parse_named_entity(node, "task")?,
+            result: parse_named_entity(node, "result")?,
+            active: node
+                .optional_child_text("active")
+                .map(|value| parse_bool(&value, "active"))
+                .transpose()?
+                .unwrap_or(false),
+            end_time: node.optional_child_text("end_time"),
+        })
+    }
+}
+
+impl GetOverridesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("override")
+            .map(Override::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "override_count")?,
+        })
+    }
+}
+
+impl CreateOverrideResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyOverrideResponse = ActionResponse;
+pub type DeleteOverrideResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_overrides() {
+        let response = Response::from(
+            r#"<get_overrides_response status="200" status_text="OK">
+                <override id="o-1">
+                    <owner><name>admin</name></owner>
+                    <name>Override One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <text>Override text</text>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.12345"><name>Some NVT</name></nvt>
+                    <hosts>192.168.1.1</hosts>
+                    <port>80/tcp</port>
+                    <severity>5.0</severity>
+                    <new_severity>2.0</new_severity>
+                    <task id="t-1"><name>Task One</name></task>
+                    <result id="r-1"><name>Result One</name></result>
+                    <active>1</active>
+                    <end_time>2027-01-01T00:00:00Z</end_time>
+                </override>
+                <override id="o-2">
+                    <name>Override Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <active>0</active>
+                </override>
+                <override_count>2<filtered>2</filtered><page>1</page></override_count>
+            </get_overrides_response>"#,
+        );
+
+        let parsed = GetOverridesResponse::from_response(&response).expect("overrides parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].text.as_deref(), Some("Override text"));
+        assert_eq!(
+            parsed.items[0].nvt_oid.as_deref(),
+            Some("1.3.6.1.4.1.25623.1.0.12345")
+        );
+        assert_eq!(parsed.items[0].new_severity.as_deref(), Some("2.0"));
+        assert_eq!(
+            parsed.items[0].task.as_ref().map(|t| t.name.as_str()),
+            Some("Task One")
+        );
+        assert!(parsed.items[0].active);
+        assert!(!parsed.items[1].active);
+    }
+
+    #[test]
+    fn parses_empty_overrides() {
+        let response = Response::from(
+            r#"<get_overrides_response status="200" status_text="OK"><override_count>0<filtered>0</filtered></override_count></get_overrides_response>"#,
+        );
+
+        let parsed = GetOverridesResponse::from_response(&response).expect("overrides parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_override_response() {
+        let response = Response::from(
+            r#"<create_override_response status="201" status_text="OK, resource created" id="o-1"/>"#,
+        );
+
+        let parsed = CreateOverrideResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "o-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_overrides_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetOverridesResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_override_fields() {
+        let response = Response::from(
+            r#"<get_overrides_response status="200" status_text="OK">
+                <override id="o-1">
+                    <name>Only Required</name>
+                </override>
+            </get_overrides_response>"#,
+        );
+
+        let parsed = GetOverridesResponse::from_response(&response).expect("overrides parse");
+        let ov = &parsed.items[0];
+
+        assert_eq!(ov.meta.comment, None);
+        assert_eq!(ov.text, None);
+        assert_eq!(ov.nvt_oid, None);
+        assert_eq!(ov.new_severity, None);
+        assert_eq!(ov.task, None);
+        assert!(!ov.active);
+    }
+}

--- a/crates/gvm-gmp/src/responses/permission.rs
+++ b/crates/gvm-gmp/src/responses/permission.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Permission response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Permission {
+    pub meta: EntityMeta,
+    pub subject_type: Option<String>,
+    pub subject: Option<NamedEntity>,
+    pub resource_type: Option<String>,
+    pub resource: Option<NamedEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetPermissionsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Permission>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreatePermissionResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Permission {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            subject_type: node
+                .child("subject")
+                .and_then(|s| s.optional_child_text("type")),
+            subject: parse_named_entity(node, "subject")?,
+            resource_type: node
+                .child("resource")
+                .and_then(|r| r.optional_child_text("type")),
+            resource: parse_named_entity(node, "resource")?,
+        })
+    }
+}
+
+impl GetPermissionsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("permission")
+            .map(Permission::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "permission_count")?,
+        })
+    }
+}
+
+impl CreatePermissionResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyPermissionResponse = ActionResponse;
+pub type DeletePermissionResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_permissions() {
+        let response = Response::from(
+            r#"<get_permissions_response status="200" status_text="OK">
+                <permission id="p-1">
+                    <owner><name>admin</name></owner>
+                    <name>get_tasks</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <subject id="u-1">
+                        <name>User One</name>
+                        <type>user</type>
+                    </subject>
+                    <resource id="t-1">
+                        <name>Task One</name>
+                        <type>task</type>
+                    </resource>
+                </permission>
+                <permission id="p-2">
+                    <name>get_alerts</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </permission>
+                <permission_count>2<filtered>2</filtered><page>1</page></permission_count>
+            </get_permissions_response>"#,
+        );
+
+        let parsed = GetPermissionsResponse::from_response(&response).expect("permissions parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].subject_type.as_deref(), Some("user"));
+        assert_eq!(
+            parsed.items[0].subject.as_ref().map(|s| s.name.as_str()),
+            Some("User One")
+        );
+        assert_eq!(parsed.items[0].resource_type.as_deref(), Some("task"));
+        assert_eq!(
+            parsed.items[0].resource.as_ref().map(|r| r.name.as_str()),
+            Some("Task One")
+        );
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_permissions() {
+        let response = Response::from(
+            r#"<get_permissions_response status="200" status_text="OK"><permission_count>0<filtered>0</filtered></permission_count></get_permissions_response>"#,
+        );
+
+        let parsed = GetPermissionsResponse::from_response(&response).expect("permissions parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_permission_response() {
+        let response = Response::from(
+            r#"<create_permission_response status="201" status_text="OK, resource created" id="p-1"/>"#,
+        );
+
+        let parsed = CreatePermissionResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "p-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_permissions_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetPermissionsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_permission_fields() {
+        let response = Response::from(
+            r#"<get_permissions_response status="200" status_text="OK">
+                <permission id="p-1">
+                    <name>get_tasks</name>
+                </permission>
+            </get_permissions_response>"#,
+        );
+
+        let parsed = GetPermissionsResponse::from_response(&response).expect("permissions parse");
+        let perm = &parsed.items[0];
+
+        assert_eq!(perm.meta.comment, None);
+        assert_eq!(perm.subject_type, None);
+        assert_eq!(perm.subject, None);
+        assert_eq!(perm.resource_type, None);
+        assert_eq!(perm.resource, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/report_config.rs
+++ b/crates/gvm-gmp/src/responses/report_config.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Report config response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportConfig {
+    pub meta: EntityMeta,
+    pub report_format: Option<NamedEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportConfigsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportConfig>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateReportConfigResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl ReportConfig {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            report_format: parse_named_entity(node, "report_format")?,
+        })
+    }
+}
+
+impl GetReportConfigsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("report_config")
+            .map(ReportConfig::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "report_config_count")?,
+        })
+    }
+}
+
+impl CreateReportConfigResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyReportConfigResponse = ActionResponse;
+pub type DeleteReportConfigResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_report_configs() {
+        let response = Response::from(
+            r#"<get_report_configs_response status="200" status_text="OK">
+                <report_config id="rc-1">
+                    <owner><name>admin</name></owner>
+                    <name>Config One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <report_format id="rf-1"><name>HTML</name></report_format>
+                </report_config>
+                <report_config id="rc-2">
+                    <name>Config Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </report_config>
+                <report_config_count>2<filtered>2</filtered><page>1</page></report_config_count>
+            </get_report_configs_response>"#,
+        );
+
+        let parsed =
+            GetReportConfigsResponse::from_response(&response).expect("report_configs parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(
+            parsed.items[0]
+                .report_format
+                .as_ref()
+                .map(|rf| rf.name.as_str()),
+            Some("HTML")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .report_format
+                .as_ref()
+                .map(|rf| rf.id.as_str()),
+            Some("rf-1")
+        );
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_report_configs() {
+        let response = Response::from(
+            r#"<get_report_configs_response status="200" status_text="OK"><report_config_count>0<filtered>0</filtered></report_config_count></get_report_configs_response>"#,
+        );
+
+        let parsed =
+            GetReportConfigsResponse::from_response(&response).expect("report_configs parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_report_config_response() {
+        let response = Response::from(
+            r#"<create_report_config_response status="201" status_text="OK, resource created" id="rc-1"/>"#,
+        );
+
+        let parsed = CreateReportConfigResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "rc-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response = Response::from(
+            r#"<get_report_configs_response status="400" status_text="Bad request"/>"#,
+        );
+
+        let error = GetReportConfigsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_report_config_fields() {
+        let response = Response::from(
+            r#"<get_report_configs_response status="200" status_text="OK">
+                <report_config id="rc-1">
+                    <name>Only Required</name>
+                </report_config>
+            </get_report_configs_response>"#,
+        );
+
+        let parsed =
+            GetReportConfigsResponse::from_response(&response).expect("report_configs parse");
+        let rc = &parsed.items[0];
+
+        assert_eq!(rc.meta.comment, None);
+        assert_eq!(rc.report_format, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/report_format.rs
+++ b/crates/gvm-gmp/src/responses/report_format.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Report format response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportFormat {
+    pub meta: EntityMeta,
+    pub content_type: Option<String>,
+    pub extension: Option<String>,
+    pub summary: Option<String>,
+    pub trust: Option<String>,
+    pub active: bool,
+    pub predefined: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportFormatsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportFormat>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateReportFormatResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl ReportFormat {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            content_type: node.optional_child_text("content_type"),
+            extension: node.optional_child_text("extension"),
+            summary: node.optional_child_text("summary"),
+            trust: node.optional_child_text("trust"),
+            active: node
+                .optional_child_text("active")
+                .map(|value| parse_bool(&value, "active"))
+                .transpose()?
+                .unwrap_or(false),
+            predefined: node
+                .optional_child_text("predefined")
+                .map(|value| parse_bool(&value, "predefined"))
+                .transpose()?
+                .unwrap_or(false),
+        })
+    }
+}
+
+impl GetReportFormatsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("report_format")
+            .map(ReportFormat::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "report_format_count")?,
+        })
+    }
+}
+
+impl CreateReportFormatResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyReportFormatResponse = ActionResponse;
+pub type DeleteReportFormatResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_report_formats() {
+        let response = Response::from(
+            r#"<get_report_formats_response status="200" status_text="OK">
+                <report_format id="rf-1">
+                    <owner><name>admin</name></owner>
+                    <name>Format One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <content_type>text/html</content_type>
+                    <extension>html</extension>
+                    <summary>HTML Report</summary>
+                    <trust>yes</trust>
+                    <active>1</active>
+                    <predefined>1</predefined>
+                </report_format>
+                <report_format id="rf-2">
+                    <name>Format Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <active>0</active>
+                    <predefined>0</predefined>
+                </report_format>
+                <report_format_count>2<filtered>2</filtered><page>1</page></report_format_count>
+            </get_report_formats_response>"#,
+        );
+
+        let parsed =
+            GetReportFormatsResponse::from_response(&response).expect("report_formats parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].content_type.as_deref(), Some("text/html"));
+        assert_eq!(parsed.items[0].extension.as_deref(), Some("html"));
+        assert_eq!(parsed.items[0].summary.as_deref(), Some("HTML Report"));
+        assert_eq!(parsed.items[0].trust.as_deref(), Some("yes"));
+        assert!(parsed.items[0].active);
+        assert!(parsed.items[0].predefined);
+        assert!(!parsed.items[1].active);
+        assert!(!parsed.items[1].predefined);
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_report_formats() {
+        let response = Response::from(
+            r#"<get_report_formats_response status="200" status_text="OK"><report_format_count>0<filtered>0</filtered></report_format_count></get_report_formats_response>"#,
+        );
+
+        let parsed =
+            GetReportFormatsResponse::from_response(&response).expect("report_formats parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_report_format_response() {
+        let response = Response::from(
+            r#"<create_report_format_response status="201" status_text="OK, resource created" id="rf-1"/>"#,
+        );
+
+        let parsed = CreateReportFormatResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "rf-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response = Response::from(
+            r#"<get_report_formats_response status="400" status_text="Bad request"/>"#,
+        );
+
+        let error = GetReportFormatsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_report_format_fields() {
+        let response = Response::from(
+            r#"<get_report_formats_response status="200" status_text="OK">
+                <report_format id="rf-1">
+                    <name>Only Required</name>
+                </report_format>
+            </get_report_formats_response>"#,
+        );
+
+        let parsed =
+            GetReportFormatsResponse::from_response(&response).expect("report_formats parse");
+        let rf = &parsed.items[0];
+
+        assert_eq!(rf.meta.comment, None);
+        assert_eq!(rf.content_type, None);
+        assert_eq!(rf.extension, None);
+        assert_eq!(rf.summary, None);
+        assert_eq!(rf.trust, None);
+        assert!(!rf.active);
+        assert!(!rf.predefined);
+    }
+}

--- a/crates/gvm-gmp/src/responses/role.rs
+++ b/crates/gvm-gmp/src/responses/role.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Role response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Role {
+    pub meta: EntityMeta,
+    pub users: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetRolesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Role>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateRoleResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Role {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            users: node.optional_child_text("users"),
+        })
+    }
+}
+
+impl GetRolesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("role")
+            .map(Role::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "role_count")?,
+        })
+    }
+}
+
+impl CreateRoleResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyRoleResponse = ActionResponse;
+pub type DeleteRoleResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_roles() {
+        let response = Response::from(
+            r#"<get_roles_response status="200" status_text="OK">
+                <role id="r-1">
+                    <owner><name>admin</name></owner>
+                    <name>Role One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <users>alice, bob</users>
+                </role>
+                <role id="r-2">
+                    <name>Role Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </role>
+                <role_count>2<filtered>2</filtered><page>1</page></role_count>
+            </get_roles_response>"#,
+        );
+
+        let parsed = GetRolesResponse::from_response(&response).expect("roles parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].users.as_deref(), Some("alice, bob"));
+        assert_eq!(
+            parsed.items[0].meta.owner.as_ref().map(|o| o.name.as_str()),
+            Some("admin")
+        );
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_roles() {
+        let response = Response::from(
+            r#"<get_roles_response status="200" status_text="OK"><role_count>0<filtered>0</filtered></role_count></get_roles_response>"#,
+        );
+
+        let parsed = GetRolesResponse::from_response(&response).expect("roles parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_role_response() {
+        let response = Response::from(
+            r#"<create_role_response status="201" status_text="OK, resource created" id="r-1"/>"#,
+        );
+
+        let parsed = CreateRoleResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "r-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_roles_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetRolesResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_role_fields() {
+        let response = Response::from(
+            r#"<get_roles_response status="200" status_text="OK">
+                <role id="r-1">
+                    <name>Only Required</name>
+                </role>
+            </get_roles_response>"#,
+        );
+
+        let parsed = GetRolesResponse::from_response(&response).expect("roles parse");
+        let role = &parsed.items[0];
+
+        assert_eq!(role.meta.comment, None);
+        assert_eq!(role.users, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/schedule.rs
+++ b/crates/gvm-gmp/src/responses/schedule.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Schedule response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Schedule {
+    pub meta: EntityMeta,
+    pub icalendar: Option<String>,
+    pub timezone: Option<String>,
+    pub duration: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetSchedulesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Schedule>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateScheduleResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Schedule {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            icalendar: node.optional_child_text("icalendar"),
+            timezone: node.optional_child_text("timezone"),
+            duration: node.optional_child_text("duration"),
+        })
+    }
+}
+
+impl GetSchedulesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("schedule")
+            .map(Schedule::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "schedule_count")?,
+        })
+    }
+}
+
+impl CreateScheduleResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyScheduleResponse = ActionResponse;
+pub type DeleteScheduleResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_schedules() {
+        let response = Response::from(
+            r#"<get_schedules_response status="200" status_text="OK">
+                <schedule id="s-1">
+                    <owner><name>admin</name></owner>
+                    <name>Schedule One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <icalendar>BEGIN:VCALENDAR&#10;END:VCALENDAR</icalendar>
+                    <timezone>UTC</timezone>
+                    <duration>3600</duration>
+                </schedule>
+                <schedule id="s-2">
+                    <name>Schedule Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </schedule>
+                <schedule_count>2<filtered>2</filtered><page>1</page></schedule_count>
+            </get_schedules_response>"#,
+        );
+
+        let parsed = GetSchedulesResponse::from_response(&response).expect("schedules parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].timezone.as_deref(), Some("UTC"));
+        assert_eq!(parsed.items[0].duration.as_deref(), Some("3600"));
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_schedules() {
+        let response = Response::from(
+            r#"<get_schedules_response status="200" status_text="OK"><schedule_count>0<filtered>0</filtered></schedule_count></get_schedules_response>"#,
+        );
+
+        let parsed = GetSchedulesResponse::from_response(&response).expect("schedules parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_schedule_response() {
+        let response = Response::from(
+            r#"<create_schedule_response status="201" status_text="OK, resource created" id="s-1"/>"#,
+        );
+
+        let parsed = CreateScheduleResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "s-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_schedules_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetSchedulesResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_schedule_fields() {
+        let response = Response::from(
+            r#"<get_schedules_response status="200" status_text="OK">
+                <schedule id="s-1">
+                    <name>Only Required</name>
+                </schedule>
+            </get_schedules_response>"#,
+        );
+
+        let parsed = GetSchedulesResponse::from_response(&response).expect("schedules parse");
+        let schedule = &parsed.items[0];
+
+        assert_eq!(schedule.meta.comment, None);
+        assert_eq!(schedule.icalendar, None);
+        assert_eq!(schedule.timezone, None);
+        assert_eq!(schedule.duration, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! System (settings, help, auth) response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{parse_document, parse_entity_id, status_from_response, ParseError};
+use crate::EntityId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Setting {
+    pub id: EntityId,
+    pub name: String,
+    pub comment: Option<String>,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetSettingsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Setting>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HelpResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub help_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DescribeAuthResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub groups: Vec<AuthGroup>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AuthGroup {
+    pub name: String,
+    pub settings: Vec<AuthConfSetting>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AuthConfSetting {
+    pub key: Option<String>,
+    pub value: Option<String>,
+}
+
+impl Setting {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: parse_entity_id(
+                node.attr("id")
+                    .ok_or_else(|| ParseError::MissingElement("setting.id".to_string()))?,
+                "setting.id",
+            )?,
+            name: node.required_child_text("name")?,
+            comment: node.optional_child_text("comment"),
+            value: node.optional_child_text("value"),
+        })
+    }
+}
+
+impl GetSettingsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("setting")
+            .map(Setting::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+        })
+    }
+}
+
+impl HelpResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        Ok(Self {
+            status,
+            status_text,
+            help_text: root.text.clone(),
+        })
+    }
+}
+
+impl DescribeAuthResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let groups = root
+            .children_named("group")
+            .map(|g| {
+                let name = g.attr("name").unwrap_or("").to_string();
+                let settings = g
+                    .children_named("auth_conf_setting")
+                    .map(|s| AuthConfSetting {
+                        key: s.optional_child_text("key"),
+                        value: s.optional_child_text("value"),
+                    })
+                    .collect();
+                Ok(AuthGroup { name, settings })
+            })
+            .collect::<Result<Vec<_>, ParseError>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            groups,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_settings() {
+        let response = Response::from(
+            r#"<get_settings_response status="200" status_text="OK">
+                <setting id="s-1">
+                    <name>Setting One</name>
+                    <comment>first setting</comment>
+                    <value>value1</value>
+                </setting>
+                <setting id="s-2">
+                    <name>Setting Two</name>
+                    <value>value2</value>
+                </setting>
+            </get_settings_response>"#,
+        );
+
+        let parsed = GetSettingsResponse::from_response(&response).expect("settings parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.items[0].id.as_str(), "s-1");
+        assert_eq!(parsed.items[0].name, "Setting One");
+        assert_eq!(parsed.items[0].comment.as_deref(), Some("first setting"));
+        assert_eq!(parsed.items[0].value.as_deref(), Some("value1"));
+        assert_eq!(parsed.items[1].name, "Setting Two");
+        assert_eq!(parsed.items[1].comment, None);
+    }
+
+    #[test]
+    fn parses_empty_settings() {
+        let response = Response::from(
+            r#"<get_settings_response status="200" status_text="OK"></get_settings_response>"#,
+        );
+
+        let parsed = GetSettingsResponse::from_response(&response).expect("settings parse");
+
+        assert!(parsed.items.is_empty());
+    }
+
+    #[test]
+    fn parses_help_response() {
+        let response = Response::from(
+            r#"<help_response status="200" status_text="OK">Available commands: get_tasks, get_alerts</help_response>"#,
+        );
+
+        let parsed = HelpResponse::from_response(&response).expect("help parse");
+
+        assert_eq!(parsed.status, 200);
+        assert_eq!(
+            parsed.help_text,
+            "Available commands: get_tasks, get_alerts"
+        );
+    }
+
+    #[test]
+    fn parses_describe_auth_response() {
+        let response = Response::from(
+            r#"<describe_auth_response status="200" status_text="OK">
+                <group name="method:ldap_connect">
+                    <auth_conf_setting>
+                        <key>ldaphost</key>
+                        <value>ldap.example.com</value>
+                    </auth_conf_setting>
+                    <auth_conf_setting>
+                        <key>enable</key>
+                        <value>true</value>
+                    </auth_conf_setting>
+                </group>
+                <group name="method:radius_connect">
+                    <auth_conf_setting>
+                        <key>radiushost</key>
+                        <value>radius.example.com</value>
+                    </auth_conf_setting>
+                </group>
+            </describe_auth_response>"#,
+        );
+
+        let parsed = DescribeAuthResponse::from_response(&response).expect("describe_auth parse");
+
+        assert_eq!(parsed.groups.len(), 2);
+        assert_eq!(parsed.groups[0].name, "method:ldap_connect");
+        assert_eq!(parsed.groups[0].settings.len(), 2);
+        assert_eq!(
+            parsed.groups[0].settings[0].key.as_deref(),
+            Some("ldaphost")
+        );
+        assert_eq!(
+            parsed.groups[0].settings[0].value.as_deref(),
+            Some("ldap.example.com")
+        );
+        assert_eq!(parsed.groups[1].name, "method:radius_connect");
+        assert_eq!(parsed.groups[1].settings.len(), 1);
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_settings_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetSettingsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+}

--- a/crates/gvm-gmp/src/responses/tag.rs
+++ b/crates/gvm-gmp/src/responses/tag.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Tag response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_u32,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Tag {
+    pub meta: EntityMeta,
+    pub value: Option<String>,
+    pub resource_type: Option<String>,
+    pub resource_count: Option<u32>,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetTagsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Tag>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateTagResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Tag {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            value: node.optional_child_text("value"),
+            resource_type: node
+                .child("resources")
+                .and_then(|r| r.optional_child_text("type")),
+            resource_count: node
+                .child("resources")
+                .and_then(|r| r.child("count"))
+                .and_then(|c| c.optional_child_text("total"))
+                .map(|v| parse_u32(&v, "resource_count"))
+                .transpose()?,
+            active: node
+                .optional_child_text("active")
+                .map(|value| parse_bool(&value, "active"))
+                .transpose()?
+                .unwrap_or(false),
+        })
+    }
+}
+
+impl GetTagsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("tag")
+            .map(Tag::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "tag_count")?,
+        })
+    }
+}
+
+impl CreateTagResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyTagResponse = ActionResponse;
+pub type DeleteTagResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_tags() {
+        let response = Response::from(
+            r#"<get_tags_response status="200" status_text="OK">
+                <tag id="t-1">
+                    <owner><name>admin</name></owner>
+                    <name>Tag One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <value>production</value>
+                    <resources>
+                        <type>task</type>
+                        <count><total>5</total></count>
+                    </resources>
+                    <active>1</active>
+                </tag>
+                <tag id="t-2">
+                    <name>Tag Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <active>0</active>
+                </tag>
+                <tag_count>2<filtered>2</filtered><page>1</page></tag_count>
+            </get_tags_response>"#,
+        );
+
+        let parsed = GetTagsResponse::from_response(&response).expect("tags parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].value.as_deref(), Some("production"));
+        assert_eq!(parsed.items[0].resource_type.as_deref(), Some("task"));
+        assert_eq!(parsed.items[0].resource_count, Some(5));
+        assert!(parsed.items[0].active);
+        assert!(!parsed.items[1].active);
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_tags() {
+        let response = Response::from(
+            r#"<get_tags_response status="200" status_text="OK"><tag_count>0<filtered>0</filtered></tag_count></get_tags_response>"#,
+        );
+
+        let parsed = GetTagsResponse::from_response(&response).expect("tags parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_tag_response() {
+        let response = Response::from(
+            r#"<create_tag_response status="201" status_text="OK, resource created" id="t-1"/>"#,
+        );
+
+        let parsed = CreateTagResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "t-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_tags_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetTagsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_tag_fields() {
+        let response = Response::from(
+            r#"<get_tags_response status="200" status_text="OK">
+                <tag id="t-1">
+                    <name>Only Required</name>
+                </tag>
+            </get_tags_response>"#,
+        );
+
+        let parsed = GetTagsResponse::from_response(&response).expect("tags parse");
+        let tag = &parsed.items[0];
+
+        assert_eq!(tag.meta.comment, None);
+        assert_eq!(tag.value, None);
+        assert_eq!(tag.resource_type, None);
+        assert_eq!(tag.resource_count, None);
+        assert!(!tag.active);
+    }
+}

--- a/crates/gvm-gmp/src/responses/ticket.rs
+++ b/crates/gvm-gmp/src/responses/ticket.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Ticket response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ticket {
+    pub meta: EntityMeta,
+    pub status: Option<String>,
+    pub assigned_to: Option<NamedEntity>,
+    pub result: Option<NamedEntity>,
+    pub task: Option<NamedEntity>,
+    pub open_note: Option<String>,
+    pub fixed_note: Option<String>,
+    pub closed_note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetTicketsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Ticket>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateTicketResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl Ticket {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            status: node.optional_child_text("status"),
+            assigned_to: parse_named_entity(node, "assigned_to")?,
+            result: parse_named_entity(node, "result")?,
+            task: parse_named_entity(node, "task")?,
+            open_note: node.optional_child_text("open_note"),
+            fixed_note: node.optional_child_text("fixed_note"),
+            closed_note: node.optional_child_text("closed_note"),
+        })
+    }
+}
+
+impl GetTicketsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("ticket")
+            .map(Ticket::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "ticket_count")?,
+        })
+    }
+}
+
+impl CreateTicketResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyTicketResponse = ActionResponse;
+pub type DeleteTicketResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_tickets() {
+        let response = Response::from(
+            r#"<get_tickets_response status="200" status_text="OK">
+                <ticket id="tk-1">
+                    <owner><name>admin</name></owner>
+                    <name>Ticket One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <status>Open</status>
+                    <assigned_to id="u-1"><name>User One</name></assigned_to>
+                    <result id="r-1"><name>Result One</name></result>
+                    <task id="t-1"><name>Task One</name></task>
+                    <open_note>Please fix this</open_note>
+                    <fixed_note></fixed_note>
+                    <closed_note></closed_note>
+                </ticket>
+                <ticket id="tk-2">
+                    <name>Ticket Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <status>Fixed</status>
+                </ticket>
+                <ticket_count>2<filtered>2</filtered><page>1</page></ticket_count>
+            </get_tickets_response>"#,
+        );
+
+        let parsed = GetTicketsResponse::from_response(&response).expect("tickets parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].status.as_deref(), Some("Open"));
+        assert_eq!(
+            parsed.items[0]
+                .assigned_to
+                .as_ref()
+                .map(|u| u.name.as_str()),
+            Some("User One")
+        );
+        assert_eq!(
+            parsed.items[0].task.as_ref().map(|t| t.name.as_str()),
+            Some("Task One")
+        );
+        assert_eq!(
+            parsed.items[0].open_note.as_deref(),
+            Some("Please fix this")
+        );
+        assert_eq!(parsed.items[1].status.as_deref(), Some("Fixed"));
+    }
+
+    #[test]
+    fn parses_empty_tickets() {
+        let response = Response::from(
+            r#"<get_tickets_response status="200" status_text="OK"><ticket_count>0<filtered>0</filtered></ticket_count></get_tickets_response>"#,
+        );
+
+        let parsed = GetTicketsResponse::from_response(&response).expect("tickets parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_ticket_response() {
+        let response = Response::from(
+            r#"<create_ticket_response status="201" status_text="OK, resource created" id="tk-1"/>"#,
+        );
+
+        let parsed = CreateTicketResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "tk-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_tickets_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetTicketsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_ticket_fields() {
+        let response = Response::from(
+            r#"<get_tickets_response status="200" status_text="OK">
+                <ticket id="tk-1">
+                    <name>Only Required</name>
+                </ticket>
+            </get_tickets_response>"#,
+        );
+
+        let parsed = GetTicketsResponse::from_response(&response).expect("tickets parse");
+        let ticket = &parsed.items[0];
+
+        assert_eq!(ticket.meta.comment, None);
+        assert_eq!(ticket.status, None);
+        assert_eq!(ticket.assigned_to, None);
+        assert_eq!(ticket.result, None);
+        assert_eq!(ticket.task, None);
+        assert_eq!(ticket.open_note, None);
+    }
+}

--- a/crates/gvm-gmp/src/responses/tls_certificate.rs
+++ b/crates/gvm-gmp/src/responses/tls_certificate.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! TLS certificate response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TlsCertificate {
+    pub meta: EntityMeta,
+    pub certificate: Option<String>,
+    pub issuer_dn: Option<String>,
+    pub activation_time: Option<String>,
+    pub expiration_time: Option<String>,
+    pub md5_fingerprint: Option<String>,
+    pub sha256_fingerprint: Option<String>,
+    pub subject_dn: Option<String>,
+    pub valid: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetTlsCertificatesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<TlsCertificate>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateTlsCertificateResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl TlsCertificate {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            certificate: node.optional_child_text("certificate"),
+            issuer_dn: node.optional_child_text("issuer_dn"),
+            activation_time: node.optional_child_text("activation_time"),
+            expiration_time: node.optional_child_text("expiration_time"),
+            md5_fingerprint: node.optional_child_text("md5_fingerprint"),
+            sha256_fingerprint: node.optional_child_text("sha256_fingerprint"),
+            subject_dn: node.optional_child_text("subject_dn"),
+            valid: node
+                .optional_child_text("valid")
+                .map(|value| parse_bool(&value, "valid"))
+                .transpose()?
+                .unwrap_or(false),
+        })
+    }
+}
+
+impl GetTlsCertificatesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("tls_certificate")
+            .map(TlsCertificate::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "tls_certificate_count")?,
+        })
+    }
+}
+
+impl CreateTlsCertificateResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyTlsCertificateResponse = ActionResponse;
+pub type DeleteTlsCertificateResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_tls_certificates() {
+        let response = Response::from(
+            r#"<get_tls_certificates_response status="200" status_text="OK">
+                <tls_certificate id="tc-1">
+                    <owner><name>admin</name></owner>
+                    <name>Cert One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <certificate>MIIB...</certificate>
+                    <issuer_dn>CN=Example CA</issuer_dn>
+                    <activation_time>2026-01-01T00:00:00Z</activation_time>
+                    <expiration_time>2027-01-01T00:00:00Z</expiration_time>
+                    <md5_fingerprint>aa:bb:cc:dd</md5_fingerprint>
+                    <sha256_fingerprint>ee:ff:00:11</sha256_fingerprint>
+                    <subject_dn>CN=example.com</subject_dn>
+                    <valid>1</valid>
+                </tls_certificate>
+                <tls_certificate id="tc-2">
+                    <name>Cert Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <valid>0</valid>
+                </tls_certificate>
+                <tls_certificate_count>2<filtered>2</filtered><page>1</page></tls_certificate_count>
+            </get_tls_certificates_response>"#,
+        );
+
+        let parsed = GetTlsCertificatesResponse::from_response(&response).expect("tls_certs parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].issuer_dn.as_deref(), Some("CN=Example CA"));
+        assert_eq!(
+            parsed.items[0].subject_dn.as_deref(),
+            Some("CN=example.com")
+        );
+        assert_eq!(
+            parsed.items[0].md5_fingerprint.as_deref(),
+            Some("aa:bb:cc:dd")
+        );
+        assert!(parsed.items[0].valid);
+        assert!(!parsed.items[1].valid);
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_tls_certificates() {
+        let response = Response::from(
+            r#"<get_tls_certificates_response status="200" status_text="OK"><tls_certificate_count>0<filtered>0</filtered></tls_certificate_count></get_tls_certificates_response>"#,
+        );
+
+        let parsed = GetTlsCertificatesResponse::from_response(&response).expect("tls_certs parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_tls_certificate_response() {
+        let response = Response::from(
+            r#"<create_tls_certificate_response status="201" status_text="OK, resource created" id="tc-1"/>"#,
+        );
+
+        let parsed = CreateTlsCertificateResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "tc-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response = Response::from(
+            r#"<get_tls_certificates_response status="400" status_text="Bad request"/>"#,
+        );
+
+        let error =
+            GetTlsCertificatesResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_tls_certificate_fields() {
+        let response = Response::from(
+            r#"<get_tls_certificates_response status="200" status_text="OK">
+                <tls_certificate id="tc-1">
+                    <name>Only Required</name>
+                </tls_certificate>
+            </get_tls_certificates_response>"#,
+        );
+
+        let parsed = GetTlsCertificatesResponse::from_response(&response).expect("tls_certs parse");
+        let cert = &parsed.items[0];
+
+        assert_eq!(cert.meta.comment, None);
+        assert_eq!(cert.certificate, None);
+        assert_eq!(cert.issuer_dn, None);
+        assert_eq!(cert.subject_dn, None);
+        assert!(!cert.valid);
+    }
+}

--- a/crates/gvm-gmp/src/responses/user.rs
+++ b/crates/gvm-gmp/src/responses/user.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! User response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct User {
+    pub meta: EntityMeta,
+    pub roles: Vec<NamedEntity>,
+    pub groups: Vec<NamedEntity>,
+    pub hosts_allow: Option<String>,
+    pub hosts: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetUsersResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<User>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateUserResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl User {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let roles = node
+            .children_named("role")
+            .map(|r| {
+                let id = parse_entity_id(
+                    r.attr("id")
+                        .ok_or_else(|| ParseError::MissingElement("role.id".to_string()))?,
+                    "role.id",
+                )?;
+                let name = r.required_child_text("name")?;
+                Ok(NamedEntity { id, name })
+            })
+            .collect::<Result<Vec<_>, ParseError>>()?;
+
+        let groups = node
+            .child("groups")
+            .map(|groups_node| {
+                groups_node
+                    .children_named("group")
+                    .map(|g| {
+                        let id = parse_entity_id(
+                            g.attr("id").ok_or_else(|| {
+                                ParseError::MissingElement("group.id".to_string())
+                            })?,
+                            "group.id",
+                        )?;
+                        let name = g.required_child_text("name")?;
+                        Ok(NamedEntity { id, name })
+                    })
+                    .collect::<Result<Vec<_>, ParseError>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            roles,
+            groups,
+            hosts_allow: node.optional_child_text("hosts_allow"),
+            hosts: node.optional_child_text("hosts"),
+        })
+    }
+}
+
+impl GetUsersResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("user")
+            .map(User::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "user_count")?,
+        })
+    }
+}
+
+impl CreateUserResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyUserResponse = ActionResponse;
+pub type DeleteUserResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_users() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <owner><name>admin</name></owner>
+                    <name>User One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <role id="r-1"><name>Admin</name></role>
+                    <role id="r-2"><name>Observer</name></role>
+                    <groups>
+                        <group id="g-1"><name>Group One</name></group>
+                    </groups>
+                    <hosts_allow>0</hosts_allow>
+                    <hosts>192.168.1.0/24</hosts>
+                </user>
+                <user id="u-2">
+                    <name>User Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </user>
+                <user_count>2<filtered>2</filtered><page>1</page></user_count>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].roles.len(), 2);
+        assert_eq!(parsed.items[0].roles[0].name, "Admin");
+        assert_eq!(parsed.items[0].roles[1].name, "Observer");
+        assert_eq!(parsed.items[0].groups.len(), 1);
+        assert_eq!(parsed.items[0].groups[0].name, "Group One");
+        assert_eq!(parsed.items[0].hosts_allow.as_deref(), Some("0"));
+        assert_eq!(parsed.items[0].hosts.as_deref(), Some("192.168.1.0/24"));
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_users() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK"><user_count>0<filtered>0</filtered></user_count></get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_user_response() {
+        let response = Response::from(
+            r#"<create_user_response status="201" status_text="OK, resource created" id="u-1"/>"#,
+        );
+
+        let parsed = CreateUserResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "u-1");
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response =
+            Response::from(r#"<get_users_response status="400" status_text="Bad request"/>"#);
+
+        let error = GetUsersResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError {
+                status: 400,
+                message
+            } if message == "Bad request"
+        ));
+    }
+
+    #[test]
+    fn parses_missing_optional_user_fields() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>Only Required</name>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+
+        assert_eq!(user.meta.comment, None);
+        assert!(user.roles.is_empty());
+        assert!(user.groups.is_empty());
+        assert_eq!(user.hosts_allow, None);
+        assert_eq!(user.hosts, None);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of the [Response Models OpenSpec](https://github.com/clawosiris/rust-gvm/blob/main/spec/response-models-openspec.md), completing typed GMP response coverage for **all remaining entity domains**.

## What's New

17 new response modules in `crates/gvm-gmp/src/responses/`:

| Module | Entity | Response Types |
|--------|--------|---------------|
| `alert` | `Alert` | Get, Create, Modify, Delete |
| `credential` | `Credential` | Get, Create, Modify, Delete |
| `filter` | `Filter` | Get, Create, Modify, Delete |
| `note` | `Note` | Get, Create, Modify, Delete |
| `override_` | `Override` | Get, Create, Modify, Delete |
| `schedule` | `Schedule` | Get, Create, Modify, Delete |
| `tag` | `Tag` | Get, Create, Modify, Delete |
| `ticket` | `Ticket` | Get, Create, Modify, Delete |
| `user` | `User` | Get, Create, Modify, Delete |
| `group` | `Group` | Get, Create, Modify, Delete |
| `role` | `Role` | Get, Create, Modify, Delete |
| `permission` | `Permission` | Get, Create, Modify, Delete |
| `host` | `Host` | Get, Create, Modify, Delete |
| `tls_certificate` | `TlsCertificate` | Get, Create, Modify, Delete |
| `system` | `Setting`, `HelpResponse`, `DescribeAuthResponse` | Get, Help, DescribeAuth |
| `report_format` | `ReportFormat` | Get, Create, Modify, Delete |
| `report_config` | `ReportConfig` | Get, Create, Modify, Delete |

## Stats

- **+3,664 lines** across 18 files (17 new modules + mod.rs updates)
- **146 response model tests** (85 new Phase 4 + 61 existing Phases 1-3)
- All tests passing, clippy clean, no changes to existing modules

## Design

Follows the same patterns established in Phases 1-3:
- `#[non_exhaustive]` on all public structs
- Optional serde behind feature flag
- `from_response(&Response)` entry point on every response type
- Standard 5-test matrix per domain (multi-item, empty, create, error, optionals)
- Timestamps as `Option<String>` (ISO 8601)

## Checklist

- [x] `cargo check --all-features -p gvm-gmp` ✅
- [x] `cargo test -p gvm-gmp` ✅ (242 unit tests pass)
- [x] `cargo clippy --all-features -p gvm-gmp` ✅
- [x] No breaking changes to existing API
- [x] All Phase 4 entities from OpenSpec covered

Completes all 4 phases of the response models initiative. Next steps per OpenSpec: consumer migration (gvm-rools, rust-gvm-api, E2E tests) and typed client methods (v0.5+).