### PR TITLE
docs: make MCP a first-class gateway surface

### DIFF
--- a/docs/gmp-api-proxy-analysis.md
+++ b/docs/gmp-api-proxy-analysis.md
@@ -23,14 +23,14 @@ That makes a proxy attractive for consumers that want:
 Rather than waiting for Greenbone to change gvmd itself, we can build a gateway on top of `rust-gvm` that:
 
 - talks GMP over Unix socket, SSH, or TLS to gvmd on the backend
-- exposes REST and gRPC on the frontend
+- exposes REST, gRPC, and MCP on the frontend
 
 ```text
-┌──────────────┐       REST / gRPC        ┌──────────────────┐      GMP/XML       ┌────────┐
+┌──────────────┐   REST / gRPC / MCP      ┌──────────────────┐      GMP/XML       ┌────────┐
 │ Web UI       │◄────────────────────────►│ gvm-gateway      │◄──────────────────►│ gvmd   │
-│ Scripts      │   HTTP/JSON or Protobuf  │ (rust-gvm based) │   Unix socket      │        │
-│ Automation   │                          │                  │   or SSH/TLS       │        │
-│ MCP Server   │                          │                  │                    │        │
+│ Scripts      │ HTTP/JSON, Protobuf,     │ (rust-gvm based) │   Unix socket      │        │
+│ Automation   │ and MCP tools/resources  │                  │   or SSH/TLS       │        │
+│ Agents       │                          │                  │                    │        │
 └──────────────┘                          └──────────────────┘                    └────────┘
 ```
 
@@ -43,13 +43,13 @@ Rather than waiting for Greenbone to change gvmd itself, we can build a gateway 
 - `gvm-gmp`: typed GMP command builders
 - `gvm-protocol`: response parsing and XML extraction
 
-A proxy service can stay relatively thin:
+A gateway service can stay relatively thin if the public surfaces share one execution core:
 
-1. Accept REST or gRPC requests.
+1. Accept REST, gRPC, or MCP requests.
 2. Map them to `gvm-gmp` command builders.
 3. Send them via `gvm-client` and `gvm-connection` to gvmd.
 4. Parse the XML response.
-5. Return structured JSON or Protobuf to the caller.
+5. Return structured JSON, Protobuf, or MCP tool/resource payloads to the caller.
 
 ## 4. API Frontend Options
 
@@ -125,32 +125,37 @@ Weaknesses:
 - harder to inspect manually than REST
 - consumers need Protobuf and gRPC tooling
 
-### Option C: Hybrid REST + gRPC
+### Option C: Hybrid REST + gRPC + MCP
 
 Expose both from one service:
 
 - `REST` as the initial and most accessible interface for scripts, `curl`, Postman, and lightweight automation
 - `gRPC` as a later addition for full-featured clients, large report retrieval, and service-to-service use
+- `MCP` as a first-class agent-facing interface for tool-driven integrations
 - a shared backend built on `gvm-client -> gvmd`
 
-This is the preferred long-term model because it avoids forcing one style onto every consumer while allowing the project to start with the simpler interface first.
+This is the preferred long-term model because it avoids forcing one style onto every consumer while allowing the project to preserve one core execution model across human, service, and agent-facing integrations.
 
 ## 5. Recommended Hybrid Architecture
 
-The gateway should have four layers:
+The gateway should have five layers:
 
 1. REST adapter for simple integrations
 2. gRPC adapter for full integrations
-3. shared application core for session bootstrap, request validation, mapping, error normalization, and auditing
-4. pooled gvmd session manager backed by `rust-gvm`
+3. MCP adapter for agent and tool-driven integrations
+4. shared application core for session bootstrap, request validation, mapping, error normalization, and auditing
+5. pooled gvmd session manager backed by `rust-gvm`
 
 In practice:
 
-- start with REST as the first public surface and cover the highest-value operations for scripts and human-operated tooling
+- start with a shared command catalog so every public surface maps to the same core operations
+- cover the highest-value operations through REST and MCP first if that is the fastest path to usable human and agent integrations
 - require clients to create a proxy session by submitting gvmd credentials to the proxy once
 - return a session token that the client includes on every subsequent API call
