### PR TITLE
chore(ci): replace external actions with native alternatives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: Run cargo deny
+        run: cargo deny check
 
   coverage:
     name: Coverage

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -246,19 +246,17 @@ jobs:
         run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Create nightly release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          tag_name: nightly
-          name: "Nightly Build (${{ steps.date.outputs.today }})"
-          prerelease: true
-          body: |
-            Automated nightly build from `main` branch.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "nightly" \
+            --title "Nightly Build (${{ steps.date.outputs.today }})" \
+            --prerelease \
+            --notes "Automated nightly build from `main` branch.
 
-            **⚠️ This is a development build — not recommended for production.**
+          **⚠️ This is a development build — not recommended for production.**
 
-            Built from commit: ${{ github.sha }}
+          Built from commit: ${{ github.sha }}
 
-            **🔐 Security:** All artifacts include Sigstore attestations for build provenance verification.
-          files: |
-            artifacts/*.tar.gz
-            artifacts/*.sha256
+          **🔐 Security:** All artifacts include Sigstore attestations for build provenance verification." \
+            artifacts/*.tar.gz artifacts/*.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,16 +268,15 @@ jobs:
           merge-multiple: true
 
       - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          generate_release_notes: true
-          body: |
-            **🔐 Security:** All artifacts include Sigstore attestations for build provenance verification.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --notes "**🔐 Security:** All artifacts include Sigstore attestations for build provenance verification.
 
-            To verify an artifact:
-            ```bash
-            gh attestation verify <artifact>.tar.gz --owner clawosiris
-            ```
-          files: |
-            artifacts/*.tar.gz
-            artifacts/*.sha256
+          To verify an artifact:
+          ```bash
+          gh attestation verify <artifact>.tar.gz --owner clawosiris
+          ```" \
+            artifacts/*.tar.gz artifacts/*.sha256


### PR DESCRIPTION
## Summary

Replaces two low-scoring external GitHub Actions with native CLI alternatives, improving supply chain security posture.

## Changes

### 1. Replace `EmbarkStudios/cargo-deny-action` (Scorecard: 4.0, Maintained: 0)

**Before:**
```yaml
- uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
```

**After:**
```yaml
- name: Install cargo-deny
  run: cargo install cargo-deny --locked
- name: Run cargo deny
  run: cargo deny check
```

### 2. Replace `softprops/action-gh-release` (Scorecard: 4.7, Code-Review: 0)

**Before:**
```yaml
- uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
```

**After:**
```yaml
- name: Create Release
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    gh release create "${{ github.ref_name }}" \
      --generate-notes \
      --notes "..." \
      artifacts/*.tar.gz artifacts/*.sha256
```

## Files Modified

- `.github/workflows/ci.yml` — cargo-deny replacement
- `.github/workflows/release.yml` — gh release replacement  
- `.github/workflows/nightly.yml` — gh release replacement (with `--prerelease`)

## Rationale

Per [OpenSSF Scorecard audit](https://github.com/clawosiris/rust-gvm/issues/91):
- `cargo-deny-action` is unmaintained (Maintained: 0)
- `action-gh-release` lacks code review (Code-Review: 0) and branch protection (Branch-Protection: 0)

Native CLI alternatives have no external dependencies and are maintained by GitHub/Rust teams directly.

Addresses #91