### PR TITLE
docs(journal): add 2026-05-29 journal entry

### DIFF
--- a/journal/2026-05-29.md
+++ b/journal/2026-05-29.md
@@ -1,0 +1,25 @@
+# 2026-05-29 — `main` Finally Moved Again, But the Bigger Story Is That the GMP Parity Lane Turned Into a Fresh Discovery Backlog
+
+## Mainline & Merged Work
+
+### The default branch absorbed one real bug fix after the 2026-05-24 baseline, while the rest of the visible movement stayed in maintenance and docs lanes
+- PR #191 (`fix(gmp): allow empty optional schedule ids`) merged on 2026-05-28 and fixed `GetTasksResponse` handling for unscheduled tasks, so the only new product-facing `main` change in this window was a targeted parser/compatibility correction rather than another broad parity tranche
+- The repo also landed PR #168 for journal PR automation plus PR #182 for the actions-group bump, which means operational maintenance still advanced even while feature throughput stayed narrow
+- Docs churn was real but self-correcting: PR #184 briefly made MCP look like a first-class gateway surface in the wrong repository, then PR #187 reverted that direction the same day
+- Journal backlog PR #186 merged as well, but that mostly cleaned up reporting debt rather than changing repository behavior
+
+## Issues
+- Issue #148 closed when PR #160 landed on 2026-05-18, confirming that the integration-config and report-helper parity slice documented in the prior entry is now complete on `main`
+- Four follow-on backlog issues opened on 2026-05-21: #172 (remaining GMP coverage roadmap), #173 (report drill-down commands), #174 (timezone and credential-store discovery), and #175 (mock fixtures / coverage for the remaining REST-support gaps)
+- The repo also converted a fresh bug report quickly: issue #190 (`GetTasksResponse rejects unscheduled tasks with empty schedule id`) opened on 2026-05-28 and closed the same day with PR #191
+- A new forward-looking issue, #192, now tracks reusable gvmd capability detection and probing primitives, so the parity lane has shifted from one-off gaps into capability discovery and coverage planning
+
+## Pull Request Queue
+- The live implementation branch is PR #193 (`feat(client): add gvmd capability discovery helpers`), which is currently the clearest follow-through from issue #192
+- PR #177 (`Add GMP REST support gap helpers`) remains open alongside older dependency bumps #181, #180, and #165, so the queue still carries both product backlog and maintenance debt instead of collapsing to one lane
+- Journal backlog PRs #188 and #189 are also still open, which reinforces that documentation automation exists now but is not yet fully draining the queue by itself
+
+## CI Health
+- The important signal on `main` is clean: the 2026-05-28 push for PR #191 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The new product-facing branch PR #193 also cleared both `CI` and `Security` on 2026-05-28, so the capability-discovery follow-on work is starting from a stable verification base
+- Operationally this repo is healthier than it looked in mid-May: the current risk is not broad branch instability, but whether the newly expanded GMP backlog keeps moving faster than the open PR pile grows


### PR DESCRIPTION
## Summary
- add the 2026-05-29 journal entry
- capture repo activity since the previous journal baseline

## Testing
- not run (docs-only journal update)
