### PR TITLE
feat(client): complete typed scan config and scanner helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -41,9 +41,13 @@ use gvm_gmp::commands::reports::{get_reports, GetReportsOpts};
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
-    create_scan_config, get_scan_configs, ConfigOpts, GetScanConfigsOpts,
+    clone_scan_config, create_scan_config, delete_scan_config, get_scan_config, get_scan_configs,
+    modify_scan_config, sync_config, ConfigOpts, GetScanConfigsOpts,
 };
-use gvm_gmp::commands::scanners::{create_scanner, get_scanners, GetScannersOpts, ScannerOpts};
+use gvm_gmp::commands::scanners::{
+    clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
+    verify_scanner, GetScannersOpts, ScannerOpts,
+};
 use gvm_gmp::commands::schedules::{
     create_schedule, get_schedules, GetSchedulesOpts, ScheduleOpts,
 };
@@ -66,16 +70,17 @@ use gvm_gmp::responses::{
     CreatePermissionResponse, CreatePortListResponse, CreateReportFormatResponse,
     CreateRoleResponse, CreateScanConfigResponse, CreateScannerResponse, CreateScheduleResponse,
     CreateTagResponse, CreateTargetResponse, CreateTaskResponse, CreateTicketResponse,
-    CreateTlsCertificateResponse, CreateUserResponse, DescribeAuthResponse, GetAlertsResponse,
-    GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialsResponse, GetCvesResponse,
-    GetDfnCertAdvisoriesResponse, GetFeedsResponse, GetFiltersResponse, GetGroupsResponse,
-    GetHostsResponse, GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse,
-    GetOverridesResponse, GetPermissionsResponse, GetPortListsResponse, GetReportConfigsResponse,
-    GetReportFormatsResponse, GetReportsResponse, GetResultsResponse, GetRolesResponse,
-    GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
-    GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
-    GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, HelpResponse,
-    StartTaskResponse,
+    CreateTlsCertificateResponse, CreateUserResponse, DeleteScanConfigResponse,
+    DeleteScannerResponse, DescribeAuthResponse, GetAlertsResponse, GetCertBundAdvisoriesResponse,
+    GetCpesResponse, GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse,
+    GetFeedsResponse, GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
+    GetNvtFamiliesResponse, GetNvtsResponse, GetOverridesResponse, GetPermissionsResponse,
+    GetPortListsResponse, GetReportConfigsResponse, GetReportFormatsResponse, GetReportsResponse,
+    GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
+    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
+    GetTasksResponse, GetTicketsResponse, GetTlsCertificatesResponse, GetUsersResponse,
+    GetVersionResponse, HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse,
+    StartTaskResponse, SyncConfigResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -161,6 +166,68 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
+    /// Send a `get_scan_config` request and return a typed [`GetScanConfigsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_scan_config(
+        &mut self,
+        config_id: &EntityId,
+    ) -> Result<GetScanConfigsResponse, GvmError> {
+        let response = self.send(get_scan_config(config_id)).await?;
+        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_scan_config` request and return a typed [`ModifyScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_scan_config(
+        &mut self,
+        config_id: &EntityId,
+        opts: ConfigOpts,
+    ) -> Result<ModifyScanConfigResponse, GvmError> {
+        let response = self.send(modify_scan_config(config_id, opts)).await?;
+        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `delete_scan_config` request and return a typed [`DeleteScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn delete_scan_config(
+        &mut self,
+        config_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<DeleteScanConfigResponse, GvmError> {
+        let response = self.send(delete_scan_config(config_id, ultimate)).await?;
+        DeleteScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `clone_scan_config` request and return a typed [`CreateScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn clone_scan_config(
+        &mut self,
+        config_id: &EntityId,
+    ) -> Result<CreateScanConfigResponse, GvmError> {
+        let response = self.send(clone_scan_config(config_id)).await?;
+        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `sync_config` request and return a typed [`SyncConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn sync_scan_config(
+        &mut self,
+        config_id: &EntityId,
+    ) -> Result<SyncConfigResponse, GvmError> {
+        let response = self.send(sync_config(config_id)).await?;
+        SyncConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
     // ── Scanners ──────────────────────────────────────────────────────────────
 
     /// Send a `get_scanners` request and return a typed [`GetScannersResponse`].
@@ -185,6 +252,68 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: ScannerOpts,
     ) -> Result<CreateScannerResponse, GvmError> {
         let response = self.send(create_scanner(name, opts)).await?;
+        CreateScannerResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_scanner` request and return a typed [`GetScannersResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_scanner(
+        &mut self,
+        scanner_id: &EntityId,
+    ) -> Result<GetScannersResponse, GvmError> {
+        let response = self.send(get_scanner(scanner_id)).await?;
+        GetScannersResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_scanner` request and return a typed [`ModifyScannerResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_scanner(
+        &mut self,
+        scanner_id: &EntityId,
+        opts: ScannerOpts,
+    ) -> Result<ModifyScannerResponse, GvmError> {
+        let response = self.send(modify_scanner(scanner_id, opts)).await?;
+        ModifyScannerResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `delete_scanner` request and return a typed [`DeleteScannerResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn delete_scanner(
+        &mut self,
+        scanner_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<DeleteScannerResponse, GvmError> {
+        let response = self.send(delete_scanner(scanner_id, ultimate)).await?;
+        DeleteScannerResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `verify_scanner` request and return a typed [`VerifyScannerResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn verify_scanner(
+        &mut self,
+        scanner_id: &EntityId,
+    ) -> Result<VerifyScannerResponse, GvmError> {
+        let response = self.send(verify_scanner(scanner_id)).await?;
+        VerifyScannerResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `clone_scanner` request and return a typed [`CreateScannerResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn clone_scanner(
+        &mut self,
+        scanner_id: &EntityId,
+    ) -> Result<CreateScannerResponse, GvmError> {
+        let response = self.send(clone_scanner(scanner_id)).await?;
         CreateScannerResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -323,21 +323,7 @@ async fn full_crud_lifecycle_succeeds() {
     server.shutdown().await;
 }
 
-#[tokio::test]
-async fn typed_scan_config_and_scanner_helpers_cover_full_lifecycle() {
-    let Some(server) = stateful_server().await else {
-        return;
-    };
-    let connection = unix_connection(&server);
-    let mut client = GmpClient::connect(connection)
-        .await
-        .expect("client should connect");
-
-    client
-        .authenticate("admin", "admin")
-        .await
-        .expect("authenticate should succeed");
-
+async fn typed_scan_config_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
     let created_config = client
         .create_scan_config(
             "Typed Config",
@@ -403,7 +389,9 @@ async fn typed_scan_config_and_scanner_helpers_cover_full_lifecycle() {
         .delete_scan_config(&config_id, true)
         .await
         .expect("delete original config should succeed");
+}
 
+async fn typed_scanner_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
     let created_scanner = client
         .create_scanner("Typed Scanner", ScannerOpts::default())
         .await
@@ -466,6 +454,25 @@ async fn typed_scan_config_and_scanner_helpers_cover_full_lifecycle() {
         .delete_scanner(&scanner_id, true)
         .await
         .expect("delete original scanner should succeed");
+}
+
+#[tokio::test]
+async fn typed_scan_config_and_scanner_helpers_cover_full_lifecycle() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    typed_scan_config_lifecycle(&mut client).await;
+    typed_scanner_lifecycle(&mut client).await;
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -7,6 +7,8 @@
 use gvm_client::{GmpClient, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::scan_configs::ConfigOpts;
+use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
@@ -21,9 +23,7 @@ fn socket_path() -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("system time should be after epoch")
         .as_nanos();
-    std::env::current_dir()
-        .expect("current dir should resolve")
-        .join(format!("gvmc-{}-{unique}.sock", std::process::id()))
+    std::env::temp_dir().join(format!("gvmc-{}-{unique}.sock", std::process::id()))
 }
 
 async fn stateful_server() -> Option<MockGmpServer> {
@@ -319,6 +319,153 @@ async fn full_crud_lifecycle_succeeds() {
         .await
         .expect("delete_target should succeed");
     assert_eq!(delete_target_response.status_code(), Some(200));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_scan_config_and_scanner_helpers_cover_full_lifecycle() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created_config = client
+        .create_scan_config(
+            "Typed Config",
+            None,
+            ConfigOpts {
+                comment: Some("created".into()),
+                usage_type: Some("scan".into()),
+            },
+        )
+        .await
+        .expect("create_scan_config should succeed");
+    let config_id = created_config.id;
+
+    let fetched_config = client
+        .get_scan_config(&config_id)
+        .await
+        .expect("get_scan_config should succeed");
+    assert_eq!(fetched_config.items.len(), 1);
+    assert_eq!(fetched_config.items[0].meta.id, config_id);
+    assert_eq!(fetched_config.items[0].meta.name, "Typed Config");
+
+    client
+        .modify_scan_config(
+            &config_id,
+            ConfigOpts {
+                comment: Some("updated".into()),
+                usage_type: Some("scan".into()),
+            },
+        )
+        .await
+        .expect("modify_scan_config should succeed");
+
+    let updated_config = client
+        .get_scan_config(&config_id)
+        .await
+        .expect("get_scan_config after modify should succeed");
+    assert_eq!(
+        updated_config.items[0].meta.comment.as_deref(),
+        Some("updated")
+    );
+
+    client
+        .sync_scan_config(&config_id)
+        .await
+        .expect("sync_scan_config should succeed");
+
+    let cloned_config = client
+        .clone_scan_config(&config_id)
+        .await
+        .expect("clone_scan_config should succeed");
+    let cloned_config_id = cloned_config.id;
+    let cloned_config_response = client
+        .get_scan_config(&cloned_config_id)
+        .await
+        .expect("get cloned config should succeed");
+    assert_eq!(cloned_config_response.items[0].meta.name, "Typed Config");
+
+    client
+        .delete_scan_config(&cloned_config_id, true)
+        .await
+        .expect("delete cloned config should succeed");
+    client
+        .delete_scan_config(&config_id, true)
+        .await
+        .expect("delete original config should succeed");
+
+    let created_scanner = client
+        .create_scanner("Typed Scanner", ScannerOpts::default())
+        .await
+        .expect("create_scanner should succeed");
+    let scanner_id = created_scanner.id;
+
+    let fetched_scanner = client
+        .get_scanner(&scanner_id)
+        .await
+        .expect("get_scanner should succeed");
+    assert_eq!(fetched_scanner.items.len(), 1);
+    assert_eq!(fetched_scanner.items[0].meta.id, scanner_id);
+    assert_eq!(fetched_scanner.items[0].meta.name, "Typed Scanner");
+
+    client
+        .modify_scanner(
+            &scanner_id,
+            ScannerOpts {
+                comment: Some("updated".into()),
+                host: Some("127.0.0.1".into()),
+                port: Some(9390),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_scanner should succeed");
+
+    let updated_scanner = client
+        .get_scanner(&scanner_id)
+        .await
+        .expect("get_scanner after modify should succeed");
+    assert_eq!(
+        updated_scanner.items[0].meta.comment.as_deref(),
+        Some("updated")
+    );
+    assert_eq!(updated_scanner.items[0].host.as_deref(), Some("127.0.0.1"));
+    assert_eq!(updated_scanner.items[0].port, Some(9390));
+
+    client
+        .verify_scanner(&scanner_id)
+        .await
+        .expect("verify_scanner should succeed");
+
+    let cloned_scanner = client
+        .clone_scanner(&scanner_id)
+        .await
+        .expect("clone_scanner should succeed");
+    let cloned_scanner_id = cloned_scanner.id;
+    let cloned_scanner_response = client
+        .get_scanner(&cloned_scanner_id)
+        .await
+        .expect("get cloned scanner should succeed");
+    assert_eq!(cloned_scanner_response.items[0].meta.name, "Typed Scanner");
+
+    client
+        .delete_scanner(&cloned_scanner_id, true)
+        .await
+        .expect("delete cloned scanner should succeed");
+    client
+        .delete_scanner(&scanner_id, true)
+        .await
+        .expect("delete original scanner should succeed");
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -91,8 +91,14 @@ pub use result::{GetResultsResponse, NvtRef, QodInfo, ScanResult};
 pub use role::{
     CreateRoleResponse, DeleteRoleResponse, GetRolesResponse, ModifyRoleResponse, Role,
 };
-pub use scan_config::{CreateScanConfigResponse, GetScanConfigsResponse, ScanConfig};
-pub use scanner::{CreateScannerResponse, GetScannersResponse, Scanner};
+pub use scan_config::{
+    CreateScanConfigResponse, DeleteScanConfigResponse, GetScanConfigsResponse,
+    ModifyScanConfigResponse, ScanConfig, SyncConfigResponse,
+};
+pub use scanner::{
+    CreateScannerResponse, DeleteScannerResponse, GetScannersResponse, ModifyScannerResponse,
+    Scanner, VerifyScannerResponse,
+};
 pub use schedule::{
     CreateScheduleResponse, DeleteScheduleResponse, GetSchedulesResponse, ModifyScheduleResponse,
     Schedule,

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -475,6 +475,7 @@ impl SessionHandler {
         let new_name = parse_element_text(raw_xml, "name");
         let new_text = parse_element_text(raw_xml, "text");
         let new_comment = parse_element_text(raw_xml, "comment");
+        let new_host = parse_element_text(raw_xml, "host");
         let new_hosts = parse_element_text(raw_xml, "hosts");
         let new_status = parse_element_text(raw_xml, "status");
         let new_nvt_oid = parse_element_text(raw_xml, "nvt_oid")
@@ -499,6 +500,9 @@ impl SessionHandler {
             }
             if let Some(ref comment) = new_comment {
                 r.comment.clone_from(comment);
+            }
+            if let Some(ref host) = new_host {
+                r.set_attr("host", host);
             }
             if let Some(ref hosts) = new_hosts {
                 r.set_attr("hosts", hosts);

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -155,7 +155,82 @@ async fn matrix_configs_create_get_list() {
 }
 
 #[tokio::test]
-async fn matrix_scanners_create_delete_ultimate() {
+async fn matrix_configs_full_lifecycle_helpers() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let config_id = create_and_get_id(
+        &mut stream,
+        b"<create_config><name>Matrix Config</name><comment>cfg</comment></create_config>",
+        "create_config",
+    )
+    .await;
+
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_config config_id=\"{config_id}\"><comment>updated</comment><usage_type>scan</usage_type></modify_config>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_configs config_id=\"{config_id}\" details=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+    let get_text = get_resp.as_str().expect("valid utf8");
+    assert!(get_text.contains("<comment>updated</comment>"));
+    assert!(get_text.contains("<usage_type>scan</usage_type>"));
+
+    let sync_resp = send_recv(
+        &mut stream,
+        format!("<sync_config config_id=\"{config_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(sync_resp.status_code(), Some(200));
+
+    let cloned_config_id = create_and_get_id(
+        &mut stream,
+        format!("<create_config><copy>{config_id}</copy></create_config>").as_bytes(),
+        "create_config",
+    )
+    .await;
+
+    let cloned_get_resp = send_recv(
+        &mut stream,
+        format!("<get_configs config_id=\"{cloned_config_id}\" details=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(cloned_get_resp.status_code(), Some(200));
+    let cloned_get_text = cloned_get_resp.as_str().expect("valid utf8");
+    assert!(cloned_get_text.contains("Matrix Config"));
+
+    let delete_resp = send_recv(
+        &mut stream,
+        format!("<delete_config config_id=\"{config_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete_resp.status_code(), Some(200));
+
+    let deleted_get_resp = send_recv(
+        &mut stream,
+        format!("<get_configs config_id=\"{config_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(deleted_get_resp.status_code(), Some(404));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn matrix_scanners_full_lifecycle_helpers() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -168,6 +243,60 @@ async fn matrix_scanners_create_delete_ultimate() {
         "create_scanner",
     )
     .await;
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_scanners scanner_id=\"{scanner_id}\" details=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+    let get_text = get_resp.as_str().expect("valid utf8");
+    assert!(get_text.contains(&scanner_id));
+    assert!(get_text.contains("Matrix Scanner"));
+
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_scanner scanner_id=\"{scanner_id}\"><comment>updated</comment><host>127.0.0.1</host><port>9390</port></modify_scanner>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+
+    let updated_get_resp = send_recv(
+        &mut stream,
+        format!("<get_scanners scanner_id=\"{scanner_id}\" details=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(updated_get_resp.status_code(), Some(200));
+    let updated_get_text = updated_get_resp.as_str().expect("valid utf8");
+    assert!(updated_get_text.contains("<comment>updated</comment>"));
+    assert!(updated_get_text.contains("<host>127.0.0.1</host>"));
+    assert!(updated_get_text.contains("<port>9390</port>"));
+
+    let verify_resp = send_recv(
+        &mut stream,
+        format!("<verify_scanner scanner_id=\"{scanner_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(verify_resp.status_code(), Some(200));
+
+    let cloned_scanner_id = create_and_get_id(
+        &mut stream,
+        format!("<create_scanner><copy>{scanner_id}</copy></create_scanner>").as_bytes(),
+        "create_scanner",
+    )
+    .await;
+
+    let cloned_get_resp = send_recv(
+        &mut stream,
+        format!("<get_scanners scanner_id=\"{cloned_scanner_id}\" details=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(cloned_get_resp.status_code(), Some(200));
+    let cloned_get_text = cloned_get_resp.as_str().expect("valid utf8");
+    assert!(cloned_get_text.contains("Matrix Scanner"));
 
     let delete_resp = send_recv(
         &mut stream,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -333,8 +333,8 @@ Convenience methods on `GmpClient<C>` that combine `send()` + `XxxResponse::from
 | version | ✅ | — | `get_version()` |
 | auth | — | — | `authenticate()` |
 | target | ✅ | ✅ | |
-| scan_config | ✅ | ✅ | |
-| scanner | ✅ | ✅ | |
+| scan_config | ✅ | ✅ | Also: `get_scan_config()`, `modify_scan_config()`, `delete_scan_config()`, `clone_scan_config()`, `sync_scan_config()` |
+| scanner | ✅ | ✅ | Also: `get_scanner()`, `modify_scanner()`, `delete_scanner()`, `verify_scanner()`, `clone_scanner()` |
 | port_list | ✅ | ✅ | |
 | task | ✅ | ✅ | Also: `start_task()` |
 | report | ✅ | — | |


### PR DESCRIPTION
## Summary
- complete the typed `gvm-client` helper surface for scan configs and scanners
- re-export the scan-config/scanner action response aliases needed by the new helpers
- add stateful mock-server coverage for the new config/scanner lifecycle paths and make the status table explicit

## What changed
- added typed scan-config helpers:
  - `get_scan_config`
  - `modify_scan_config`
  - `delete_scan_config`
  - `clone_scan_config`
  - `sync_scan_config`
- added typed scanner helpers:
  - `get_scanner`
  - `modify_scanner`
  - `delete_scanner`
  - `verify_scanner`
  - `clone_scanner`
- re-exported `Modify*` / `Delete*` / `Verify*` / `Sync*` response aliases for the affected families
- extended stateful mock coverage for config and scanner lifecycle helper paths
- taught the stateful mock server to persist scanner `host` on modify so the scanner helper path can be exercised meaningfully
- updated `docs/STATUS.md` to make the scan-config/scanner typed-helper table entries explicit
- hardened the `gvm-client` unix-socket integration test helper to use a shorter temp-dir socket path

Closes #143.

## Validation
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration -- --nocapture`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix -- --nocapture`
- `cargo test -p gvm-gmp --test test_scan_configs -- --nocapture`
- `cargo test -p gvm-gmp --test test_scanners -- --nocapture`
