### PR TITLE
docs(journal): add 2026-04-01 — CI modernization, release documentation

### DIFF
--- a/journal/2026-04-01.md
+++ b/journal/2026-04-01.md
@@ -1,0 +1,46 @@
+# 2026-04-01 — CI Modernization, Release Documentation
+
+## Major Highlights
+- **CI modernization** — Replaced external GitHub Actions with native alternatives
+- **Release process** — Removed obsolete workflows, added comprehensive documentation
+- **OpenSSF audit** — Completed Scorecard audit for GitHub Actions security
+
+## CI/CD Changes
+
+### External Actions Replacement (PR #104)
+- Replaced external GitHub Actions with native GitHub alternatives
+- Improves supply chain security by reducing third-party action dependencies
+- Addresses findings from OpenSSF Scorecard audit
+
+### Release Workflow Modernization (PR #105)
+- Removed obsolete release workflows
+- Added release documentation for manual release process
+- Streamlines release procedure while maintaining control
+
+## Security Initiatives
+
+### OpenSSF Scorecard Audit (PR #101)
+- Added comprehensive OpenSSF Scorecard audit documentation for GitHub Actions
+- Documents security posture assessment methodology
+- Closes #93
+
+## Response Models
+
+### Typed Response Completion (PR #103, closes #102)
+- Completed typed response coverage for all GMP commands
+- All commands now return typed Response structs
+- Final milestone in structured response model initiative
+
+## Issues
+- **Closed:** #93 (OpenSSF Scorecard audit), #102 (typed Response structs)
+
+## Open Issues
+- [#92](https://github.com/clawosiris/rust-gvm/issues/92) — Security: Code Review of External GitHub Actions
+- [#91](https://github.com/clawosiris/rust-gvm/issues/91) — Security: OpenSSF Scorecard Analysis of External GitHub Actions
+- [#72](https://github.com/clawosiris/rust-gvm/issues/72) — CI: add OpenSSF Scorecard for project security posture
+- [#71](https://github.com/clawosiris/rust-gvm/issues/71) — Evaluate cargo-crev for distributed dependency reviews
+- [#59](https://github.com/clawosiris/rust-gvm/issues/59) — RUSTSEC-2026-0074 via russh/libcrux
+
+## CI Health
+- **Main branch**: ✅ Green
+- **Security**: OpenSSF Scorecard + Semgrep SAST active


### PR DESCRIPTION
## Summary

Daily journal entry covering activity since 2026-03-31:

### Highlights
- CI modernization — replaced external GitHub Actions with native alternatives (PR #104)
- Release documentation — removed obsolete workflows, added comprehensive docs (PR #105)
- OpenSSF audit — completed Scorecard audit for GitHub Actions (PR #101)
- Typed responses — completed typed Response coverage for all commands (PR #103)

### Issues Closed
- #93 (OpenSSF Scorecard audit)
- #102 (typed Response structs)

---
*Automated journal update*