### PR TITLE
docs(journal): add 2026-05-17 journal entry

### DIFF
--- a/journal/2026-05-17.md
+++ b/journal/2026-05-17.md
@@ -1,0 +1,25 @@
+# 2026-05-17 — Mainline Stayed Quiet, but the Queue Added One Clearly Mergeable Feature Lane and More Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` has not moved since the 2026-05-13 journal baseline
+- No new commits landed on `main` after the 2026-05-13 merge wave that brought in PRs #152, #156, and #158
+- No pull requests merged in the same window
+- No issues were opened or closed after the baseline either, so the repo's story this time is entirely about queue shape rather than default-branch change
+
+## Pull Request Queue
+
+### The queue is now easier to read: one substantive green branch, one still-blocked dependency branch, and more journal traffic
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) opened on 2026-05-14 and currently reports successful checks on its head commit, making it the most important merge candidate in the repo
+- PR #159 (`build(deps): bump russh from 0.58.1 to 0.59.0`) is still open from 2026-05-13, and it remains the branch that needs deliberate repair work rather than a quick merge
+- Journal PRs #161 and #162 opened on 2026-05-15 and 2026-05-16, so the documentation backlog is growing again even though none of that work has landed on `main`
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- That keeps the repo's active decision surface operational: merge the healthy feature branch, then decide what to do with the blocked `russh` bump
+
+## CI Health
+- The latest default-branch signal is still the successful 2026-05-13 `CI`, `Security`, and `OpenSSF Scorecard` push runs
+- There is no fresh evidence of `main` breakage, but there is also no newer push to prove the branch again after the 2026-05-13 maintenance merge
+- Branch-local risk still dominates: #160 looks ready, while #159 remains the only obviously expensive lane


### PR DESCRIPTION
## Summary
- add the 2026-05-17 journal entry
- capture repository activity since the last committed journal entry
- note current queue and CI state where relevant

## Testing
- not run (documentation-only change)