-- add gRPC later for complete GMP coverage, typed contracts, and streaming-heavy workflows
+- add gRPC for complete GMP coverage, typed contracts, and streaming-heavy workflows
 - route both through the same execution core so command mapping and gvmd behavior stay consistent
+
+See [MCP Gateway Surface Analysis](mcp-gateway-surface-analysis.md) for the adapter-level model and parity requirements.
 
 ## 6. Connection Pooling and Session Management
 
@@ -295,7 +300,7 @@ Default deployment should prefer the gvmd Unix socket. SSH and TLS backends can 
 
 | Consumer | Current | With proxy |
 |----------|---------|------------|
-| `openvas-mcp-server` | Talks GMP/XML directly | Create a proxy session once, then reuse the session token; prefer gRPC for fuller integration |
+| `openvas-mcp-server` | Talks GMP/XML directly | Either consume the gateway's native MCP surface or reuse the shared gateway session model through MCP tools |
 | `gvm-tools` / CLI automation | Talks GMP/XML directly | Start a session with gvmd credentials, then use REST with the returned token |
 | GSA or other web UIs | Talks GMP/XML through existing components | Browser-facing flows can use REST if the proxy handles secure session bootstrap carefully |
 | Custom services | Need GMP expertise or a GMP client library | Use session bootstrap plus REST or gRPC with a stable token-based contract |
@@ -305,12 +310,13 @@ Default deployment should prefer the gvmd Unix socket. SSH and TLS backends can 
 
 Adopt the hybrid model in phases:
 
-- start with `REST` because it is the fastest path to a usable public interface for scripts, `curl`, and low-friction automation
+- treat `REST`, `gRPC`, and `MCP` as peer adapters over one shared execution core
+- enforce capability parity so MCP does not lag behind the other gateway surfaces
 - make `POST /api/v1/sessions` the mandatory entry point so the proxy can authenticate to gvmd, validate credentials, and bind a live connection to a returned token
 - define the shared execution core so the gateway is ready to support multiple frontends from the beginning
-- add `gRPC` later for complete command coverage, typed clients, and streaming-heavy use cases such as large reports
+- add or expand `gRPC` for complete command coverage, typed clients, and streaming-heavy use cases such as large reports
 
-This gives the project a pragmatic path forward: immediate value through REST, a concrete session model that matches gvmd's stateful behavior, and a clear upgrade path to a richer gRPC interface without changing gvmd itself.
+This gives the project a pragmatic path forward: immediate value through low-friction public surfaces, a concrete session model that matches gvmd's stateful behavior, and a coherent contract for browser, service, and agent-facing integrations without changing gvmd itself.
 
 ## 10. Gateway Extension
 

