### PR TITLE
docs(journal): add 2026-05-03 journal entry

### DIFF
--- a/journal/2026-05-03.md
+++ b/journal/2026-05-03.md
@@ -1,0 +1,31 @@
+# 2026-05-03 — Journal Backfill Landed on Main, Repair Queue Still Split
+
+## Mainline & Journal History
+
+### The backlog of missing journal history was finally merged into `main`
+- `main` advanced on 2026-04-23 with merged journal PRs #106, #108, #110, #115, #118, #119, #120, #122, #123, #124, and #127
+- There were no non-journal commits on `main` after the 2026-04-23 entry itself landed
+- This closes the historical gap in the `journal/` directory, but it also means the repo's recent story is mostly operational rather than product-delivery work
+
+### New journal branches resumed without being merged
+- New open journal PRs #135 (2026-04-30), #136 (2026-05-01), and #137 (2026-05-02) are now stacked on top of `main`
+- Journal PRs #129, #130, #132, #133, and #134 were opened and then closed unmerged during the 2026-04-25 through 2026-04-29 cleanup window
+- The repo is no longer missing old journal files on `main`, but it is already accumulating a fresh journal backlog in the PR queue
+
+## Maintenance Queue
+
+### Issue #59 is still unresolved and now has three active repair lanes
+- PR #128 (`build(deps): bump russh from 0.58.0 to 0.60.1`) opened on 2026-04-24 and remains open
+- PR #131 (`build(deps): bump the cargo group with 4 updates`) opened on 2026-04-27 and remains open
+- Older repair PR #114 is still open alongside those newer attempts, so the repo is still carrying multiple competing fixes for the same security/dependency problem
+
+### The rest of the queue remains mostly maintenance-heavy
+- PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`) is still open and is currently the cleanest-looking non-journal lane
+- Older dependency/CI PRs #121, #125, and #126 remain open but are marked behind rather than actively merged forward
+- No issues were opened or closed after the 2026-04-23 journal entry; the unresolved work remains concentrated in the existing CI/security backlog
+
+## CI Health
+- **Main branch Security**: the latest scheduled `Security` run on `main` failed on 2026-04-27
+- **OpenSSF Scorecard**: after a series of skipped scheduled runs around the 2026-04-23 journal backfill, the 2026-05-03 scheduled Scorecard run finally succeeded
+- **Dependabot on main**: cargo-related update runs succeeded on 2026-04-24, 2026-04-27, and 2026-04-30, but the 2026-04-27 GitHub Actions lane and the 2026-05-01 pip lane both failed
+- The repo looks better instrumented than it did in early April, but `main` still does not have a fresh green scheduled `Security` baseline after the 2026-04-27 failure


### PR DESCRIPTION
## Summary
- add the 2026-05-03 journal entry
- capture post-baseline repo activity and CI state

## Testing
- not run (journal-only change)
