### PR TITLE
Add GMP parity commands for integration configs and report helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use gvm_gmp::commands::tasks::CreateTaskOpts;
 
 #[tokio::main]
 async fn main() -> Result<(), GvmError> {
-    // 1. Create a transport and connect — auto-negotiates GMP version (22.4–22.7+)
+    // 1. Create a transport and connect — auto-negotiates GMP version (22.4–22.8+)
     let conn = UnixSocketConnection::new(UnixSocketConfig::new("/run/gvmd/gvmd.sock"));
     let mut client = GmpClient::connect(conn).await?;
     println!("Connected, GMP version: {}", client.version());

--- a/crates/gvm-client/src/error.rs
+++ b/crates/gvm-client/src/error.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use gvm_connection::ConnectionError;
 use gvm_gmp::responses::ParseError;
+use gvm_gmp::types::GmpVersion;
 use thiserror::Error;
 
 /// High-level client errors.
@@ -40,6 +41,17 @@ pub enum GvmError {
     /// Server advertised an unsupported GMP version.
     #[error("unsupported GMP version: {0}.{1}")]
     UnsupportedVersion(u16, u16),
+
+    /// Command is known but not supported by the negotiated GMP version.
+    #[error("command '{command}' requires GMP >= {required}; server reports {version}")]
+    UnsupportedCommand {
+        /// Command name.
+        command: String,
+        /// Negotiated GMP version.
+        version: GmpVersion,
+        /// Minimum required GMP version or version family.
+        required: &'static str,
+    },
 
     /// Operation timed out.
     #[error("timeout after {0:?}")]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -15,16 +15,30 @@ mod version;
 
 use gvm_connection::GvmConnection;
 use gvm_gmp::commands::features::get_features;
+use gvm_gmp::commands::integration_configs::{
+    get_integration_config, get_integration_configs, modify_integration_config,
+};
 use gvm_gmp::commands::report_configs::{
     create_report_config, delete_report_config, get_report_configs, modify_report_config,
 };
+use gvm_gmp::commands::reports::{
+    get_report_applications, get_report_cves, get_report_hosts, get_report_operating_systems,
+    get_report_ports,
+};
 use gvm_gmp::commands::version::get_version;
-use gvm_gmp::types::GmpVersion;
+use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
 pub use error::GvmError;
+pub use gvm_gmp::commands::integration_configs::{
+    GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
+};
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
-pub use version::{map_supported_version, parse_version_text};
+pub use gvm_gmp::commands::reports::GetReportDetailsOpts;
+pub use version::{
+    command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
+    required_version_label,
+};
 
 /// High-level async GMP client over an abstract transport.
 #[derive(Debug)]
@@ -66,7 +80,9 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if request transmission or response parsing fails.
     pub async fn send<R: Request>(&mut self, request: R) -> Result<Response, GvmError> {
-        Self::send_on(&mut self.connection, request).await
+        let request_bytes = request.to_bytes();
+        self.ensure_command_supported(&request_bytes)?;
+        Self::send_on_bytes(&mut self.connection, request_bytes).await
     }
 
     /// Send a request and raise a server error on non-2xx responses.
@@ -107,9 +123,141 @@ impl<C: GvmConnection> GmpClient<C> {
     }
 
     async fn send_on<R: Request>(connection: &mut C, request: R) -> Result<Response, GvmError> {
-        connection.send(&request.to_bytes()).await?;
+        Self::send_on_bytes(connection, request.to_bytes()).await
+    }
+
+    async fn send_on_bytes(
+        connection: &mut C,
+        request_bytes: Vec<u8>,
+    ) -> Result<Response, GvmError> {
+        connection.send(&request_bytes).await?;
         let bytes = connection.read().await?;
         Ok(Response::new(bytes))
+    }
+
+    fn ensure_command_supported(&self, request_bytes: &[u8]) -> Result<(), GvmError> {
+        let Some(command_name) = request_command_name(request_bytes) else {
+            return Ok(());
+        };
+
+        if version::command_supported(command_name, self.version) {
+            return Ok(());
+        }
+
+        let required =
+            version::required_version_label(command_name).unwrap_or("a newer GMP version");
+
+        Err(GvmError::UnsupportedCommand {
+            command: command_name.to_string(),
+            version: self.version,
+            required,
+        })
+    }
+
+    /// Get a single integration configuration.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<Response, GvmError> {
+        self.call(get_integration_config(integration_config_id, details))
+            .await
+    }
+
+    /// List integration configurations.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_integration_configs(
+        &mut self,
+        opts: GetIntegrationConfigsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_integration_configs(opts)).await
+    }
+
+    /// Modify an integration configuration.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn modify_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        opts: ModifyIntegrationConfigOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(modify_integration_config(integration_config_id, opts))
+            .await
+    }
+
+    /// Get host summaries for a report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_report_hosts(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_hosts(report_id, opts)).await
+    }
+
+    /// Get port summaries for a report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_report_ports(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_ports(report_id, opts)).await
+    }
+
+    /// Get application summaries for a report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_report_applications(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_applications(report_id, opts)).await
+    }
+
+    /// Get operating system summaries for a report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_report_operating_systems(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_operating_systems(report_id, opts))
+            .await
+    }
+
+    /// Get CVE summaries for a report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_report_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_cves(report_id, opts)).await
     }
 
     fn raise_for_status(response: Response) -> Result<Response, GvmError> {
@@ -171,6 +319,65 @@ pub trait Gmp226Commands {
 
     /// Send a `delete_report_config` request.
     async fn delete_report_config(&mut self, id: &str) -> Result<Response, GvmError>;
+}
+
+/// Commands available only in GMP 22.8 and later.
+#[async_trait::async_trait]
+pub trait GmpNextCommands {
+    /// Get a single integration configuration.
+    async fn get_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<Response, GvmError>;
+
+    /// List integration configurations.
+    async fn get_integration_configs(
+        &mut self,
+        opts: GetIntegrationConfigsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Modify an integration configuration.
+    async fn modify_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        opts: ModifyIntegrationConfigOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report host summaries.
+    async fn get_report_hosts(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report port summaries.
+    async fn get_report_ports(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report application summaries.
+    async fn get_report_applications(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report operating system summaries.
+    async fn get_report_operating_systems(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report CVE summaries.
+    async fn get_report_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -296,3 +503,82 @@ impl<C: GvmConnection> GmpVersioned<C> {
 impl_gmp226_commands!(Gmp226);
 impl_gmp226_commands!(Gmp227);
 impl_gmp226_commands!(GmpNext);
+
+#[async_trait::async_trait]
+impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
+    async fn get_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .get_integration_config(integration_config_id, details)
+            .await
+    }
+
+    async fn get_integration_configs(
+        &mut self,
+        opts: GetIntegrationConfigsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_integration_configs(opts).await
+    }
+
+    async fn modify_integration_config(
+        &mut self,
+        integration_config_id: &EntityId,
+        opts: ModifyIntegrationConfigOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .modify_integration_config(integration_config_id, opts)
+            .await
+    }
+
+    async fn get_report_hosts(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_report_hosts(report_id, opts).await
+    }
+
+    async fn get_report_ports(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_report_ports(report_id, opts).await
+    }
+
+    async fn get_report_applications(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_report_applications(report_id, opts).await
+    }
+
+    async fn get_report_operating_systems(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_report_operating_systems(report_id, opts).await
+    }
+
+    async fn get_report_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_report_cves(report_id, opts).await
+    }
+}
+
+fn request_command_name(request_bytes: &[u8]) -> Option<&str> {
+    let request = std::str::from_utf8(request_bytes).ok()?.trim_start();
+    let request = request.strip_prefix('<')?;
+    let end = request
+        .find(|ch: char| ch == '>' || ch == '/' || ch.is_whitespace())
+        .unwrap_or(request.len());
+    Some(&request[..end])
+}

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -7,6 +7,42 @@ use gvm_gmp::types::GmpVersion;
 
 use crate::GvmError;
 
+/// Minimum GMP version required for a command, when version-gated.
+#[must_use]
+pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
+    match command_name {
+        "create_report_config"
+        | "delete_report_config"
+        | "get_report_configs"
+        | "modify_report_config"
+        | "get_features" => Some(GmpVersion(22, 6)),
+        "get_integration_configs"
+        | "modify_integration_config"
+        | "get_report_hosts"
+        | "get_report_ports"
+        | "get_report_applications"
+        | "get_report_operating_systems"
+        | "get_report_cves" => Some(GmpVersion(22, 8)),
+        _ => None,
+    }
+}
+
+/// Return whether a command is supported by the negotiated version.
+#[must_use]
+pub fn command_supported(command_name: &str, version: GmpVersion) -> bool {
+    minimum_version_for_command(command_name).map_or(true, |minimum| version >= minimum)
+}
+
+/// Human-readable minimum version label for a version-gated command.
+#[must_use]
+pub fn required_version_label(command_name: &str) -> Option<&'static str> {
+    match minimum_version_for_command(command_name) {
+        Some(GmpVersion(22, 6)) => Some("22.6"),
+        Some(GmpVersion(22, 8)) => Some("22.8"),
+        Some(_) | None => None,
+    }
+}
+
 /// Parse a GMP version string into a major/minor pair.
 ///
 /// Accepts `major.minor` and optional `major.minor.patch` strings.
@@ -129,5 +165,18 @@ mod tests {
             map_supported_version(GmpVersion(22, 3)).expect_err("unsupported"),
             GvmError::UnsupportedVersion(22, 3)
         ));
+    }
+
+    #[test]
+    fn command_support_respects_version_gates() {
+        assert!(command_supported("get_tasks", GmpVersion(22, 4)));
+        assert!(!command_supported("get_features", GmpVersion(22, 5)));
+        assert!(command_supported("get_features", GmpVersion(22, 6)));
+        assert!(!command_supported("get_report_hosts", GmpVersion(22, 7)));
+        assert!(command_supported("get_report_hosts", GmpVersion(22, 8)));
+        assert_eq!(
+            minimum_version_for_command("get_report_cves"),
+            Some(GmpVersion(22, 8))
+        );
     }
 }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -4,15 +4,17 @@
 #![cfg(feature = "unix-socket-tests")]
 #![allow(missing_docs)]
 