--- a/docs/mcp-gateway-surface-analysis.md
+++ b/docs/mcp-gateway-surface-analysis.md
@@ -1,0 +1,427 @@
+# MCP Gateway Surface Analysis
+
+## 1. Scope
+
+This document defines how an MCP server fits into the `rust-gvm` gateway architecture.
+
+The key decision is simple:
+
+- `MCP` should be a first-class gateway surface
+- it should live at the same architectural layer as `REST` and `gRPC`
+- every gateway capability exposed through REST or gRPC should also be reachable through MCP
+
+This is an adapter-layer decision, not a transport-layer one. The backend remains `rust-gvm -> GMP/XML -> gvmd`.
+
+## 2. Why MCP Is Not Just Another Client
+
+The earlier proxy analysis treats the MCP server as a downstream consumer that would call the gateway over REST or gRPC. That simplifies one integration, but it undershoots what MCP actually is in this system.
+
+MCP is not just "another HTTP client." It is a separate interaction model with its own strengths:
+
+- tool-oriented invocation rather than resource-oriented HTTP routes
+- structured tool schemas rather than OpenAPI or `.proto`
+- agent-friendly workflows where discovery, capability descriptions, and invocation metadata matter as much as the payload
+- natural support for assistant-driven orchestration, not just human-driven dashboards or service-to-service RPC
+
+If MCP is forced to sit behind REST or gRPC as a mere client:
+
+- the gateway ends up with two architectural layers doing request mapping
+- MCP semantics become constrained by whichever frontend sits in front of it
+- endpoint parity becomes accidental rather than enforced
+- the MCP contract drifts from the canonical execution model
+
+The better model is to treat `REST`, `gRPC`, and `MCP` as three peer adapters over one shared application core.
+
+## 3. Architectural Placement
+
+### 3.1 Layer model
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ Gateway Surfaces                                                │
+│                                                                 │
+│  REST Adapter      gRPC Adapter      MCP Adapter                │
+│  HTTP/JSON         Protobuf/RPC      Tools/Resources            │
+└───────────────┬───────────────┬───────────────┬─────────────────┘
+                │               │               │
+                └───────────────┴───────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│ Shared Gateway Core                                              │
+│                                                                 │
+│ - command catalog                                                 │
+│ - request validation                                              │
+│ - auth/session handling                                           │
+│ - endpoint routing                                                │
+│ - policy enforcement                                              │
+│ - error normalization                                             │
+│ - audit events                                                    │
+│ - pagination/streaming policy                                     │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+┌─────────────────────────────────────────────────────────────────┐
+│ rust-gvm Execution Layer                                         │
+│                                                                 │
+│ - gvm-client                                                     │
+│ - gvm-gmp                                                        │
+│ - gvm-protocol                                                   │
+│ - gvm-connection                                                 │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                           GMP/XML to gvmd
+```
+
+### 3.2 Consequence
+
+The gateway should not implement business logic three times. It should define one execution contract, then expose that contract through three surface adapters:
+
+- REST for browser/script-friendly HTTP integrations
+- gRPC for typed service-to-service and streaming-heavy integrations
+- MCP for agent/tool-driven integrations
+
+## 4. Core Design Principle: Surface Parity
+
+The gateway should enforce **surface parity**.
+
+That means:
+
+- if an operation is available through REST, it must be available through MCP
+- if an operation is available through gRPC, it must be available through MCP
+- if an operation is intentionally absent from one surface, that omission must be explicit and documented
+
+This rule matters because MCP will otherwise become a partial sidecar interface that falls behind the "real" API.
+
+### 4.1 What parity means in practice
+
+Parity does not require identical wire shapes. It requires identical gateway capability.
+
+Examples:
+
+- REST: `POST /api/v1/tasks/{id}/start`
+- gRPC: `StartTask(TaskIdRequest)`
+- MCP: tool `tasks.start` with `{ "task_id": "..." }`
+
+All three invoke the same core operation:
+
+- operation id: `tasks.start`
+- authorization category: `scan`
+- execution handler: `start_task`
+- audit event name: `task.started`
+
+The surface adapter translates into the canonical operation, not directly into GMP.
+
+## 5. Canonical Operation Catalog
+
+The cleanest way to preserve parity is to define a canonical command catalog inside the gateway core.
+
+Each operation should declare:
+
+- stable operation id
+- human description
+- request schema
+- response schema
+- auth requirements
+- idempotency semantics
+- streaming or pagination behavior
+- backend GMP mapping
+- surface exposure metadata
+
+Example shape:
+
+```text
+Operation: reports.get
+Category: report
+Request: { report_id, details?, filter?, page?, page_size? }
+Response: { report, results?, page_info? }
+Streaming: optional
+Surfaces:
+  - REST: GET /api/v1/reports/{id}
+  - gRPC: GetReport(GetReportRequest)
+  - MCP: reports.get
+Backend:
+  - GMP: get_report
+```
+
+This catalog becomes the source of truth for:
+
+- route generation
+- gRPC service definitions
+- MCP tool manifests
+- authorization tables
+- audit event names
+- conformance tests
+
+## 6. MCP Adapter Model
+
+### 6.1 MCP should expose tools, not raw GMP
+
+The MCP layer should not expose a "send arbitrary XML" escape hatch as its primary contract. That would bypass the value of the shared execution core and create an unstable surface.
+
+Instead, MCP should expose named tools aligned with the canonical operation catalog.
+
+Examples:
+
+- `system.get_version`
+- `sessions.create`
+- `sessions.delete`
+- `targets.list`
+- `targets.create`
+- `targets.modify`
+- `targets.delete`
+- `tasks.list`
+- `tasks.create`
+- `tasks.start`
+- `tasks.stop`
+- `reports.get`
+- `reports.list`
+- `assets.list`
+
+This keeps MCP consistent with the gateway's typed surface rather than turning it into a raw transport wrapper.
+
+### 6.2 Tool grouping
+
+Tools should be grouped by domain, matching the gateway core rather than REST path structure:
+
+- `system.*`
+- `sessions.*`
+- `targets.*`
+- `tasks.*`
+- `reports.*`
+- `configs.*`
+- `schedules.*`
+- `notes.*`
+- `overrides.*`
+- `tickets.*`
+- `assets.*`
+
+This grouping works well for agents because discovery stays legible and semantically organized.
+
+### 6.3 Resource exposure
+
+If the MCP server also exposes resources in addition to tools, those resources should be derived from the same catalog and authorization rules.
+
+Examples:
+
+- endpoint inventory resource
+- session status resource
+- report snapshot resource
+- gateway health/capability resource
+
+Resources are optional. Tool parity is mandatory.
+
+## 7. Session and Identity Model
+
+The earlier proxy design uses explicit session bootstrap. That still holds.
+
+### 7.1 One session model, three surfaces
+
+The gateway should not invent a different authentication model for MCP. All three surfaces should use the same backend session semantics:
+
+1. authenticate once
+2. bind the authenticated gvmd connection to a gateway session
+3. use that session for subsequent operations
+4. apply expiry/revocation/cleanup uniformly
+
+### 7.2 MCP-specific consequence
+
+The MCP adapter should map client identity into the same gateway session model used by REST and gRPC.
+
+Two viable patterns:
+
+#### Pattern A: MCP tool calls carry a gateway session token
+
+- simplest alignment with existing proxy design
+- best when MCP clients already manage auth explicitly
+
+#### Pattern B: MCP server owns session bootstrap internally
+
+- useful for tightly managed local deployments
+- simpler for agent consumers
+- but increases credential-handling responsibility inside the MCP adapter
+
+Recommendation:
+
+- keep the canonical gateway session model external and explicit
+- allow the MCP adapter to offer a `sessions.create` tool rather than hiding session creation out of band
+
+That preserves observability and keeps authorization behavior consistent across surfaces.
+
+## 8. Error Model
+
+MCP cannot be an afterthought here because agent behavior is very sensitive to error shape.
+
+The gateway core should define normalized errors once, then map them to each adapter:
+
+- REST: HTTP status + JSON body
+- gRPC: status code + structured details
+- MCP: tool error with machine-readable code + human-readable message + retry hint when applicable
+
+Recommended canonical error fields:
+
+- `code`
+- `message`
+- `category`
+- `retryable`
+- `details`
+- `operation_id`
+- `endpoint_id`
+
+Example categories:
+
+- `auth_failed`
+- `permission_denied`
+- `not_found`
+- `invalid_argument`
+- `conflict`
+- `rate_limited`
+- `backend_unavailable`
+- `session_expired`
+- `unsupported_operation`
+
+Without this normalization, REST, gRPC, and MCP will drift in behavior even if they hit the same backend handler.
+
+## 9. Long-Running Operations and Streaming
+
+The tri-surface design has to account for differences in interaction style.
+
+### 9.1 REST
+
+- good for polling
+- acceptable for paginated reports
+- awkward for very large report payloads unless chunked download or export endpoints exist
+
+### 9.2 gRPC
+
+- best fit for server streaming
+- strong candidate for large report retrieval, event streams, or progress channels
+
+### 9.3 MCP
+
+- good fit for agent-driven polling and structured partial results
+- can expose explicit tools such as `tasks.status`, `reports.get_chunk`, or `reports.export`
+- should not depend on REST polling semantics internally
+
+Recommendation:
+
+- keep the core operation model independent of polling vs streaming
+- let each surface expose the most natural interaction pattern
+- preserve parity at the capability level, not the transport-mechanics level
+
+Example:
+
+- all surfaces support report retrieval
+- REST may provide paginated JSON
+- gRPC may provide streaming chunks
+- MCP may provide chunked tool calls or summarized + export-oriented tools
+
+Same capability. Different surface ergonomics.
+
+## 10. Authorization and Audit
+
+Authorization must live below the adapters, not inside them.
+
+If `tasks.delete` is denied:
+
+- REST returns `403`
+- gRPC returns `PERMISSION_DENIED`
+- MCP returns a tool error
+
+But the decision itself comes from one shared policy engine evaluating one canonical operation id.
+
+The audit log should capture:
+
+- authenticated subject
+- surface: `rest | grpc | mcp`
+- operation id
+- endpoint id
+- target resource ids when available
+- result
+- latency
+
+Including `surface` in audit events is important. MCP use will often represent agent activity rather than a human dashboard or backend service.
+
+## 11. Testing Strategy
+
+Surface parity should be enforced by tests, not by intention.
+
+### 11.1 Conformance tests
+
+For each canonical operation in the catalog:
+
+- verify REST exposure if marked enabled
+- verify gRPC exposure if marked enabled
+- verify MCP exposure if marked enabled
+
+### 11.2 Contract drift checks
+
+Generate or validate:
+
+- REST route list from the catalog
+- gRPC service coverage from the catalog
+- MCP tool manifest coverage from the catalog
+
+If `reports.get` exists in the catalog but not in MCP, CI should fail.
+
+### 11.3 Behavioral equivalence tests
+
+Select representative operations and assert that:
+
+- REST adapter
+- gRPC adapter
+- MCP adapter
+
+all yield the same core result and same normalized error category for the same backend condition.
+
+## 12. Phased Rollout
+
+### Phase 1: Build tri-surface core from day one
+
+- define canonical operation catalog
+- define normalized auth/session/error/audit model
+- implement REST + MCP first if that is the fastest route
+- keep gRPC contract-ready even if not fully exposed yet
+
+Why:
+
+- MCP parity is easiest to preserve when the catalog exists before surface sprawl begins
+
+### Phase 2: Add gRPC without changing core semantics
+
+- map existing canonical operations into `.proto`
+- reuse auth, policy, and audit logic
+- use streaming where it materially improves report-heavy workflows
+
+### Phase 3: Expand enterprise deployment concerns
+
+- multi-endpoint routing
+- forwarded identity from upstream proxies
+- richer event streams
+- conformance automation for every exposed domain
+
+## 13. Recommendation
+
+Adopt the following architecture rule:
+
+> The `rust-gvm` gateway should expose `REST`, `gRPC`, and `MCP` as peer adapters over one shared execution core. MCP is not a downstream client of the gateway; it is one of the gateway's native public surfaces.
+
+Concretely:
+
+- design the gateway around a canonical operation catalog
+- generate or derive surface bindings from that catalog
+- require endpoint parity across REST, gRPC, and MCP
+- centralize auth, policy, routing, errors, and audit below the adapters
+- allow each surface to express the same capability using interaction patterns natural to that surface
+
+This keeps the architecture coherent, prevents MCP drift, and makes the gateway equally useful to:
+
+- browser and script consumers
+- service-to-service integrations
+- agentic and assistant-driven workflows
+
+## 14. Open Questions
+
+1. Should the canonical operation catalog live as Rust types, declarative metadata, or both?
+2. Which MCP capabilities should be tools only, and which should also be exposed as resources?
+3. Should report export/download be modeled as a shared core operation with surface-specific delivery modes?
+4. Do we want a raw "expert mode" passthrough operation anywhere, or should all public surfaces stay fully catalog-driven?
+5. Should the first implementation repo be `gvm-gateway` or a crate/workspace addition under `rust-gvm`?

--- a/docs/proxy-access-control-analysis.md
+++ b/docs/proxy-access-control-analysis.md
@@ -508,6 +508,7 @@ Strict tenant isolation through policy engine. Customer A cannot see Customer B'
 | Component | Complexity | Notes |
 |-----------|-----------|-------|
 | REST API layer (axum) | Medium | Endpoint-scoped routes, OpenAPI |
+| MCP adapter layer | Medium | Tool/resource exposure with parity to the canonical operation catalog |
 | Auth layer (OIDC + API keys) | Medium | Tower middleware |
 | Policy engine (RBAC) | Medium | Config-driven, evaluate per request |
 | Connection pool | Medium | Per-endpoint, async pool with health checks |
@@ -522,12 +523,13 @@ Strict tenant isolation through policy engine. Customer A cannot see Customer B'
 
 **Phase 1: Single-endpoint gateway with auth + audit**
 - REST API (axum + OpenAPI)
+- MCP adapter for the same operation set
 - Single gvmd endpoint
 - API key authentication
 - Operation-level RBAC
 - Audit logging
 - Connection pooling
-- *Delivers: REST access, auth, audit trail*
+- *Delivers: REST + MCP access, auth, audit trail*
 
 **Phase 2: Multi-endpoint with routing**
 - Endpoint registry (multiple gvmd)
@@ -541,9 +543,10 @@ Strict tenant isolation through policy engine. Customer A cannot see Customer B'
 - OIDC/LDAP integration
 - Cross-endpoint aggregation queries
 - gRPC interface with streaming
+- surface conformance testing across REST/gRPC/MCP
 - Vault integration for credentials
 - SIEM export (syslog, OTEL)
-- *Delivers: enterprise/MSP readiness*
+- *Delivers: enterprise/MSP readiness with tri-surface parity*
 
 ---
 
@@ -555,7 +558,7 @@ GSA is Greenbone's web UI. It talks GMP to gvmd via an intermediary daemon (`gsa
 
 ### openvas-mcp-server
 
