### PR TITLE
docs(journal): add 2026-05-13 journal entry

### DIFF
--- a/journal/2026-05-13.md
+++ b/journal/2026-05-13.md
@@ -1,0 +1,25 @@
+# 2026-05-13 — Mainline Picked Up Fresh CI Maintenance, While the Queue Split Into One Fixable Branch and One Expensive Branch
+
+## Mainline & Merged Work
+
+### `main` moved once after the 2026-05-07 journal baseline, and the change was meaningful even though it was small
+- `main` picked up one new commit in the window: PR #154 (`ci(deps): bump the actions group with 11 updates`) merged on 2026-05-12 at commit `272537b`
+- That merge did not change product surface area, but it materially refreshed repository automation by updating the actions stack across the CI and security workflows
+- Compared with the noisy backlog earlier in the month, the important signal here is that the default branch stayed mergeable and accepted maintenance cleanly
+
+## Pull Request Queue
+
+### The open queue is now mostly review and branch-drift management
+- PR #152 (`build(deps): bump the cargo group with 2 updates`) still looks like the easiest maintenance win: nearly the whole matrix is green, but `Cargo Vet` fails, which makes aggregate `Security` fail too
+- PR #153 (`build(deps): bump russh from 0.58.1 to 0.60.2`) is still the expensive branch: `Clippy`, `Documentation`, `Coverage`, `MSRV Check`, `Test (all features)`, `Cargo Geiger Workspace Gate`, `Cargo Vet`, and aggregate `Security` all fail
+- Journal PRs #149, #150, #151, #155, and #156 now represent the backlog since the last committed entry; older ones are already `BEHIND`, while the newest docs PR #156 is blocked on review rather than on automation
+
+## Issues
+- No issues were opened after the 2026-05-07 journal baseline
+- No issues were closed in the same window
+- The repo's active work is still operational rather than product-driven: dependency triage and queue cleanup dominate the decision surface
+
+## CI Health
+- `main` got fresh successful `CI`, `Security`, and `OpenSSF Scorecard` push runs on 2026-05-12 immediately after PR #154 landed
+- Scheduled `Security` and `OpenSSF Scorecard` runs also stayed green on 2026-05-10 and 2026-05-11, so the default branch currently has recent proof from both push-triggered and scheduled automation
+- The biggest CI risk is branch-local rather than repo-wide: #152 is one failing `Cargo Vet` fix away from landing, while #153 still looks better as a deliberate repair project than as a quick maintenance merge


### PR DESCRIPTION
## Summary
- add the 2026-05-13 journal entry
- capture repo activity since the last committed journal baseline

## Testing
- not run (documentation-only change)