-use gvm_client::{GmpClient, GmpVersioned, GvmError};
+use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::reports::get_report_hosts;
 use gvm_gmp::commands::scan_configs::ConfigOpts;
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
+use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 use std::path::PathBuf;
@@ -91,6 +93,7 @@ async fn connect_negotiates_supported_versions() {
         (MockVersion::V22_5, GmpVersion(22, 5), 225_u16),
         (MockVersion::V22_6, GmpVersion(22, 6), 226_u16),
         (MockVersion::V22_7, GmpVersion(22, 7), 227_u16),
+        (MockVersion::V22_8, GmpVersion(22, 8), 228_u16),
     ] {
         let Some(server) = stateful_server_with_version(mock_version).await else {
             return;
@@ -105,7 +108,8 @@ async fn connect_negotiates_supported_versions() {
             (224, GmpVersioned::V224(_))
             | (225, GmpVersioned::V225(_))
             | (226, GmpVersioned::V226(_))
-            | (227, GmpVersioned::V227(_)) => {}
+            | (227, GmpVersioned::V227(_))
+            | (228, GmpVersioned::Next(_)) => {}
             (_, other) => panic!("unexpected versioned client: {other:?}"),
         }
 
@@ -235,6 +239,101 @@ async fn versioned_enum_returns_v225_for_default_mock_server() {
 
     assert!(matches!(client, GmpVersioned::V225(_)));
     assert_eq!(client.version(), GmpVersion(22, 5));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn unsupported_next_command_rejected_before_send() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_7).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    let error = client
+        .call(get_report_hosts(
+            &EntityId::new("report-1").expect("valid id"),
+            Default::default(),
+        ))
+        .await
+        .expect_err("22.7 should reject next-only command");
+
+    match error {
+        GvmError::UnsupportedCommand {
+            command,
+            version,
+            required,
+        } => {
+            assert_eq!(command, "get_report_hosts");
+            assert_eq!(version, GmpVersion(22, 7));
+            assert_eq!(required, "22.8");
+        }
+        other => panic!("expected unsupported command error, got {other:?}"),
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_commands_work_on_v22_8() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    let integration_config_id =
+        EntityId::new("00000000-0000-0000-0000-000000000100").expect("valid id");
+    let get_response = client
+        .get_integration_config(&integration_config_id, Some(true))
+        .await
+        .expect("get_integration_config should succeed");
+    assert_eq!(get_response.status_code(), Some(200));
+
+    let list_response = client
+        .get_integration_configs(Default::default())
+        .await
+        .expect("get_integration_configs should succeed");
+    assert_eq!(list_response.status_code(), Some(200));
+
+    let modify_response = client
+        .modify_integration_config(
+            &integration_config_id,
+            gvm_client::ModifyIntegrationConfigOpts {
+                service_url: Some("https://updated.example".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_integration_config should succeed");
+    assert_eq!(modify_response.status_code(), Some(200));
+
+    let report_id = EntityId::new("00000000-0000-0000-0000-000000000200").expect("valid id");
+    let helper_error = client
+        .get_report_hosts(&report_id, Default::default())
+        .await
+        .expect_err("missing report should return server error");
+    assert!(matches!(helper_error, GvmError::Server { status: 404, .. }));
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::print_stderr, missing_docs)]
 
-use gvm_client::{Gmp226Commands, GmpVersioned};
+use gvm_client::{Gmp226Commands, GmpNextCommands, GmpVersioned};
 use gvm_connection::UnixSocketConnection;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 
@@ -42,6 +42,7 @@ async fn versioned_client_resolves_correct_variant() {
         (MockVersion::V22_5, 225_u16),
         (MockVersion::V22_6, 226_u16),
         (MockVersion::V22_7, 227_u16),
+        (MockVersion::V22_8, 228_u16),
     ] {
         let Some(server) = stateful_server(version).await else {
             return;
@@ -55,12 +56,44 @@ async fn versioned_client_resolves_correct_variant() {
             (224, GmpVersioned::V224(_))
             | (225, GmpVersioned::V225(_))
             | (226, GmpVersioned::V226(_))
-            | (227, GmpVersioned::V227(_)) => {}
+            | (227, GmpVersioned::V227(_))
+            | (228, GmpVersioned::Next(_)) => {}
             (_, other) => panic!("unexpected versioned client: {other:?}"),
         }
 
         server.shutdown().await;
     }
+}
+
+#[tokio::test]
+async fn next_client_exposes_next_trait_methods() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    let response = client
+        .get_integration_configs(Default::default())
+        .await
+        .expect("next-only command should succeed");
+    assert_eq!(response.status_code(), Some(200));
+
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/gvm-gmp/src/commands/integration_configs.rs
+++ b/crates/gvm-gmp/src/commands/integration_configs.rs
@@ -65,35 +65,34 @@ pub fn modify_integration_config(
     let mut cmd = XmlCommand::new("modify_integration_config")
         .attribute("uuid", integration_config_id.as_str());
 
-    let service = cmd.add_element("service");
-    if let Some(service_url) = opts.service_url.as_deref() {
-        service.add_child_with_text("url", service_url);
-    } else {
-        service.add_child("url");
-    }
-    if let Some(service_cacert) = opts.service_cacert.as_deref() {
-        service.add_child_with_text("cacert", service_cacert);
-    } else {
-        service.add_child("cacert");
+    if opts.service_url.is_some() || opts.service_cacert.is_some() {
+        let service = cmd.add_element("service");
+        if let Some(service_url) = opts.service_url.as_deref() {
+            service.add_child_with_text("url", service_url);
+        }
+        if let Some(service_cacert) = opts.service_cacert.as_deref() {
+            service.add_child_with_text("cacert", service_cacert);
+        }
     }
 
-    let oidc = cmd.add_element("oidc");
-    if let Some(oidc_provider_url) = opts.oidc_provider_url.as_deref() {
-        oidc.add_child_with_text("oidc_provider_url", oidc_provider_url);
-    } else {
-        oidc.add_child("oidc_provider_url");
-    }
+    if opts.oidc_provider_url.is_some()
+        || opts.oidc_provider_client_id.is_some()
+        || opts.oidc_provider_client_secret.is_some()
+    {
+        let oidc = cmd.add_element("oidc");
+        if let Some(oidc_provider_url) = opts.oidc_provider_url.as_deref() {
+            oidc.add_child_with_text("oidc_provider_url", oidc_provider_url);
+        }
 
-    let client = oidc.add_child("client");
-    if let Some(client_id) = opts.oidc_provider_client_id.as_deref() {
-        client.add_child_with_text("id", client_id);
-    } else {
-        client.add_child("id");
-    }
-    if let Some(client_secret) = opts.oidc_provider_client_secret.as_deref() {
-        client.add_child_with_text("secret", client_secret);
-    } else {
-        client.add_child("secret");
+        if opts.oidc_provider_client_id.is_some() || opts.oidc_provider_client_secret.is_some() {
+            let client = oidc.add_child("client");
+            if let Some(client_id) = opts.oidc_provider_client_id.as_deref() {
+                client.add_child_with_text("id", client_id);
+            }
+            if let Some(client_secret) = opts.oidc_provider_client_secret.as_deref() {
+                client.add_child_with_text("secret", client_secret);
+            }
+        }
     }
 
     cmd
@@ -140,7 +139,7 @@ mod tests {
         );
         assert_eq!(
             xml(modify_integration_config(&id("ic1"), Default::default())),
-            "<modify_integration_config uuid=\"ic1\"><service><url/><cacert/></service><oidc><oidc_provider_url/><client><id/><secret/></client></oidc></modify_integration_config>"
+            "<modify_integration_config uuid=\"ic1\"/>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/integration_configs.rs
+++ b/crates/gvm-gmp/src/commands/integration_configs.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Integration configuration command builders.
+
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::common::{add_filter_attrs, set_optional_bool_attr};
+use crate::types::EntityId;
+
+/// Options for `get_integration_configs` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetIntegrationConfigsOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+}
+
+/// Options for `modify_integration_config` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyIntegrationConfigOpts {
+    /// Optional integration service URL.
+    pub service_url: Option<String>,
+    /// Optional integration service CA certificate.
+    pub service_cacert: Option<String>,
+    /// Optional OIDC provider URL.
+    pub oidc_provider_url: Option<String>,
+    /// Optional OIDC provider client id.
+    pub oidc_provider_client_id: Option<String>,
+    /// Optional OIDC provider client secret.
+    pub oidc_provider_client_secret: Option<String>,
+}
+
+/// Build a `get_integration_configs` request.
+#[must_use]
+pub fn get_integration_configs(opts: GetIntegrationConfigsOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_integration_configs");
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    cmd
+}
+
+/// Build a `get_integration_config` request.
+#[must_use]
+pub fn get_integration_config(
+    integration_config_id: &EntityId,
+    details: Option<bool>,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("get_integration_configs")
+        .attribute("integration_config_id", integration_config_id.as_str());
+    set_optional_bool_attr(&mut cmd, "details", details);
+    cmd
+}
+
+/// Build a `modify_integration_config` request.
+#[must_use]
+pub fn modify_integration_config(
+    integration_config_id: &EntityId,
+    opts: ModifyIntegrationConfigOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("modify_integration_config")
+        .attribute("uuid", integration_config_id.as_str());
+
+    let service = cmd.add_element("service");
+    if let Some(service_url) = opts.service_url.as_deref() {
+        service.add_child_with_text("url", service_url);
+    } else {
+        service.add_child("url");
+    }
+    if let Some(service_cacert) = opts.service_cacert.as_deref() {
+        service.add_child_with_text("cacert", service_cacert);
+    } else {
+        service.add_child("cacert");
+    }
+
+    let oidc = cmd.add_element("oidc");
+    if let Some(oidc_provider_url) = opts.oidc_provider_url.as_deref() {
+        oidc.add_child_with_text("oidc_provider_url", oidc_provider_url);
+    } else {
+        oidc.add_child("oidc_provider_url");
+    }
+
+    let client = oidc.add_child("client");
+    if let Some(client_id) = opts.oidc_provider_client_id.as_deref() {
+        client.add_child_with_text("id", client_id);
+    } else {
+        client.add_child("id");
+    }
+    if let Some(client_secret) = opts.oidc_provider_client_secret.as_deref() {
+        client.add_child_with_text("secret", client_secret);
+    } else {
+        client.add_child("secret");
+    }
+
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::xml;
+
+    fn id(value: &str) -> EntityId {
+        EntityId::new(value).expect("valid id")
+    }
+
+    #[test]
+    fn integration_config_gets_build_xml() {
+        assert_eq!(
+            xml(get_integration_configs(GetIntegrationConfigsOpts {
+                filter_string: Some("name=demo".into()),
+                filter_id: Some(id("f1")),
+            })),
+            "<get_integration_configs filt_id=\"f1\" filter=\"name=demo\"/>"
+        );
+        assert_eq!(
+            xml(get_integration_config(&id("ic1"), Some(true))),
+            "<get_integration_configs details=\"1\" integration_config_id=\"ic1\"/>"
+        );
+    }
+
+    #[test]
+    fn integration_config_modify_builds_xml() {
+        assert_eq!(
+            xml(modify_integration_config(
+                &id("ic1"),
+                ModifyIntegrationConfigOpts {
+                    service_url: Some("https://service.example".into()),
+                    service_cacert: Some("CERT".into()),
+                    oidc_provider_url: Some("https://oidc.example".into()),
+                    oidc_provider_client_id: Some("client-id".into()),
+                    oidc_provider_client_secret: Some("client-secret".into()),
+                }
+            )),
+            "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert>CERT</cacert></service><oidc><oidc_provider_url>https://oidc.example</oidc_provider_url><client><id>client-id</id><secret>client-secret</secret></client></oidc></modify_integration_config>"
+        );
+        assert_eq!(
+            xml(modify_integration_config(&id("ic1"), Default::default())),
+            "<modify_integration_config uuid=\"ic1\"><service><url/><cacert/></service><oidc><oidc_provider_url/><client><id/><secret/></client></oidc></modify_integration_config>"
+        );
+    }
+}

--- a/crates/gvm-gmp/src/commands/mod.rs
+++ b/crates/gvm-gmp/src/commands/mod.rs
@@ -23,6 +23,8 @@ pub mod groups;
 pub mod help;
 /// Host command builders.
 pub mod hosts;
+/// Integration configuration command builders.
+pub mod integration_configs;
 /// Note command builders.
 pub mod notes;
 /// NVT command builders.

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -35,6 +35,19 @@ pub struct GetReportsOpts {
     pub no_report: Option<bool>,
 }
 
+/// Shared options for `get_report_*` helper requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetReportDetailsOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether pagination should be ignored.
+    pub ignore_pagination: Option<bool>,
+    /// Whether to request detailed output. Defaults to true when omitted.
+    pub details: Option<bool>,
+}
+
 /// Build a `create_report` request.
 #[must_use]
 pub fn create_report(task_id: &EntityId, opts: CreateReportOpts) -> impl Request {
@@ -99,6 +112,55 @@ pub fn delete_audit_report(report_id: &EntityId) -> impl Request {
     delete_report(report_id, false)
 }
 
+fn get_report_detail_command(
+    command_name: &str,
+    report_id: &EntityId,
+    opts: GetReportDetailsOpts,
+) -> XmlCommand {
+    let mut cmd = XmlCommand::new(command_name).attribute("report_id", report_id.as_str());
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "ignore_pagination", opts.ignore_pagination);
+    set_optional_bool_attr(&mut cmd, "details", Some(opts.details.unwrap_or(true)));
+    cmd
+}
+
+/// Build a `get_report_hosts` request.
+#[must_use]
+pub fn get_report_hosts(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_hosts", report_id, opts)
+}
+
+/// Build a `get_report_ports` request.
+#[must_use]
+pub fn get_report_ports(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_ports", report_id, opts)
+}
+
+/// Build a `get_report_applications` request.
+#[must_use]
+pub fn get_report_applications(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_applications", report_id, opts)
+}
+
+/// Build a `get_report_operating_systems` request.
+#[must_use]
+pub fn get_report_operating_systems(
+    report_id: &EntityId,
+    opts: GetReportDetailsOpts,
+) -> impl Request {
+    get_report_detail_command("get_report_operating_systems", report_id, opts)
+}
+
+/// Build a `get_report_cves` request.
+#[must_use]
+pub fn get_report_cves(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_cves", report_id, opts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,6 +211,42 @@ mod tests {
         assert_eq!(
             xml(delete_audit_report(&id("r1"))),
             "<delete_report report_id=\"r1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn report_helper_commands_build_xml() {
+        let opts = GetReportDetailsOpts {
+            filter_string: Some("severity>5".into()),
+            filter_id: Some(id("f1")),
+            ignore_pagination: Some(true),
+            details: Some(false),
+        };
+        assert_eq!(
+            xml(get_report_hosts(&id("r1"), opts.clone())),
+            "<get_report_hosts details=\"0\" filt_id=\"f1\" filter=\"severity&gt;5\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_ports(&id("r1"), GetReportDetailsOpts::default())),
+            "<get_report_ports details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_applications(
+                &id("r1"),
+                GetReportDetailsOpts::default()
+            )),
+            "<get_report_applications details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_operating_systems(
+                &id("r1"),
+                GetReportDetailsOpts::default()
+            )),
+            "<get_report_operating_systems details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_cves(&id("r1"), GetReportDetailsOpts::default())),
+            "<get_report_cves details=\"1\" report_id=\"r1\"/>"
         );
     }
 }

--- a/crates/gvm-gmp/tests/test_integration_configs.rs
+++ b/crates/gvm-gmp/tests/test_integration_configs.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+mod common;
+
+use common::{id, xml};
+use gvm_gmp::commands::integration_configs::*;
+
+#[test]
+fn test_get_integration_configs_variants() {
+    assert_eq!(
+        xml(get_integration_configs(GetIntegrationConfigsOpts::default())),
+        "<get_integration_configs/>"
+    );
+    assert_eq!(
+        xml(get_integration_configs(GetIntegrationConfigsOpts {
+            filter_string: Some("name=demo".into()),
+            filter_id: Some(id("f1")),
+        })),
+        "<get_integration_configs filt_id=\"f1\" filter=\"name=demo\"/>"
+    );
+    assert_eq!(
+        xml(get_integration_config(&id("ic1"), Some(false))),
+        "<get_integration_configs details=\"0\" integration_config_id=\"ic1\"/>"
+    );
+}
+
+#[test]
+fn test_modify_integration_config_variants() {
+    assert_eq!(
+        xml(modify_integration_config(&id("ic1"), Default::default())),
+        "<modify_integration_config uuid=\"ic1\"><service><url/><cacert/></service><oidc><oidc_provider_url/><client><id/><secret/></client></oidc></modify_integration_config>"
+    );
+    assert_eq!(
+        xml(modify_integration_config(
+            &id("ic1"),
+            ModifyIntegrationConfigOpts {
+                service_url: Some("https://service.example".into()),
+                oidc_provider_client_id: Some("client-id".into()),
+                ..Default::default()
+            },
+        )),
+        "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert/></service><oidc><oidc_provider_url/><client><id>client-id</id><secret/></client></oidc></modify_integration_config>"
+    );
+}

--- a/crates/gvm-gmp/tests/test_integration_configs.rs
+++ b/crates/gvm-gmp/tests/test_integration_configs.rs
@@ -31,7 +31,7 @@ fn test_get_integration_configs_variants() {
 fn test_modify_integration_config_variants() {
     assert_eq!(
         xml(modify_integration_config(&id("ic1"), Default::default())),
-        "<modify_integration_config uuid=\"ic1\"><service><url/><cacert/></service><oidc><oidc_provider_url/><client><id/><secret/></client></oidc></modify_integration_config>"
+        "<modify_integration_config uuid=\"ic1\"/>"
     );
     assert_eq!(
         xml(modify_integration_config(
@@ -42,6 +42,6 @@ fn test_modify_integration_config_variants() {
                 ..Default::default()
             },
         )),
-        "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert/></service><oidc><oidc_provider_url/><client><id>client-id</id><secret/></client></oidc></modify_integration_config>"
+        "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url></service><oidc><client><id>client-id</id></client></oidc></modify_integration_config>"
     );
 }

--- a/crates/gvm-gmp/tests/test_reports.rs
+++ b/crates/gvm-gmp/tests/test_reports.rs
@@ -42,3 +42,42 @@ fn test_report_get_and_delete() {
         "<delete_report report_id=\"r1\" ultimate=\"0\"/>"
     );
 }
+
+#[test]
+fn test_report_helper_commands() {
+    assert_eq!(
+        xml(get_report_hosts(
+            &id("r1"),
+            GetReportDetailsOpts {
+                filter_string: Some("severity>5".into()),
+                filter_id: Some(id("f1")),
+                ignore_pagination: Some(true),
+                details: Some(false),
+            }
+        )),
+        "<get_report_hosts details=\"0\" filt_id=\"f1\" filter=\"severity&gt;5\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+    );
+    assert_eq!(
+        xml(get_report_ports(
+            &id("r1"),
+            GetReportDetailsOpts {
+                ignore_pagination: Some(false),
+                details: Some(true),
+                ..Default::default()
+            }
+        )),
+        "<get_report_ports details=\"1\" ignore_pagination=\"0\" report_id=\"r1\"/>"
+    );
+    assert_eq!(
+        xml(get_report_applications(&id("r1"), Default::default())),
+        "<get_report_applications details=\"1\" report_id=\"r1\"/>"
+    );
+    assert_eq!(
+        xml(get_report_operating_systems(&id("r1"), Default::default())),
+        "<get_report_operating_systems details=\"1\" report_id=\"r1\"/>"
+    );
+    assert_eq!(
+        xml(get_report_cves(&id("r1"), Default::default())),
+        "<get_report_cves details=\"1\" report_id=\"r1\"/>"
+    );
+}

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -394,6 +394,11 @@ impl SessionHandler {
             "get_aggregates" => return render_aggregates_response(cmd),
             "get_system_reports" => return render_system_reports_response(),
             "get_info" => return render_secinfo_response(cmd),
+            "get_report_hosts"
+            | "get_report_ports"
+            | "get_report_applications"
+            | "get_report_operating_systems"
+            | "get_report_cves" => return self.render_report_detail_response(cmd, store),
             _ => {}
         }
 
@@ -464,7 +469,13 @@ impl SessionHandler {
         let resource_type = cmd.name.strip_prefix("modify_").unwrap_or("unknown");
         let id_attr = format!("{resource_type}_id");
 
-        let Some(id_str) = cmd.attr(&id_attr) else {
+        let Some(id_str) = cmd.attr(&id_attr).or_else(|| {
+            if cmd.name == "modify_integration_config" {
+                cmd.attr("uuid")
+            } else {
+                None
+            }
+        }) else {
             return error_response(&cmd.name, 400, "Missing required attribute: id");
         };
 
@@ -489,6 +500,11 @@ impl SessionHandler {
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
         let new_value = parse_element_text(raw_xml, "value");
+        let new_service_url = parse_element_text(raw_xml, "url");
+        let new_service_cacert = parse_element_text(raw_xml, "cacert");
+        let new_oidc_provider_url = parse_element_text(raw_xml, "oidc_provider_url");
+        let new_oidc_client_id = parse_element_text(raw_xml, "id");
+        let new_oidc_client_secret = parse_element_text(raw_xml, "secret");
 
         let modified = store.modify(&uuid, |r| {
             if matches!(resource_type, "note" | "override") {
@@ -533,6 +549,21 @@ impl SessionHandler {
             }
             if let Some(ref value) = new_value {
                 r.set_attr("value", value);
+            }
+            if let Some(ref service_url) = new_service_url {
+                r.set_attr("service_url", service_url);
+            }
+            if let Some(ref service_cacert) = new_service_cacert {
+                r.set_attr("service_cacert", service_cacert);
+            }
+            if let Some(ref oidc_provider_url) = new_oidc_provider_url {
+                r.set_attr("oidc_provider_url", oidc_provider_url);
+            }
+            if let Some(ref oidc_client_id) = new_oidc_client_id {
+                r.set_attr("oidc_provider_client_id", oidc_client_id);
+            }
+            if let Some(ref oidc_client_secret) = new_oidc_client_secret {
+                r.set_attr("oidc_provider_client_secret", oidc_client_secret);
             }
             if resource_type == "ticket" {
                 if let Some(ref status) = new_status {
@@ -731,6 +762,77 @@ impl SessionHandler {
             comment = xml_escape(&report.comment),
             creation_time = report.creation_time,
             modification_time = report.modification_time,
+        )
+        .into_bytes()
+    }
+
+    fn render_report_detail_response(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let Some(report_id) = cmd.attr("report_id") else {
+            return error_response(&cmd.name, 400, "Missing required attribute: report_id");
+        };
+
+        let Ok(report_uuid) = Uuid::parse_str(report_id) else {
+            return error_response(&cmd.name, 400, "Invalid UUID");
+        };
+
+        if store.get(&report_uuid).is_none() {
+            return error_response(&cmd.name, 404, "Resource not found");
+        }
+
+        let (element_name, items) = match cmd.name.as_str() {
+            "get_report_hosts" => (
+                "host",
+                vec![
+                    "<host id=\"host-1\"><name>192.0.2.10</name><severity>7.5</severity></host>"
+                        .to_string(),
+                    "<host id=\"host-2\"><name>192.0.2.20</name><severity>5.0</severity></host>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_ports" => (
+                "port",
+                vec![
+                    "<port id=\"port-1\"><name>22/tcp</name><severity>6.5</severity></port>"
+                        .to_string(),
+                    "<port id=\"port-2\"><name>443/tcp</name><severity>4.2</severity></port>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_applications" => (
+                "application",
+                vec![
+                    "<application id=\"app-1\"><name>OpenSSH</name><severity>6.5</severity></application>"
+                        .to_string(),
+                    "<application id=\"app-2\"><name>nginx</name><severity>4.0</severity></application>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_operating_systems" => (
+                "operating_system",
+                vec![
+                    "<operating_system id=\"os-1\"><name>Debian</name><severity>5.5</severity></operating_system>"
+                        .to_string(),
+                    "<operating_system id=\"os-2\"><name>Ubuntu</name><severity>3.1</severity></operating_system>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_cves" => (
+                "cve",
+                vec![
+                    "<cve id=\"cve-1\"><name>CVE-2026-0001</name><severity>8.0</severity></cve>"
+                        .to_string(),
+                    "<cve id=\"cve-2\"><name>CVE-2026-0002</name><severity>6.0</severity></cve>"
+                        .to_string(),
+                ],
+            ),
+            _ => return error_response(&cmd.name, 400, "Unsupported report detail command"),
+        };
+
+        let count = items.len();
+        let items = items.join("");
+        format!(
+            "<{name}_response status=\"200\" status_text=\"OK\">{items}<{element_name}_count>{count}<filtered>{count}</filtered></{element_name}_count></{name}_response>",
+            name = cmd.name,
         )
         .into_bytes()
     }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -469,14 +469,17 @@ impl SessionHandler {
         let resource_type = cmd.name.strip_prefix("modify_").unwrap_or("unknown");
         let id_attr = format!("{resource_type}_id");
 
-        let Some(id_str) = cmd.attr(&id_attr).or_else(|| {
-            if cmd.name == "modify_integration_config" {
-                cmd.attr("uuid")
-            } else {
-                None
-            }
-        }) else {
-            return error_response(&cmd.name, 400, "Missing required attribute: id");
+        let id_str = if cmd.name == "modify_integration_config" {
+            let Some(id) = cmd.attr("uuid") else {
+                return error_response(&cmd.name, 400, "Missing required attribute: uuid");
+            };
+            id
+        } else {
+            let Some(id) = cmd.attr(&id_attr) else {
+                let message = format!("Missing required attribute: {id_attr}");
+                return error_response(&cmd.name, 400, &message);
+            };
+            id
         };
 
         let Ok(uuid) = Uuid::parse_str(id_str) else {
@@ -500,11 +503,23 @@ impl SessionHandler {
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
         let new_value = parse_element_text(raw_xml, "value");
-        let new_service_url = parse_element_text(raw_xml, "url");
-        let new_service_cacert = parse_element_text(raw_xml, "cacert");
-        let new_oidc_provider_url = parse_element_text(raw_xml, "oidc_provider_url");
-        let new_oidc_client_id = parse_element_text(raw_xml, "id");
-        let new_oidc_client_secret = parse_element_text(raw_xml, "secret");
+        let (
+            new_service_url,
+            new_service_cacert,
+            new_oidc_provider_url,
+            new_oidc_client_id,
+            new_oidc_client_secret,
+        ) = if resource_type == "integration_config" {
+            (
+                nested_child_text(cmd, &["service", "url"]),
+                nested_child_text(cmd, &["service", "cacert"]),
+                nested_child_text(cmd, &["oidc", "oidc_provider_url"]),
+                nested_child_text(cmd, &["oidc", "client", "id"]),
+                nested_child_text(cmd, &["oidc", "client", "secret"]),
+            )
+        } else {
+            (None, None, None, None, None)
+        };
 
         let modified = store.modify(&uuid, |r| {
             if matches!(resource_type, "note" | "override") {
@@ -969,6 +984,15 @@ fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
         "<get_info_response status=\"200\" status_text=\"OK\">{items}<{element}_count>2<filtered>2</filtered></{element}_count></get_info_response>"
     )
     .into_bytes()
+}
+
+fn nested_child_text(cmd: &ParsedCommand, path: &[&str]) -> Option<String> {
+    let (first, rest) = path.split_first()?;
+    let mut element = cmd.children.iter().find(|child| child.name == *first)?;
+    for name in rest {
+        element = element.children.iter().find(|child| child.name == **name)?;
+    }
+    Some(element.text.clone().unwrap_or_default())
 }
 
 fn singularize_resource_type(plural: &str) -> &str {

--- a/crates/gvm-mock-server/src/main.rs
+++ b/crates/gvm-mock-server/src/main.rs
@@ -49,8 +49,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "22.5" => GmpVersion::V22_5,
         "22.6" => GmpVersion::V22_6,
         "22.7" => GmpVersion::V22_7,
+        "22.8" => GmpVersion::V22_8,
         other => {
-            eprintln!("Unknown version: {other}. Use 22.4, 22.5, 22.6, or 22.7.");
+            eprintln!("Unknown version: {other}. Use 22.4, 22.5, 22.6, 22.7, or 22.8.");
             std::process::exit(1);
         }
     };

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -163,6 +163,19 @@ fn default_resources() -> HashMap<Uuid, Resource> {
     rows_per_page.set_attr("value", "100");
     resources.insert(rows_per_page.id, rows_per_page);
 
+    let mut integration_config = Resource::with_id(
+        "integration_config",
+        "Default Integration Config",
+        Uuid::parse_str("00000000-0000-0000-0000-000000000100").expect("valid uuid"),
+    );
+    integration_config.comment = "Mock integration config".to_string();
+    integration_config.set_attr("service_url", "https://service.example.invalid");
+    integration_config.set_attr("service_cacert", "MOCK-CA-CERT");
+    integration_config.set_attr("oidc_provider_url", "https://oidc.example.invalid");
+    integration_config.set_attr("oidc_provider_client_id", "mock-client-id");
+    integration_config.set_attr("oidc_provider_client_secret", "mock-client-secret");
+    resources.insert(integration_config.id, integration_config);
+
     resources
 }
 

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -15,6 +15,8 @@ pub enum GmpVersion {
     V22_6,
     /// GMP 22.7
     V22_7,
+    /// GMP 22.8
+    V22_8,
 }
 
 impl GmpVersion {
@@ -25,6 +27,7 @@ impl GmpVersion {
             Self::V22_5 => "22.5",
             Self::V22_6 => "22.6",
             Self::V22_7 => "22.7",
+            Self::V22_8 => "22.8",
         }
     }
 }
@@ -44,11 +47,28 @@ const GMP_22_6_COMMANDS: &[&str] = &[
     "get_features",
 ];
 
+/// Commands only available in GMP 22.8+ / GMP Next.
+const GMP_22_8_COMMANDS: &[&str] = &[
+    "get_integration_configs",
+    "modify_integration_config",
+    "get_report_hosts",
+    "get_report_ports",
+    "get_report_applications",
+    "get_report_operating_systems",
+    "get_report_cves",
+];
+
 /// Check if a command is available in the given GMP version.
 #[must_use]
 pub fn command_available(command_name: &str, version: GmpVersion) -> bool {
+    if GMP_22_8_COMMANDS.contains(&command_name) {
+        return matches!(version, GmpVersion::V22_8);
+    }
     if GMP_22_6_COMMANDS.contains(&command_name) {
-        return matches!(version, GmpVersion::V22_6 | GmpVersion::V22_7);
+        return matches!(
+            version,
+            GmpVersion::V22_6 | GmpVersion::V22_7 | GmpVersion::V22_8
+        );
     }
     true
 }
@@ -63,6 +83,7 @@ mod tests {
         assert_eq!(GmpVersion::V22_5.as_str(), "22.5");
         assert_eq!(GmpVersion::V22_6.as_str(), "22.6");
         assert_eq!(GmpVersion::V22_7.as_str(), "22.7");
+        assert_eq!(GmpVersion::V22_8.as_str(), "22.8");
     }
 
     #[test]
@@ -71,6 +92,7 @@ mod tests {
         assert_eq!(format!("{}", GmpVersion::V22_5), "22.5");
         assert_eq!(format!("{}", GmpVersion::V22_6), "22.6");
         assert_eq!(format!("{}", GmpVersion::V22_7), "22.7");
+        assert_eq!(format!("{}", GmpVersion::V22_8), "22.8");
     }
 
     #[test]
@@ -110,6 +132,7 @@ mod tests {
         ));
         assert!(command_available("create_report_config", GmpVersion::V22_6));
         assert!(command_available("create_report_config", GmpVersion::V22_7));
+        assert!(command_available("create_report_config", GmpVersion::V22_8));
         assert!(!command_available(
             "delete_report_config",
             GmpVersion::V22_4
@@ -122,5 +145,20 @@ mod tests {
         assert!(!command_available("get_features", GmpVersion::V22_5));
         assert!(command_available("get_features", GmpVersion::V22_6));
         assert!(command_available("get_features", GmpVersion::V22_7));
+        assert!(command_available("get_features", GmpVersion::V22_8));
+    }
+
+    #[test]
+    fn test_command_available_for_next_commands() {
+        assert!(!command_available(
+            "get_integration_configs",
+            GmpVersion::V22_7
+        ));
+        assert!(command_available(
+            "get_integration_configs",
+            GmpVersion::V22_8
+        ));
+        assert!(!command_available("get_report_hosts", GmpVersion::V22_6));
+        assert!(command_available("get_report_hosts", GmpVersion::V22_8));
     }
 }

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -12,7 +12,11 @@
 
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::features::get_features;
+use gvm_gmp::commands::integration_configs::{
+    get_integration_config, get_integration_configs, modify_integration_config,
+};
 use gvm_gmp::commands::report_configs::{create_report_config, get_report_configs};
+use gvm_gmp::commands::reports::{get_report_cves, get_report_hosts};
 use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response};
@@ -155,6 +159,7 @@ async fn base_commands_work_on_all_versions() {
         GmpVersion::V22_5,
         GmpVersion::V22_6,
         GmpVersion::V22_7,
+        GmpVersion::V22_8,
     ] {
         let Some(server) = stateful_server(version).await else {
             return;
@@ -177,4 +182,85 @@ async fn base_commands_work_on_all_versions() {
 
         server.shutdown().await;
     }
+}
+
+#[tokio::test]
+async fn version_22_7_rejects_next_commands() {
+    let Some(server) = stateful_server(GmpVersion::V22_7).await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate_admin(&mut stream).await;
+
+    let response = send_recv(&mut stream, get_integration_configs(Default::default())).await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response
+        .status_text()
+        .unwrap()
+        .contains("get_integration_configs"));
+
+    let response = send_recv(
+        &mut stream,
+        get_report_hosts(
+            &id("00000000-0000-0000-0000-000000000200"),
+            Default::default(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("get_report_hosts"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn version_22_8_accepts_next_commands() {
+    let Some(server) = stateful_server(GmpVersion::V22_8).await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate_admin(&mut stream).await;
+
+    let get_response = send_recv(
+        &mut stream,
+        get_integration_config(&id("00000000-0000-0000-0000-000000000100"), Some(true)),
+    )
+    .await;
+    assert_eq!(get_response.status_code(), Some(200));
+
+    let list_response = send_recv(&mut stream, get_integration_configs(Default::default())).await;
+    assert_eq!(list_response.status_code(), Some(200));
+    assert!(list_response
+        .as_str()
+        .expect("utf8")
+        .contains("Default Integration Config"));
+
+    let modify_response = send_recv(
+        &mut stream,
+        modify_integration_config(
+            &id("00000000-0000-0000-0000-000000000100"),
+            gvm_gmp::commands::integration_configs::ModifyIntegrationConfigOpts {
+                service_url: Some("https://updated.example".into()),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(modify_response.status_code(), Some(200));
+
+    let report_helper = send_recv(
+        &mut stream,
+        get_report_cves(
+            &id("00000000-0000-0000-0000-000000000200"),
+            Default::default(),
+        ),
+    )
+    .await;
+    assert_eq!(report_helper.status_code(), Some(404));
+
+    server.shutdown().await;
+}
+
+fn id(value: &str) -> gvm_gmp::EntityId {
+    gvm_gmp::EntityId::new(value).expect("valid id")
 }

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -19,7 +19,7 @@ use gvm_gmp::commands::report_configs::{create_report_config, get_report_configs
 use gvm_gmp::commands::reports::{get_report_cves, get_report_hosts};
 use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
-use gvm_protocol::{Request, Response};
+use gvm_protocol::{Request, Response, XmlCommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
@@ -247,6 +247,26 @@ async fn version_22_8_accepts_next_commands() {
     )
     .await;
     assert_eq!(modify_response.status_code(), Some(200));
+
+    let modified_get_response = send_recv(
+        &mut stream,
+        get_integration_config(&id("00000000-0000-0000-0000-000000000100"), Some(true)),
+    )
+    .await;
+    let modified_xml = modified_get_response.as_str().expect("utf8");
+    assert!(modified_xml.contains("<service_url>https://updated.example</service_url>"));
+    assert!(modified_xml.contains("<service_cacert>MOCK-CA-CERT</service_cacert>"));
+    assert!(
+        modified_xml.contains("<oidc_provider_client_id>mock-client-id</oidc_provider_client_id>")
+    );
+
+    let missing_uuid_response =
+        send_recv(&mut stream, XmlCommand::new("modify_integration_config")).await;
+    assert_eq!(missing_uuid_response.status_code(), Some(400));
+    assert!(missing_uuid_response
+        .status_text()
+        .expect("status text")
+        .contains("uuid"));
 
     let report_helper = send_recv(
         &mut stream,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -71,7 +71,7 @@ Last updated: 2026-03-29
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Mode selection | ✅ | `.mode(ServerMode::Stateful)` |
-| Version configuration | ✅ | `.version(GmpVersion::V22_5)` — supports 22.4–22.7 |
+| Version configuration | ✅ | `.version(GmpVersion::V22_5)` — supports 22.4–22.8 |
 | Unix socket (path) | ✅ | `.unix_socket("/tmp/gvmd.sock")` |
 | Unix socket (auto temp) | ✅ | `.unix_socket_auto()` |
 | TCP listener | ✅ | `.tcp("127.0.0.1:9390")` |

--- a/journal/2026-05-14.md
+++ b/journal/2026-05-14.md
@@ -1,0 +1,15 @@
+# 2026-05-14 — GMP Parity Lane Adds Integration Config and Report Helper Command Support
+
+## Product Surface
+
+### Issue #148 implementation
+- Added `gvm-gmp` command builders for the recent `python-gvm` parity gap: integration config requests plus report helper commands for hosts, ports, applications, operating systems, and CVEs.
+- Exposed matching high-level `gvm-client` methods and versioned-client traits so callers can use the new GMP surface without hand-building XML.
+- Extended `gvm-mock-server` command handling/version coverage with deterministic responses for the new command family.
+
+## Validation Scope
+- XML request-shape coverage now includes integration-config list/single/modify variants and report-helper filter, pagination, and details attributes.
+- Client and mock-server tests cover round-trips and version gating for the new commands.
+
+## Notes
+- This entry documents the release-facing behavior change for the PR closing #148.


### PR DESCRIPTION
## Summary
- add `gvm-gmp` builders for integration-config and report-helper GMP parity commands from #148
- expose matching `gvm-client` convenience methods plus Next-version trait/version gating
- extend `gvm-mock-server` with GMP 22.8 command surface, seeded integration config, report-helper responses, and tests
- add a 2026-05-14 journal entry documenting the parity addition

Closes #148.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --workspace --all-features --no-deps`

## Notes
- Local `tests/integration/test_python_gvm.py` could not run in this container because Python lacks `pip`/`gvm` (`No module named pip`; original failure: `No module named 'gvm'`).
- Local `cargo +1.75.0 check --workspace --all-features` is blocked by registry metadata for `getrandom v0.4.2` using `edition2024` under Cargo 1.75; this appears unrelated to this diff.
