### PR TITLE
docs(journal): add 2026-05-09 journal entry

### DIFF
--- a/journal/2026-05-09.md
+++ b/journal/2026-05-09.md
@@ -1,0 +1,23 @@
+# 2026-05-09 — Repo Stayed Quiet After the Backlog Flush, With Only the New Journal PR Waiting
+
+## Mainline & Merged Work
+
+### `main` did not move after the 2026-05-07 journal baseline
+- No new commits landed on `main` after the 2026-05-07 entry, so the merge burst captured in yesterday's pending journal update is still the last shipped work
+- There were no newly merged pull requests after that baseline, and no additional implementation lane opened behind the typed scanner-helper work that landed in PR #144
+- That leaves the repo in an intentionally quiet state rather than in a hidden backlog or broken-CI state
+
+## Issues
+- No issues were opened after the 2026-05-07 journal baseline beyond #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`), which remains the clearest next backlog candidate
+- No issues were closed in the same window after #143 closed through PR #144 on 2026-05-07
+- The repo's active decision is still prioritization, not triage: decide whether to open implementation work for #148 or let the queue stay empty a bit longer
+
+## Pull Request Queue
+- The only open pull request now is #149 (`docs(journal): add 2026-05-08 journal entry`)
+- PR #149 is `BLOCKED` only by required review; its checks are green, so this is review latency rather than code or CI trouble
+- Compared with the truly empty queue captured at the end of the 2026-05-08 activity window, the repo has added only routine journal maintenance and no new product or dependency lane
+
+## CI Health
+- The freshest `main` signals are still the successful 2026-05-07 `CI`, `Security`, and `OpenSSF Scorecard` runs that followed the last merge wave
+- The new journal PR also received a green `Security` pull-request run on 2026-05-08, which is consistent with the earlier docs-only workflow coverage improvement
+- There is still no fresh evidence of instability; the repo remains operationally healthy, just quiet


### PR DESCRIPTION
## Summary
- add the 2026-05-09 journal entry
- capture repo activity since the last journal entry on main
- note current PR queue and CI posture
