### PR TITLE
docs(journal): add 2026-05-20 journal entry

### DIFF
--- a/journal/2026-05-20.md
+++ b/journal/2026-05-20.md
@@ -1,0 +1,26 @@
+# 2026-05-20 — `main` Stayed Still, but the Fresh Journal Branch Confirmed the Queue Is Waiting on Human Merges, Not More CI
+
+## Mainline & Merged Work
+
+### There was no new default-branch or merge activity after the 2026-05-19 journal baseline
+- No commits landed on `main`
+- No pull requests merged
+- No issues opened or closed
+- So the repo did not materially change behavior; the only fresh movement was another documentation/automation lap through the queue
+
+## Pull Request Queue
+- PR #169 (`docs(journal): add 2026-05-19 journal entry`) opened on 2026-05-19 and immediately came up broadly green, which means even the newest branch in the repo is not blocked by CI
+- PR #168 (`ci: add journal PR automation workflow`) is still the obvious next maintenance merge: fresh, green, and low-risk
+- PR #166 (`ci(deps): bump the actions group with 4 updates`) is also still green, but it now reads more like aging queue inventory than urgent work
+- PRs #164 (`build(deps): bump russh from 0.58.1 to 0.60.3`) and #165 (`build(deps): bump quick-xml from 0.39.4 to 0.40.1`) are still the broken lanes in plain sight, with failures spread across test, docs, security, coverage, and compatibility checks
+- The practical story did not change from yesterday: the healthy work is piling up faster than it is being merged
+
+## Issues
+- No new issues were opened after the 2026-05-19 journal baseline
+- No issues were closed in the same window
+- That keeps this period focused on queue management rather than backlog churn
+
+## CI Health
+- The freshest signal in the repo is branch-level rather than `main`-level: PR #169 ran clean across the same broad security/quality surface that matters for routine maintenance work
+- There were no new `main` workflow runs after the 2026-05-19 journal baseline, so default-branch confidence is unchanged rather than refreshed
+- The split is now very sharp: #166, #168, and #169 all look merge-ready, while #164 and #165 still fail loudly enough that nobody should confuse the queue for uniformly healthy


### PR DESCRIPTION
## Summary
- add the 2026-05-20 journal entry
- capture repo activity since the 2026-05-19 journal baseline
- document current PR queue and CI signal
