### PR TITLE
fix(gmp): align typed enums with gvmd/python-gvm 22.7

### DIFF
--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -99,13 +99,13 @@ pub fn test_alert(alert_id: &EntityId) -> impl Request {
 fn add_alert_body(cmd: &mut XmlCommand, opts: &AlertOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     if let Some(event) = opts.event {
-        cmd.add_element_with_text("event", event.as_gmp_str());
+        cmd.add_element_with_text("event", event.as_alert_name());
     }
     if let Some(condition) = opts.condition {
-        cmd.add_element_with_text("condition", condition.as_gmp_str());
+        cmd.add_element_with_text("condition", condition.as_alert_name());
     }
     if let Some(method) = opts.method {
-        cmd.add_element_with_text("method", method.as_gmp_str());
+        cmd.add_element_with_text("method", method.as_alert_name());
     }
     if let Some(filter_id) = opts.filter_id.as_ref() {
         cmd.add_element("filter")
@@ -134,7 +134,9 @@ mod tests {
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<event>task_run_status_changed</event>"));
+        assert!(rendered.contains("<event>Task run status changed</event>"));
+        assert!(rendered.contains("<condition>Always</condition>"));
+        assert!(rendered.contains("<method>Email</method>"));
         assert!(rendered.contains("<filter id=\"f1\"/>"));
         assert_eq!(
             xml(clone_alert(&id("a1"))),
@@ -157,12 +159,13 @@ mod tests {
             &id("a1"),
             AlertOpts {
                 comment: Some("updated".into()),
+                method: Some(AlertMethod::SysLog),
                 ..Default::default()
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_alert alert_id=\"a1\"><comment>updated</comment></modify_alert>"
+            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>SysLog</method></modify_alert>"
         );
         assert_eq!(
             xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -165,7 +165,7 @@ mod tests {
         ));
         assert_eq!(
             rendered,
-            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>SysLog</method></modify_alert>"
+            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>Syslog</method></modify_alert>"
         );
         assert_eq!(
             xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/src/commands/port_lists.rs
+++ b/crates/gvm-gmp/src/commands/port_lists.rs
@@ -57,7 +57,7 @@ pub fn create_port_range(
 ) -> impl Request {
     XmlCommand::new("create_port_range")
         .attribute("port_list_id", port_list_id.as_str())
-        .attribute("type", range_type.as_gmp_str())
+        .attribute("type", range_type.as_port_range_type())
         .attribute("start", &start.to_string())
         .attribute("end", &end.to_string())
 }
@@ -137,7 +137,7 @@ mod tests {
         );
         assert_eq!(
             xml(create_port_range(&id("pl1"), PortRangeType::Tcp, 1, 5)),
-            "<create_port_range end=\"5\" port_list_id=\"pl1\" start=\"1\" type=\"tcp\"/>"
+            "<create_port_range end=\"5\" port_list_id=\"pl1\" start=\"1\" type=\"TCP\"/>"
         );
     }
 

--- a/crates/gvm-gmp/src/commands/scanners.rs
+++ b/crates/gvm-gmp/src/commands/scanners.rs
@@ -54,7 +54,7 @@ pub fn create_scanner(name: &str, opts: ScannerOpts) -> impl Request {
         cmd.add_element_with_text("port", &port.to_string());
     }
     if let Some(scanner_type) = opts.scanner_type {
-        cmd.add_element_with_text("type", scanner_type.as_gmp_str());
+        cmd.add_element_with_text("type", scanner_type.as_scanner_type());
     }
     if let Some(credential_id) = opts.credential_id.as_ref() {
         cmd.add_element("credential")
@@ -133,7 +133,7 @@ mod tests {
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<type>OpenVAS</type>"));
+        assert!(rendered.contains("<type>2</type>"));
         assert!(rendered.contains("<credential id=\"cred1\"/>"));
         assert_eq!(
             xml(clone_scanner(&id("s1"))),

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -79,7 +79,7 @@ pub fn create_target(name: &str, opts: CreateTargetOpts) -> impl Request {
         cmd.add_element_with_text("exclude_hosts", &opts.exclude_hosts.join(","));
     }
     if let Some(alive_test) = opts.alive_test {
-        cmd.add_element_with_text("alive_test", alive_test.as_gmp_str());
+        cmd.add_element_with_text("alive_test", alive_test.as_target_name());
     }
     add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
     if let Some(value) = opts.reverse_lookup_only {
@@ -126,7 +126,7 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
         cmd.add_element_with_text("exclude_hosts", &opts.exclude_hosts.join(","));
     }
     if let Some(alive_test) = opts.alive_test {
-        cmd.add_element_with_text("alive_test", alive_test.as_gmp_str());
+        cmd.add_element_with_text("alive_test", alive_test.as_target_name());
     }
     add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
     cmd
@@ -191,12 +191,13 @@ mod tests {
             &id("t1"),
             ModifyTargetOpts {
                 name: Some("n".into()),
+                alive_test: Some(AliveTest::IcmpAndArpPing),
                 ..Default::default()
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_target target_id=\"t1\"><name>n</name></modify_target>"
+            "<modify_target target_id=\"t1\"><name>n</name><alive_test>ICMP &amp; ARP Ping</alive_test></modify_target>"
         );
         assert_eq!(
             xml(delete_target(&id("t1"), false)),

--- a/crates/gvm-gmp/src/commands/tickets.rs
+++ b/crates/gvm-gmp/src/commands/tickets.rs
@@ -97,7 +97,7 @@ fn add_ticket_body(cmd: &mut XmlCommand, opts: &TicketOpts) {
     add_text_element(cmd, "assigned_to", opts.assigned_to.as_deref());
     add_text_element(cmd, "comment", opts.comment.as_deref());
     if let Some(status) = opts.status {
-        cmd.add_element_with_text("status", status.as_gmp_str());
+        cmd.add_element_with_text("status", status.as_ticket_status());
     }
     add_text_element(cmd, "open_note", opts.open_note.as_deref());
     add_text_element(cmd, "fixed_note", opts.fixed_note.as_deref());
@@ -124,7 +124,7 @@ mod tests {
             },
         ));
         assert!(rendered.contains("<result id=\"r1\"/>"));
-        assert!(rendered.contains("<status>open</status>"));
+        assert!(rendered.contains("<status>Open</status>"));
         assert_eq!(
             xml(clone_ticket(&id("tick1"))),
             "<create_ticket><copy>tick1</copy></create_ticket>"

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -76,8 +76,8 @@ impl AlertEvent {
     pub const fn as_alert_name(self) -> &'static str {
         match self {
             Self::TaskRunStatusChanged => "Task run status changed",
-            Self::UpdatedSecInfo => "Updated SecInfo",
-            Self::NewSecInfo => "New SecInfo",
+            Self::UpdatedSecInfo => "Updated SecInfo arrived",
+            Self::NewSecInfo => "New SecInfo arrived",
         }
     }
 }
@@ -88,8 +88,16 @@ impl FromStr for AlertEvent {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "task_run_status_changed" | "Task run status changed" => Ok(Self::TaskRunStatusChanged),
-            "updated_secinfo" | "Updated SecInfo" | "Updated Secinfo" => Ok(Self::UpdatedSecInfo),
-            "new_secinfo" | "New SecInfo" | "New Secinfo" => Ok(Self::NewSecInfo),
+            "updated_secinfo"
+            | "Updated SecInfo arrived"
+            | "Updated Secinfo arrived"
+            | "Updated SecInfo"
+            | "Updated Secinfo" => Ok(Self::UpdatedSecInfo),
+            "new_secinfo"
+            | "New SecInfo arrived"
+            | "New Secinfo arrived"
+            | "New SecInfo"
+            | "New Secinfo" => Ok(Self::NewSecInfo),
             _ => Err(EnumParseError {
                 enum_name: "AlertEvent",
                 value: s.to_string(),
@@ -218,16 +226,16 @@ impl AlertMethod {
             Self::Email => "Email",
             Self::HttpGet => "HTTP Get",
             Self::Scp => "SCP",
-            Self::SendEmail => "Send Email",
+            Self::SendEmail => "Send",
             Self::Smb => "SMB",
             Self::Snmp => "SNMP",
             Self::SourcefireConnector => "Sourcefire Connector",
             Self::StartTask => "Start Task",
-            Self::SysLog => "SysLog",
-            Self::TippingPoint => "TippingPoint",
-            Self::VeriniceCe => "Verinice CE",
-            Self::VeriniceNet => "Verinice Net",
-            Self::Alemba => "Alemba",
+            Self::SysLog => "Syslog",
+            Self::TippingPoint => "TippingPoint SMS",
+            Self::VeriniceCe => "verinice Connector",
+            Self::VeriniceNet => "verinice Connector",
+            Self::Alemba => "Alemba vFire",
         }
     }
 }
@@ -240,16 +248,17 @@ impl FromStr for AlertMethod {
             "email" | "Email" => Ok(Self::Email),
             "http_get" | "HTTP Get" | "Http Get" => Ok(Self::HttpGet),
             "scp" | "SCP" => Ok(Self::Scp),
-            "send_email" | "Send Email" | "SendEmail" => Ok(Self::SendEmail),
+            "send_email" | "Send" | "Send Email" | "SendEmail" => Ok(Self::SendEmail),
             "smb" | "SMB" => Ok(Self::Smb),
             "snmp" | "SNMP" => Ok(Self::Snmp),
             "sourcefire_connector" | "Sourcefire Connector" => Ok(Self::SourcefireConnector),
             "start_task" | "Start Task" => Ok(Self::StartTask),
             "syslog" | "SysLog" | "Syslog" => Ok(Self::SysLog),
-            "tippingpoint" | "TippingPoint" => Ok(Self::TippingPoint),
-            "verinice_ce" | "Verinice CE" => Ok(Self::VeriniceCe),
+            "tippingpoint" | "TippingPoint" | "TippingPoint SMS" => Ok(Self::TippingPoint),
+            // gvmd collapses the legacy Verinice variants into one display name.
+            "verinice_ce" | "verinice Connector" | "Verinice CE" => Ok(Self::VeriniceCe),
             "verinice_net" | "Verinice Net" => Ok(Self::VeriniceNet),
-            "alemba" | "Alemba" => Ok(Self::Alemba),
+            "alemba" | "Alemba" | "Alemba vFire" => Ok(Self::Alemba),
             _ => Err(EnumParseError {
                 enum_name: "AlertMethod",
                 value: s.to_string(),

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -180,7 +180,7 @@ pub enum AlertMethod {
     StartTask,
     /// Deliver the alert to Syslog.
     SysLog,
-    /// Deliver the alert to TippingPoint.
+    /// Deliver the alert to `TippingPoint`.
     TippingPoint,
     /// Deliver the alert to Verinice CE.
     VeriniceCe,

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -258,18 +258,87 @@ impl FromStr for AlertMethod {
     }
 }
 
-gmp_enum!(AliveTest {
-    ScanConfigDefault => "Scan Config Default",
-    IcmpPing => "ICMP Ping",
-    TcpAckServicePing => "TCP-ACK Service Ping",
-    TcpSynServicePing => "TCP-SYN Service Ping",
-    ArpPing => "ARP Ping",
-    IcmpAndTcpAckServicePing => "ICMP, TCP-ACK Service Ping",
-    IcmpAndArpPing => "ICMP, ARP Ping",
-    TcpAckServiceAndArpPing => "TCP-ACK Service, ARP Ping",
-    IcmpTcpAckServiceAndArpPing => "ICMP, TCP-ACK Service, ARP Ping",
-    ConsiderAlive => "Consider Alive"
-});
+/// Stable alive-test values plus gvmd/python-gvm 22.7 aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AliveTest {
+    ScanConfigDefault,
+    IcmpPing,
+    TcpAckServicePing,
+    TcpSynServicePing,
+    ArpPing,
+    IcmpAndTcpAckServicePing,
+    IcmpAndArpPing,
+    TcpAckServiceAndArpPing,
+    IcmpTcpAckServiceAndArpPing,
+    ConsiderAlive,
+}
+
+impl AliveTest {
+    /// Returns the stable consumer-facing value retained for backward compatibility.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::ScanConfigDefault => "Scan Config Default",
+            Self::IcmpPing => "ICMP Ping",
+            Self::TcpAckServicePing => "TCP-ACK Service Ping",
+            Self::TcpSynServicePing => "TCP-SYN Service Ping",
+            Self::ArpPing => "ARP Ping",
+            Self::IcmpAndTcpAckServicePing => "ICMP, TCP-ACK Service Ping",
+            Self::IcmpAndArpPing => "ICMP, ARP Ping",
+            Self::TcpAckServiceAndArpPing => "TCP-ACK Service, ARP Ping",
+            Self::IcmpTcpAckServiceAndArpPing => "ICMP, TCP-ACK Service, ARP Ping",
+            Self::ConsiderAlive => "Consider Alive",
+        }
+    }
+
+    /// Returns the gvmd/python-gvm 22.7 value accepted by target create/modify.
+    #[must_use]
+    pub const fn as_target_name(self) -> &'static str {
+        match self {
+            Self::ScanConfigDefault => "Scan Config Default",
+            Self::IcmpPing => "ICMP Ping",
+            Self::TcpAckServicePing => "TCP-ACK Service Ping",
+            Self::TcpSynServicePing => "TCP-SYN Service Ping",
+            Self::ArpPing => "ARP Ping",
+            Self::IcmpAndTcpAckServicePing => "ICMP & TCP-ACK Service Ping",
+            Self::IcmpAndArpPing => "ICMP & ARP Ping",
+            Self::TcpAckServiceAndArpPing => "TCP-ACK Service & ARP Ping",
+            Self::IcmpTcpAckServiceAndArpPing => "ICMP, TCP-ACK Service & ARP Ping",
+            Self::ConsiderAlive => "Consider Alive",
+        }
+    }
+}
+
+impl FromStr for AliveTest {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Scan Config Default" => Ok(Self::ScanConfigDefault),
+            "ICMP Ping" => Ok(Self::IcmpPing),
+            "TCP-ACK Service Ping" => Ok(Self::TcpAckServicePing),
+            "TCP-SYN Service Ping" => Ok(Self::TcpSynServicePing),
+            "ARP Ping" => Ok(Self::ArpPing),
+            "ICMP, TCP-ACK Service Ping" | "ICMP & TCP-ACK Service Ping" => {
+                Ok(Self::IcmpAndTcpAckServicePing)
+            }
+            "ICMP, ARP Ping" | "ICMP & ARP Ping" => Ok(Self::IcmpAndArpPing),
+            "TCP-ACK Service, ARP Ping" | "TCP-ACK Service & ARP Ping" => {
+                Ok(Self::TcpAckServiceAndArpPing)
+            }
+            "ICMP, TCP-ACK Service, ARP Ping" | "ICMP, TCP-ACK Service & ARP Ping" => {
+                Ok(Self::IcmpTcpAckServiceAndArpPing)
+            }
+            "Consider Alive" => Ok(Self::ConsiderAlive),
+            _ => Err(EnumParseError {
+                enum_name: "AliveTest",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(AggregateStatistic {
     Count => "count",
     CMax => "c_max",
@@ -389,10 +458,49 @@ gmp_enum!(PermissionSubjectType {
     Role => "role",
     User => "user"
 });
-gmp_enum!(PortRangeType {
-    Tcp => "tcp",
-    Udp => "udp"
-});
+/// Stable port-range values plus gvmd/python-gvm 22.7 aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PortRangeType {
+    Tcp,
+    Udp,
+}
+
+impl PortRangeType {
+    /// Returns the stable consumer-facing value retained for backward compatibility.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        }
+    }
+
+    /// Returns the gvmd/python-gvm 22.7 value accepted by `create_port_range`.
+    #[must_use]
+    pub const fn as_port_range_type(self) -> &'static str {
+        match self {
+            Self::Tcp => "TCP",
+            Self::Udp => "UDP",
+        }
+    }
+}
+
+impl FromStr for PortRangeType {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "tcp" | "TCP" => Ok(Self::Tcp),
+            "udp" | "UDP" => Ok(Self::Udp),
+            _ => Err(EnumParseError {
+                enum_name: "PortRangeType",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(ReportFormatType {
     Anonymous => "anonymous",
     Csv => "csv",
@@ -405,11 +513,57 @@ gmp_enum!(ReportFormatType {
     Verinice => "verinice",
     Xml => "xml"
 });
-gmp_enum!(ScannerType {
-    OpenVasScanner => "OpenVAS",
-    CveScannerType => "CVE",
-    GreenBoneSensorType => "OSP"
-});
+/// Stable scanner-type values plus gvmd/python-gvm 22.7 aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ScannerType {
+    OpenVasScanner,
+    CveScannerType,
+    GreenBoneSensorType,
+    OpenVasdScannerType,
+}
+
+impl ScannerType {
+    /// Returns the stable consumer-facing value retained for backward compatibility.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::OpenVasScanner => "OpenVAS",
+            Self::CveScannerType => "CVE",
+            Self::GreenBoneSensorType => "OSP",
+            Self::OpenVasdScannerType => "6",
+        }
+    }
+
+    /// Returns the gvmd/python-gvm 22.7 value accepted by scanner create/modify.
+    #[must_use]
+    pub const fn as_scanner_type(self) -> &'static str {
+        match self {
+            Self::OpenVasScanner => "2",
+            Self::CveScannerType => "3",
+            Self::GreenBoneSensorType => "5",
+            Self::OpenVasdScannerType => "6",
+        }
+    }
+}
+
+impl FromStr for ScannerType {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OpenVAS" | "2" => Ok(Self::OpenVasScanner),
+            "CVE" | "3" => Ok(Self::CveScannerType),
+            "OSP" | "5" => Ok(Self::GreenBoneSensorType),
+            "6" => Ok(Self::OpenVasdScannerType),
+            _ => Err(EnumParseError {
+                enum_name: "ScannerType",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(SnmpAuthAlgorithm {
     Md5 => "md5",
     Sha1 => "sha1"
@@ -429,11 +583,53 @@ gmp_enum!(SeverityLevel {
     Log => "log",
     Alarm => "alarm"
 });
-gmp_enum!(TicketStatus {
-    Open => "open",
-    Fixed => "fixed",
-    Closed => "closed"
-});
+/// Stable ticket-status values plus gvmd/python-gvm 22.7 aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TicketStatus {
+    Open,
+    Fixed,
+    Closed,
+}
+
+impl TicketStatus {
+    /// Returns the stable consumer-facing value retained for backward compatibility.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Fixed => "fixed",
+            Self::Closed => "closed",
+        }
+    }
+
+    /// Returns the gvmd/python-gvm 22.7 value accepted by ticket create/modify.
+    #[must_use]
+    pub const fn as_ticket_status(self) -> &'static str {
+        match self {
+            Self::Open => "Open",
+            Self::Fixed => "Fixed",
+            Self::Closed => "Closed",
+        }
+    }
+}
+
+impl FromStr for TicketStatus {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "open" | "Open" => Ok(Self::Open),
+            "fixed" | "Fixed" => Ok(Self::Fixed),
+            "closed" | "Closed" => Ok(Self::Closed),
+            _ => Err(EnumParseError {
+                enum_name: "TicketStatus",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(UserAuthType {
     File => "file",
     LdapConnect => "ldap_connect",

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -9,6 +9,7 @@ macro_rules! gmp_enum {
     ($name:ident { $($variant:ident => $value:literal),+ $(,)? }) => {
         #[doc = concat!("GMP enum values for `", stringify!($name), "`.")]
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub enum $name {
             $(#[doc = concat!("Maps to the GMP wire value `", $value, "`.")] $variant),+
         }
@@ -47,33 +48,216 @@ pub struct EnumParseError {
     value: String,
 }
 
-gmp_enum!(AlertEvent {
-    TaskRunStatusChanged => "task_run_status_changed",
-    UpdatedSecInfo => "updated_secinfo",
-    NewSecInfo => "new_secinfo"
-});
-gmp_enum!(AlertCondition {
-    Always => "always",
-    FilterCountAtLeast => "filter_count_at_least",
-    FilterCountChanged => "filter_count_changed",
-    SeverityAtLeast => "severity_at_least",
-    SeverityChanged => "severity_changed"
-});
-gmp_enum!(AlertMethod {
-    Email => "email",
-    HttpGet => "http_get",
-    Scp => "scp",
-    SendEmail => "send_email",
-    Smb => "smb",
-    Snmp => "snmp",
-    SourcefireConnector => "sourcefire_connector",
-    StartTask => "start_task",
-    SysLog => "syslog",
-    TippingPoint => "tippingpoint",
-    VeriniceCe => "verinice_ce",
-    VeriniceNet => "verinice_net",
-    Alemba => "alemba"
-});
+/// Stable alert event values plus gvmd-compatible display-name aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AlertEvent {
+    /// Alert on task run status changes.
+    TaskRunStatusChanged,
+    /// Alert on updated security information.
+    UpdatedSecInfo,
+    /// Alert on new security information.
+    NewSecInfo,
+}
+
+impl AlertEvent {
+    /// Returns the stable GMP-facing value used by downstream consumers.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::TaskRunStatusChanged => "task_run_status_changed",
+            Self::UpdatedSecInfo => "updated_secinfo",
+            Self::NewSecInfo => "new_secinfo",
+        }
+    }
+
+    /// Returns the gvmd-compatible display name accepted by alert create/modify.
+    #[must_use]
+    pub const fn as_alert_name(self) -> &'static str {
+        match self {
+            Self::TaskRunStatusChanged => "Task run status changed",
+            Self::UpdatedSecInfo => "Updated SecInfo",
+            Self::NewSecInfo => "New SecInfo",
+        }
+    }
+}
+
+impl FromStr for AlertEvent {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "task_run_status_changed" | "Task run status changed" => Ok(Self::TaskRunStatusChanged),
+            "updated_secinfo" | "Updated SecInfo" | "Updated Secinfo" => Ok(Self::UpdatedSecInfo),
+            "new_secinfo" | "New SecInfo" | "New Secinfo" => Ok(Self::NewSecInfo),
+            _ => Err(EnumParseError {
+                enum_name: "AlertEvent",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
+
+/// Stable alert condition values plus gvmd-compatible display-name aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AlertCondition {
+    /// Trigger the alert unconditionally.
+    Always,
+    /// Trigger when the filter count reaches at least a threshold.
+    FilterCountAtLeast,
+    /// Trigger when the filter count changes.
+    FilterCountChanged,
+    /// Trigger when severity reaches at least a threshold.
+    SeverityAtLeast,
+    /// Trigger when severity changes.
+    SeverityChanged,
+}
+
+impl AlertCondition {
+    /// Returns the stable GMP-facing value used by downstream consumers.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::FilterCountAtLeast => "filter_count_at_least",
+            Self::FilterCountChanged => "filter_count_changed",
+            Self::SeverityAtLeast => "severity_at_least",
+            Self::SeverityChanged => "severity_changed",
+        }
+    }
+
+    /// Returns the gvmd-compatible display name accepted by alert create/modify.
+    #[must_use]
+    pub const fn as_alert_name(self) -> &'static str {
+        match self {
+            Self::Always => "Always",
+            Self::FilterCountAtLeast => "Filter count at least",
+            Self::FilterCountChanged => "Filter count changed",
+            Self::SeverityAtLeast => "Severity at least",
+            Self::SeverityChanged => "Severity changed",
+        }
+    }
+}
+
+impl FromStr for AlertCondition {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "always" | "Always" => Ok(Self::Always),
+            "filter_count_at_least" | "Filter count at least" => Ok(Self::FilterCountAtLeast),
+            "filter_count_changed" | "Filter count changed" => Ok(Self::FilterCountChanged),
+            "severity_at_least" | "Severity at least" => Ok(Self::SeverityAtLeast),
+            "severity_changed" | "Severity changed" => Ok(Self::SeverityChanged),
+            _ => Err(EnumParseError {
+                enum_name: "AlertCondition",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
+
+/// Stable alert method values plus gvmd-compatible display-name aliases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AlertMethod {
+    /// Deliver the alert by email.
+    Email,
+    /// Deliver the alert with an HTTP GET request.
+    HttpGet,
+    /// Deliver the alert over SCP.
+    Scp,
+    /// Deliver the alert with the gvmd Send Email method.
+    SendEmail,
+    /// Deliver the alert over SMB.
+    Smb,
+    /// Deliver the alert over SNMP.
+    Snmp,
+    /// Deliver the alert to a Sourcefire connector.
+    SourcefireConnector,
+    /// Trigger a task start action.
+    StartTask,
+    /// Deliver the alert to Syslog.
+    SysLog,
+    /// Deliver the alert to TippingPoint.
+    TippingPoint,
+    /// Deliver the alert to Verinice CE.
+    VeriniceCe,
+    /// Deliver the alert to Verinice Net.
+    VeriniceNet,
+    /// Deliver the alert to Alemba.
+    Alemba,
+}
+
+impl AlertMethod {
+    /// Returns the stable GMP-facing value used by downstream consumers.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Email => "email",
+            Self::HttpGet => "http_get",
+            Self::Scp => "scp",
+            Self::SendEmail => "send_email",
+            Self::Smb => "smb",
+            Self::Snmp => "snmp",
+            Self::SourcefireConnector => "sourcefire_connector",
+            Self::StartTask => "start_task",
+            Self::SysLog => "syslog",
+            Self::TippingPoint => "tippingpoint",
+            Self::VeriniceCe => "verinice_ce",
+            Self::VeriniceNet => "verinice_net",
+            Self::Alemba => "alemba",
+        }
+    }
+
+    /// Returns the gvmd-compatible display name accepted by alert create/modify.
+    #[must_use]
+    pub const fn as_alert_name(self) -> &'static str {
+        match self {
+            Self::Email => "Email",
+            Self::HttpGet => "HTTP Get",
+            Self::Scp => "SCP",
+            Self::SendEmail => "Send Email",
+            Self::Smb => "SMB",
+            Self::Snmp => "SNMP",
+            Self::SourcefireConnector => "Sourcefire Connector",
+            Self::StartTask => "Start Task",
+            Self::SysLog => "SysLog",
+            Self::TippingPoint => "TippingPoint",
+            Self::VeriniceCe => "Verinice CE",
+            Self::VeriniceNet => "Verinice Net",
+            Self::Alemba => "Alemba",
+        }
+    }
+}
+
+impl FromStr for AlertMethod {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "email" | "Email" => Ok(Self::Email),
+            "http_get" | "HTTP Get" | "Http Get" => Ok(Self::HttpGet),
+            "scp" | "SCP" => Ok(Self::Scp),
+            "send_email" | "Send Email" | "SendEmail" => Ok(Self::SendEmail),
+            "smb" | "SMB" => Ok(Self::Smb),
+            "snmp" | "SNMP" => Ok(Self::Snmp),
+            "sourcefire_connector" | "Sourcefire Connector" => Ok(Self::SourcefireConnector),
+            "start_task" | "Start Task" => Ok(Self::StartTask),
+            "syslog" | "SysLog" | "Syslog" => Ok(Self::SysLog),
+            "tippingpoint" | "TippingPoint" => Ok(Self::TippingPoint),
+            "verinice_ce" | "Verinice CE" => Ok(Self::VeriniceCe),
+            "verinice_net" | "Verinice Net" => Ok(Self::VeriniceNet),
+            "alemba" | "Alemba" => Ok(Self::Alemba),
+            _ => Err(EnumParseError {
+                enum_name: "AlertMethod",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
+
 gmp_enum!(AliveTest {
     ScanConfigDefault => "Scan Config Default",
     IcmpPing => "ICMP Ping",

--- a/crates/gvm-gmp/src/responses/alert.rs
+++ b/crates/gvm-gmp/src/responses/alert.rs
@@ -3,12 +3,15 @@
 
 //! Alert response models.
 
+use std::str::FromStr;
+
 use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
     status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
 };
+use crate::{AlertCondition, AlertEvent, AlertMethod};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -45,9 +48,13 @@ impl Alert {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            event: node.optional_child_text("event"),
-            condition: node.optional_child_text("condition"),
-            method: node.optional_child_text("method"),
+            event: node.optional_child_text("event").map(normalize_alert_event),
+            condition: node
+                .optional_child_text("condition")
+                .map(normalize_alert_condition),
+            method: node
+                .optional_child_text("method")
+                .map(normalize_alert_method),
             filter: parse_named_entity(node, "filter")?,
             active: node
                 .optional_child_text("active")
@@ -94,6 +101,27 @@ impl CreateAlertResponse {
 
 pub type ModifyAlertResponse = ActionResponse;
 pub type DeleteAlertResponse = ActionResponse;
+
+fn normalize_alert_event(value: String) -> String {
+    AlertEvent::from_str(&value)
+        .map(AlertEvent::as_gmp_str)
+        .unwrap_or(value.as_str())
+        .to_string()
+}
+
+fn normalize_alert_condition(value: String) -> String {
+    AlertCondition::from_str(&value)
+        .map(AlertCondition::as_gmp_str)
+        .unwrap_or(value.as_str())
+        .to_string()
+}
+
+fn normalize_alert_method(value: String) -> String {
+    AlertMethod::from_str(&value)
+        .map(AlertMethod::as_gmp_str)
+        .unwrap_or(value.as_str())
+        .to_string()
+}
 
 #[cfg(test)]
 mod tests {
@@ -148,6 +176,34 @@ mod tests {
         assert!(parsed.items[0].active);
         assert!(!parsed.items[1].active);
         assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn normalizes_gvmd_alert_display_names_to_stable_values() {
+        let response = Response::from(
+            r#"<get_alerts_response status="200" status_text="OK">
+                <alert id="a-1">
+                    <name>Display Name Alert</name>
+                    <event>Task run status changed</event>
+                    <condition>Always</condition>
+                    <method>SysLog</method>
+                </alert>
+                <alert id="a-2">
+                    <name>Alternate Method Casing</name>
+                    <method>Syslog</method>
+                </alert>
+            </get_alerts_response>"#,
+        );
+
+        let parsed = GetAlertsResponse::from_response(&response).expect("alerts parse");
+
+        assert_eq!(
+            parsed.items[0].event.as_deref(),
+            Some("task_run_status_changed")
+        );
+        assert_eq!(parsed.items[0].condition.as_deref(), Some("always"));
+        assert_eq!(parsed.items[0].method.as_deref(), Some("syslog"));
+        assert_eq!(parsed.items[1].method.as_deref(), Some("syslog"));
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -54,7 +54,7 @@ fn test_alert_get_modify_delete_and_test() {
                 ..Default::default()
             }
         )),
-        "<modify_alert alert_id=\"a1\"><event>Task run status changed</event><condition>Always</condition><method>SysLog</method></modify_alert>"
+        "<modify_alert alert_id=\"a1\"><event>Task run status changed</event><condition>Always</condition><method>Syslog</method></modify_alert>"
     );
     assert_eq!(
         xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -30,7 +30,7 @@ fn test_create_alert_with_all_optionals() {
                 filter_id: Some(id("f1")),
             }
         )),
-        "<create_alert><name>a</name><comment>c</comment><event>task_run_status_changed</event><condition>always</condition><method>email</method><filter id=\"f1\"/></create_alert>"
+        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed</event><condition>Always</condition><method>Email</method><filter id=\"f1\"/></create_alert>"
     );
 }
 
@@ -43,6 +43,18 @@ fn test_alert_get_modify_delete_and_test() {
     assert_eq!(
         xml(get_alert(&id("a1"))),
         "<get_alerts alert_id=\"a1\" details=\"1\"/>"
+    );
+    assert_eq!(
+        xml(modify_alert(
+            &id("a1"),
+            AlertOpts {
+                event: Some(AlertEvent::TaskRunStatusChanged),
+                condition: Some(AlertCondition::Always),
+                method: Some(AlertMethod::SysLog),
+                ..Default::default()
+            }
+        )),
+        "<modify_alert alert_id=\"a1\"><event>Task run status changed</event><condition>Always</condition><method>SysLog</method></modify_alert>"
     );
     assert_eq!(
         xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/tests/test_enums.rs
+++ b/crates/gvm-gmp/tests/test_enums.rs
@@ -20,6 +20,10 @@ fn test_alertevent_taskrunstatuschanged_from_str() {
         AlertEvent::from_str("task_run_status_changed").unwrap(),
         AlertEvent::TaskRunStatusChanged
     );
+    assert_eq!(
+        AlertEvent::from_str("Task run status changed").unwrap(),
+        AlertEvent::TaskRunStatusChanged
+    );
 }
 #[test]
 fn test_alertevent_updatedsecinfo_as_gmp_str() {
@@ -56,6 +60,10 @@ fn test_alertcondition_always_as_gmp_str() {
 fn test_alertcondition_always_from_str() {
     assert_eq!(
         AlertCondition::from_str("always").unwrap(),
+        AlertCondition::Always
+    );
+    assert_eq!(
+        AlertCondition::from_str("Always").unwrap(),
         AlertCondition::Always
     );
 }
@@ -207,6 +215,14 @@ fn test_alertmethod_syslog_as_gmp_str() {
 fn test_alertmethod_syslog_from_str() {
     assert_eq!(
         AlertMethod::from_str("syslog").unwrap(),
+        AlertMethod::SysLog
+    );
+    assert_eq!(
+        AlertMethod::from_str("SysLog").unwrap(),
+        AlertMethod::SysLog
+    );
+    assert_eq!(
+        AlertMethod::from_str("Syslog").unwrap(),
         AlertMethod::SysLog
     );
 }

--- a/crates/gvm-gmp/tests/test_enums.rs
+++ b/crates/gvm-gmp/tests/test_enums.rs
@@ -349,6 +349,10 @@ fn test_alivetest_icmpandtcpackserviceping_from_str() {
         AliveTest::from_str("ICMP, TCP-ACK Service Ping").unwrap(),
         AliveTest::IcmpAndTcpAckServicePing
     );
+    assert_eq!(
+        AliveTest::from_str("ICMP & TCP-ACK Service Ping").unwrap(),
+        AliveTest::IcmpAndTcpAckServicePing
+    );
 }
 #[test]
 fn test_alivetest_icmpandarpping_as_gmp_str() {
@@ -358,6 +362,10 @@ fn test_alivetest_icmpandarpping_as_gmp_str() {
 fn test_alivetest_icmpandarpping_from_str() {
     assert_eq!(
         AliveTest::from_str("ICMP, ARP Ping").unwrap(),
+        AliveTest::IcmpAndArpPing
+    );
+    assert_eq!(
+        AliveTest::from_str("ICMP & ARP Ping").unwrap(),
         AliveTest::IcmpAndArpPing
     );
 }
@@ -374,6 +382,10 @@ fn test_alivetest_tcpackserviceandarpping_from_str() {
         AliveTest::from_str("TCP-ACK Service, ARP Ping").unwrap(),
         AliveTest::TcpAckServiceAndArpPing
     );
+    assert_eq!(
+        AliveTest::from_str("TCP-ACK Service & ARP Ping").unwrap(),
+        AliveTest::TcpAckServiceAndArpPing
+    );
 }
 #[test]
 fn test_alivetest_icmptcpackserviceandarpping_as_gmp_str() {
@@ -386,6 +398,10 @@ fn test_alivetest_icmptcpackserviceandarpping_as_gmp_str() {
 fn test_alivetest_icmptcpackserviceandarpping_from_str() {
     assert_eq!(
         AliveTest::from_str("ICMP, TCP-ACK Service, ARP Ping").unwrap(),
+        AliveTest::IcmpTcpAckServiceAndArpPing
+    );
+    assert_eq!(
+        AliveTest::from_str("ICMP, TCP-ACK Service & ARP Ping").unwrap(),
         AliveTest::IcmpTcpAckServiceAndArpPing
     );
 }
@@ -1414,6 +1430,7 @@ fn test_portrangetype_tcp_as_gmp_str() {
 #[test]
 fn test_portrangetype_tcp_from_str() {
     assert_eq!(PortRangeType::from_str("tcp").unwrap(), PortRangeType::Tcp);
+    assert_eq!(PortRangeType::from_str("TCP").unwrap(), PortRangeType::Tcp);
 }
 #[test]
 fn test_portrangetype_udp_as_gmp_str() {
@@ -1422,6 +1439,7 @@ fn test_portrangetype_udp_as_gmp_str() {
 #[test]
 fn test_portrangetype_udp_from_str() {
     assert_eq!(PortRangeType::from_str("udp").unwrap(), PortRangeType::Udp);
+    assert_eq!(PortRangeType::from_str("UDP").unwrap(), PortRangeType::Udp);
 }
 #[test]
 fn test_portrangetype_invalid_string_returns_error() {
@@ -1553,6 +1571,10 @@ fn test_scannertype_openvasscanner_from_str() {
         ScannerType::from_str("OpenVAS").unwrap(),
         ScannerType::OpenVasScanner
     );
+    assert_eq!(
+        ScannerType::from_str("2").unwrap(),
+        ScannerType::OpenVasScanner
+    );
 }
 #[test]
 fn test_scannertype_cvescannertype_as_gmp_str() {
@@ -1562,6 +1584,10 @@ fn test_scannertype_cvescannertype_as_gmp_str() {
 fn test_scannertype_cvescannertype_from_str() {
     assert_eq!(
         ScannerType::from_str("CVE").unwrap(),
+        ScannerType::CveScannerType
+    );
+    assert_eq!(
+        ScannerType::from_str("3").unwrap(),
         ScannerType::CveScannerType
     );
 }
@@ -1574,6 +1600,21 @@ fn test_scannertype_greenbonesensortype_from_str() {
     assert_eq!(
         ScannerType::from_str("OSP").unwrap(),
         ScannerType::GreenBoneSensorType
+    );
+    assert_eq!(
+        ScannerType::from_str("5").unwrap(),
+        ScannerType::GreenBoneSensorType
+    );
+}
+#[test]
+fn test_scannertype_openvasdscannertype_as_gmp_str() {
+    assert_eq!(ScannerType::OpenVasdScannerType.as_gmp_str(), "6");
+}
+#[test]
+fn test_scannertype_openvasdscannertype_from_str() {
+    assert_eq!(
+        ScannerType::from_str("6").unwrap(),
+        ScannerType::OpenVasdScannerType
     );
 }
 #[test]
@@ -1723,6 +1764,7 @@ fn test_ticketstatus_open_as_gmp_str() {
 #[test]
 fn test_ticketstatus_open_from_str() {
     assert_eq!(TicketStatus::from_str("open").unwrap(), TicketStatus::Open);
+    assert_eq!(TicketStatus::from_str("Open").unwrap(), TicketStatus::Open);
 }
 #[test]
 fn test_ticketstatus_fixed_as_gmp_str() {
@@ -1734,6 +1776,10 @@ fn test_ticketstatus_fixed_from_str() {
         TicketStatus::from_str("fixed").unwrap(),
         TicketStatus::Fixed
     );
+    assert_eq!(
+        TicketStatus::from_str("Fixed").unwrap(),
+        TicketStatus::Fixed
+    );
 }
 #[test]
 fn test_ticketstatus_closed_as_gmp_str() {
@@ -1743,6 +1789,10 @@ fn test_ticketstatus_closed_as_gmp_str() {
 fn test_ticketstatus_closed_from_str() {
     assert_eq!(
         TicketStatus::from_str("closed").unwrap(),
+        TicketStatus::Closed
+    );
+    assert_eq!(
+        TicketStatus::from_str("Closed").unwrap(),
         TicketStatus::Closed
     );
 }

--- a/crates/gvm-gmp/tests/test_enums.rs
+++ b/crates/gvm-gmp/tests/test_enums.rs
@@ -35,6 +35,10 @@ fn test_alertevent_updatedsecinfo_from_str() {
         AlertEvent::from_str("updated_secinfo").unwrap(),
         AlertEvent::UpdatedSecInfo
     );
+    assert_eq!(
+        AlertEvent::from_str("Updated SecInfo arrived").unwrap(),
+        AlertEvent::UpdatedSecInfo
+    );
 }
 #[test]
 fn test_alertevent_newsecinfo_as_gmp_str() {
@@ -44,6 +48,10 @@ fn test_alertevent_newsecinfo_as_gmp_str() {
 fn test_alertevent_newsecinfo_from_str() {
     assert_eq!(
         AlertEvent::from_str("new_secinfo").unwrap(),
+        AlertEvent::NewSecInfo
+    );
+    assert_eq!(
+        AlertEvent::from_str("New SecInfo arrived").unwrap(),
         AlertEvent::NewSecInfo
     );
 }
@@ -165,6 +173,10 @@ fn test_alertmethod_sendemail_from_str() {
         AlertMethod::from_str("send_email").unwrap(),
         AlertMethod::SendEmail
     );
+    assert_eq!(
+        AlertMethod::from_str("Send").unwrap(),
+        AlertMethod::SendEmail
+    );
 }
 #[test]
 fn test_alertmethod_smb_as_gmp_str() {
@@ -236,6 +248,10 @@ fn test_alertmethod_tippingpoint_from_str() {
         AlertMethod::from_str("tippingpoint").unwrap(),
         AlertMethod::TippingPoint
     );
+    assert_eq!(
+        AlertMethod::from_str("TippingPoint SMS").unwrap(),
+        AlertMethod::TippingPoint
+    );
 }
 #[test]
 fn test_alertmethod_verinicece_as_gmp_str() {
@@ -245,6 +261,10 @@ fn test_alertmethod_verinicece_as_gmp_str() {
 fn test_alertmethod_verinicece_from_str() {
     assert_eq!(
         AlertMethod::from_str("verinice_ce").unwrap(),
+        AlertMethod::VeriniceCe
+    );
+    assert_eq!(
+        AlertMethod::from_str("verinice Connector").unwrap(),
         AlertMethod::VeriniceCe
     );
 }
@@ -267,6 +287,10 @@ fn test_alertmethod_alemba_as_gmp_str() {
 fn test_alertmethod_alemba_from_str() {
     assert_eq!(
         AlertMethod::from_str("alemba").unwrap(),
+        AlertMethod::Alemba
+    );
+    assert_eq!(
+        AlertMethod::from_str("Alemba vFire").unwrap(),
         AlertMethod::Alemba
     );
 }

--- a/crates/gvm-gmp/tests/test_port_lists.rs
+++ b/crates/gvm-gmp/tests/test_port_lists.rs
@@ -25,7 +25,7 @@ fn test_create_port_list_and_range_with_options() {
     );
     assert_eq!(
         xml(create_port_range(&id("pl1"), PortRangeType::Tcp, 1, 5)),
-        "<create_port_range end=\"5\" port_list_id=\"pl1\" start=\"1\" type=\"tcp\"/>"
+        "<create_port_range end=\"5\" port_list_id=\"pl1\" start=\"1\" type=\"TCP\"/>"
     );
 }
 

--- a/crates/gvm-gmp/tests/test_scanners.rs
+++ b/crates/gvm-gmp/tests/test_scanners.rs
@@ -30,7 +30,7 @@ fn test_create_scanner_with_optionals() {
                 credential_id: Some(id("cred1")),
             }
         )),
-        "<create_scanner><name>scanner</name><comment>c</comment><host>127.0.0.1</host><port>9390</port><type>OpenVAS</type><credential id=\"cred1\"/></create_scanner>"
+        "<create_scanner><name>scanner</name><comment>c</comment><host>127.0.0.1</host><port>9390</port><type>2</type><credential id=\"cred1\"/></create_scanner>"
     );
 }
 

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -26,13 +26,13 @@ fn test_create_target_with_optionals() {
                 comment: Some("c".into()),
                 hosts: vec!["1.1.1.1".into(), "2.2.2.2".into()],
                 exclude_hosts: vec!["3.3.3.3".into()],
-                alive_test: Some(AliveTest::IcmpPing),
+                alive_test: Some(AliveTest::IcmpAndArpPing),
                 port_list_id: Some(id("pl1")),
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
             }
         )),
-        "<create_target><name>target</name><comment>c</comment><hosts>1.1.1.1,2.2.2.2</hosts><exclude_hosts>3.3.3.3</exclude_hosts><alive_test>ICMP Ping</alive_test><port_list id=\"pl1\"/><reverse_lookup_only>1</reverse_lookup_only><reverse_lookup_unify>0</reverse_lookup_unify></create_target>"
+        "<create_target><name>target</name><comment>c</comment><hosts>1.1.1.1,2.2.2.2</hosts><exclude_hosts>3.3.3.3</exclude_hosts><alive_test>ICMP &amp; ARP Ping</alive_test><port_list id=\"pl1\"/><reverse_lookup_only>1</reverse_lookup_only><reverse_lookup_unify>0</reverse_lookup_unify></create_target>"
     );
 }
 

--- a/crates/gvm-gmp/tests/test_tickets.rs
+++ b/crates/gvm-gmp/tests/test_tickets.rs
@@ -31,7 +31,7 @@ fn test_create_ticket_with_optionals() {
                 closed_note: Some("cl".into()),
             }
         )),
-        "<create_ticket><result id=\"r1\"/><assigned_to>alice</assigned_to><comment>c</comment><status>open</status><open_note>o</open_note><fixed_note>f</fixed_note><closed_note>cl</closed_note></create_ticket>"
+        "<create_ticket><result id=\"r1\"/><assigned_to>alice</assigned_to><comment>c</comment><status>Open</status><open_note>o</open_note><fixed_note>f</fixed_note><closed_note>cl</closed_note></create_ticket>"
     );
 }
 


### PR DESCRIPTION
## Summary

- emit gvmd/python-gvm 22.7 wire values from typed GMP command builders for alerts, targets, port lists, scanners, and tickets
- normalize known gvmd alert display-name variants back to the existing stable consumer-facing values in typed responses
- widen enum parsing and regression coverage for the affected compatibility aliases while preserving existing stable helper strings for downstream callers

## Why

The original breakage showed up first in typed alert APIs, but the branch grew into a broader protocol-compatibility pass once the parity scan found additional request-wire mismatches in enum families emitted directly by `gvm-gmp`.

This change keeps gvmd/python-gvm 22.7 quirks inside `rust-gvm` instead of pushing custom translation logic into downstream consumers such as `rust-gvm-api`.

## Testing

- cargo fmt --all
- cargo test -p gvm-gmp --lib commands::alerts::tests:: -- --nocapture
- cargo test -p gvm-gmp --lib commands::targets::tests:: -- --nocapture
- cargo test -p gvm-gmp --lib commands::port_lists::tests:: -- --nocapture
- cargo test -p gvm-gmp --lib commands::tickets::tests:: -- --nocapture
- cargo test -p gvm-gmp --lib commands::scanners::tests:: -- --nocapture
- cargo test -p gvm-gmp --test test_alerts -- --nocapture
- cargo test -p gvm-gmp --test test_targets -- --nocapture
- cargo test -p gvm-gmp --test test_port_lists -- --nocapture
- cargo test -p gvm-gmp --test test_tickets -- --nocapture
- cargo test -p gvm-gmp --test test_scanners -- --nocapture
- cargo test -p gvm-gmp --test test_enums -- --nocapture
- cargo clippy --workspace --all-targets --all-features -- -D warnings

Closes #201

Agent: Thoth
