### PR TITLE
feat(gmp): type comma-separated response fields as vectors

### DIFF
--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -235,6 +235,15 @@ pub(crate) fn parse_bool(value: &str, field: &str) -> Result<bool, ParseError> {
     }
 }
 
+pub(crate) fn parse_csv_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 pub(crate) fn parse_u16(value: &str, field: &str) -> Result<u16, ParseError> {
     value.parse::<u16>().map_err(|_| ParseError::InvalidValue {
         field: field.to_string(),

--- a/crates/gvm-gmp/src/responses/group.rs
+++ b/crates/gvm-gmp/src/responses/group.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
-    ActionResponse, CountInfo, EntityMeta, ParseError,
+    count_info, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,7 +15,7 @@ use crate::responses::common::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Group {
     pub meta: EntityMeta,
-    pub users: Option<String>,
+    pub users: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,7 +41,10 @@ impl Group {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            users: node.optional_child_text("users"),
+            users: node
+                .optional_child_text("users")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
         })
     }
 }
@@ -101,7 +104,7 @@ mod tests {
                     <modification_time>2026-01-02T00:00:00Z</modification_time>
                     <writable>1</writable>
                     <in_use>0</in_use>
-                    <users>alice, bob</users>
+                    <users>alice, bob, ,charlie</users>
                 </group>
                 <group id="g-2">
                     <name>Group Two</name>
@@ -118,7 +121,14 @@ mod tests {
         assert_eq!(parsed.counts.total, Some(2));
         assert_eq!(parsed.counts.filtered, Some(2));
         assert_eq!(parsed.counts.page, Some(1));
-        assert_eq!(parsed.items[0].users.as_deref(), Some("alice, bob"));
+        assert_eq!(
+            parsed.items[0].users,
+            vec![
+                "alice".to_string(),
+                "bob".to_string(),
+                "charlie".to_string()
+            ]
+        );
         assert_eq!(
             parsed.items[0].meta.owner.as_ref().map(|o| o.name.as_str()),
             Some("admin")
@@ -179,6 +189,6 @@ mod tests {
         let group = &parsed.items[0];
 
         assert_eq!(group.meta.comment, None);
-        assert_eq!(group.users, None);
+        assert!(group.users.is_empty());
     }
 }

--- a/crates/gvm-gmp/src/responses/note.rs
+++ b/crates/gvm-gmp/src/responses/note.rs
@@ -6,8 +6,9 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
-    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
+    ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,7 +18,7 @@ pub struct Note {
     pub meta: EntityMeta,
     pub text: Option<String>,
     pub nvt_oid: Option<String>,
-    pub hosts: Option<String>,
+    pub hosts: Vec<String>,
     pub port: Option<String>,
     pub severity: Option<String>,
     pub task: Option<NamedEntity>,
@@ -54,7 +55,10 @@ impl Note {
                 .child("nvt")
                 .and_then(|n| n.attr("oid"))
                 .map(String::from),
-            hosts: node.optional_child_text("hosts"),
+            hosts: node
+                .optional_child_text("hosts")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
             port: node.optional_child_text("port"),
             severity: node.optional_child_text("severity"),
             task: parse_named_entity(node, "task")?,
@@ -126,7 +130,7 @@ mod tests {
                     <in_use>0</in_use>
                     <text>This is a note</text>
                     <nvt oid="1.3.6.1.4.1.25623.1.0.12345"><name>Some NVT</name></nvt>
-                    <hosts>192.168.1.1</hosts>
+                    <hosts>192.168.1.1, 192.168.1.2, </hosts>
                     <port>80/tcp</port>
                     <severity>5.0</severity>
                     <task id="t-1"><name>Task One</name></task>
@@ -155,7 +159,10 @@ mod tests {
             parsed.items[0].nvt_oid.as_deref(),
             Some("1.3.6.1.4.1.25623.1.0.12345")
         );
-        assert_eq!(parsed.items[0].hosts.as_deref(), Some("192.168.1.1"));
+        assert_eq!(
+            parsed.items[0].hosts,
+            vec!["192.168.1.1".to_string(), "192.168.1.2".to_string()]
+        );
         assert_eq!(parsed.items[0].port.as_deref(), Some("80/tcp"));
         assert_eq!(
             parsed.items[0].task.as_ref().map(|t| t.name.as_str()),
@@ -220,7 +227,7 @@ mod tests {
         assert_eq!(note.meta.comment, None);
         assert_eq!(note.text, None);
         assert_eq!(note.nvt_oid, None);
-        assert_eq!(note.hosts, None);
+        assert!(note.hosts.is_empty());
         assert_eq!(note.task, None);
         assert!(!note.active);
     }

--- a/crates/gvm-gmp/src/responses/override_.rs
+++ b/crates/gvm-gmp/src/responses/override_.rs
@@ -6,8 +6,9 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
-    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
+    ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,7 +18,7 @@ pub struct Override {
     pub meta: EntityMeta,
     pub text: Option<String>,
     pub nvt_oid: Option<String>,
-    pub hosts: Option<String>,
+    pub hosts: Vec<String>,
     pub port: Option<String>,
     pub severity: Option<String>,
     pub new_severity: Option<String>,
@@ -55,7 +56,10 @@ impl Override {
                 .child("nvt")
                 .and_then(|n| n.attr("oid"))
                 .map(String::from),
-            hosts: node.optional_child_text("hosts"),
+            hosts: node
+                .optional_child_text("hosts")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
             port: node.optional_child_text("port"),
             severity: node.optional_child_text("severity"),
             new_severity: node.optional_child_text("new_severity"),
@@ -128,7 +132,7 @@ mod tests {
                     <in_use>0</in_use>
                     <text>Override text</text>
                     <nvt oid="1.3.6.1.4.1.25623.1.0.12345"><name>Some NVT</name></nvt>
-                    <hosts>192.168.1.1</hosts>
+                    <hosts>192.168.1.1,192.168.1.2, </hosts>
                     <port>80/tcp</port>
                     <severity>5.0</severity>
                     <new_severity>2.0</new_severity>
@@ -159,6 +163,10 @@ mod tests {
             Some("1.3.6.1.4.1.25623.1.0.12345")
         );
         assert_eq!(parsed.items[0].new_severity.as_deref(), Some("2.0"));
+        assert_eq!(
+            parsed.items[0].hosts,
+            vec!["192.168.1.1".to_string(), "192.168.1.2".to_string()]
+        );
         assert_eq!(
             parsed.items[0].task.as_ref().map(|t| t.name.as_str()),
             Some("Task One")
@@ -222,6 +230,7 @@ mod tests {
         assert_eq!(ov.meta.comment, None);
         assert_eq!(ov.text, None);
         assert_eq!(ov.nvt_oid, None);
+        assert!(ov.hosts.is_empty());
         assert_eq!(ov.new_severity, None);
         assert_eq!(ov.task, None);
         assert!(!ov.active);

--- a/crates/gvm-gmp/src/responses/role.rs
+++ b/crates/gvm-gmp/src/responses/role.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
-    ActionResponse, CountInfo, EntityMeta, ParseError,
+    count_info, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,7 +15,7 @@ use crate::responses::common::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Role {
     pub meta: EntityMeta,
-    pub users: Option<String>,
+    pub users: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,7 +41,10 @@ impl Role {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            users: node.optional_child_text("users"),
+            users: node
+                .optional_child_text("users")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
         })
     }
 }
@@ -101,7 +104,7 @@ mod tests {
                     <modification_time>2026-01-02T00:00:00Z</modification_time>
                     <writable>1</writable>
                     <in_use>0</in_use>
-                    <users>alice, bob</users>
+                    <users>alice, bob, ,charlie</users>
                 </role>
                 <role id="r-2">
                     <name>Role Two</name>
@@ -118,7 +121,14 @@ mod tests {
         assert_eq!(parsed.counts.total, Some(2));
         assert_eq!(parsed.counts.filtered, Some(2));
         assert_eq!(parsed.counts.page, Some(1));
-        assert_eq!(parsed.items[0].users.as_deref(), Some("alice, bob"));
+        assert_eq!(
+            parsed.items[0].users,
+            vec![
+                "alice".to_string(),
+                "bob".to_string(),
+                "charlie".to_string()
+            ]
+        );
         assert_eq!(
             parsed.items[0].meta.owner.as_ref().map(|o| o.name.as_str()),
             Some("admin")
@@ -179,6 +189,6 @@ mod tests {
         let role = &parsed.items[0];
 
         assert_eq!(role.meta.comment, None);
-        assert_eq!(role.users, None);
+        assert!(role.users.is_empty());
     }
 }

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -6,7 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
+    count_info, optional_u32, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
     parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
     ParseError,
 };
@@ -16,8 +16,8 @@ use crate::responses::common::{
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Target {
     pub meta: EntityMeta,
-    pub hosts: Option<String>,
-    pub exclude_hosts: Option<String>,
+    pub hosts: Vec<String>,
+    pub exclude_hosts: Vec<String>,
     pub alive_tests: Option<String>,
     pub reverse_lookup_only: bool,
     pub reverse_lookup_unify: bool,
@@ -48,8 +48,14 @@ impl Target {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            hosts: node.optional_child_text("hosts"),
-            exclude_hosts: node.optional_child_text("exclude_hosts"),
+            hosts: node
+                .optional_child_text("hosts")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
+            exclude_hosts: node
+                .optional_child_text("exclude_hosts")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
             alive_tests: node.optional_child_text("alive_tests"),
             reverse_lookup_only: node
                 .optional_child_text("reverse_lookup_only")
@@ -122,8 +128,8 @@ mod tests {
                     <modification_time>2026-01-02T00:00:00Z</modification_time>
                     <writable>1</writable>
                     <in_use>0</in_use>
-                    <hosts>192.168.1.0/24</hosts>
-                    <exclude_hosts>192.168.1.5</exclude_hosts>
+                    <hosts>192.168.1.0/24, 192.168.2.0/24, </hosts>
+                    <exclude_hosts>192.168.1.5, ,192.168.1.6</exclude_hosts>
                     <alive_tests>Scan Config Default</alive_tests>
                     <reverse_lookup_only>0</reverse_lookup_only>
                     <reverse_lookup_unify>1</reverse_lookup_unify>
@@ -159,6 +165,14 @@ mod tests {
                 .as_ref()
                 .map(|port_list| port_list.name.as_str()),
             Some("All TCP")
+        );
+        assert_eq!(
+            parsed.items[0].hosts,
+            vec!["192.168.1.0/24".to_string(), "192.168.2.0/24".to_string()]
+        );
+        assert_eq!(
+            parsed.items[0].exclude_hosts,
+            vec!["192.168.1.5".to_string(), "192.168.1.6".to_string()]
         );
         assert!(parsed.items[0].reverse_lookup_unify);
         assert!(parsed.items[1].meta.in_use);
@@ -217,7 +231,8 @@ mod tests {
         let target = &parsed.items[0];
 
         assert_eq!(target.meta.comment, None);
-        assert_eq!(target.hosts, None);
+        assert!(target.hosts.is_empty());
+        assert!(target.exclude_hosts.is_empty());
         assert_eq!(target.port_list, None);
         assert!(!target.meta.in_use);
         assert!(!target.meta.writable);


### PR DESCRIPTION
## Summary

Implements the API consistency cleanup from https://github.com/clawosiris/rust-gvm/issues/76 using the **breaking cleanup now** path.

### Changed response fields (typed lists)

- `Target.hosts: Option<String> -> Vec<String>`
- `Target.exclude_hosts: Option<String> -> Vec<String>`
- `Note.hosts: Option<String> -> Vec<String>`
- `Override.hosts: Option<String> -> Vec<String>`
- `Group.users: Option<String> -> Vec<String>`
- `Role.users: Option<String> -> Vec<String>`

## Implementation

- Added shared helper in `responses/common.rs`:
  - `parse_csv_list(value: &str) -> Vec<String>`
  - behavior: split by comma, trim whitespace, drop empty segments
- Updated all affected parsers to use the helper and default to empty vec when field is absent.
- Extended/updated unit tests in each affected response module to verify:
  - multi-value parsing
  - whitespace trimming
  - empty/trailing segment filtering
  - missing field -> empty vec

## Why this scope

Issue #76 explicitly called out targets and requested an audit of related comma-separated surfaces. This PR includes those audited domains in one coherent breaking change so command/response ergonomics are consistent.

## Validation

- `cargo test -p gvm-gmp` ✅
- `cargo test --workspace --all-features` ✅

## API impact (breaking)

This changes public response field types. Consumers that previously handled raw comma-separated strings must switch to vector handling.

Closes #76
