### PR TITLE
docs(journal): add 2026-06-01 journal entry

### DIFF
--- a/journal/2026-06-01.md
+++ b/journal/2026-06-01.md
@@ -1,0 +1,22 @@
+# 2026-06-01 — Mainline Moved from the #148 Parity Drop into Follow-up GMP Fixes, Roadmap Expansion, and Journal Automation
+
+## Product Surface
+
+### The product-facing code that actually landed on `main` after the 2026-05-14 baseline was narrower than the issue queue that formed around it
+- PR #160 closed issue #148 on 2026-05-18 and carried the integration-config plus report-helper parity work from the prior journal entry onto `main`.
+- PR #191 then landed a targeted parser fix on 2026-05-28 so unscheduled tasks with empty optional schedule IDs no longer break `GetTasksResponse`, closing issue #190 the same day.
+- No larger follow-up parity slice merged yet, but the repository opened the next planning wave immediately afterward through issues #172, #173, #174, #175, and #192.
+
+## Documentation & Planning
+- The repo took a meaningful docs and planning detour on 2026-05-25: PR #184 briefly made MCP a first-class gateway surface, and PR #187 reverted it later the same day after the repo concluded that work belonged elsewhere.
+- PR #186 consolidated pending journal entries through 2026-05-24, which means the repo used `main` to catch up its narrative backlog before the next implementation lane.
+
+## Issues
+- Six issues opened after the 2026-05-14 journal baseline: #172, #173, #174, #175, #190, and #192.
+- Two issues closed in the same window: #148 when the integration-config/report-helper parity work merged, and #190 when the empty-schedule-id fix landed.
+- The backlog shape shifted from one concrete parity issue to a broader roadmap: report drill-down coverage, timezone and credential-store discovery, REST-supporting mock coverage, and reusable gvmd capability probing are now explicit tracked follow-ons instead of implied future work.
+
+## CI Health
+- CI itself changed materially even though only one new product fix landed: PR #168 added journal PR automation, and PR #182 refreshed the GitHub Actions dependency group.
+- `main` still produces mixed maintenance signals rather than an all-green wall. On 2026-06-01 the latest `Dependabot Updates` batch split between successful cargo updates and failures in the pip and GitHub Actions lanes.
+- The latest product push signal is still healthy: the 2026-05-28 `OpenSSF Scorecard` run for PR #191 completed successfully on `main`.


### PR DESCRIPTION
Adds the 2026-06-01 journal entry covering post-2026-05-14 activity on `main`:
- GMP follow-up merge and empty schedule-id fix
- new roadmap issues opened after the #148 parity drop
- journal automation / actions maintenance and current CI signal

Agent: Thoth
