### PR TITLE
docs(journal): add 2026-04-23 journal entry

### DIFF
--- a/journal/2026-04-23.md
+++ b/journal/2026-04-23.md
@@ -1,0 +1,37 @@
+# 2026-04-23 — Alpha Release Cut, Mainline Security Failures, Journal Backlog Growth
+
+## Release & Mainline Changes
+
+### 0.4.0-alpha.1 released on main
+- `main` advanced on 2026-04-01 with the automatic `0.4.0-alpha.1` release commit
+- This was the only non-journal commit to land after the 2026-03-31 entry
+- The release followed the late-2026-03-31 merge set that completed typed response coverage and release-documentation cleanup
+
+### Late 2026-03-31 cleanup landed before the release cut
+- PR #103 completed typed response coverage for all commands
+- PR #104 replaced external GitHub Actions usage with native alternatives
+- PR #105 removed obsolete release workflows and added release documentation
+- Issue #102 (all commands must return typed `Response` structs) closed with the typed-response completion work
+- Issue #93 (OpenSSF Scorecard audit) also closed on 2026-03-31
+
+## Maintenance Queue
+
+### Journal and dependency PRs are now stacked on top of the release commit
+- Open journal PRs #123 and #124 remain unmerged, extending the journal backlog
+- Older journal branches from 2026-04-01 through 2026-04-20 also remain open, so maintenance history is piling up instead of being consolidated
+- Dependabot PR #121 for GitHub Actions updates opened on 2026-04-20 and is still red
+- Fresh cargo Dependabot PRs #125 (`rustls-webpki`) and #126 (`rand`) opened on 2026-04-22 and immediately failed CI and Security
+
+### Existing repair branches are still stalled
+- PR #109 to restore the release workflow remains open with failing CI/Security runs from 2026-04-02
+- PR #114 to bump `russh` remains open and failing since 2026-04-06
+- The repo still looks dominated by maintenance drift rather than new feature delivery
+
+## Issues
+- **Closed:** #102 (all commands must return typed `Response` structs), #93 (OpenSSF Scorecard audit)
+- No new issues were opened after the 2026-03-31 entry
+
+## CI Health
+- **Main branch**: release reached `main`, but scheduled `Security` runs failed on 2026-04-06, 2026-04-13, and 2026-04-20
+- **Dependabot**: multiple update runs on `main` alternated between success and failure; new PRs #121, #125, and #126 all failed CI/Security immediately
+- **OpenSSF Scorecard**: scheduled runs on 2026-04-05, 2026-04-12, and 2026-04-19 were skipped rather than producing a pass/fail signal


### PR DESCRIPTION
## Summary\n- add the 2026-04-23 journal entry\n- capture repo activity since the last journal entry\n- document current CI / maintenance state\n