### PR TITLE
journal: 2026-04-02 — Release Preparations

### DIFF
--- a/journal/2026-04-02.md
+++ b/journal/2026-04-02.md
@@ -1,0 +1,28 @@
+# 2026-04-02 — Release Preparations
+
+## Summary
+Light activity day focused on release automation. Alpha release commit landed on main.
+
+## Releases
+
+### Version 0.4.0-alpha.1
+- Automatic release commit merged to main (36f38f6)
+- Bumps version to 0.4.0-alpha.1
+- Follows completion of response models and security hardening work from prior sprint
+
+## Open Issues
+- [#92](https://github.com/clawosiris/rust-gvm/issues/92) — Security: Code Review of External GitHub Actions
+- [#91](https://github.com/clawosiris/rust-gvm/issues/91) — Security: OpenSSF Scorecard Analysis of External GitHub Actions
+- [#72](https://github.com/clawosiris/rust-gvm/issues/72) — CI: add OpenSSF Scorecard for project security posture
+- [#71](https://github.com/clawosiris/rust-gvm/issues/71) — Evaluate cargo-crev for distributed dependency reviews
+- [#59](https://github.com/clawosiris/rust-gvm/issues/59) — RUSTSEC-2026-0074 via russh/libcrux
+- [#38](https://github.com/clawosiris/rust-gvm/issues/38) — Architecture: Multi-endpoint access control gateway
+- [#20](https://github.com/clawosiris/rust-gvm/issues/20) — Improve SBOM quality scores (sbomqs 7.6 → 9.0+)
+- [#9](https://github.com/clawosiris/rust-gvm/issues/9) — Mock Server: Record-and-replay support roadmap
+- [#7](https://github.com/clawosiris/rust-gvm/issues/7) — Mock Server: TLS client certificate authentication behavior
+- [#4](https://github.com/clawosiris/rust-gvm/issues/4) — Spec: Strategy for streaming very large report responses
+
+## CI Health
+- **Main branch**: ❌ Failing (Test, Clippy, Documentation, Coverage, MSRV)
+- **Note**: CI failures likely related to version bump or dependency changes — needs investigation
+- **Security**: OpenSSF Scorecard skipped, Semgrep failing


### PR DESCRIPTION
## Summary
Daily journal entry for 2026-04-02.

## Contents
- Documented 0.4.0-alpha.1 release commit
- Updated open issues list
- Noted CI health issues requiring investigation