### PR TITLE
Add GMP REST support gap helpers

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -14,6 +14,7 @@ mod typed;
 mod version;
 
 use gvm_connection::GvmConnection;
+use gvm_gmp::commands::credentials::get_credential_stores;
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
@@ -22,9 +23,11 @@ use gvm_gmp::commands::report_configs::{
     create_report_config, delete_report_config, get_report_configs, modify_report_config,
 };
 use gvm_gmp::commands::reports::{
-    get_report_applications, get_report_cves, get_report_hosts, get_report_operating_systems,
-    get_report_ports,
+    get_report_applications, get_report_closed_cves, get_report_cves, get_report_errors,
+    get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
+    get_report_vulns,
 };
+use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
@@ -378,6 +381,40 @@ pub trait GmpNextCommands {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError>;
+
+    /// Get report vulnerability summaries.
+    async fn get_report_vulns(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report TLS certificate summaries.
+    async fn get_report_tls_certificates(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report error summaries.
+    async fn get_report_errors(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get report closed CVE summaries.
+    async fn get_report_closed_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// List timezones.
+    async fn get_timezones(&mut self) -> Result<Response, GvmError>;
+
+    /// List credential stores.
+    async fn get_credential_stores(&mut self) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -571,6 +608,48 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
         self.0.get_report_cves(report_id, opts).await
+    }
+
+    async fn get_report_vulns(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.call(get_report_vulns(report_id, opts)).await
+    }
+
+    async fn get_report_tls_certificates(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(get_report_tls_certificates(report_id, opts))
+            .await
+    }
+
+    async fn get_report_errors(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.call(get_report_errors(report_id, opts)).await
+    }
+
+    async fn get_report_closed_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.call(get_report_closed_cves(report_id, opts)).await
+    }
+
+    async fn get_timezones(&mut self) -> Result<Response, GvmError> {
+        self.0.call(get_timezones()).await
+    }
+
+    async fn get_credential_stores(&mut self) -> Result<Response, GvmError> {
+        self.0.call(get_credential_stores()).await
     }
 }
 

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -15,7 +15,7 @@ use gvm_connection::GvmConnection;
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
-    create_credential, get_credentials, CredentialOpts, GetCredentialsOpts,
+    create_credential, get_credential_stores, get_credentials, CredentialOpts, GetCredentialsOpts,
 };
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
@@ -37,7 +37,10 @@ use gvm_gmp::commands::report_configs::{get_report_configs_opts, GetReportConfig
 use gvm_gmp::commands::report_formats::{
     create_report_format, get_report_formats, GetReportFormatsOpts, ReportFormatOpts,
 };
-use gvm_gmp::commands::reports::{get_reports, GetReportsOpts};
+use gvm_gmp::commands::reports::{
+    get_report_closed_cves, get_report_errors, get_report_tls_certificates, get_report_vulns,
+    get_reports, GetReportDetailsOpts, GetReportsOpts,
+};
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
@@ -54,7 +57,7 @@ use gvm_gmp::commands::schedules::{
 use gvm_gmp::commands::secinfo::{
     get_cert_bund_advisories, get_cpes, get_cves, get_dfn_cert_advisories, GetSecInfoOpts,
 };
-use gvm_gmp::commands::system::{describe_auth, get_settings, FilteredGetOpts};
+use gvm_gmp::commands::system::{describe_auth, get_settings, get_timezones, FilteredGetOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
 use gvm_gmp::commands::tasks::{create_task, get_tasks, start_task, CreateTaskOpts, GetTasksOpts};
@@ -72,15 +75,18 @@ use gvm_gmp::responses::{
     CreateTagResponse, CreateTargetResponse, CreateTaskResponse, CreateTicketResponse,
     CreateTlsCertificateResponse, CreateUserResponse, DeleteScanConfigResponse,
     DeleteScannerResponse, DescribeAuthResponse, GetAlertsResponse, GetCertBundAdvisoriesResponse,
-    GetCpesResponse, GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse,
-    GetFeedsResponse, GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
-    GetNvtFamiliesResponse, GetNvtsResponse, GetOverridesResponse, GetPermissionsResponse,
-    GetPortListsResponse, GetReportConfigsResponse, GetReportFormatsResponse, GetReportsResponse,
-    GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
-    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
-    GetTasksResponse, GetTicketsResponse, GetTlsCertificatesResponse, GetUsersResponse,
-    GetVersionResponse, HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse,
-    StartTaskResponse, SyncConfigResponse, VerifyScannerResponse,
+    GetCpesResponse, GetCredentialStoresResponse, GetCredentialsResponse, GetCvesResponse,
+    GetDfnCertAdvisoriesResponse, GetFeedsResponse, GetFiltersResponse, GetGroupsResponse,
+    GetHostsResponse, GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse,
+    GetOverridesResponse, GetPermissionsResponse, GetPortListsResponse,
+    GetReportClosedCvesResponse, GetReportConfigsResponse, GetReportErrorsResponse,
+    GetReportFormatsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
+    GetReportsResponse, GetResultsResponse, GetRolesResponse, GetScanConfigsResponse,
+    GetScannersResponse, GetSchedulesResponse, GetSettingsResponse, GetTagsResponse,
+    GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
+    GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, HelpResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, StartTaskResponse, SyncConfigResponse,
+    VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -396,6 +402,60 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         GetReportsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
+    /// Send a `get_report_vulns` request and return a typed [`GetReportVulnsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_vulns(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportVulnsResponse, GvmError> {
+        let response = self.send(get_report_vulns(report_id, opts)).await?;
+        GetReportVulnsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_tls_certificates` request and return a typed [`GetReportTlsCertificatesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_tls_certificates(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportTlsCertificatesResponse, GvmError> {
+        let response = self
+            .send(get_report_tls_certificates(report_id, opts))
+            .await?;
+        GetReportTlsCertificatesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_errors` request and return a typed [`GetReportErrorsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_errors(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportErrorsResponse, GvmError> {
+        let response = self.send(get_report_errors(report_id, opts)).await?;
+        GetReportErrorsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_closed_cves` request and return a typed [`GetReportClosedCvesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_closed_cves(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportClosedCvesResponse, GvmError> {
+        let response = self.send(get_report_closed_cves(report_id, opts)).await?;
+        GetReportClosedCvesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
     // ── Results ───────────────────────────────────────────────────────────────
 
     /// Send a `get_results` request and return a typed [`GetResultsResponse`].
@@ -419,6 +479,24 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn get_feeds(&mut self) -> Result<GetFeedsResponse, GvmError> {
         let response = self.send(get_feeds()).await?;
         GetFeedsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_timezones` request and return a typed [`GetTimezonesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_timezones(&mut self) -> Result<GetTimezonesResponse, GvmError> {
+        let response = self.send(get_timezones()).await?;
+        GetTimezonesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_credential_stores` request and return a typed [`GetCredentialStoresResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_credential_stores(&mut self) -> Result<GetCredentialStoresResponse, GvmError> {
+        let response = self.send(get_credential_stores()).await?;
+        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── NVTs ──────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -22,7 +22,13 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_report_ports"
         | "get_report_applications"
         | "get_report_operating_systems"
-        | "get_report_cves" => Some(GmpVersion(22, 8)),
+        | "get_report_cves"
+        | "get_report_vulns"
+        | "get_report_tls_certificates"
+        | "get_report_errors"
+        | "get_report_closed_cves"
+        | "get_timezones"
+        | "get_credential_stores" => Some(GmpVersion(22, 8)),
         _ => None,
     }
 }
@@ -176,6 +182,16 @@ mod tests {
         assert!(command_supported("get_report_hosts", GmpVersion(22, 8)));
         assert_eq!(
             minimum_version_for_command("get_report_cves"),
+            Some(GmpVersion(22, 8))
+        );
+        assert!(!command_supported("get_timezones", GmpVersion(22, 7)));
+        assert!(command_supported("get_timezones", GmpVersion(22, 8)));
+        assert_eq!(
+            minimum_version_for_command("get_report_vulns"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("get_credential_stores"),
             Some(GmpVersion(22, 8))
         );
     }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -10,6 +10,7 @@ use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::reports::get_report_hosts;
 use gvm_gmp::commands::scan_configs::ConfigOpts;
 use gvm_gmp::commands::scanners::ScannerOpts;
+use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
@@ -56,6 +57,20 @@ async fn fixture_server_with_version_response(version_xml: &str) -> Option<MockG
                 "<get_version_response status=\"200\" status_text=\"OK\"><version>{version_xml}</version></get_version_response>"
             ),
         )
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+async fn fixture_server(version: MockVersion) -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Fixture)
+        .version(version)
+        .unix_socket(socket_path())
         .build()
         .await
     {
@@ -279,6 +294,19 @@ async fn unsupported_next_command_rejected_before_send() {
         other => panic!("expected unsupported command error, got {other:?}"),
     }
 
+    let error = client
+        .call(get_timezones())
+        .await
+        .expect_err("22.7 should reject get_timezones");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == "get_timezones"
+    ));
+
     server.shutdown().await;
 }
 
@@ -334,6 +362,61 @@ async fn next_commands_work_on_v22_8() {
         .await
         .expect_err("missing report should return server error");
     assert!(matches!(helper_error, GvmError::Server { status: 404, .. }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
+    let Some(server) = fixture_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let report_id = EntityId::new("report-1").expect("valid id");
+
+    let vulns = client
+        .get_report_vulns(&report_id, Default::default())
+        .await
+        .expect("report vulns should parse");
+    assert_eq!(vulns.items.len(), 1);
+    assert_eq!(vulns.items[0].severity.as_deref(), Some("8.2"));
+
+    let tls = client
+        .get_report_tls_certificates(&report_id, Default::default())
+        .await
+        .expect("report tls certs should parse");
+    assert_eq!(tls.items[0].issuer.as_deref(), Some("CN=Example CA"));
+
+    let errors = client
+        .get_report_errors(&report_id, Default::default())
+        .await
+        .expect("report errors should parse");
+    assert_eq!(errors.items[0].nvt_name.as_deref(), Some("Ping Host"));
+
+    let closed_cves = client
+        .get_report_closed_cves(&report_id, Default::default())
+        .await
+        .expect("closed cves should parse");
+    assert_eq!(closed_cves.items[0].cve.as_deref(), Some("CVE-2025-9999"));
+
+    let timezones = client
+        .get_timezones()
+        .await
+        .expect("timezones should parse");
+    assert!(timezones
+        .items
+        .iter()
+        .any(|timezone| timezone.name == "UTC"));
+
+    let stores = client
+        .get_credential_stores()
+        .await
+        .expect("credential stores should parse");
+    assert_eq!(stores.items[0].name, "Local credential store");
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -82,6 +82,12 @@ pub fn get_credential(credential_id: &EntityId) -> impl Request {
         .attribute("details", "1")
 }
 
+/// Build a `get_credential_stores` request.
+#[must_use]
+pub fn get_credential_stores() -> impl Request {
+    XmlCommand::new("get_credential_stores")
+}
+
 /// Build a `modify_credential` request.
 #[must_use]
 pub fn modify_credential(credential_id: &EntityId, opts: CredentialOpts) -> impl Request {
@@ -150,6 +156,7 @@ mod tests {
         assert!(rendered.contains("<get_credentials "));
         assert!(rendered.contains("credential_id=\"c1\""));
         assert!(rendered.contains("details=\"1\""));
+        assert_eq!(xml(get_credential_stores()), "<get_credential_stores/>");
     }
 
     #[test]

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -161,6 +161,33 @@ pub fn get_report_cves(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl
     get_report_detail_command("get_report_cves", report_id, opts)
 }
 
+/// Build a `get_report_vulns` request.
+#[must_use]
+pub fn get_report_vulns(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_vulns", report_id, opts)
+}
+
+/// Build a `get_report_tls_certificates` request.
+#[must_use]
+pub fn get_report_tls_certificates(
+    report_id: &EntityId,
+    opts: GetReportDetailsOpts,
+) -> impl Request {
+    get_report_detail_command("get_report_tls_certificates", report_id, opts)
+}
+
+/// Build a `get_report_errors` request.
+#[must_use]
+pub fn get_report_errors(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_errors", report_id, opts)
+}
+
+/// Build a `get_report_closed_cves` request.
+#[must_use]
+pub fn get_report_closed_cves(report_id: &EntityId, opts: GetReportDetailsOpts) -> impl Request {
+    get_report_detail_command("get_report_closed_cves", report_id, opts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,6 +274,31 @@ mod tests {
         assert_eq!(
             xml(get_report_cves(&id("r1"), GetReportDetailsOpts::default())),
             "<get_report_cves details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_vulns(&id("r1"), GetReportDetailsOpts::default())),
+            "<get_report_vulns details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_tls_certificates(
+                &id("r1"),
+                GetReportDetailsOpts::default()
+            )),
+            "<get_report_tls_certificates details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_errors(
+                &id("r1"),
+                GetReportDetailsOpts::default()
+            )),
+            "<get_report_errors details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_closed_cves(
+                &id("r1"),
+                GetReportDetailsOpts::default()
+            )),
+            "<get_report_closed_cves details=\"1\" report_id=\"r1\"/>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -102,6 +102,12 @@ pub fn get_settings(opts: FilteredGetOpts) -> impl Request {
     cmd
 }
 
+/// Build a `get_timezones` request.
+#[must_use]
+pub fn get_timezones() -> impl Request {
+    XmlCommand::new("get_timezones")
+}
+
 /// Build a `get_aggregates` request.
 #[must_use]
 pub fn get_aggregates(opts: GetAggregatesOpts) -> impl Request {
@@ -273,6 +279,7 @@ mod tests {
         assert!(rendered.contains("statistic=\"count\""));
         assert_eq!(xml(get_license()), "<get_license/>");
         assert_eq!(xml(describe_auth()), "<describe_auth/>");
+        assert_eq!(xml(get_timezones()), "<get_timezones/>");
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -34,6 +34,25 @@ pub struct GetCredentialsResponse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CredentialStore {
+    pub id: Option<String>,
+    pub name: String,
+    pub type_: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetCredentialStoresResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<CredentialStore>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCredentialResponse {
     pub status: u16,
     pub status_text: String,
@@ -69,6 +88,33 @@ impl GetCredentialsResponse {
             status_text,
             items,
             counts: count_info(&root, "credential_count")?,
+        })
+    }
+}
+
+impl CredentialStore {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: node.attr("id").map(ToString::to_string),
+            name: node.required_child_text("name")?,
+            type_: node.optional_child_text("type"),
+        })
+    }
+}
+
+impl GetCredentialStoresResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("credential_store")
+            .map(CredentialStore::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "credential_store_count")?,
         })
     }
 }
@@ -153,6 +199,24 @@ mod tests {
 
         assert!(parsed.items.is_empty());
         assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_credential_stores() {
+        let response = Response::from(
+            r#"<get_credential_stores_response status="200" status_text="OK">
+                <credential_store id="store-1"><name>Default store</name><type>local</type></credential_store>
+                <credential_store_count>1<filtered>1</filtered></credential_store_count>
+            </get_credential_stores_response>"#,
+        );
+
+        let parsed =
+            GetCredentialStoresResponse::from_response(&response).expect("credential stores parse");
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].name, "Default store");
+        assert_eq!(parsed.items[0].type_.as_deref(), Some("local"));
+        assert_eq!(parsed.counts.total, Some(1));
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -50,8 +50,8 @@ pub use alert::{
 pub use auth::AuthenticateResponse;
 pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, ParseError};
 pub use credential::{
-    CreateCredentialResponse, Credential, DeleteCredentialResponse, GetCredentialsResponse,
-    ModifyCredentialResponse,
+    CreateCredentialResponse, Credential, CredentialStore, DeleteCredentialResponse,
+    GetCredentialStoresResponse, GetCredentialsResponse, ModifyCredentialResponse,
 };
 pub use features::{Feature, GetFeaturesResponse};
 pub use feed::{Feed, GetFeedsResponse};
@@ -77,7 +77,11 @@ pub use permission::{
     ModifyPermissionResponse, Permission,
 };
 pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
-pub use report::{DeleteReportResponse, GetReportsResponse, Report, ResultCount, Severity};
+pub use report::{
+    DeleteReportResponse, GetReportClosedCvesResponse, GetReportErrorsResponse,
+    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse, Report,
+    ReportClosedCve, ReportError, ReportTlsCertificate, ReportVulnerability, ResultCount, Severity,
+};
 pub use report_config::{
     CreateReportConfigResponse, DeleteReportConfigResponse, GetReportConfigsResponse,
     ModifyReportConfigResponse, ReportConfig,
@@ -109,7 +113,8 @@ pub use secinfo::{
     GetVulnerabilitiesResponse, OperatingSystem, Vulnerability,
 };
 pub use system::{
-    AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, HelpResponse, Setting,
+    AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, GetTimezonesResponse,
+    HelpResponse, Setting, Timezone,
 };
 pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -49,6 +49,98 @@ pub struct GetReportsResponse {
     pub counts: CountInfo,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportVulnerability {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<String>,
+    pub threat: Option<String>,
+    pub severity: Option<String>,
+    pub family: Option<String>,
+    pub cves: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportTlsCertificate {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<String>,
+    pub subject: Option<String>,
+    pub issuer: Option<String>,
+    pub serial: Option<String>,
+    pub activation_time: Option<String>,
+    pub expiration_time: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportError {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<String>,
+    pub description: Option<String>,
+    pub nvt_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportClosedCve {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub cve: Option<String>,
+    pub host: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportVulnsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportVulnerability>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportTlsCertificatesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportTlsCertificate>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportErrorsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportError>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportClosedCvesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportClosedCve>,
+    pub counts: CountInfo,
+}
+
 impl Report {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         let details = node.child("report");
@@ -105,6 +197,115 @@ impl GetReportsResponse {
         })
     }
 }
+
+impl ReportVulnerability {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Self {
+        Self {
+            id: node.attr("id").map(ToString::to_string),
+            name: node.optional_child_text("name"),
+            host: node.optional_child_text("host"),
+            port: node.optional_child_text("port"),
+            threat: node.optional_child_text("threat"),
+            severity: node.optional_child_text("severity"),
+            family: node.optional_child_text("family"),
+            cves: node
+                .children_named("cve")
+                .map(|cve| cve.text.clone())
+                .collect(),
+        }
+    }
+}
+
+impl ReportTlsCertificate {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Self {
+        Self {
+            id: node.attr("id").map(ToString::to_string),
+            name: node.optional_child_text("name"),
+            host: node.optional_child_text("host"),
+            port: node.optional_child_text("port"),
+            subject: node.optional_child_text("subject"),
+            issuer: node.optional_child_text("issuer"),
+            serial: node.optional_child_text("serial"),
+            activation_time: node.optional_child_text("activation_time"),
+            expiration_time: node.optional_child_text("expiration_time"),
+        }
+    }
+}
+
+impl ReportError {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Self {
+        Self {
+            id: node.attr("id").map(ToString::to_string),
+            name: node.optional_child_text("name"),
+            host: node.optional_child_text("host"),
+            port: node.optional_child_text("port"),
+            description: node.optional_child_text("description"),
+            nvt_name: node
+                .child("nvt")
+                .and_then(|nvt| nvt.optional_child_text("name")),
+        }
+    }
+}
+
+impl ReportClosedCve {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Self {
+        Self {
+            id: node.attr("id").map(ToString::to_string),
+            name: node.optional_child_text("name"),
+            cve: node
+                .optional_child_text("cve")
+                .or_else(|| node.optional_child_text("name")),
+            host: node.optional_child_text("host"),
+            severity: node.optional_child_text("severity"),
+        }
+    }
+}
+
+macro_rules! impl_report_detail_response {
+    ($response:ident, $item:ident, [$($item_name:literal),+], $count_name:literal) => {
+        impl $response {
+            pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+                let (status, status_text) = status_from_response(response)?;
+                let root = parse_document(response.data())?;
+                let mut items = Vec::new();
+                $(
+                    items.extend(root.children_named($item_name).map($item::from_node));
+                )+
+                Ok(Self {
+                    status,
+                    status_text,
+                    items,
+                    counts: count_info(&root, $count_name)?,
+                })
+            }
+        }
+    };
+}
+
+impl_report_detail_response!(
+    GetReportVulnsResponse,
+    ReportVulnerability,
+    ["vuln", "vulnerability"],
+    "vuln_count"
+);
+impl_report_detail_response!(
+    GetReportTlsCertificatesResponse,
+    ReportTlsCertificate,
+    ["tls_certificate", "certificate"],
+    "tls_certificate_count"
+);
+impl_report_detail_response!(
+    GetReportErrorsResponse,
+    ReportError,
+    ["error"],
+    "error_count"
+);
+impl_report_detail_response!(
+    GetReportClosedCvesResponse,
+    ReportClosedCve,
+    ["closed_cve", "cve"],
+    "closed_cve_count"
+);
 
 pub type DeleteReportResponse = ActionResponse;
 
@@ -250,5 +451,104 @@ mod tests {
         assert_eq!(report.result_count, None);
         assert_eq!(report.severity, None);
         assert_eq!(report.host_count, None);
+    }
+
+    #[test]
+    fn parses_report_vulns_response() {
+        let response = Response::from(
+            r#"<get_report_vulns_response status="200" status_text="OK">
+                <vuln id="vuln-1">
+                    <name>OpenSSL Vulnerability</name>
+                    <host>192.0.2.10</host>
+                    <port>443/tcp</port>
+                    <threat>High</threat>
+                    <severity>8.2</severity>
+                    <family>General</family>
+                    <cve>CVE-2026-0001</cve>
+                </vuln>
+                <vuln_count>1<filtered>1</filtered></vuln_count>
+            </get_report_vulns_response>"#,
+        );
+
+        let parsed = GetReportVulnsResponse::from_response(&response).expect("vulns parse");
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.counts.total, Some(1));
+        assert_eq!(parsed.items[0].host.as_deref(), Some("192.0.2.10"));
+        assert_eq!(parsed.items[0].cves, vec!["CVE-2026-0001"]);
+    }
+
+    #[test]
+    fn parses_report_tls_certificates_response() {
+        let response = Response::from(
+            r#"<get_report_tls_certificates_response status="200" status_text="OK">
+                <tls_certificate id="tls-1">
+                    <name>example.com</name>
+                    <host>192.0.2.10</host>
+                    <port>443/tcp</port>
+                    <subject>CN=example.com</subject>
+                    <issuer>CN=Example CA</issuer>
+                    <serial>01</serial>
+                    <expiration_time>2027-01-01T00:00:00Z</expiration_time>
+                </tls_certificate>
+                <tls_certificate_count>1<filtered>1</filtered></tls_certificate_count>
+            </get_report_tls_certificates_response>"#,
+        );
+
+        let parsed = GetReportTlsCertificatesResponse::from_response(&response)
+            .expect("tls certificates parse");
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].issuer.as_deref(), Some("CN=Example CA"));
+        assert_eq!(
+            parsed.items[0].expiration_time.as_deref(),
+            Some("2027-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn parses_report_errors_response() {
+        let response = Response::from(
+            r#"<get_report_errors_response status="200" status_text="OK">
+                <error id="err-1">
+                    <name>Host dead</name>
+                    <host>192.0.2.20</host>
+                    <port>general/tcp</port>
+                    <description>Could not reach host.</description>
+                    <nvt><name>Ping Host</name></nvt>
+                </error>
+                <error_count>1<filtered>1</filtered></error_count>
+            </get_report_errors_response>"#,
+        );
+
+        let parsed = GetReportErrorsResponse::from_response(&response).expect("errors parse");
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(
+            parsed.items[0].description.as_deref(),
+            Some("Could not reach host.")
+        );
+        assert_eq!(parsed.items[0].nvt_name.as_deref(), Some("Ping Host"));
+    }
+
+    #[test]
+    fn parses_report_closed_cves_response() {
+        let response = Response::from(
+            r#"<get_report_closed_cves_response status="200" status_text="OK">
+                <closed_cve id="closed-1">
+                    <name>CVE-2025-9999</name>
+                    <host>192.0.2.30</host>
+                    <severity>5.0</severity>
+                </closed_cve>
+                <closed_cve_count>1<filtered>1</filtered></closed_cve_count>
+            </get_report_closed_cves_response>"#,
+        );
+
+        let parsed =
+            GetReportClosedCvesResponse::from_response(&response).expect("closed cves parse");
+
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].cve.as_deref(), Some("CVE-2025-9999"));
+        assert_eq!(parsed.items[0].severity.as_deref(), Some("5.0"));
     }
 }

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -30,6 +30,23 @@ pub struct GetSettingsResponse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Timezone {
+    pub name: String,
+    pub offset: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetTimezonesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Timezone>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HelpResponse {
     pub status: u16,
     pub status_text: String,
@@ -83,6 +100,39 @@ impl GetSettingsResponse {
         let items = root
             .children_named("setting")
             .map(Setting::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+        })
+    }
+}
+
+impl Timezone {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let name = node
+            .optional_child_text("name")
+            .or_else(|| node.attr("name").map(ToString::to_string))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| node.text.clone());
+        if name.is_empty() {
+            return Err(ParseError::MissingElement("timezone.name".to_string()));
+        }
+        Ok(Self {
+            name,
+            offset: node.optional_child_text("offset"),
+        })
+    }
+}
+
+impl GetTimezonesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("timezone")
+            .map(Timezone::from_node)
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             status,
@@ -172,6 +222,22 @@ mod tests {
         let parsed = GetSettingsResponse::from_response(&response).expect("settings parse");
 
         assert!(parsed.items.is_empty());
+    }
+
+    #[test]
+    fn parses_timezones() {
+        let response = Response::from(
+            r#"<get_timezones_response status="200" status_text="OK">
+                <timezone>UTC</timezone>
+                <timezone><name>Europe/Berlin</name><offset>+01:00</offset></timezone>
+            </get_timezones_response>"#,
+        );
+
+        let parsed = GetTimezonesResponse::from_response(&response).expect("timezones parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.items[0].name, "UTC");
+        assert_eq!(parsed.items[1].offset.as_deref(), Some("+01:00"));
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/fixtures.rs
+++ b/crates/gvm-mock-server/src/fixtures.rs
@@ -266,6 +266,16 @@ impl FixtureStore {
                 .to_string(),
         );
 
+        // get_credential_stores
+        self.fixtures.insert(
+            "get_credential_stores".to_string(),
+            "<get_credential_stores_response status=\"200\" status_text=\"OK\">\
+             <credential_store id=\"local\"><name>Local credential store</name><type>local</type></credential_store>\
+             <credential_store_count>1<filtered>1</filtered></credential_store_count>\
+             </get_credential_stores_response>"
+                .to_string(),
+        );
+
         // create_credential
         self.fixtures.insert(
             "create_credential".to_string(),
@@ -349,6 +359,49 @@ impl FixtureStore {
              </report>\
              <report_count>1<filtered>1</filtered></report_count>\
              </get_reports_response>"
+                .to_string(),
+        );
+
+        // report drill-down helpers
+        self.fixtures.insert(
+            "get_report_vulns".to_string(),
+            "<get_report_vulns_response status=\"200\" status_text=\"OK\">\
+             <vuln id=\"vuln-1\"><name>OpenSSL Vulnerability</name><host>192.0.2.10</host><port>443/tcp</port><threat>High</threat><severity>8.2</severity><family>General</family><cve>CVE-2026-0001</cve></vuln>\
+             <vuln_count>1<filtered>1</filtered></vuln_count>\
+             </get_report_vulns_response>"
+                .to_string(),
+        );
+        self.fixtures.insert(
+            "get_report_tls_certificates".to_string(),
+            "<get_report_tls_certificates_response status=\"200\" status_text=\"OK\">\
+             <tls_certificate id=\"tls-1\"><name>example.com</name><host>192.0.2.10</host><port>443/tcp</port><subject>CN=example.com</subject><issuer>CN=Example CA</issuer><serial>01</serial><expiration_time>2027-01-01T00:00:00Z</expiration_time></tls_certificate>\
+             <tls_certificate_count>1<filtered>1</filtered></tls_certificate_count>\
+             </get_report_tls_certificates_response>"
+                .to_string(),
+        );
+        self.fixtures.insert(
+            "get_report_errors".to_string(),
+            "<get_report_errors_response status=\"200\" status_text=\"OK\">\
+             <error id=\"err-1\"><name>Host dead</name><host>192.0.2.20</host><port>general/tcp</port><description>Could not reach host.</description><nvt><name>Ping Host</name></nvt></error>\
+             <error_count>1<filtered>1</filtered></error_count>\
+             </get_report_errors_response>"
+                .to_string(),
+        );
+        self.fixtures.insert(
+            "get_report_closed_cves".to_string(),
+            "<get_report_closed_cves_response status=\"200\" status_text=\"OK\">\
+             <closed_cve id=\"closed-1\"><name>CVE-2025-9999</name><host>192.0.2.30</host><severity>5.0</severity></closed_cve>\
+             <closed_cve_count>1<filtered>1</filtered></closed_cve_count>\
+             </get_report_closed_cves_response>"
+                .to_string(),
+        );
+
+        // get_timezones
+        self.fixtures.insert(
+            "get_timezones".to_string(),
+            "<get_timezones_response status=\"200\" status_text=\"OK\">\
+             <timezone>UTC</timezone><timezone><name>Europe/Berlin</name><offset>+01:00</offset></timezone>\
+             </get_timezones_response>"
                 .to_string(),
         );
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -398,7 +398,17 @@ impl SessionHandler {
             | "get_report_ports"
             | "get_report_applications"
             | "get_report_operating_systems"
-            | "get_report_cves" => return self.render_report_detail_response(cmd, store),
+            | "get_report_cves"
+            | "get_report_vulns"
+            | "get_report_tls_certificates"
+            | "get_report_errors"
+            | "get_report_closed_cves" => return self.render_report_detail_response(cmd, store),
+            "get_timezones" => {
+                return "<get_timezones_response status=\"200\" status_text=\"OK\"><timezone>UTC</timezone><timezone><name>Europe/Berlin</name><offset>+01:00</offset></timezone></get_timezones_response>".as_bytes().to_vec();
+            }
+            "get_credential_stores" => {
+                return "<get_credential_stores_response status=\"200\" status_text=\"OK\"><credential_store id=\"local\"><name>Local credential store</name><type>local</type></credential_store><credential_store_count>1<filtered>1</filtered></credential_store_count></get_credential_stores_response>".as_bytes().to_vec();
+            }
             _ => {}
         }
 
@@ -837,6 +847,34 @@ impl SessionHandler {
                     "<cve id=\"cve-1\"><name>CVE-2026-0001</name><severity>8.0</severity></cve>"
                         .to_string(),
                     "<cve id=\"cve-2\"><name>CVE-2026-0002</name><severity>6.0</severity></cve>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_vulns" => (
+                "vuln",
+                vec![
+                    "<vuln id=\"vuln-1\"><name>OpenSSL Vulnerability</name><host>192.0.2.10</host><port>443/tcp</port><threat>High</threat><severity>8.2</severity><family>General</family><cve>CVE-2026-0001</cve></vuln>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_tls_certificates" => (
+                "tls_certificate",
+                vec![
+                    "<tls_certificate id=\"tls-1\"><name>example.com</name><host>192.0.2.10</host><port>443/tcp</port><subject>CN=example.com</subject><issuer>CN=Example CA</issuer><serial>01</serial><expiration_time>2027-01-01T00:00:00Z</expiration_time></tls_certificate>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_errors" => (
+                "error",
+                vec![
+                    "<error id=\"err-1\"><name>Host dead</name><host>192.0.2.20</host><port>general/tcp</port><description>Could not reach host.</description><nvt><name>Ping Host</name></nvt></error>"
+                        .to_string(),
+                ],
+            ),
+            "get_report_closed_cves" => (
+                "closed_cve",
+                vec![
+                    "<closed_cve id=\"closed-1\"><name>CVE-2025-9999</name><host>192.0.2.30</host><severity>5.0</severity></closed_cve>"
                         .to_string(),
                 ],
             ),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -403,11 +403,11 @@ impl SessionHandler {
             | "get_report_tls_certificates"
             | "get_report_errors"
             | "get_report_closed_cves" => return self.render_report_detail_response(cmd, store),
-            "get_timezones" => {
-                return "<get_timezones_response status=\"200\" status_text=\"OK\"><timezone>UTC</timezone><timezone><name>Europe/Berlin</name><offset>+01:00</offset></timezone></get_timezones_response>".as_bytes().to_vec();
-            }
-            "get_credential_stores" => {
-                return "<get_credential_stores_response status=\"200\" status_text=\"OK\"><credential_store id=\"local\"><name>Local credential store</name><type>local</type></credential_store><credential_store_count>1<filtered>1</filtered></credential_store_count></get_credential_stores_response>".as_bytes().to_vec();
+            "get_timezones" | "get_credential_stores" => {
+                return FixtureStore::new(self.version)
+                    .get(&cmd.name)
+                    .expect("built-in fixture present")
+                    .into_bytes();
             }
             _ => {}
         }

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -56,6 +56,12 @@ const GMP_22_8_COMMANDS: &[&str] = &[
     "get_report_applications",
     "get_report_operating_systems",
     "get_report_cves",
+    "get_report_vulns",
+    "get_report_tls_certificates",
+    "get_report_errors",
+    "get_report_closed_cves",
+    "get_timezones",
+    "get_credential_stores",
 ];
 
 /// Check if a command is available in the given GMP version.
@@ -160,5 +166,11 @@ mod tests {
         ));
         assert!(!command_available("get_report_hosts", GmpVersion::V22_6));
         assert!(command_available("get_report_hosts", GmpVersion::V22_8));
+        assert!(!command_available("get_report_vulns", GmpVersion::V22_7));
+        assert!(command_available("get_report_vulns", GmpVersion::V22_8));
+        assert!(command_available(
+            "get_credential_stores",
+            GmpVersion::V22_8
+        ));
     }
 }

--- a/crates/gvm-mock-server/tests/fixture_coverage.rs
+++ b/crates/gvm-mock-server/tests/fixture_coverage.rs
@@ -122,6 +122,42 @@ async fn fixture_get_reports() {
 }
 
 #[tokio::test]
+async fn fixture_get_report_drill_downs() {
+    for (command, marker) in [
+        ("get_report_vulns", "<vuln "),
+        ("get_report_tls_certificates", "<tls_certificate "),
+        ("get_report_errors", "<error "),
+        ("get_report_closed_cves", "<closed_cve "),
+    ] {
+        let Some((server, mut s)) = server().await else {
+            return;
+        };
+        let request = format!("<{command} report_id=\"report-1\"/>");
+        let r = send_recv(&mut s, request.as_bytes()).await;
+        assert!(r.is_success(), "{command} should succeed");
+        assert!(r.as_str().expect("utf8").contains(marker));
+        server.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn fixture_get_timezones_and_credential_stores() {
+    let Some((server, mut s)) = server().await else {
+        return;
+    };
+
+    let r = send_recv(&mut s, b"<get_timezones/>").await;
+    assert!(r.is_success());
+    assert!(r.as_str().expect("utf8").contains("UTC"));
+
+    let r = send_recv(&mut s, b"<get_credential_stores/>").await;
+    assert!(r.is_success());
+    assert!(r.as_str().expect("utf8").contains("Local credential store"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn fixture_get_schedules() {
     let Some((server, mut s)) = server().await else {
         return;

--- a/crates/gvm-mock-server/tests/fixture_coverage.rs
+++ b/crates/gvm-mock-server/tests/fixture_coverage.rs
@@ -25,10 +25,14 @@ async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
 }
 
 async fn server() -> Option<(MockGmpServer, UnixStream)> {
+    server_with_version(GmpVersion::V22_5).await
+}
+
+async fn server_with_version(version: GmpVersion) -> Option<(MockGmpServer, UnixStream)> {
     let s = build_server(
         MockGmpServer::builder()
             .mode(ServerMode::Fixture)
-            .version(GmpVersion::V22_5)
+            .version(version)
             .unix_socket_auto(),
     )
     .await?;
@@ -129,7 +133,7 @@ async fn fixture_get_report_drill_downs() {
         ("get_report_errors", "<error "),
         ("get_report_closed_cves", "<closed_cve "),
     ] {
-        let Some((server, mut s)) = server().await else {
+        let Some((server, mut s)) = server_with_version(GmpVersion::V22_8).await else {
             return;
         };
         let request = format!("<{command} report_id=\"report-1\"/>");
@@ -142,7 +146,7 @@ async fn fixture_get_report_drill_downs() {
 
 #[tokio::test]
 async fn fixture_get_timezones_and_credential_stores() {
-    let Some((server, mut s)) = server().await else {
+    let Some((server, mut s)) = server_with_version(GmpVersion::V22_8).await else {
         return;
     };
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-03-29
+Last updated: 2026-05-25
 
 ## Crate Status
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,14 +153,14 @@ Last updated: 2026-03-29
 
 | Category | Commands Covered |
 |----------|-----------------|
-| System | get_version, authenticate, help |
+| System | get_version, authenticate, help, get_timezones |
 | Tasks | get_tasks, create_task, modify_task, delete_task, start_task, stop_task |
 | Targets | get_targets |
-| Reports | get_reports (with nested results) |
+| Reports | get_reports (with nested results), get_report_vulns, get_report_tls_certificates, get_report_errors, get_report_closed_cves |
 | Configs | get_scan_configs |
 | Scanners | get_scanners |
 | Alerts | get_alerts |
-| Credentials | get_credentials |
+| Credentials | get_credentials, get_credential_stores |
 | Filters | get_filters |
 | Notes | get_notes |
 | Overrides | get_overrides |
@@ -179,6 +179,7 @@ Last updated: 2026-03-29
 | Version-specific command rejection | ✅ | Returns 400 for commands unavailable in configured version |
 | `report_config` commands (22.5+) | ✅ | create, get, modify, delete |
 | `features` command (22.6+) | ✅ | get_features |
+| REST-support GMP helpers (22.8+) | ✅ | report drill-downs, get_timezones, get_credential_stores |
 | Version range metadata in responses | ✅ | Status text includes version requirement |
 
 ### CLI (Standalone Binary)
@@ -337,13 +338,13 @@ Convenience methods on `GmpClient<C>` that combine `send()` + `XxxResponse::from
 | scanner | ✅ | ✅ | Also: `get_scanner()`, `modify_scanner()`, `delete_scanner()`, `verify_scanner()`, `clone_scanner()` |
 | port_list | ✅ | ✅ | |
 | task | ✅ | ✅ | Also: `start_task()` |
-| report | ✅ | — | |
+| report | ✅ | — | Also: typed report drill-down helpers for vulns, TLS certificates, errors, closed CVEs |
 | result | ✅ | — | |
 | feed | ✅ | — | |
 | nvt | ✅ | — | Also: `get_nvt_families()` |
 | secinfo | ✅ | — | CVE, CPE, CERT-Bund, DFN-CERT |
 | alert | ✅ | ✅ | |
-| credential | ✅ | ✅ | |
+| credential | ✅ | ✅ | Also: `get_credential_stores()` |
 | filter | ✅ | ✅ | |
 | note | ✅ | ✅ | |
 | override | ✅ | ✅ | |
@@ -358,7 +359,7 @@ Convenience methods on `GmpClient<C>` that combine `send()` + `XxxResponse::from
 | tls_certificate | ✅ | ✅ | |
 | report_format | ✅ | ✅ | |
 | report_config | ✅ | — | `get_report_configs_parsed()` |
-| system | ✅ | — | `get_settings()`, `get_help()`, `describe_auth()` |
+| system | ✅ | — | `get_settings()`, `get_help()`, `describe_auth()`, `get_timezones()` |
 
 ### Features
 

--- a/spec/openspec.md
+++ b/spec/openspec.md
@@ -409,7 +409,7 @@ The following commands map 1:1 from GMP 22.5 (base = v22.4, extended by later ve
 | 22.5 | `ResourceNames` adds `ResourceType` enum with expanded types |
 | 22.6 | Adds `ReportConfigs` (create/get/modify/delete), `AuditReports`, modified `Filters` and `Reports` |
 | 22.7 | Modified `Scanners` |
-| next (22.8+) | Adds `Agents`, `AgentGroups`, `AgentInstallers`, `CredentialStores`, `OciImageTargets`, modified `Tasks`/`Credentials` |
+| next (22.8+) | Adds `Agents`, `AgentGroups`, `AgentInstallers`, `CredentialStores`, `OciImageTargets`, report drill-down helpers (`get_report_vulns`, `get_report_tls_certificates`, `get_report_errors`, `get_report_closed_cves`), `get_timezones`, modified `Tasks`/`Credentials` |
 
 ---
 


### PR DESCRIPTION
## Summary
- add GMP builders and typed parsers/client helpers for report drill-down commands: get_report_vulns, get_report_tls_certificates, get_report_errors, get_report_closed_cves
- add get_timezones and get_credential_stores support with 22.8 version gates
- add mock-server fixtures/stateful responses, integration coverage, and docs/spec updates

Closes #173
Closes #174
Closes #175

## Validation
- cargo fmt --all -- --check
- cargo test -p gvm-gmp --all-features
- cargo test -p gvm-client --features unix-socket-tests
- cargo test -p gvm-mock-server --features unix-socket-tests
- cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --features unix-socket-tests -- -D warnings