### PR TITLE
docs(journal): add 2026-04-04 — release infrastructure issues, PR activity

### DIFF
--- a/journal/2026-04-04.md
+++ b/journal/2026-04-04.md
@@ -1,0 +1,56 @@
+# 2026-04-04 — Release Infrastructure Issues, PR Activity
+
+## Release & CI
+
+### Version 0.4.0-alpha.1 Released (2026-04-01)
+- Automatic release to 0.4.0-alpha.1 via pontos
+- Cargo.lock dependency updates (233 insertions, 118 deletions)
+- Version bump in Cargo.toml
+
+### Release Infrastructure Issues
+- **CI failures detected** — main branch CI and Security workflows failing since 2026-04-01
+- Root cause under investigation
+- OpenSSF Scorecard skipped on private repo
+
+## Pull Requests
+
+### Open PRs (pending merge)
+- **#109** — fix(ci): restore release.yml with SBOM, Docker, binaries (opened 2026-04-02)
+  - Restores critical release workflow deleted in PR #105
+  - Adds back: gvm-mock-server binaries (5 platforms), Docker images, SBOM generation
+  - Fixes orchestration architecture — tag-triggered workflow for artifact publishing
+  - Supersedes PR #107's approach (which only removed wait step)
+  - Updates RELEASING.md with complete architecture documentation
+  
+- **#108** — journal: 2026-04-02 — Release Preparations (opened 2026-04-02)
+  - Daily journal entry for 2026-04-02
+  - Documents release commit and CI health issues
+  
+- **#106** — docs(journal): add 2026-04-01 — CI modernization, release documentation (opened 2026-04-01)
+  - Daily journal entry for 2026-04-01
+  - Covers CI modernization (PR #104), release docs (PR #105), OpenSSF audit (PR #101), typed responses (PR #103)
+
+### Closed PRs
+- **#107** — fix(ci): remove wait for non-existent release.yml (closed 2026-04-02)
+  - Attempted to fix orchestrator test failures by removing wait step
+  - Superseded by PR #109's more comprehensive solution
+
+## Issues
+
+### Open Issues (no new issues since 2026-04-01)
+- [#92](https://github.com/clawosiris/rust-gvm/issues/92) — Security: Code Review of External GitHub Actions
+- [#91](https://github.com/clawosiris/rust-gvm/issues/91) — Security: OpenSSF Scorecard Analysis of External GitHub Actions
+- [#72](https://github.com/clawosiris/rust-gvm/issues/72) — CI: add OpenSSF Scorecard for project security posture
+- [#71](https://github.com/clawosiris/rust-gvm/issues/71) — Evaluate cargo-crev for distributed dependency reviews
+- [#59](https://github.com/clawosiris/rust-gvm/issues/59) — CI: Cargo Audit/Deny failures due to RUSTSEC-2026-0074 via russh/libcrux (affects main)
+- [#38](https://github.com/clawosiris/rust-gvm/issues/38) — Architecture: Multi-endpoint access control gateway (gvm-gateway)
+- [#20](https://github.com/clawosiris/rust-gvm/issues/20) — Improve SBOM quality scores (sbomqs 7.6 → 9.0+)
+- [#9](https://github.com/clawosiris/rust-gvm/issues/9) — Mock Server Open Question: Record-and-replay support roadmap
+- [#7](https://github.com/clawosiris/rust-gvm/issues/7) — Mock Server Open Question: TLS client certificate authentication behavior
+- [#4](https://github.com/clawosiris/rust-gvm/issues/4) — Spec Open Question: Strategy for streaming very large report responses
+
+## CI Health
+- **Main branch**: ❌ **Failing** (CI + Security workflows)
+- **Root cause**: Under investigation (failures started 2026-04-01)
+- **Impact**: Release infrastructure broken — SBOM, Docker, binaries not published
+- **Fix in progress**: PR #109 restores complete release workflow


### PR DESCRIPTION
## Summary

Daily journal entry covering activity from 2026-04-01 to 2026-04-04.

### Highlights
- Version 0.4.0-alpha.1 released via automatic workflow (2026-04-01)
- CI/Security workflows failing on main since 2026-04-01 — under investigation
- PR #109 restores complete release workflow (SBOM, Docker, binaries)
- PR #107 closed in favor of PR #109's comprehensive approach
- Three open journal PRs (#106, #108, this one)

### Activity Summary
- **Release**: 0.4.0-alpha.1 automatic release with dependency updates
- **Open PRs**: #109 (release.yml restoration), #108 (2026-04-02 journal), #106 (2026-04-01 journal)
- **Closed PRs**: #107 (CI wait fix — superseded)
- **CI Status**: ❌ Failing (both CI and Security workflows)
- **Open Issues**: No changes (10 open issues remain)

---
*Automated journal update*