### PR TITLE
docs(journal): add 2026-04-28 journal entry

### DIFF
--- a/journal/2026-04-28.md
+++ b/journal/2026-04-28.md
@@ -1,0 +1,24 @@
+# 2026-04-28 — Journal Backlog Merged, Security Still Red, New Dependency Lane Opened
+
+## Repository Activity
+
+### Mainline stayed code-stable after the 2026-04-23 entry
+- No new commits landed on `main` after the 2026-04-23 journal baseline.
+- The most visible change since that entry was maintenance consolidation rather than feature delivery.
+
+### Journal backlog from April 1–23 was merged all at once
+- PRs **#106**, **#108**, **#110**, **#115**, **#118**, **#119**, **#120**, **#122**, **#123**, **#124**, and **#127** all merged on 2026-04-23.
+- That bulk merge brought the repo journal history on `main` up through the 2026-04-23 entry in one pass.
+
+### Dependency maintenance expanded, but no repair lane is green yet
+- Open PR **#121** (actions group updates) was refreshed on 2026-04-27.
+- New cargo bundle PR **#131** opened on 2026-04-27.
+- Existing dependency repair lanes **#109**, **#125**, **#126**, and **#128** remain open, while new journal PRs **#129**, **#130**, and **#132** extended the maintenance queue.
+
+## Issues
+- No issues were opened or closed after the 2026-04-23 journal entry.
+
+## CI Health
+- **Main branch**: the scheduled `Security` workflow failed again on 2026-04-27.
+- **Dependabot on main**: 2026-04-27 dynamic update runs split between success and failure — cargo and grouped GitHub Actions update jobs completed successfully, while the targeted security-action update path failed.
+- **Open PRs**: the active dependency queue is still not in a merge-ready state, so the repo remains blocked on maintenance cleanup rather than new code delivery.


### PR DESCRIPTION
## Summary
- add the 2026-04-28 journal entry
- capture repo activity since the previous journal baseline
- note current CI / PR queue state
