### PR TITLE
docs(journal): add 2026-05-24 journal entry

### DIFF
--- a/journal/2026-05-24.md
+++ b/journal/2026-05-24.md
@@ -1,0 +1,23 @@
+# 2026-05-24 — Mainline Landed the Integration-Config Parity Slice While the Follow-on GMP Gap Queue Grew
+
+## Mainline & Merged Work
+
+### `main` absorbed one real product change after the 2026-05-14 journal baseline
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) merged on 2026-05-18 and is the only default-branch commit in this window
+- That merge added typed GMP/client support for integration-config requests plus report helper commands, extending the parity lane documented in issue #148
+- No other product, dependency, or CI changes have landed on `main` since then, so the repository moved materially once and then stalled again
+
+## Issues
+- Issue #148 (integration-config/report-helper parity) closed when PR #160 merged
+- Four new follow-on issues opened on 2026-05-21: #172 (remaining GMP coverage roadmap), #173 (report drill-down commands), #174 (timezone and credential-store discovery), and #175 (mock-fixture/test coverage)
+- So the repo did convert one completed parity slice into a clearer next-work backlog instead of simply letting the gap list drift
+
+## Pull Request Queue
+- The main new implementation branch is PR #177 (`Add GMP REST support gap helpers`), opened on 2026-05-22 as the immediate follow-through from the new issue cluster
+- Journal automation also entered the queue via PR #168, and the journal backlog kept growing with #167, #169, #170, #171, #176, and #178 still open
+- The maintenance lane is aging in place: PR #166 (actions updates) plus dependency bumps #164 (`russh`) and #165 (`quick-xml`) are all still open on top of the newer journal and feature work
+
+## CI Health
+- Recent pull-request CI remains strong where it matters: PR #177 passed both `CI` and `Security` on 2026-05-22
+- The newest journal branch (#178) also cleared `Security` on 2026-05-23, so docs-only changes are still validating cleanly
+- Recent `main` automation is usable rather than noisy: visible `Dependabot Updates` runs on 2026-05-21 completed successfully, with no fresh signal of broad branch instability


### PR DESCRIPTION
## Summary
- add the 2026-05-24 journal entry
- capture repo activity since the last journal file on `main`

## Testing
- not run (journal-only update)
