### PR TITLE
docs(journal): consolidate pending journal entries

### DIFF
--- a/journal/2026-05-08.md
+++ b/journal/2026-05-08.md
@@ -1,0 +1,23 @@
+# 2026-05-08 — Backlog Landed, Repo Reset to an Issue-Driven Queue
+
+## Mainline & Merged Work
+
+### `main` converted yesterday’s waiting queue into shipped work after the 2026-05-07 journal baseline
+- `main` picked up four commits in the window, all on 2026-05-07: journal PR #142 (`docs(journal): add 2026-05-05 journal entry`), feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), dependency refresh PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and the consolidated journal PR #147 (`docs(journal): consolidate pending journal entries through 2026-05-07`)
+- The important product move was PR #144, which finished the typed scan-config and scanner helper lane that had been waiting in review yesterday
+- PR #141 also landed cleanly, so the earlier `BEHIND` maintenance branch is gone rather than lingering as queue debt
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`) on 2026-05-07
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`) on 2026-05-07 via PR #144
+- With #143 closed and no open PRs left, the repo’s active work has shifted back from merge-queue management to backlog prioritization
+
+## Pull Request Queue
+- The queue is empty right now: there are no open pull requests on the repo
+- That is a meaningful state change from yesterday, when the feature lane, the dependency lane, and pending journal work were all still stacked in review
+- The next visible decision is whether to open implementation work for issue #148 immediately or let the repo stay briefly clear
+
+## CI Health
+- `CI`, `Security`, and `OpenSSF Scorecard` all succeeded on `main` after the merge wave on 2026-05-07
+- The freshest signals came from the merged feature and dependency commits, and both ended green on `main`
+- There is no fresh evidence of hidden instability; the repo looks operationally healthy after the burst of merges

--- a/journal/2026-05-09.md
+++ b/journal/2026-05-09.md
@@ -1,0 +1,23 @@
+# 2026-05-09 — Repo Stayed Quiet After the Backlog Flush, With Only the New Journal PR Waiting
+
+## Mainline & Merged Work
+
+### `main` did not move after the 2026-05-07 journal baseline
+- No new commits landed on `main` after the 2026-05-07 entry, so the merge burst captured in yesterday's pending journal update is still the last shipped work
+- There were no newly merged pull requests after that baseline, and no additional implementation lane opened behind the typed scanner-helper work that landed in PR #144
+- That leaves the repo in an intentionally quiet state rather than in a hidden backlog or broken-CI state
+
+## Issues
+- No issues were opened after the 2026-05-07 journal baseline beyond #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`), which remains the clearest next backlog candidate
+- No issues were closed in the same window after #143 closed through PR #144 on 2026-05-07
+- The repo's active decision is still prioritization, not triage: decide whether to open implementation work for #148 or let the queue stay empty a bit longer
+
+## Pull Request Queue
+- The only open pull request now is #149 (`docs(journal): add 2026-05-08 journal entry`)
+- PR #149 is `BLOCKED` only by required review; its checks are green, so this is review latency rather than code or CI trouble
+- Compared with the truly empty queue captured at the end of the 2026-05-08 activity window, the repo has added only routine journal maintenance and no new product or dependency lane
+
+## CI Health
+- The freshest `main` signals are still the successful 2026-05-07 `CI`, `Security`, and `OpenSSF Scorecard` runs that followed the last merge wave
+- The new journal PR also received a green `Security` pull-request run on 2026-05-08, which is consistent with the earlier docs-only workflow coverage improvement
+- There is still no fresh evidence of instability; the repo remains operationally healthy, just quiet

--- a/journal/2026-05-10.md
+++ b/journal/2026-05-10.md
@@ -1,0 +1,25 @@
+# 2026-05-10 — Typed Scanner Helpers Landed, Then the Repo Settled Back Into a Review-Only Queue
+
+## Mainline & Merged Work
+
+### `main` moved meaningfully after the 2026-05-07 journal baseline, but only for one real product lane
+- `main` picked up four commits in the window, all on 2026-05-07: journal PR #142 for 2026-05-05, feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), Dependabot PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and journal consolidation PR #147 through 2026-05-07
+- PR #144 is the only substantive product change in that set: it shipped the typed scan-config and scanner helper work that had been queued behind issue #143
+- After that merge burst, the repo stopped moving on `main`; the remaining activity has been journal queue management and a newly opened follow-on issue rather than more code landing
+
+## Pull Request Queue
+
+### The queue has narrowed to documentation-only review work
+- PRs #149 and #150 (`docs(journal): add 2026-05-08/2026-05-09 journal entry`) are both still open, both are `BLOCKED` only by required review, and both have fully green `Security` runs
+- There are no open feature or dependency PRs left competing for attention, so the repo's immediate bottleneck is reviewer throughput rather than implementation quality or CI noise
+- Compared with the 2026-05-07 entry, the active queue actually got simpler: the typed-helper feature landed, and what remains is mostly journal backlog absorption
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`)
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`), resolved by merged PR #144
+- That issue churn matters because it shows the repo closed one concrete feature gap and immediately surfaced the next parity lane instead of going quiet accidentally
+
+## CI Health
+- `main` is green across the most recent push-triggered `CI`, `Security`, and `OpenSSF Scorecard` runs that followed PRs #141, #144, and #147 on 2026-05-07
+- The scheduled `OpenSSF Scorecard` run on 2026-05-10 also succeeded, so there is no new default-branch security regression hiding behind the review backlog
+- The open journal PRs are healthy too, reinforcing that the repo's current delay is social rather than technical

