### PR TITLE
docs(journal): add 2026-05-08 journal entry

### DIFF
--- a/journal/2026-05-08.md
+++ b/journal/2026-05-08.md
@@ -1,0 +1,23 @@
+# 2026-05-08 — Backlog Landed, Repo Reset to an Issue-Driven Queue
+
+## Mainline & Merged Work
+
+### `main` converted yesterday’s waiting queue into shipped work after the 2026-05-07 journal baseline
+- `main` picked up four commits in the window, all on 2026-05-07: journal PR #142 (`docs(journal): add 2026-05-05 journal entry`), feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), dependency refresh PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and the consolidated journal PR #147 (`docs(journal): consolidate pending journal entries through 2026-05-07`)
+- The important product move was PR #144, which finished the typed scan-config and scanner helper lane that had been waiting in review yesterday
+- PR #141 also landed cleanly, so the earlier `BEHIND` maintenance branch is gone rather than lingering as queue debt
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`) on 2026-05-07
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`) on 2026-05-07 via PR #144
+- With #143 closed and no open PRs left, the repo’s active work has shifted back from merge-queue management to backlog prioritization
+
+## Pull Request Queue
+- The queue is empty right now: there are no open pull requests on the repo
+- That is a meaningful state change from yesterday, when the feature lane, the dependency lane, and pending journal work were all still stacked in review
+- The next visible decision is whether to open implementation work for issue #148 immediately or let the repo stay briefly clear
+
+## CI Health
+- `CI`, `Security`, and `OpenSSF Scorecard` all succeeded on `main` after the merge wave on 2026-05-07
+- The freshest signals came from the merged feature and dependency commits, and both ended green on `main`
+- There is no fresh evidence of hidden instability; the repo looks operationally healthy after the burst of merges


### PR DESCRIPTION
## Summary
- add the 2026-05-08 journal entry
- capture repo activity since the latest journal entry on `main`

## Testing
- not run (journal/documentation update only)
