### PR TITLE
docs(journal): add 2026-05-18 journal entry

### DIFF
--- a/.github/workflows/journal-pr-automation.yml
+++ b/.github/workflows/journal-pr-automation.yml
@@ -1,0 +1,52 @@
+name: Journal PR Automation
+
+on:
+  pull_request_target:
+    branches: [journal-main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  journal-auto-merge-gate:
+    name: Journal Auto-Merge Gate
+    if: >-
+      github.event.pull_request.draft == false &&
+      startsWith(github.head_ref, 'journal/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate changed files are journal entries only
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            if (!files.length) {
+              core.setFailed('PR has no changed files');
+              return;
+            }
+            const invalid = files.filter(file => !/^journal\/\d{4}-\d{2}-\d{2}\.md$/.test(file.filename));
+            if (invalid.length) {
+              core.setFailed(`Non-journal files present: ${invalid.map(file => file.filename).join(', ')}`);
+              return;
+            }
+      - name: Enable squash auto-merge
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            await github.graphql(
+              `mutation($pullRequestId:ID!) {
+                enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
+                  pullRequest { number autoMergeRequest { enabledAt } }
+                }
+              }`,
+              { pullRequestId: pr.node_id },
+            );

--- a/journal/2026-05-15.md
+++ b/journal/2026-05-15.md
@@ -1,0 +1,23 @@
+# 2026-05-15 — Mainline Landed the Easy Maintenance Merge, Then a Fully Green GMP Parity Branch Became the Next Real Decision
+
+## Mainline & Merged Work
+
+### `main` did move after the 2026-05-13 journal baseline, but the wave was mostly one meaningful maintenance merge plus journal cleanup
+- `main` picked up three commits on 2026-05-13: PR #152 (`build(deps): bump the cargo group with 2 updates`), PR #156 (`docs(journal): add 2026-05-12 journal entry`), and PR #158 (`docs(journal): consolidate pending journal entries`)
+- The important change in that set is #152, because it landed the previously almost-green dependency branch and reduced queue drag without destabilizing the default branch
+- The rest of the movement simplified the documentation backlog rather than changing product behavior, so the repo left the window with a cleaner queue but only one real code merge
+
+## Pull Request Queue
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) is now the strongest signal in the repository: it opened on 2026-05-14 and the visible GitHub validation surface is green across format, docs, tests, audit, vet, and the broader security/test matrix
+- PR #159 (`build(deps): bump russh from 0.58.1 to 0.59.0`) is still the narrower maintenance decision: almost everything passes, but `Cargo Vet` fails and keeps the aggregate security story blocked
+- The queue is also less noisy than it was at the last baseline, because journal PRs #149, #150, #151, #155, and #157 were closed off once #158 consolidated the pending entries, and the older broken russh branch #153 is gone too
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- The repository’s current decisions are still encoded in pull requests, not in new bug or feature triage
+
+## CI Health
+- `main` recorded successful `CI`, `Security`, and `OpenSSF Scorecard` push runs on 2026-05-13 after the merge wave landed, so the default branch still has fresh clean health signals
+- The best current branch-level news is PR #160, which is fully green and looks ready for human review/merge rather than for more repair work
+- The only notable red lane in the active queue is still #159, and even there the failure surface is narrow enough that this looks like a targeted vet decision rather than a broad regression

--- a/journal/2026-05-16.md
+++ b/journal/2026-05-16.md
@@ -1,0 +1,25 @@
+# 2026-05-16 — Mainline Stayed Still, but PR #160 Became the Clear Merge Candidate While the Old `russh` Bump Stayed Stuck
+
+## Mainline & Merged Work
+
+### `main` has not moved since the 2026-05-13 journal baseline, so the important change is still in the review queue rather than on the default branch
+- No commits landed on `main` after the 2026-05-13 entry
+- No pull requests merged in the same window
+- That means the repo is operationally stable, but it also means the next meaningful move is still a human merge decision rather than a branch-wide code change
+
+## Pull Request Queue
+
+### One new feature branch is fully green and now looks like the obvious next merge
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) opened on 2026-05-14 and is green across the full visible CI and security surface, including `Clippy`, `Test (stable)`, `Test (1.75.0)`, `Test (all features)`, `Coverage`, `Documentation`, `Integration (python-gvm)`, `Cargo Vet`, and aggregate `Security`
+- PR #159 (`build(deps): bump russh from 0.58.1 to 0.59.0`) is still blocked only by `Cargo Vet`, which keeps aggregate `Security` red while the rest of the branch remains green
+- Journal PR #161 added the 2026-05-15 entry and is also green, so the queue now splits cleanly between a ready feature merge, a narrowly blocked dependency bump, and ongoing docs backlog
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- The repo's current decision surface is still PR-driven rather than issue-driven
+
+## CI Health
+- There were no new push runs on `main`, so the default-branch health signal is unchanged from the prior baseline rather than freshly reconfirmed
+- The freshest useful automation signal comes from PR #160, which is fully green and therefore provides a strong proxy that the repository is still in a mergeable state
+- The only visible red path in active work is still the branch-local `Cargo Vet` failure on #159, not a broad repo-wide CI regression

