### PR TITLE
docs(journal): add 2026-05-11 journal entry

### DIFF
--- a/journal/2026-05-11.md
+++ b/journal/2026-05-11.md
@@ -1,0 +1,25 @@
+# 2026-05-11 — Typed Scanner Helpers Landed, and a Fresh Dependabot Stack Arrived
+
+## Mainline & Merged Work
+
+### `main` moved again immediately after the 2026-05-07 journal baseline
+- `main` picked up four commits in-scope on 2026-05-07: journal PR #142 (`docs(journal): add 2026-05-05 journal entry`), feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), maintenance PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and consolidation PR #147 (`docs(journal): consolidate pending journal entries through 2026-05-07`)
+- PR #144 is the meaningful product landing in this window: it shipped the typed scan-config and scanner helper work that had been opened as issue #143
+- The dependency bump in PR #141 also made it through cleanly, so the repo did not merely catch up on journaling; it absorbed both a real feature lane and one maintenance lane on `main`
+
+## Pull Request Queue
+
+### The queue refilled with maintenance work after the merge burst
+- Three new Dependabot PRs opened on 2026-05-11: #152 (`build(deps): bump the cargo group with 2 updates`), #153 (`build(deps): bump russh from 0.58.1 to 0.60.2`), and #154 (`ci(deps): bump the actions group with 11 updates`)
+- They are not equally healthy. PR #154 is fully green and blocked only on review, PR #152 is mostly green but still fails `Cargo Vet`, and PR #153 is the noisy one with failures in `Clippy`, `Cargo Vet`, `Test (all features)`, `Documentation`, and the cargo-geiger workspace gate
+- Journal automation also resumed immediately after the 2026-05-07 consolidation: PRs #149, #150, and #151 are open, and the superseded 2026-05-06 journal PR #146 was closed unmerged once #147 consolidated the backlog
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`)
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`) via merged PR #144
+- The repo therefore shifted cleanly from one finished helper lane into the next parity/backlog lane without any gap in tracked work
+
+## CI Health
+- `main` remained healthy through the feature and dependency merges on 2026-05-07: push-triggered `CI`, `Security`, and `OpenSSF Scorecard` runs all succeeded after PRs #141 and #144 landed
+- The freshest default-branch signal is mixed only in the `Dependabot Updates` sweep on 2026-05-11, where one dynamic run succeeded and another failed, so current noise is concentrated in automation maintenance rather than in the product branch itself
+- The most actionable queue signal is straightforward: merge-ready PR #154 can move now, PR #152 needs cargo-vet attention, and PR #153 needs real follow-up before it stops being red


### PR DESCRIPTION
## Summary\n- add the 2026-05-11 journal entry\n- capture repo activity since the last merged journal entry\n- note current PR queue and CI posture\n