### PR TITLE
docs(journal): add 2026-05-04 journal entry

### DIFF
--- a/journal/2026-05-04.md
+++ b/journal/2026-05-04.md
@@ -1,0 +1,26 @@
+# 2026-05-04 — Quiet Mainline, Repair PR #109 Ready, Dependabot Noise Continues
+
+## Mainline & Merged Work
+
+### No new default-branch commits landed after the 2026-04-23 journal baseline
+- `main` has not moved since PR #127 merged the 2026-04-23 journal entry
+- The 2026-04-23 merge burst only consolidated older journal backlog (#106, #108, #110, #115, #118, #119, #120, #122, #123, #124, and #127)
+- No newer feature, release, or dependency PRs have merged after that backlog landed
+
+## Pull Request Queue
+
+### Repair and dependency branches kept moving even though nothing merged
+- PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`) is now the cleanest lane in the repo: `CLEAN`, approved, and green on `CI` + `Security` as of 2026-05-02
+- New dependency PRs opened after the last journal entry: #128 (`build(deps): bump russh from 0.58.0 to 0.60.1`) on 2026-04-24 and #131 (`build(deps): bump the cargo group with 4 updates`) on 2026-04-27
+- Journal automation kept churning without landing: #129, #130, #132, #133, and #134 were opened and later closed, while #135, #136, #137, and #138 are still open
+- Older maintenance PRs #114, #121, #125, and #126 are still hanging around behind the same review / rebase backlog
+
+## Issues
+- No issues were opened or closed after the 2026-04-23 journal entry
+- Issue #59 still effectively exists as a branch-management problem because multiple dependency/CI repair branches remain open around the same area
+
+## CI Health
+- PR #109 gave the repo its freshest clean signal with successful `CI` and `Security` pull-request runs on 2026-05-02
+- `OpenSSF Scorecard` on `main` succeeded on 2026-05-03
+- The 2026-05-04 `Dependabot Updates` cycle on `main` was mixed again: three dynamic updates succeeded while one GitHub Actions update path failed
+- `main` still does not have a fresher green scheduled `Security` baseline than the branch-level success on PR #109


### PR DESCRIPTION
## Summary
- add the 2026-05-04 journal entry
- capture repo activity since the latest journal entry on main

## Testing
- not run (documentation only)