### PR TITLE
docs(journal): add 2026-05-21 journal entry

### DIFF
--- a/journal/2026-05-21.md
+++ b/journal/2026-05-21.md
@@ -1,0 +1,21 @@
+# 2026-05-21 — Mainline Finally Absorbed the GMP Parity Work While Review-Blocked Maintenance Kept Stacking
+
+## Product Surface
+
+### PR #160 finally landed the integration-config and report-helper expansion that had only been journaled before
+- `main` picked up one real default-branch commit after the 2026-05-14 baseline: PR #160 (`Add GMP parity commands for integration configs and report helpers`), merged on 2026-05-18.
+- That commit is the actual landing of issue #148, so the repo has now absorbed the `gvm-gmp` builders, `gvm-client` methods, versioned-client traits, and mock-server coverage for the recent `python-gvm` parity gap.
+- In other words: the 2026-05-14 entry described the behavior change; this entry records that the work is now truly on `main` rather than only queued in GitHub.
+
+## Validation Scope
+- The merged PR carried the validation surface implied by issue #148: XML request-shape coverage for integration-config and report-helper commands plus client/mock-server round-trip coverage.
+- Default-branch confidence looks good after the merge. The latest push-triggered `CI`, `Security`, and `OpenSSF Scorecard` runs on `main` all completed successfully on 2026-05-18.
+- The newer journal and automation branches also validated cleanly, so there is no sign that the repo destabilized while the feature landed.
+
+## Queue & Follow-Through
+- Issue #148 closed when PR #160 merged, so the notable issue movement since the baseline is backlog burn-down rather than new product scope.
+- The open queue is now almost entirely maintenance and workflow throughput: automation PR #168 is green, journal PRs #167/#169/#170 are all waiting on review or branch-policy resolution, approved dependency PR #166 is green but already `BEHIND`, and dependency branches #164/#165 are still the red outliers.
+- The repo is healthy on trunk; the active problem is that merge-ready work is accumulating faster than anyone is draining it.
+
+## Notes
+- This entry is mainly a state transition: the GMP parity lane described on 2026-05-14 is no longer prospective work — it shipped to `main` on 2026-05-18.


### PR DESCRIPTION
## Summary
- add the 2026-05-21 journal entry
- summarize repository activity since the last merged journal file in   `journal/`
- capture current PR/CI posture for follow-up
