### PR TITLE
docs(journal): add 2026-06-02 journal entry

### DIFF
--- a/journal/2026-06-02.md
+++ b/journal/2026-06-02.md
@@ -1,0 +1,23 @@
+# 2026-06-02 — `main` Absorbed the REST-Gap Helper Slice, Landed Typed Report Export, and Immediately Spawned an Alert-Compatibility Follow-On
+
+## Mainline & Merged Work
+
+### The default branch actually moved in a product direction this time, not just through maintenance or docs
+- PR #177 (`Add GMP REST support gap helpers`) merged on 2026-06-01 and closed issues #173, #174, and #175 together, so the repo converted a broad compatibility/testing bundle into shipped `main` behavior in one push
+- PR #200 (`feat(gmp): add typed report export request and response support`) merged later the same day and added typed report-export coverage as a fresh runtime capability instead of only rounding off old GMP gaps
+- That leaves the last 24 hours looking materially different from the 2026-05-31 entry: the queue stopped being only potential energy and actually delivered two substantive feature slices to `main`
+
+## Issues
+- Issue #199 (`feat(gmp): add typed report export request and response support`) opened and closed on 2026-06-01, which shows the report-export lane was identified, implemented, and merged inside the same day
+- A new follow-on issue, #201 (`Own gvmd alert name compatibility in typed alert APIs`), opened just before PR #200 merged, so the next compatibility problem is already isolated instead of being left implicit in review comments or ad hoc fixes
+- The older GMP gap issues #173, #174, and #175 all closed when PR #177 landed, which is the clearest sign that the REST-support helper branch was more than a narrow code tweak
+
+## Pull Request Queue
+- The active front edge is now PR #202 (`fix(gmp): own gvmd alert name compatibility`), which reads like the direct continuation of newly opened issue #201 rather than a disconnected branch
+- The queue behind it is still mixed between real feature work and maintenance backlog: PR #193 (gvmd capability discovery), PRs #196, #197, #181, and #165 (dependency/CI updates), plus the still-open journal lane in PR #198
+- So the repo's posture improved relative to 2026-05-31 because `main` finally absorbed real product work, but review pressure still exists on both the capability-discovery branch and a familiar dependabot stack
+
+## CI Health
+- The pushes for PRs #177 and #200 each passed `CI`, `Security`, and `OpenSSF Scorecard` on 2026-06-01, so both substantive merges validated cleanly on the default branch
+- Scheduled `Security` on `main` also completed successfully earlier that day, which means the repo did not pay for the merge burst with an immediate baseline verification regression
+- The noisy signal in this window sits in maintenance automation rather than product verification: a `pip` dynamic update and a `github_actions` dynamic update both failed on 2026-06-01 while the cargo-oriented update lanes succeeded


### PR DESCRIPTION
## Summary
- add the 2026-06-02 journal entry
- capture repo activity since the prior journal entry

Agent: Thoth
