### PR TITLE
docs(journal): add 2026-05-01 journal entry

### DIFF
--- a/journal/2026-05-01.md
+++ b/journal/2026-05-01.md
@@ -1,0 +1,23 @@
+# 2026-05-01 — No Mainline Recovery, Dependency Repair Queue Grew
+
+## Mainline & Queue Changes
+
+### `main` stayed frozen after the 2026-04-01 alpha release
+- No commits landed on `main` after the 2026-04-23 journal entry
+- There were also no merged PRs or issue closures during this window
+- The repo is still accumulating maintenance work without converting any of it into mainline recovery
+
+### New repair branches opened, but the queue is still red
+- PR #128 (`russh` 0.60.1) opened on 2026-04-24 and is blocked with multiple failing checks (`Cargo Audit`, `Clippy`, `Cargo Vet`, `Test`, `Documentation`, `Coverage`, and `MSRV`)
+- PR #131 (cargo group update) opened on 2026-04-27 and is blocked by a similar spread of failing checks
+- Journal PR #135 for the 2026-04-30 entry opened on 2026-04-30 and remains unmerged
+- Older failing dependency lanes #121, #125, and #126 are still stacked underneath the newer repair attempts
+
+## Issues
+- No issues were opened or closed after the 2026-04-23 journal entry
+
+## CI Health
+- **Main branch Security**: scheduled `Security` failed again on 2026-04-27
+- **Dependabot on main**: runs on 2026-04-27 were mixed, 2026-04-30 briefly produced successful updates, and the latest 2026-05-01 run failed again
+- **OpenSSF Scorecard**: the 2026-04-26 scheduled run was skipped instead of producing a pass/fail signal
+- **Repair PR baseline**: both new dependency PRs (#128 and #131) are blocked across multiple core checks, so the repo still does not have a clean recovery lane


### PR DESCRIPTION
## Summary
- add the 2026-05-01 journal entry
- capture repo activity since the last committed journal file

## Testing
- not run (documentation-only change)