-The MCP server currently needs to implement its own GMP connection handling. With the gateway, it would be a simple REST client — dramatically simpler integration.
+The MCP server currently needs to implement its own GMP connection handling. With the gateway, MCP should become one of the gateway's native public surfaces, not merely a REST client layered on top. That keeps agent-facing capability at parity with REST and gRPC while still reusing the same auth, policy, routing, and audit core.
 
 ### gvm-tools / gvm-rools
 

--- a/journal/2026-05-25.md
+++ b/journal/2026-05-25.md
@@ -1,0 +1,30 @@
+# 2026-05-25 — MCP Becomes a First-Class Gateway Surface
+
+## Product Surface
+
+### Gateway architecture analysis
+- Added a dedicated analysis for treating `MCP` as a first-class public gateway surface alongside `REST` and `gRPC`, instead of treating it as a downstream client of one of those adapters.
+- Defined the core architectural rule: all gateway capabilities should flow through one canonical operation catalog and be exposed with surface parity across REST, gRPC, and MCP.
+- Clarified that the adapter boundary sits above the shared gateway core, while `rust-gvm` remains the execution layer speaking GMP/XML to `gvmd`.
+
+### Surface parity requirement
+- Specified that any operation exposed through REST or gRPC must also be reachable through MCP unless an explicit, documented exception exists.
+- Framed parity as capability parity rather than wire-shape parity: each surface may present the same operation using interaction patterns natural to that surface.
+
+### MCP adapter direction
+- Recommended domain-grouped MCP tools derived from the same canonical operation catalog used by REST routes and gRPC methods.
+- Kept authentication, authorization, routing, error normalization, and auditing in the shared gateway core rather than duplicating that logic in the MCP adapter.
+
+## Architectural Notes
+
+- MCP should not be modeled as "just another client" if the project wants durable agent-facing integration. That approach would create a second mapping layer and make parity accidental.
+- Long-running and large-payload operations should keep one shared capability model while allowing different surface ergonomics: REST pagination, gRPC streaming, and MCP chunked or task-oriented tool calls.
+- Audit trails should record which public surface executed each canonical operation so agent-driven activity is distinguishable from browser or service traffic.
+
+## Validation Scope
+
+- This change is analysis and journal only. It does not yet implement a gateway binary or any runtime surface adapters.
+
+## Notes
+
+- This entry documents the architecture shift requested for future gateway and MCP work so follow-on implementation can start from one coherent surface model.


### PR DESCRIPTION
## Summary
- add a dedicated analysis for modeling MCP as a peer gateway adapter alongside REST and gRPC
- update the existing proxy docs to treat MCP as a native public surface instead of a downstream REST client
- add a 2026-05-25 journal entry capturing the architecture shift

## Testing
- not run (docs/journal only)
