### PR TITLE
docs(journal): add 2026-04-30 journal entry

### DIFF
--- a/journal/2026-04-30.md
+++ b/journal/2026-04-30.md
@@ -1,0 +1,22 @@
+# 2026-04-30 — Journal Catch-up Merges, New Dependency Lanes, Security Still Red
+
+## Repository Activity
+
+### Mainline movement was journal-only catch-up
+- `main` advanced on 2026-04-23 through a stack of journal-entry merges: PRs #106, #108, #110, #115, #118, #119, #120, #122, #123, #124, and #127
+- No new feature, release, or dependency-repair code landed on `main` after the 2026-04-23 journal entry
+- The repo's visible progress since that entry is documentation/history consolidation rather than shipped code
+
+### New maintenance branches opened, but the queue is still split
+- New open PRs since the last journal entry include dependency lanes #128 (`russh` 0.60.1) and #131 (cargo group updates) plus journal PRs #129, #130, #132, #133, and #134
+- Clean backlog remains sizable: #109, #121, #125, #126, and the journal PRs #129, #130, #132, #133, #134 are all currently mergeable
+- Unstable repair lanes still block confidence: #114 (`russh` 0.60.0), #128 (`russh` 0.60.1), and #131 (cargo group) all remain red
+
+## Issues
+- No issues were opened after the 2026-04-23 journal entry
+- No issues were closed after the 2026-04-23 journal entry
+
+## CI Health
+- **Main branch Security**: the latest scheduled `Security` run failed on 2026-04-27, so the repo still lacks a trustworthy green baseline
+- **Dependabot on main**: 2026-04-24 cargo update runs succeeded, and on 2026-04-27 one cargo update plus one GitHub Actions update succeeded while another actions-group update failed
+- **OpenSSF Scorecard**: the 2026-04-23 push-triggered run and 2026-04-26 scheduled run were both skipped, so scorecard coverage is still not producing a live pass/fail signal


### PR DESCRIPTION
## Summary
- add the 2026-04-30 journal entry
- capture repo activity since the last committed journal file

## Testing
- not run (docs-only journal update)