### PR TITLE
docs(journal): add 2026-05-19 journal entry

### DIFF
--- a/journal/2026-05-19.md
+++ b/journal/2026-05-19.md
@@ -1,0 +1,23 @@
+# 2026-05-19 — GMP Parity Work Finally Landed on `main`, Then the Queue Split Cleanly Into One Fresh Automation Branch, One Green Dependency Refresh, and Two Obviously Broken Updates
+
+## Mainline & Merged Work
+
+### `main` finally moved after the 2026-05-14 baseline, and this time it was real product-facing surface area rather than journal churn
+- `main` picked up commit `e5a3e30` on 2026-05-18 from merged PR #160 (`Add GMP parity commands for integration configs and report helpers`)
+- That merge landed the GMP parity work for issue #148: integration-config commands plus report-helper support for hosts, ports, applications, operating systems, and CVEs are now on the default branch instead of sitting in review
+- This matters because the repo's story changed from "strong feature branch waiting to merge" to "feature already absorbed by mainline and validated there"
+
+## Issues
+- Issue #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`) closed when PR #160 merged, so the biggest open product item tied to this repo's recent work is no longer backlog — it is shipped into `main`
+- No new issues were opened after the 2026-05-14 journal baseline
+
+## Pull Request Queue
+- PR #168 (`ci: add journal PR automation workflow`) opened after the #160 merge and is already broadly green, so the next low-risk maintenance move is obvious
+- PR #166 (`ci(deps): bump the actions group with 4 updates`) is still the healthiest dependency lane, but it is now behind `main` and should be refreshed before sitting long enough to rot
+- PRs #164 (`build(deps): bump russh from 0.58.1 to 0.60.3`) and #165 (`build(deps): bump quick-xml from 0.39.4 to 0.40.1`) are still the bad branches in plain sight: both remain broadly red across CI/security surfaces even after the default branch advanced
+- Journal PRs #161, #162, and #163 were opened and then closed without merge as the backlog was reshaped, while PR #167 now carries the 2026-05-18 entry on the `journal-main` lane
+
+## CI Health
+- The important change here is not just that PR #160 merged, but that `main` immediately validated the merge with successful push runs in `CI`, `Security`, and `OpenSSF Scorecard` on 2026-05-18
+- Scheduled `Security` also succeeded the same day, so the default branch has fresh clean signal instead of stale inferred health
+- The only mixed note is the routine `Dependabot Updates` churn on 2026-05-18, where the cargo lane succeeded but a GitHub Actions update lane failed; that is queue noise, not evidence that the newly merged GMP parity work destabilized `main`


### PR DESCRIPTION
## Summary
- add 2026-05-19 journal entry
- capture repo activity since the last committed journal entry

## Testing
- not run (docs-only journal update)
