### PR TITLE
feat(client): add gvmd capability discovery helpers

### DIFF
--- a/crates/gvm-client/src/capabilities.rs
+++ b/crates/gvm-client/src/capabilities.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! gvmd/GMP capability discovery helpers.
+
+use std::collections::BTreeMap;
+
+use gvm_gmp::types::GmpVersion;
+
+/// A typed snapshot of backend capability facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GvmdCapabilitySnapshot {
+    /// Negotiated backend descriptor metadata.
+    pub backend: GvmdBackendDescriptor,
+    /// Capability facts keyed by protocol-oriented identifiers.
+    pub capabilities: BTreeMap<GvmdCapability, CapabilitySupport>,
+}
+
+/// Low-level backend descriptor facts discovered during negotiation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GvmdBackendDescriptor {
+    /// gvmd application version when the backend exposes it.
+    pub gvmd_version: Option<String>,
+    /// Negotiated GMP version.
+    pub gmp_version: Option<GmpVersion>,
+    /// Backend product name when the backend exposes it.
+    pub product_name: Option<String>,
+}
+
+/// Typed capability identifiers kept close to GMP/gvmd concepts.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GvmdCapability {
+    /// Command-oriented capability such as `get_features`.
+    Command(CommandKind),
+    /// Semantic backend fact such as a named feature flag.
+    Semantic(SemanticKind),
+}
+
+/// Command-level capability identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CommandKind {
+    /// `get_features`
+    GetFeatures,
+    /// `create_report_config`
+    CreateReportConfig,
+    /// `delete_report_config`
+    DeleteReportConfig,
+    /// `get_report_configs`
+    GetReportConfigs,
+    /// `modify_report_config`
+    ModifyReportConfig,
+    /// `get_integration_config`
+    GetIntegrationConfig,
+    /// `get_integration_configs`
+    GetIntegrationConfigs,
+    /// `modify_integration_config`
+    ModifyIntegrationConfig,
+    /// `get_report_hosts`
+    GetReportHosts,
+    /// `get_report_ports`
+    GetReportPorts,
+    /// `get_report_applications`
+    GetReportApplications,
+    /// `get_report_operating_systems`
+    GetReportOperatingSystems,
+    /// `get_report_cves`
+    GetReportCves,
+}
+
+/// Semantic or feature-like backend facts.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SemanticKind {
+    /// A raw named feature reported by `get_features`.
+    BackendFeature(String),
+}
+
+/// Capability support state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupportState {
+    /// The capability is supported.
+    Supported,
+    /// The capability is unsupported.
+    Unsupported,
+    /// The capability could not be determined conclusively.
+    Unknown,
+    /// The capability is only partially supported at protocol level.
+    Partial,
+}
+
+/// Evidence used to infer a capability state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityEvidence {
+    /// Determined by issuing a specific probe request.
+    ExplicitProbe,
+    /// Determined from the response body of `get_features`.
+    FeatureCommand,
+    /// Determined from the centralized version fallback table.
+    VersionTable,
+    /// Determined from a static or built-in fixture fact.
+    StaticFixture,
+}
+
+/// Support status plus evidence metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilitySupport {
+    /// Support state for the capability.
+    pub state: SupportState,
+    /// Evidence source used to infer the state.
+    pub source: CapabilityEvidence,
+    /// Optional explanatory detail such as a version threshold or probe outcome.
+    pub detail: Option<String>,
+}
+
+impl CapabilitySupport {
+    /// Create a support record with explicit state and evidence.
+    #[must_use]
+    pub fn new(state: SupportState, source: CapabilityEvidence) -> Self {
+        Self {
+            state,
+            source,
+            detail: None,
+        }
+    }
+
+    /// Attach an explanatory detail string.
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+}
+
+/// Build a pure capability snapshot from negotiated GMP version facts.
+#[must_use]
+pub fn capability_snapshot_for_version(version: GmpVersion) -> GvmdCapabilitySnapshot {
+    let mut capabilities = BTreeMap::new();
+    for capability in versioned_capabilities() {
+        let support = minimum_version_for_capability(capability).map_or(
+            CapabilitySupport::new(SupportState::Supported, CapabilityEvidence::StaticFixture),
+            |minimum| {
+                let state = if version >= minimum {
+                    SupportState::Supported
+                } else {
+                    SupportState::Unsupported
+                };
+                CapabilitySupport::new(state, CapabilityEvidence::VersionTable)
+                    .with_detail(format!("requires GMP >= {}.{}", minimum.0, minimum.1))
+            },
+        );
+        capabilities.insert(capability.clone(), support);
+    }
+
+    GvmdCapabilitySnapshot {
+        backend: GvmdBackendDescriptor {
+            gvmd_version: None,
+            gmp_version: Some(version),
+            product_name: None,
+        },
+        capabilities,
+    }
+}
+
+/// Minimum GMP version required for a command-level capability, when version-gated.
+#[must_use]
+pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
+    command_capability(command_name)
+        .and_then(|capability| minimum_version_for_capability(&capability))
+}
+
+/// Return whether a command is supported by the negotiated version.
+#[must_use]
+pub fn command_supported(command_name: &str, version: GmpVersion) -> bool {
+    match minimum_version_for_command(command_name) {
+        Some(minimum) => version >= minimum,
+        None => true,
+    }
+}
+
+/// Human-readable minimum version label for a version-gated command.
+#[must_use]
+pub fn required_version_label(command_name: &str) -> Option<&'static str> {
+    match minimum_version_for_command(command_name) {
+        Some(GmpVersion(22, 6)) => Some("22.6"),
+        Some(GmpVersion(22, 8)) => Some("22.8"),
+        Some(_) | None => None,
+    }
+}
+
+#[must_use]
+pub(crate) fn command_capability(command_name: &str) -> Option<GvmdCapability> {
+    Some(GvmdCapability::Command(match command_name {
+        "get_features" => CommandKind::GetFeatures,
+        "create_report_config" => CommandKind::CreateReportConfig,
+        "delete_report_config" => CommandKind::DeleteReportConfig,
+        "get_report_configs" => CommandKind::GetReportConfigs,
+        "modify_report_config" => CommandKind::ModifyReportConfig,
+        "get_integration_config" => CommandKind::GetIntegrationConfig,
+        "get_integration_configs" => CommandKind::GetIntegrationConfigs,
+        "modify_integration_config" => CommandKind::ModifyIntegrationConfig,
+        "get_report_hosts" => CommandKind::GetReportHosts,
+        "get_report_ports" => CommandKind::GetReportPorts,
+        "get_report_applications" => CommandKind::GetReportApplications,
+        "get_report_operating_systems" => CommandKind::GetReportOperatingSystems,
+        "get_report_cves" => CommandKind::GetReportCves,
+        _ => return None,
+    }))
+}
+
+#[must_use]
+pub(crate) fn minimum_version_for_capability(capability: &GvmdCapability) -> Option<GmpVersion> {
+    match capability {
+        GvmdCapability::Command(
+            CommandKind::CreateReportConfig
+            | CommandKind::DeleteReportConfig
+            | CommandKind::GetReportConfigs
+            | CommandKind::ModifyReportConfig
+            | CommandKind::GetFeatures,
+        ) => Some(GmpVersion(22, 6)),
+        GvmdCapability::Command(
+            CommandKind::GetIntegrationConfig
+            | CommandKind::GetIntegrationConfigs
+            | CommandKind::ModifyIntegrationConfig
+            | CommandKind::GetReportHosts
+            | CommandKind::GetReportPorts
+            | CommandKind::GetReportApplications
+            | CommandKind::GetReportOperatingSystems
+            | CommandKind::GetReportCves,
+        ) => Some(GmpVersion(22, 8)),
+        GvmdCapability::Semantic(_) => None,
+    }
+}
+
+fn versioned_capabilities() -> &'static [GvmdCapability] {
+    const CAPABILITIES: &[GvmdCapability] = &[
+        GvmdCapability::Command(CommandKind::GetFeatures),
+        GvmdCapability::Command(CommandKind::CreateReportConfig),
+        GvmdCapability::Command(CommandKind::DeleteReportConfig),
+        GvmdCapability::Command(CommandKind::GetReportConfigs),
+        GvmdCapability::Command(CommandKind::ModifyReportConfig),
+        GvmdCapability::Command(CommandKind::GetIntegrationConfig),
+        GvmdCapability::Command(CommandKind::GetIntegrationConfigs),
+        GvmdCapability::Command(CommandKind::ModifyIntegrationConfig),
+        GvmdCapability::Command(CommandKind::GetReportHosts),
+        GvmdCapability::Command(CommandKind::GetReportPorts),
+        GvmdCapability::Command(CommandKind::GetReportApplications),
+        GvmdCapability::Command(CommandKind::GetReportOperatingSystems),
+        GvmdCapability::Command(CommandKind::GetReportCves),
+    ];
+
+    CAPABILITIES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_snapshot_marks_unsupported_capabilities() {
+        let snapshot = capability_snapshot_for_version(GmpVersion(22, 5));
+
+        assert_eq!(
+            snapshot
+                .capabilities
+                .get(&GvmdCapability::Command(CommandKind::GetFeatures))
+                .expect("get_features capability"),
+            &CapabilitySupport::new(SupportState::Unsupported, CapabilityEvidence::VersionTable)
+                .with_detail("requires GMP >= 22.6")
+        );
+    }
+
+    #[test]
+    fn version_snapshot_marks_newer_commands_supported() {
+        let snapshot = capability_snapshot_for_version(GmpVersion(22, 8));
+
+        assert_eq!(
+            snapshot
+                .capabilities
+                .get(&GvmdCapability::Command(CommandKind::GetReportHosts))
+                .expect("get_report_hosts capability"),
+            &CapabilitySupport::new(SupportState::Supported, CapabilityEvidence::VersionTable)
+                .with_detail("requires GMP >= 22.8")
+        );
+    }
+
+    #[test]
+    fn command_mapping_reuses_capability_table() {
+        assert_eq!(
+            minimum_version_for_command("get_report_cves"),
+            Some(GmpVersion(22, 8))
+        );
+        assert!(command_supported("get_features", GmpVersion(22, 6)));
+        assert!(!command_supported("get_features", GmpVersion(22, 5)));
+    }
+}

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![forbid(unsafe_code)]
 
