### PR TITLE
docs(journal): add 2026-05-28 journal entry

### DIFF
--- a/journal/2026-05-28.md
+++ b/journal/2026-05-28.md
@@ -1,0 +1,24 @@
+# 2026-05-28 — `main` Only Absorbed Automation and Docs Churn, While the Real GMP Follow-on Branch Fell Further Behind
+
+## Mainline & Merged Work
+
+### The default branch moved five times after the 2026-05-24 baseline, but none of that movement shipped new GMP client surface
+- PR #168 (`ci: add journal PR automation workflow`) merged on 2026-05-25 and is the only durable repository-level workflow change in this window
+- PR #182 (`ci(deps): bump the actions group across 1 directory with 9 updates`) also landed the same day, so the maintenance lane did move even though product work did not
+- The only contentful docs experiment, PR #184 (`docs: make MCP a first-class gateway surface`), was reverted within hours by PR #187, which means `main` ended the window with churn but not a net documentation expansion
+- PR #186 then consolidated the pending journal backlog through 2026-05-24, so the repo was active, but mostly operationally rather than through new library capability
+
+## Issues
+- No new issues were opened after the last journal entry
+- No issues were closed in the same window either
+- That leaves the repo in an unusual state for this project: branch and workflow activity continued, but the issue tracker effectively paused
+
+## Pull Request Queue
+- The main substantive branch is still PR #177 (`Add GMP REST support gap helpers`), but it is now behind `main` instead of moving toward merge
+- The maintenance queue is also aging rather than draining: dependency PRs #165, #180, and #181 are all behind the branch tip
+- The new journal lane is open as PR #188, but it is blocked rather than already folded into the default branch
+
+## CI Health
+- The important default-branch signal stayed clean: `CI` and `Security` both succeeded for the automation merge in PR #168 and for the actions-update merge in PR #182
+- `OpenSSF Scorecard` also passed on the post-merge pushes, including the fast doc add/revert pair (#184 and #187)
+- So the repo does not look unstable; it looks under-merged on feature work while routine automation and branch protection changes continue to land cleanly


### PR DESCRIPTION
## Summary
- add the 2026-05-28 journal entry in the existing repo-specific style
- capture commits, merged PRs, issue movement, and CI signals since the last journal baseline

## Testing
- not run (documentation-only change)
