### PR TITLE
docs(journal): add 2026-04-25 journal entry

### DIFF
--- a/journal/2026-04-25.md
+++ b/journal/2026-04-25.md
@@ -1,0 +1,31 @@
+# 2026-04-25 — Journal Backlog Landed, Fresh russh Security Bump Failed Fast
+
+## Mainline Changes
+
+### Journal backlog merged into `main` on 2026-04-23
+- PRs #106, #108, #110, #115, #118, #119, #120, #122, #123, #124, and #127 all merged on 2026-04-23
+- `main` advanced through the previously queued journal history from 2026-04-01 through 2026-04-23
+- No feature or library code landed on `main` after the 2026-04-23 journal entry; default-branch movement since then has been documentation-only plus automation runs
+
+## Maintenance Queue
+
+### Release workflow repair branch recovered
+- PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`) is still open
+- After a failing run on 2026-04-23, a fresh rerun later that day turned both CI and Security green
+- That makes #109 look merge-ready again from a checks perspective
+
+### Most open maintenance PRs are green except the new `russh` attempt
+- PR #121 (GitHub Actions group update) remains open with green CI and Security
+- PR #125 (`rustls-webpki` 0.103.13) remains open with green CI and Security
+- PR #126 (`rand` 0.8.6) remains open with green CI and Security
+- New Dependabot PR #128 (`russh` 0.60.1) opened on 2026-04-24 and immediately failed across Clippy, docs, tests, Cargo Audit, and Cargo Vet
+- Older PR #114 (`russh` 0.60.0) is still open, so the repo now has two unresolved `russh` upgrade attempts in flight
+
+## Issues
+- No issues were opened or closed after the last journal entry
+
+## CI Health
+- **Main branch**: no new feature/test/release commits landed after the 2026-04-23 journal merge sweep
+- **Dependabot on main**: update runs on 2026-04-24 completed successfully
+- **Open maintenance PRs**: #109, #121, #125, and #126 are green; #128 is the new unstable outlier
+- **OpenSSF Scorecard**: the burst of `main` pushes on 2026-04-23 continued to produce skipped Scorecard runs rather than new pass/fail signal


### PR DESCRIPTION
## Summary
- add the 2026-04-25 journal entry
- capture repo activity since the last checked-in journal baseline
- document current CI and maintenance-queue state
