### PR TITLE
docs(journal): add 2026-04-18 journal entry

### DIFF
--- a/journal/2026-04-18.md
+++ b/journal/2026-04-18.md
@@ -1,0 +1,26 @@
+# 2026-04-18 — Release Workflow Rework, Dependency Maintenance, CI Regressions
+
+## Repository Activity
+
+### Release pipeline work remains open
+- Opened PR #109 to restore `release.yml` with SBOM, Docker, and binary packaging
+- Closed PR #107 after removing a wait on a non-existent release workflow
+- No release-workflow changes have merged to `main` since the 2026-03-31 entry
+
+### Dependency maintenance continued in open PRs
+- Opened Dependabot PR #114 to bump `russh` from 0.58.0 to 0.60.0
+- Opened Dependabot PR #116 for cargo dependency group updates
+- Opened Dependabot PR #117 for GitHub Actions dependency updates
+
+### Journal queue grew
+- Opened journal PRs #106, #108, #110, #115, and #118 covering 2026-04-01 through 2026-04-14
+- Those journal updates are still unmerged, so `main` has not advanced beyond the 2026-03-31 journal snapshot
+
+## Issues
+- No new issues opened since the last journal entry
+- Closed: #102 (all commands must return typed response structs), #93 (OpenSSF Scorecard audit for GitHub Actions)
+
+## CI Health
+- **Main branch**: ❌ CI failures observed on 2026-04-06 and 2026-04-13
+- **Security**: ❌ scheduled Security runs failed on 2026-04-06 and 2026-04-13
+- **Dependabot**: Mixed results, recent action and cargo update runs include failures


### PR DESCRIPTION
## Summary
- add 2026-04-18 journal entry
- capture repo activity since the last journal entry
- note current CI and maintenance state