+mod capabilities;
 mod error;
 mod typed;
 mod version;
@@ -26,19 +27,22 @@ use gvm_gmp::commands::reports::{
     get_report_ports,
 };
 use gvm_gmp::commands::version::get_version;
+use gvm_gmp::responses::features::GetFeaturesResponse;
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
+pub use capabilities::{
+    capability_snapshot_for_version, command_supported, minimum_version_for_command,
+    required_version_label, CapabilityEvidence, CapabilitySupport, CommandKind,
+    GvmdBackendDescriptor, GvmdCapability, GvmdCapabilitySnapshot, SemanticKind, SupportState,
+};
 pub use error::GvmError;
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::GetReportDetailsOpts;
-pub use version::{
-    command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
-    required_version_label,
-};
+pub use version::{map_supported_version, parse_version_text};
 
 /// High-level async GMP client over an abstract transport.
 #[derive(Debug)]
@@ -73,6 +77,86 @@ impl<C: GvmConnection> GmpClient<C> {
     #[must_use]
     pub fn version(&self) -> GmpVersion {
         self.version
+    }
+
+    /// Discover a reusable backend capability snapshot.
+    ///
+    /// The returned snapshot always includes version-table facts derived from
+    /// the negotiated GMP version. When the backend is new enough to expose
+    /// `get_features`, the client also attempts a live probe and records the
+    /// evidence source explicitly.
+    ///
+    /// # Errors
+    /// Returns an error if transport fails or a successful probe response
+    /// cannot be parsed.
+    pub async fn discover_capabilities(&mut self) -> Result<GvmdCapabilitySnapshot, GvmError> {
+        let mut snapshot = capability_snapshot_for_version(self.version);
+
+        if !command_supported("get_features", self.version) {
+            return Ok(snapshot);
+        }
+
+        let response = self.send(get_features()).await?;
+        let status = response.status_code().unwrap_or(0);
+        match status {
+            200..=299 => {
+                snapshot.capabilities.insert(
+                    GvmdCapability::Command(CommandKind::GetFeatures),
+                    CapabilitySupport::new(
+                        SupportState::Supported,
+                        CapabilityEvidence::ExplicitProbe,
+                    )
+                    .with_detail("get_features probe succeeded"),
+                );
+
+                let parsed = GetFeaturesResponse::from_response(&response)?;
+                for feature in parsed.features {
+                    let state = if feature.enabled {
+                        SupportState::Supported
+                    } else {
+                        SupportState::Unsupported
+                    };
+                    snapshot.capabilities.insert(
+                        GvmdCapability::Semantic(SemanticKind::BackendFeature(feature.name)),
+                        CapabilitySupport::new(state, CapabilityEvidence::FeatureCommand),
+                    );
+                }
+            }
+            400 if response
+                .status_text()
+                .as_deref()
+                .is_some_and(|text| text.contains("get_features")) =>
+            {
+                snapshot.capabilities.insert(
+                    GvmdCapability::Command(CommandKind::GetFeatures),
+                    CapabilitySupport::new(
+                        SupportState::Unsupported,
+                        CapabilityEvidence::ExplicitProbe,
+                    )
+                    .with_detail(
+                        response
+                            .status_text()
+                            .unwrap_or_else(|| "get_features probe rejected".to_string()),
+                    ),
+                );
+            }
+            _ => {
+                snapshot.capabilities.insert(
+                    GvmdCapability::Command(CommandKind::GetFeatures),
+                    CapabilitySupport::new(
+                        SupportState::Unknown,
+                        CapabilityEvidence::ExplicitProbe,
+                    )
+                    .with_detail(
+                        response
+                            .status_text()
+                            .unwrap_or_else(|| format!("probe returned status {status}")),
+                    ),
+                );
+            }
+        }
+
+        Ok(snapshot)
     }
 
     /// Send a request and return the raw parsed response.
@@ -140,12 +224,11 @@ impl<C: GvmConnection> GmpClient<C> {
             return Ok(());
         };
 
-        if version::command_supported(command_name, self.version) {
+        if command_supported(command_name, self.version) {
             return Ok(());
         }
 
-        let required =
-            version::required_version_label(command_name).unwrap_or("a newer GMP version");
+        let required = required_version_label(command_name).unwrap_or("a newer GMP version");
 
         Err(GvmError::UnsupportedCommand {
             command: command_name.to_string(),
@@ -472,6 +555,15 @@ impl<C: GvmConnection> GmpVersioned<C> {
     #[must_use]
     pub fn version(&self) -> GmpVersion {
         self.inner().version()
+    }
+
+    /// Discover a reusable backend capability snapshot.
+    ///
+    /// # Errors
+    /// Returns an error if transport fails or a successful probe response
+    /// cannot be parsed.
+    pub async fn discover_capabilities(&mut self) -> Result<GvmdCapabilitySnapshot, GvmError> {
+        self.inner_mut().discover_capabilities().await
     }
 
     /// Send a request and return the raw parsed response.

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -7,42 +7,6 @@ use gvm_gmp::types::GmpVersion;
 
 use crate::GvmError;
 
-/// Minimum GMP version required for a command, when version-gated.
-#[must_use]
-pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
-    match command_name {
-        "create_report_config"
-        | "delete_report_config"
-        | "get_report_configs"
-        | "modify_report_config"
-        | "get_features" => Some(GmpVersion(22, 6)),
-        "get_integration_configs"
-        | "modify_integration_config"
-        | "get_report_hosts"
-        | "get_report_ports"
-        | "get_report_applications"
-        | "get_report_operating_systems"
-        | "get_report_cves" => Some(GmpVersion(22, 8)),
-        _ => None,
-    }
-}
-
-/// Return whether a command is supported by the negotiated version.
-#[must_use]
-pub fn command_supported(command_name: &str, version: GmpVersion) -> bool {
-    minimum_version_for_command(command_name).map_or(true, |minimum| version >= minimum)
-}
-
-/// Human-readable minimum version label for a version-gated command.
-#[must_use]
-pub fn required_version_label(command_name: &str) -> Option<&'static str> {
-    match minimum_version_for_command(command_name) {
-        Some(GmpVersion(22, 6)) => Some("22.6"),
-        Some(GmpVersion(22, 8)) => Some("22.8"),
-        Some(_) | None => None,
-    }
-}
-
 /// Parse a GMP version string into a major/minor pair.
 ///
 /// Accepts `major.minor` and optional `major.minor.patch` strings.
@@ -94,6 +58,7 @@ pub fn map_supported_version(version: GmpVersion) -> Result<GmpVersion, GvmError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities;
 
     #[test]
     fn parses_major_minor() {
@@ -169,13 +134,28 @@ mod tests {
 
     #[test]
     fn command_support_respects_version_gates() {
-        assert!(command_supported("get_tasks", GmpVersion(22, 4)));
-        assert!(!command_supported("get_features", GmpVersion(22, 5)));
-        assert!(command_supported("get_features", GmpVersion(22, 6)));
-        assert!(!command_supported("get_report_hosts", GmpVersion(22, 7)));
-        assert!(command_supported("get_report_hosts", GmpVersion(22, 8)));
+        assert!(capabilities::command_supported(
+            "get_tasks",
+            GmpVersion(22, 4)
+        ));
+        assert!(!capabilities::command_supported(
+            "get_features",
+            GmpVersion(22, 5)
+        ));
+        assert!(capabilities::command_supported(
+            "get_features",
+            GmpVersion(22, 6)
+        ));
+        assert!(!capabilities::command_supported(
+            "get_report_hosts",
+            GmpVersion(22, 7)
+        ));
+        assert!(capabilities::command_supported(
+            "get_report_hosts",
+            GmpVersion(22, 8)
+        ));
         assert_eq!(
-            minimum_version_for_command("get_report_cves"),
+            capabilities::minimum_version_for_command("get_report_cves"),
             Some(GmpVersion(22, 8))
         );
     }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
+//! Integration tests for the high-level GMP client.
+
 #![cfg(feature = "unix-socket-tests")]
 #![allow(missing_docs)]
 
-use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
+use gvm_client::{
+    CapabilityEvidence, CommandKind, GmpClient, GmpNextCommands, GmpVersioned, GvmError,
+    GvmdCapability, SemanticKind, SupportState,
+};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::reports::get_report_hosts;
@@ -56,6 +61,29 @@ async fn fixture_server_with_version_response(version_xml: &str) -> Option<MockG
                 "<get_version_response status=\"200\" status_text=\"OK\"><version>{version_xml}</version></get_version_response>"
             ),
         )
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+async fn fixture_server_with_features(
+    version_xml: &str,
+    features_xml: &str,
+) -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Fixture)
+        .unix_socket(socket_path())
+        .override_response(
+            "get_version",
+            &format!(
+                "<get_version_response status=\"200\" status_text=\"OK\"><version>{version_xml}</version></get_version_response>"
+            ),
+        )
+        .override_response("get_features", features_xml)
         .build()
         .await
     {
@@ -152,6 +180,94 @@ async fn authenticate_succeeds() {
         response.root_element_name().as_deref(),
         Some("authenticate_response")
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn discover_capabilities_uses_version_fallback_for_older_backends() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_5).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let snapshot = client
+        .discover_capabilities()
+        .await
+        .expect("capability discovery should succeed");
+
+    let get_features = snapshot
+        .capabilities
+        .get(&GvmdCapability::Command(CommandKind::GetFeatures))
+        .expect("get_features capability");
+    assert_eq!(get_features.state, SupportState::Unsupported);
+    assert_eq!(get_features.source, CapabilityEvidence::VersionTable);
+    assert!(!snapshot
+        .capabilities
+        .contains_key(&GvmdCapability::Semantic(SemanticKind::BackendFeature(
+            "SCAP".to_string()
+        ))));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn discover_capabilities_records_probe_and_feature_evidence() {
+    let Some(server) = fixture_server_with_features(
+        "22.8",
+        r#"<get_features_response status="200" status_text="OK">
+            <feature><name>SCAP</name><_enabled>1</_enabled></feature>
+            <feature><name>ENTERPRISE</name><_enabled>0</_enabled></feature>
+        </get_features_response>"#,
+    )
+    .await
+    else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let snapshot = client
+        .discover_capabilities()
+        .await
+        .expect("capability discovery should succeed");
+
+    let get_features = snapshot
+        .capabilities
+        .get(&GvmdCapability::Command(CommandKind::GetFeatures))
+        .expect("get_features capability");
+    assert_eq!(get_features.state, SupportState::Supported);
+    assert_eq!(get_features.source, CapabilityEvidence::ExplicitProbe);
+
+    let get_report_hosts = snapshot
+        .capabilities
+        .get(&GvmdCapability::Command(CommandKind::GetReportHosts))
+        .expect("get_report_hosts capability");
+    assert_eq!(get_report_hosts.state, SupportState::Supported);
+    assert_eq!(get_report_hosts.source, CapabilityEvidence::VersionTable);
+
+    let scap = snapshot
+        .capabilities
+        .get(&GvmdCapability::Semantic(SemanticKind::BackendFeature(
+            "SCAP".to_string(),
+        )))
+        .expect("SCAP feature");
+    assert_eq!(scap.state, SupportState::Supported);
+    assert_eq!(scap.source, CapabilityEvidence::FeatureCommand);
+
+    let enterprise = snapshot
+        .capabilities
+        .get(&GvmdCapability::Semantic(SemanticKind::BackendFeature(
+            "ENTERPRISE".to_string(),
+        )))
+        .expect("ENTERPRISE feature");
+    assert_eq!(enterprise.state, SupportState::Unsupported);
+    assert_eq!(enterprise.source, CapabilityEvidence::FeatureCommand);
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
+//! Integration tests for version-specific client wrappers.
+
 #![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::print_stderr, missing_docs)]
 


### PR DESCRIPTION
## Summary
- add a reusable `gvm-client` capability snapshot model with typed command/semantic identifiers and explicit evidence sources
- centralize version-table fallback facts for the currently version-gated GMP commands and reuse that table for existing command gating
- add `discover_capabilities()` helpers that overlay a live `get_features` probe onto the version snapshot and record feature-command evidence
- cover both the version fallback path and the explicit probe path with mock-server integration tests

## Testing
- `cargo test -p gvm-client --features unix-socket-tests`
- `cargo clippy -p gvm-client --all-targets --features unix-socket-tests -- -D warnings`

Closes #192.
