### PR TITLE
docs(journal): add 2026-05-05 journal entry

### DIFF
--- a/journal/2026-05-05.md
+++ b/journal/2026-05-05.md
@@ -1,0 +1,25 @@
+# 2026-05-05 — CI Repair Landed, Mainline Green Again, Maintenance Queue Narrowed
+
+## Mainline & Merged Work
+
+### Three substantive PRs finally landed on `main`
+- `main` moved again on 2026-05-04 with three non-journal merges: PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`), PR #121 (`ci(deps): bump the actions group across 1 directory with 4 updates`), and PR #126 (`build(deps): bump rand from 0.8.5 to 0.8.6`)
+- This is the first real mainline movement since the 2026-04-01 release cut captured in the 2026-04-23 journal entry
+- The long-stalled release-workflow repair lane is no longer theoretical: #109 merged and immediately produced fresh successful push runs on `CI`, `Security`, and `OpenSSF Scorecard`
+
+### The merge train also cleaned up part of the old dependency backlog
+- PR #131 (`build(deps): bump the cargo group with 4 updates`) was closed on 2026-05-04 instead of merging
+- PR #128 (`build(deps): bump russh from 0.58.0 to 0.60.1`) was closed on 2026-05-05 after repeated failed validation
+- No issues were opened or closed during this window
+
+## Pull Request Queue
+- The only substantive open maintenance PR is now #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`)
+- #141 opened on 2026-05-04 after #140 was superseded and closed the same day
+- #141 is currently green across `CI`, `Security`, `Cargo Audit`, `Clippy`, `Cargo Vet`, `Unused Dependencies`, and the rest of the normal validation stack
+- Journal PR backlog is still present on #135, #136, #137, #138, and #139
+
+## CI Health
+- **Main branch**: materially healthier than on 2026-04-23; the 2026-05-04 merges produced fresh successful `CI`, `Security`, and `OpenSSF Scorecard` push runs on `main`
+- **Scheduled security**: the repo still logged failing scheduled `Security` runs on 2026-04-27 and 2026-05-04 before the merge set landed
+- **Dependabot on main**: update runs stayed noisy through late April and early May, including a failed GitHub Actions lane on 2026-05-04, but the post-merge cargo batch later succeeded on `main`
+- **PR validation**: #141 briefly failed `Security` on first open, then reran green and is currently the cleanest merge candidate in the repo


### PR DESCRIPTION
## Summary
- add the 2026-05-05 journal entry
- capture repo activity since the last journal entry on `main`

## Testing
- not run (docs only)
