### PR TITLE
docs(journal): add 2026-04-21 journal entry

### DIFF
--- a/journal/2026-04-21.md
+++ b/journal/2026-04-21.md
@@ -1,0 +1,40 @@
+# 2026-04-21 — Release Cut, CI Friction, Dependabot Churn
+
+## Major Highlights
+- **0.4.0-alpha.1 released** — automated release commit landed on `main`
+- **Release workflow follow-up remains open** — release restoration work is still parked in PR #109
+- **Dependency automation keeps failing** — closed bot PRs were immediately replaced by a new failing actions update PR
+
+## Release Activity
+
+### 0.4.0-alpha.1 published (commit `36f38f6`)
+- `main` advanced on 2026-04-01 with `Automatic release to 0.4.0-alpha.1`
+- This is the only new mainline commit since the 2026-03-31 journal entry
+
+### Release workflow repair is still pending (PR #109)
+- Follow-up PR #107 to remove waiting on a missing `release.yml` was closed on 2026-04-02
+- Replacement PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`) was opened the same day and remains unmerged
+- Release automation is therefore still in a transitional state after the alpha cut
+
+## Dependency and PR Activity
+
+### Dependabot PRs keep recycling without landing
+- Cargo update PR #112 was opened on 2026-04-06 and closed on 2026-04-13 without merge
+- Actions update PR #113 followed the same pattern, closing unmerged on 2026-04-13
+- A broader cargo group update PR #116 closed unmerged on 2026-04-20
+- Actions update PR #117 also closed unmerged on 2026-04-20
+- A fresh replacement, PR #121, opened immediately on 2026-04-20 and is already failing
+
+### Manual CI probe was closed quickly (PR #111)
+- PR #111 (`test: CI pipeline verification`) was opened and closed on 2026-04-04
+- It suggests maintainers were validating pipeline behavior rather than landing product changes
+
+## Issues
+- **Closed:** #102 (typed response coverage complete), #93 (OpenSSF Scorecard audit)
+- No new non-PR issues were opened after the last journal entry
+
+## CI Health
+- **Main branch**: release commit landed, but no subsequent feature merges reached `main`
+- **Security**: scheduled `Security` runs on `main` failed on 2026-04-06, 2026-04-13, and 2026-04-20
+- **Dependabot**: update runs on `main` continue to alternate between partial success and failure, with bot PRs closing unmerged and reopening in new batches
+- **OpenSSF Scorecard**: scheduled runs are being skipped rather than reporting active findings


### PR DESCRIPTION
## Summary\n- add the 2026-04-21 journal entry\n- capture repository activity since the previous journal entry\n- document current CI and maintenance signals\n