### PR TITLE
docs(journal): add 2026-05-22 journal entry

### DIFF
--- a/journal/2026-05-22.md
+++ b/journal/2026-05-22.md
@@ -1,0 +1,23 @@
+# 2026-05-22 — GMP Parity Landed on `main`, Then the Queue Turned into Journal Automation Plus a Fresh Coverage Roadmap
+
+## Mainline & Merged Work
+
+### `main` actually moved after the 2026-05-14 journal baseline, and it moved for a real product-facing reason
+- `main` picked up PR #160 on 2026-05-18: `Add GMP parity commands for integration configs and report helpers`
+- That merge closed issue #148 and landed the integration-config plus report-helper GMP surface that the 2026-05-14 entry had been tracking as in-flight work
+- So this repo did not just accumulate maintenance noise after the last baseline; it finished and merged the outstanding parity lane
+
+## Issues
+- Issue #148 (`Add GMP parity for recent python-gvm integration-config and report helper commands`) was closed when PR #160 merged on 2026-05-18
+- A new roadmap burst arrived on 2026-05-21: #172 (remaining GMP coverage gaps vs gvmd), #173 (report drill-down commands and typed client support), #174 (timezone and credential-store discovery), and #175 (mock fixtures and coverage for REST-support GMP gaps)
+- The issue story has shifted from one concrete parity implementation to a broader follow-on roadmap for closing the remaining GMP surface gaps
+
+## Pull Request Queue
+- Journal automation is now the loudest source of activity: open PRs #167, #169, #170, and #171 all add daily journal entries, while #168 introduces the journal PR automation workflow itself
+- The maintenance queue is now easy to classify: PR #166 (`actions` updates) is green but `BEHIND`, while dependency bumps #164 (`russh`) and #165 (`quick-xml`) are both behind `main` and failing CI
+- This leaves the repo in an odd but readable state: the meaningful product merge already happened, but the visible queue is now mostly blocked journal/process work plus a small set of maintenance branches that need either rebasing or replacement
+
+## CI Health
+- The default branch looked healthy immediately after PR #160 merged: `CI`, `Security`, and `OpenSSF Scorecard` all completed successfully on the 2026-05-18 push to `main`
+- Fresh Dependabot maintenance runs on `main` also succeeded on 2026-05-21, so the current branch-level signal is still reassuring
+- The only obviously bad lanes are the stale dependency PRs #164 and #165, both of which are failing while the default branch itself remains green


### PR DESCRIPTION
## Summary
- add the 2026-05-22 journal entry
- capture repo activity since the last journal file on `main`
- document mainline movement, issue churn, queue state, and CI signal

## Testing
- not run (journal-only update)