--- a/journal/2026-05-11.md
+++ b/journal/2026-05-11.md
@@ -1,0 +1,25 @@
+# 2026-05-11 — Typed Scanner Helpers Landed, and a Fresh Dependabot Stack Arrived
+
+## Mainline & Merged Work
+
+### `main` moved again immediately after the 2026-05-07 journal baseline
+- `main` picked up four commits in-scope on 2026-05-07: journal PR #142 (`docs(journal): add 2026-05-05 journal entry`), feature PR #144 (`feat(client): complete typed scan config and scanner helpers`), maintenance PR #141 (`build(deps): bump the cargo group across 1 directory with 7 updates`), and consolidation PR #147 (`docs(journal): consolidate pending journal entries through 2026-05-07`)
+- PR #144 is the meaningful product landing in this window: it shipped the typed scan-config and scanner helper work that had been opened as issue #143
+- The dependency bump in PR #141 also made it through cleanly, so the repo did not merely catch up on journaling; it absorbed both a real feature lane and one maintenance lane on `main`
+
+## Pull Request Queue
+
+### The queue refilled with maintenance work after the merge burst
+- Three new Dependabot PRs opened on 2026-05-11: #152 (`build(deps): bump the cargo group with 2 updates`), #153 (`build(deps): bump russh from 0.58.1 to 0.60.2`), and #154 (`ci(deps): bump the actions group with 11 updates`)
+- They are not equally healthy. PR #154 is fully green and blocked only on review, PR #152 is mostly green but still fails `Cargo Vet`, and PR #153 is the noisy one with failures in `Clippy`, `Cargo Vet`, `Test (all features)`, `Documentation`, and the cargo-geiger workspace gate
+- Journal automation also resumed immediately after the 2026-05-07 consolidation: PRs #149, #150, and #151 are open, and the superseded 2026-05-06 journal PR #146 was closed unmerged once #147 consolidated the backlog
+
+## Issues
+- **Opened:** #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`)
+- **Closed:** #143 (`feat(client): add missing typed scan-config and scanner helpers`) via merged PR #144
+- The repo therefore shifted cleanly from one finished helper lane into the next parity/backlog lane without any gap in tracked work
+
+## CI Health
+- `main` remained healthy through the feature and dependency merges on 2026-05-07: push-triggered `CI`, `Security`, and `OpenSSF Scorecard` runs all succeeded after PRs #141 and #144 landed
+- The freshest default-branch signal is mixed only in the `Dependabot Updates` sweep on 2026-05-11, where one dynamic run succeeded and another failed, so current noise is concentrated in automation maintenance rather than in the product branch itself
+- The most actionable queue signal is straightforward: merge-ready PR #154 can move now, PR #152 needs cargo-vet attention, and PR #153 needs real follow-up before it stops being red

--- a/journal/2026-05-13.md
+++ b/journal/2026-05-13.md
@@ -1,0 +1,25 @@
+# 2026-05-13 — Mainline Picked Up Fresh CI Maintenance, While the Queue Split Into One Fixable Branch and One Expensive Branch
+
+## Mainline & Merged Work
+
+### `main` moved once after the 2026-05-07 journal baseline, and the change was meaningful even though it was small
+- `main` picked up one new commit in the window: PR #154 (`ci(deps): bump the actions group with 11 updates`) merged on 2026-05-12 at commit `272537b`
+- That merge did not change product surface area, but it materially refreshed repository automation by updating the actions stack across the CI and security workflows
+- Compared with the noisy backlog earlier in the month, the important signal here is that the default branch stayed mergeable and accepted maintenance cleanly
+
+## Pull Request Queue
+
+### The open queue is now mostly review and branch-drift management
+- PR #152 (`build(deps): bump the cargo group with 2 updates`) still looks like the easiest maintenance win: nearly the whole matrix is green, but `Cargo Vet` fails, which makes aggregate `Security` fail too
+- PR #153 (`build(deps): bump russh from 0.58.1 to 0.60.2`) is still the expensive branch: `Clippy`, `Documentation`, `Coverage`, `MSRV Check`, `Test (all features)`, `Cargo Geiger Workspace Gate`, `Cargo Vet`, and aggregate `Security` all fail
+- Journal PRs #149, #150, #151, #155, and #156 now represent the backlog since the last committed entry; older ones are already `BEHIND`, while the newest docs PR #156 is blocked on review rather than on automation
+
+## Issues
+- No issues were opened after the 2026-05-07 journal baseline
+- No issues were closed in the same window
+- The repo's active work is still operational rather than product-driven: dependency triage and queue cleanup dominate the decision surface
+
+## CI Health
+- `main` got fresh successful `CI`, `Security`, and `OpenSSF Scorecard` push runs on 2026-05-12 immediately after PR #154 landed
+- Scheduled `Security` and `OpenSSF Scorecard` runs also stayed green on 2026-05-10 and 2026-05-11, so the default branch currently has recent proof from both push-triggered and scheduled automation
+- The biggest CI risk is branch-local rather than repo-wide: #152 is one failing `Cargo Vet` fix away from landing, while #153 still looks better as a deliberate repair project than as a quick maintenance merge


### PR DESCRIPTION
$Consolidates the remaining open journal entry PRs into a single branch so they can run one fresh set of checks and merge together.\n\nIncluded entries:\n- 2026-05-08\n- 2026-05-09\n- 2026-05-10\n- 2026-05-11\n- 2026-05-13\n\nSupersedes: #149, #150, #151, #155, #157.