### PR TITLE
docs(journal): add 2026-05-10 journal entry

### DIFF
--- a/journal/2026-05-10.md
+++ b/journal/2026-05-10.md
@@ -1,0 +1,25 @@
+# 2026-05-10 — Typed Scanner Helpers Landed, Then the Repo Settled Back Into a Review-Only Queue
+
+## Mainline & Merged Work
+
+### `main` moved meaningfully after the 2026-05-07 journal baseline, but only for one real product lane
+- `main` picked up four commits in the window, all on 2026-05-07: journal PR #142 for 2026-05-05, feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), Dependabot PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and journal consolidation PR #147 through 2026-05-07
+- PR #144 is the only substantive product change in that set: it shipped the typed scan-config and scanner helper work that had been queued behind issue #143
+- After that merge burst, the repo stopped moving on `main`; the remaining activity has been journal queue management and a newly opened follow-on issue rather than more code landing
+
+## Pull Request Queue
+
+### The queue has narrowed to documentation-only review work
+- PRs #149 and #150 (`docs(journal): add 2026-05-08/2026-05-09 journal entry`) are both still open, both are `BLOCKED` only by required review, and both have fully green `Security` runs
+- There are no open feature or dependency PRs left competing for attention, so the repo's immediate bottleneck is reviewer throughput rather than implementation quality or CI noise
+- Compared with the 2026-05-07 entry, the active queue actually got simpler: the typed-helper feature landed, and what remains is mostly journal backlog absorption
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`)
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`), resolved by merged PR #144
+- That issue churn matters because it shows the repo closed one concrete feature gap and immediately surfaced the next parity lane instead of going quiet accidentally
+
+## CI Health
+- `main` is green across the most recent push-triggered `CI`, `Security`, and `OpenSSF Scorecard` runs that followed PRs #141, #144, and #147 on 2026-05-07
+- The scheduled `OpenSSF Scorecard` run on 2026-05-10 also succeeded, so there is no new default-branch security regression hiding behind the review backlog
+- The open journal PRs are healthy too, reinforcing that the repo's current delay is social rather than technical


### PR DESCRIPTION
## Summary
- add the 2026-05-10 journal entry
- capture repo activity since the last in-repo journal entry

## Testing
- not run (docs-only update)