### PR TITLE
ci: run security workflow on docs-only pull requests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,14 +11,9 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
   pull_request:
+    # Keep the workflow running for docs-only PRs so branch protection always
+    # receives the required `Security` status check.
     branches: [main]
-    paths-ignore:
-      - 'journal/**'
-      - 'docs/**'
-      - 'spec/**'
-      - '*.md'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: "0 6 * * 1"


### PR DESCRIPTION
## Summary
- stop skipping the `Security` workflow on docs-only pull requests
- preserve the existing `push.paths-ignore` behavior for docs/journal changes on branches like `main`
- unblock PRs that are approved but deadlocked by branch protection waiting for a missing `Security` check

## Why
`main` branch protection requires the `Security` status check.

Before this change, `.github/workflows/security.yml` used `pull_request.paths-ignore` for `journal/**`, `docs/**`, `*.md`, and related docs-only paths. That meant docs-only PRs never emitted a `Security` workflow run, so they stayed `APPROVED` + `BLOCKED` forever even when there was nothing actually failing.

This change keeps the workflow running on PRs so the required `Security` check always exists for branch protection.

## Scope
- `pull_request`: always run for PRs into `main`
- `push`: keep the existing path-ignore behavior unchanged

## Follow-up
After this merges, the currently blocked journal PRs (#135-#139) should be able to get normal `Security` runs instead of waiting on a check that never appears.
