### PR TITLE
docs(journal): add 2026-05-25 journal entry

### DIFF
--- a/journal/2026-05-25.md
+++ b/journal/2026-05-25.md
@@ -1,0 +1,23 @@
+# 2026-05-25 — The Parity Merge Still Stands Alone While the Follow-on REST and Maintenance Queue Keeps Growing
+
+## Mainline & Merged Work
+
+### `main` still reflects a single real delivery after the 2026-05-14 journal baseline
+- PR #160 (`Add GMP parity commands for integration configs and report helpers`) merged on 2026-05-18 and remains the only default-branch commit in this window
+- That change closed issue #148 and extended typed GMP/client support for integration-config requests plus report helper commands
+- No additional product, dependency, or CI work has landed on `main` since then, so the repo has a clear completed slice but no follow-through merged behind it yet
+
+## Issues
+- Issue #148 closed when PR #160 merged on 2026-05-18
+- Four new follow-on issues opened on 2026-05-21: #172 (remaining GMP coverage roadmap), #173 (report drill-down commands), #174 (timezone and credential-store discovery), and #175 (mock-fixture/test coverage)
+- That is a healthy sign of decomposition rather than drift: one parity milestone landed, then the remaining gaps were turned into a more explicit backlog
+
+## Pull Request Queue
+- The main new implementation branch is still PR #177 (`Add GMP REST support gap helpers`), opened on 2026-05-22 and still green across the visible CI lanes
+- The queue also widened again on 2026-05-25 with PR #182 (actions updates, green), plus red dependency bumps #180 (`serde_json`) and #181 (`russh`)
+- Journal and automation backlog continue to stack on top of that: PR #168 (journal automation) remains open, and journal PRs #167, #169, #170, #171, #176, #178, and #179 are still waiting on review
+
+## CI Health
+- The strongest product-path signal is still PR #177, which passed both `CI` and `Security` on 2026-05-22
+- The newest maintenance signal is split: PR #182 is green, while PRs #180 and #181 are both failing in `CI` and `Security`
+- Recent `main` automation is mixed but understandable rather than alarming, with 2026-05-25 `Dependabot Updates` showing one failing cargo lane alongside successful action-update lanes


### PR DESCRIPTION
## Summary
- add the 2026-05-25 journal entry
- capture repo activity since the last checked-in journal baseline
- document current queue and CI state
