### PR TITLE
docs(journal): add 2026-05-16 journal entry

### DIFF
--- a/journal/2026-05-16.md
+++ b/journal/2026-05-16.md
@@ -1,0 +1,25 @@
+# 2026-05-16 — Mainline Stayed Still, but PR #160 Became the Clear Merge Candidate While the Old `russh` Bump Stayed Stuck
+
+## Mainline & Merged Work
+
+### `main` has not moved since the 2026-05-13 journal baseline, so the important change is still in the review queue rather than on the default branch
+- No commits landed on `main` after the 2026-05-13 entry
+- No pull requests merged in the same window
+- That means the repo is operationally stable, but it also means the next meaningful move is still a human merge decision rather than a branch-wide code change
+
+## Pull Request Queue
+
+### One new feature branch is fully green and now looks like the obvious next merge
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) opened on 2026-05-14 and is green across the full visible CI and security surface, including `Clippy`, `Test (stable)`, `Test (1.75.0)`, `Test (all features)`, `Coverage`, `Documentation`, `Integration (python-gvm)`, `Cargo Vet`, and aggregate `Security`
+- PR #159 (`build(deps): bump russh from 0.58.1 to 0.59.0`) is still blocked only by `Cargo Vet`, which keeps aggregate `Security` red while the rest of the branch remains green
+- Journal PR #161 added the 2026-05-15 entry and is also green, so the queue now splits cleanly between a ready feature merge, a narrowly blocked dependency bump, and ongoing docs backlog
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- The repo's current decision surface is still PR-driven rather than issue-driven
+
+## CI Health
+- There were no new push runs on `main`, so the default-branch health signal is unchanged from the prior baseline rather than freshly reconfirmed
+- The freshest useful automation signal comes from PR #160, which is fully green and therefore provides a strong proxy that the repository is still in a mergeable state
+- The only visible red path in active work is still the branch-local `Cargo Vet` failure on #159, not a broad repo-wide CI regression


### PR DESCRIPTION
## Summary
- add the 2026-05-16 journal entry
- capture repo activity since the previous committed journal entry

## Testing
- not run (docs-only change)