### PR TITLE
feat(gmp): add typed report export request and response support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -996,6 +1002,7 @@ dependencies = [
 name = "gvm-gmp"
 version = "0.4.0-alpha.1"
 dependencies = [
+ "base64",
  "gvm-protocol",
  "pretty_assertions",
  "proptest",
@@ -2041,7 +2048,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2427,7 +2434,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 
 # UUID
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -38,8 +38,8 @@ use gvm_gmp::commands::report_formats::{
     create_report_format, get_report_formats, GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    get_report_closed_cves, get_report_errors, get_report_tls_certificates, get_report_vulns,
-    get_reports, GetReportDetailsOpts, GetReportsOpts,
+    get_report_closed_cves, get_report_errors, get_report_export, get_report_tls_certificates,
+    get_report_vulns, get_reports, GetReportDetailsOpts, GetReportsOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -85,8 +85,8 @@ use gvm_gmp::responses::{
     GetScannersResponse, GetSchedulesResponse, GetSettingsResponse, GetTagsResponse,
     GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
     GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, HelpResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, StartTaskResponse, SyncConfigResponse,
-    VerifyScannerResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ReportExport, StartTaskResponse,
+    SyncConfigResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -454,6 +454,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<GetReportClosedCvesResponse, GvmError> {
         let response = self.send(get_report_closed_cves(report_id, opts)).await?;
         GetReportClosedCvesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_reports` export request and return a typed [`ReportExport`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_export(
+        &mut self,
+        report_id: &EntityId,
+        report_format_id: &EntityId,
+    ) -> Result<ReportExport, GvmError> {
+        let response = self
+            .send(get_report_export(report_id, report_format_id))
+            .await?;
+        ReportExport::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Results ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -28,6 +28,7 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_report_errors"
         | "get_report_closed_cves"
         | "get_timezones"
+        | "get_report_export"
         | "get_credential_stores" => Some(GmpVersion(22, 8)),
         _ => None,
     }
@@ -180,6 +181,8 @@ mod tests {
         assert!(command_supported("get_features", GmpVersion(22, 6)));
         assert!(!command_supported("get_report_hosts", GmpVersion(22, 7)));
         assert!(command_supported("get_report_hosts", GmpVersion(22, 8)));
+        assert!(!command_supported("get_report_export", GmpVersion(22, 7)));
+        assert!(command_supported("get_report_export", GmpVersion(22, 8)));
         assert_eq!(
             minimum_version_for_command("get_report_cves"),
             Some(GmpVersion(22, 8))

--- a/crates/gvm-gmp/Cargo.toml
+++ b/crates/gvm-gmp/Cargo.toml
@@ -18,6 +18,7 @@ gvm-protocol.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 quick-xml.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -92,6 +92,16 @@ pub fn get_report(report_id: &EntityId) -> impl Request {
         .attribute("details", "1")
 }
 
+/// Build a `get_reports` export request for a specific report format.
+#[must_use]
+pub fn get_report_export(report_id: &EntityId, report_format_id: &EntityId) -> impl Request {
+    XmlCommand::new("get_reports")
+        .attribute("report_id", report_id.as_str())
+        .attribute("format_id", report_format_id.as_str())
+        .attribute("details", "1")
+        .attribute("ignore_pagination", "1")
+}
+
 /// Build a `delete_report` request.
 #[must_use]
 pub fn delete_report(report_id: &EntityId, ultimate: bool) -> impl Request {
@@ -212,6 +222,10 @@ mod tests {
         assert_eq!(
             xml(get_report(&id("r1"))),
             "<get_reports details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_export(&id("r1"), &id("rf1"))),
+            "<get_reports details=\"1\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
         );
     }
 

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -80,7 +80,8 @@ pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
 pub use report::{
     DeleteReportResponse, GetReportClosedCvesResponse, GetReportErrorsResponse,
     GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse, Report,
-    ReportClosedCve, ReportError, ReportTlsCertificate, ReportVulnerability, ResultCount, Severity,
+    ReportClosedCve, ReportError, ReportExport, ReportTlsCertificate, ReportVulnerability,
+    ResultCount, Severity,
 };
 pub use report_config::{
     CreateReportConfigResponse, DeleteReportConfigResponse, GetReportConfigsResponse,

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -3,7 +3,10 @@
 
 //! Report response models.
 
+use base64::Engine as _;
 use gvm_protocol::Response;
+use quick_xml::events::Event;
+use quick_xml::Writer;
 
 use crate::responses::common::{
     count_info, optional_u32, parse_document, parse_entity_meta, parse_named_entity,
@@ -139,6 +142,15 @@ pub struct GetReportClosedCvesResponse {
     pub status_text: String,
     pub items: Vec<ReportClosedCve>,
     pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportExport {
+    pub bytes: Vec<u8>,
+    pub content_type: Option<String>,
+    pub extension: Option<String>,
 }
 
 impl Report {
@@ -306,6 +318,142 @@ impl_report_detail_response!(
     ["closed_cve", "cve"],
     "closed_cve_count"
 );
+
+impl ReportExport {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let text = std::str::from_utf8(response.data())?;
+        let mut reader = quick_xml::Reader::from_str(text);
+        reader.config_mut().trim_text(false);
+
+        let mut saw_report = false;
+        let mut nested_depth = 0usize;
+        let mut nested_xml = Vec::new();
+        let mut base64_body = String::new();
+        let mut content_type = None;
+        let mut extension = None;
+
+        loop {
+            match reader.read_event()? {
+                Event::Start(event) if event.name().as_ref() == b"get_reports_response" => {
+                    let status = parse_status_attr(&event, "status")?
+                        .ok_or_else(|| ParseError::MissingElement("status".to_string()))?;
+                    let status_text = parse_string_attr(&event, "status_text")
+                        .ok_or_else(|| ParseError::MissingElement("status_text".to_string()))?;
+                    if !(200..300).contains(&status) {
+                        return Err(ParseError::ServerError {
+                            status,
+                            message: status_text,
+                        });
+                    }
+                }
+                Event::Start(event) if event.name().as_ref() == b"report" && !saw_report => {
+                    saw_report = true;
+                    content_type = parse_string_attr(&event, "content_type");
+                    extension = parse_string_attr(&event, "extension");
+                }
+                Event::Start(event) if saw_report => {
+                    nested_depth += 1;
+                    serialize_event(&mut nested_xml, Event::Start(event.into_owned()))?;
+                }
+                Event::Empty(event) if saw_report => {
+                    serialize_event(&mut nested_xml, Event::Empty(event.into_owned()))?;
+                }
+                Event::End(event) if saw_report => {
+                    if event.name().as_ref() == b"report" && nested_depth == 0 {
+                        break;
+                    }
+                    serialize_event(&mut nested_xml, Event::End(event.into_owned()))?;
+                    nested_depth = nested_depth.saturating_sub(1);
+                }
+                Event::Text(event) if saw_report => {
+                    if nested_depth == 0 && nested_xml.is_empty() {
+                        let chunk = event.decode().map_err(quick_xml::Error::from)?;
+                        if !chunk.trim().is_empty() {
+                            base64_body.push_str(&chunk);
+                        }
+                    } else {
+                        serialize_event(&mut nested_xml, Event::Text(event.into_owned()))?;
+                    }
+                }
+                Event::CData(event) if saw_report => {
+                    if nested_depth == 0 && nested_xml.is_empty() {
+                        base64_body.push_str(&String::from_utf8_lossy(event.as_ref()));
+                    } else {
+                        serialize_event(&mut nested_xml, Event::CData(event.into_owned()))?;
+                    }
+                }
+                Event::Eof => break,
+                Event::Decl(_)
+                | Event::PI(_)
+                | Event::DocType(_)
+                | Event::Comment(_)
+                | Event::GeneralRef(_) => {}
+                _ => {}
+            }
+        }
+
+        if !saw_report {
+            return Err(ParseError::MissingElement("report".to_string()));
+        }
+
+        let bytes = if nested_xml.is_empty() {
+            base64::engine::general_purpose::STANDARD
+                .decode(strip_ascii_whitespace(&base64_body))
+                .map_err(|_| ParseError::InvalidValue {
+                    field: "report export".to_string(),
+                    value: base64_body,
+                })?
+        } else {
+            nested_xml
+        };
+
+        Ok(Self {
+            bytes,
+            content_type,
+            extension,
+        })
+    }
+}
+
+fn parse_status_attr(
+    event: &quick_xml::events::BytesStart<'_>,
+    name: &str,
+) -> Result<Option<u16>, ParseError> {
+    parse_string_attr(event, name)
+        .map(|value| {
+            value.parse::<u16>().map_err(|_| ParseError::InvalidValue {
+                field: name.to_string(),
+                value,
+            })
+        })
+        .transpose()
+}
+
+fn parse_string_attr(event: &quick_xml::events::BytesStart<'_>, name: &str) -> Option<String> {
+    event
+        .attributes()
+        .flatten()
+        .find(|attribute| attribute.key.as_ref() == name.as_bytes())
+        .map(|attribute| String::from_utf8_lossy(attribute.value.as_ref()).into_owned())
+}
+
+fn serialize_event(buffer: &mut Vec<u8>, event: Event<'_>) -> Result<(), ParseError> {
+    let mut writer = Writer::new(buffer);
+    writer
+        .write_event(event)
+        .map_err(|error| ParseError::InvalidValue {
+            field: "report export xml".to_string(),
+            value: error.to_string(),
+        })?;
+    Ok(())
+}
+
+fn strip_ascii_whitespace(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .collect()
+}
 
 pub type DeleteReportResponse = ActionResponse;
 
@@ -550,5 +698,53 @@ mod tests {
         assert_eq!(parsed.items.len(), 1);
         assert_eq!(parsed.items[0].cve.as_deref(), Some("CVE-2025-9999"));
         assert_eq!(parsed.items[0].severity.as_deref(), Some("5.0"));
+    }
+
+    #[test]
+    fn parses_base64_report_export() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="report-1" format_id="format-1" extension="pdf" content_type="application/pdf">SGVsbG8gUERG</report>
+            </get_reports_response>"#,
+        );
+
+        let export = ReportExport::from_response(&response).expect("export parse");
+
+        assert_eq!(export.bytes, b"Hello PDF");
+        assert_eq!(export.content_type.as_deref(), Some("application/pdf"));
+        assert_eq!(export.extension.as_deref(), Some("pdf"));
+    }
+
+    #[test]
+    fn parses_nested_xml_report_export() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="report-1" format_id="format-xml" extension="xml" content_type="text/xml"><report id="report-1"><results><result id="r1"/></results></report></report>
+            </get_reports_response>"#,
+        );
+
+        let export = ReportExport::from_response(&response).expect("export parse");
+        let xml = String::from_utf8(export.bytes).expect("utf8 xml");
+
+        assert_eq!(export.content_type.as_deref(), Some("text/xml"));
+        assert_eq!(export.extension.as_deref(), Some("xml"));
+        assert!(xml.contains(r#"<report id="report-1">"#));
+        assert!(xml.contains(r#"<result id="r1"/>"#));
+    }
+
+    #[test]
+    fn rejects_invalid_base64_report_export() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="report-1">not-base64***</report>
+            </get_reports_response>"#,
+        );
+
+        let error = ReportExport::from_response(&response).expect_err("invalid base64");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, .. } if field == "report export"
+        ));
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -14,7 +14,8 @@ use crate::fault::{FaultAction, FaultEngine};
 use crate::fixtures::FixtureStore;
 use crate::history::CommandHistory;
 use crate::response_gen::{
-    echo_response, error_response, generate_large_report, LargeReportConfig,
+    echo_response, error_response, generate_binary_report_export, generate_large_report,
+    generate_xml_report_export, LargeReportConfig, REPORT_EXPORT_XML_FORMAT_ID,
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 use crate::store::{Resource, ResourceStore, TaskStatus};
@@ -753,6 +754,15 @@ impl SessionHandler {
         report: &Resource,
         store: &ResourceStore,
     ) -> Vec<u8> {
+        if let Some(format_id) = cmd.attr("format_id") {
+            let format_uuid = Uuid::parse_str(format_id)
+                .unwrap_or(crate::response_gen::REPORT_EXPORT_BINARY_FORMAT_ID);
+            if format_uuid == REPORT_EXPORT_XML_FORMAT_ID {
+                return generate_xml_report_export(report.id, format_uuid).into_bytes();
+            }
+            return generate_binary_report_export(report.id, format_uuid).into_bytes();
+        }
+
         if let Some(config) = self.large_report {
             if report.attr("task_id").is_some() {
                 return generate_large_report(report.id, &config).into_bytes();

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -10,10 +10,17 @@ use uuid::Uuid;
 use crate::util::xml_escape_attr;
 
 const LARGE_REPORT_FORMAT_ID: Uuid = Uuid::from_u128(0xc402cc3e_b531_11e1_9163_406186ea4fc5);
+/// Well-known report-format UUID that returns a binary export payload in the mock server.
+pub const REPORT_EXPORT_BINARY_FORMAT_ID: Uuid =
+    Uuid::from_u128(0xaaaaaaaa_aaaa_aaaa_aaaa_aaaaaaaaaaaa);
+/// Well-known report-format UUID that returns a nested-XML export payload in the mock server.
+pub const REPORT_EXPORT_XML_FORMAT_ID: Uuid =
+    Uuid::from_u128(0xbbbbbbbb_bbbb_bbbb_bbbb_bbbbbbbbbbbb);
 const PORTS: [u16; 5] = [22, 80, 443, 8080, 8443];
 const SEVERITIES: [&str; 7] = ["2.1", "4.3", "5.0", "6.5", "7.5", "8.1", "9.8"];
 const DESCRIPTION_SENTENCE: &str =
     "Synthetic result payload generated for large-response integration testing. ";
+const REPORT_EXPORT_BINARY_BODY: &str = "SGVsbG8gUERG";
 
 /// Configuration for synthetic large report generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -288,6 +295,28 @@ pub fn generate_large_report(report_id: Uuid, config: &LargeReportConfig) -> Str
     xml
 }
 
+/// Generate a deterministic base64-backed report export response.
+#[must_use]
+pub fn generate_binary_report_export(report_id: Uuid, format_id: Uuid) -> String {
+    format!(
+        "<get_reports_response status=\"200\" status_text=\"OK\">\
+         <report id=\"{report_id}\" format_id=\"{format_id}\" extension=\"pdf\" content_type=\"application/pdf\">{REPORT_EXPORT_BINARY_BODY}</report>\
+         </get_reports_response>"
+    )
+}
+
+/// Generate a deterministic nested-XML report export response.
+#[must_use]
+pub fn generate_xml_report_export(report_id: Uuid, format_id: Uuid) -> String {
+    format!(
+        "<get_reports_response status=\"200\" status_text=\"OK\">\
+         <report id=\"{report_id}\" format_id=\"{format_id}\" extension=\"xml\" content_type=\"text/xml\">\
+         <report id=\"{report_id}\"><results><result id=\"result-1\"/></results></report>\
+         </report>\
+         </get_reports_response>"
+    )
+}
+
 fn build_description_payload(target_bytes: usize) -> String {
     let mut description = String::with_capacity(target_bytes);
     while description.len() < target_bytes {
@@ -457,5 +486,27 @@ mod tests {
             (lower_bound..=upper_bound).contains(&total_description_bytes),
             "description payload bytes {total_description_bytes} not within 10% of {expected}"
         );
+    }
+
+    #[test]
+    fn generate_binary_report_export_contains_metadata() {
+        let report_id =
+            Uuid::parse_str("44444444-4444-4444-4444-444444444444").expect("valid uuid");
+        let xml = generate_binary_report_export(report_id, REPORT_EXPORT_BINARY_FORMAT_ID);
+
+        assert!(xml.contains("content_type=\"application/pdf\""));
+        assert!(xml.contains("extension=\"pdf\""));
+        assert!(xml.contains(REPORT_EXPORT_BINARY_BODY));
+    }
+
+    #[test]
+    fn generate_xml_report_export_contains_nested_report() {
+        let report_id =
+            Uuid::parse_str("55555555-5555-5555-5555-555555555555").expect("valid uuid");
+        let xml = generate_xml_report_export(report_id, REPORT_EXPORT_XML_FORMAT_ID);
+
+        assert!(xml.contains("content_type=\"text/xml\""));
+        assert!(xml.contains("extension=\"xml\""));
+        assert!(xml.contains(r#"<report id="55555555-5555-5555-5555-555555555555"><results>"#));
     }
 }


### PR DESCRIPTION
Closes #199.

## Summary
- add a dedicated `get_report_export(...)` GMP command helper and typed `GmpClient::get_report_export(...)` convenience API
- add `ReportExport` parsing for both base64-backed binary exports and nested XML export payloads while preserving `content_type` and `extension`
- extend version gating and mock-server coverage for export-oriented `get_reports format_id=...` responses

## Validation
- `cargo fmt --all`
- `cargo test -p gvm-gmp report:: -- --nocapture`
- `cargo test -p gvm-gmp reports -- --nocapture`
- `cargo test -p gvm-client --lib -- --nocapture`
- `cargo test -p gvm-client version:: -- --nocapture`
- `cargo test -p gvm-mock-server response_gen:: -- --nocapture`

Agent: Thoth