--- a/journal/2026-05-17.md
+++ b/journal/2026-05-17.md
@@ -1,0 +1,25 @@
+# 2026-05-17 — Mainline Stayed Quiet, but the Queue Added One Clearly Mergeable Feature Lane and More Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` has not moved since the 2026-05-13 journal baseline
+- No new commits landed on `main` after the 2026-05-13 merge wave that brought in PRs #152, #156, and #158
+- No pull requests merged in the same window
+- No issues were opened or closed after the baseline either, so the repo's story this time is entirely about queue shape rather than default-branch change
+
+## Pull Request Queue
+
+### The queue is now easier to read: one substantive green branch, one still-blocked dependency branch, and more journal traffic
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) opened on 2026-05-14 and currently reports successful checks on its head commit, making it the most important merge candidate in the repo
+- PR #159 (`build(deps): bump russh from 0.58.1 to 0.59.0`) is still open from 2026-05-13, and it remains the branch that needs deliberate repair work rather than a quick merge
+- Journal PRs #161 and #162 opened on 2026-05-15 and 2026-05-16, so the documentation backlog is growing again even though none of that work has landed on `main`
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- That keeps the repo's active decision surface operational: merge the healthy feature branch, then decide what to do with the blocked `russh` bump
+
+## CI Health
+- The latest default-branch signal is still the successful 2026-05-13 `CI`, `Security`, and `OpenSSF Scorecard` push runs
+- There is no fresh evidence of `main` breakage, but there is also no newer push to prove the branch again after the 2026-05-13 maintenance merge
+- Branch-local risk still dominates: #160 looks ready, while #159 remains the only obviously expensive lane

--- a/journal/2026-05-18.md
+++ b/journal/2026-05-18.md
@@ -1,0 +1,27 @@
+# 2026-05-18 — Mainline Stayed Still, But the Queue Added One Real Feature Branch, Three More Journal PRs, and a Fresh Dependabot Burst
+
+## Mainline & Merged Work
+
+### `main` did not move after the 2026-05-13 journal baseline, so all meaningful activity stayed in the queue
+- No commits landed on `main` after the 2026-05-13 entry
+- No pull requests merged in that window either, so the repo is still waiting on review and merge decisions rather than absorbing completed work
+- That means the default-branch story is not about shipped changes; it is about whether the current queue is being managed well enough to keep maintenance and feature work from stalling
+
+## Pull Request Queue
+
+### The queue got busier, and it now has one strong product branch plus a fresh split between green and red maintenance lanes
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) opened on 2026-05-14 and is fully green across the current check surface, which makes it the clearest substantive merge candidate in the repo right now
+- Journal PRs #161, #162, and #163 added the 2026-05-15 through 2026-05-17 entries to the backlog, so the docs queue kept growing even though nothing merged
+- Dependabot opened three more branches on 2026-05-18: #164 (`build(deps): bump russh from 0.58.1 to 0.60.3`), #165 (`build(deps): bump quick-xml from 0.39.4 to 0.40.1`), and #166 (`ci(deps): bump the actions group with 4 updates`)
+- The contrast between those new maintenance branches is sharp: #166 is green, while #164 fails `Clippy`, `Cargo Vet`, `Test (all features)`, `Documentation`, `Cargo Geiger Workspace Gate`, `Coverage`, `Security`, and `MSRV Check`; #165 is also broadly red across `Clippy`, stable/all-features tests, `Cargo Vet`, `Documentation`, `Coverage`, and aggregate `Security`
+- The earlier branch picture still matters too: PR #159 remains blocked only by `Cargo Vet` and aggregate `Security`, so the queue now contains two separate `russh` bump attempts alongside the cleaner feature branch in #160
+
+## Issues
+- No issues were opened after the 2026-05-13 journal baseline
+- No issues were closed in the same window
+- The repo is still being driven by review throughput and dependency triage rather than by new bug intake or resolved product tickets
+
+## CI Health
+- `main` still did not receive a push-triggered validation cycle because nothing merged, but it did pick up a fresh scheduled `OpenSSF Scorecard` success on 2026-05-17
+- The default branch also saw new Dependabot-generated update runs on 2026-05-18: the cargo update lane succeeded, while the GitHub Actions update lane failed
+- So the repo does have fresh automation signal, but it is maintenance-generated rather than merge-generated, and the most important operational decision is still obvious: merge the green work (#160 and likely #166) before the queue gets any noisier


### PR DESCRIPTION
## Summary
- add the 2026-05-18 journal entry
- capture the new PR backlog and fresh Dependabot burst since the 2026-05-13 committed entry
- note the latest default-branch automation signal

## Testing
- not run (journal-only change)
