### PR TITLE
feat(tasks): type resume task responses

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -60,7 +60,9 @@ use gvm_gmp::commands::secinfo::{
 use gvm_gmp::commands::system::{describe_auth, get_settings, get_timezones, FilteredGetOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
-use gvm_gmp::commands::tasks::{create_task, get_tasks, start_task, CreateTaskOpts, GetTasksOpts};
+use gvm_gmp::commands::tasks::{
+    create_task, get_tasks, resume_task, start_task, CreateTaskOpts, GetTasksOpts,
+};
 use gvm_gmp::commands::tickets::{create_ticket, get_tickets, GetTicketsOpts, TicketOpts};
 use gvm_gmp::commands::tls_certificates::{
     create_tls_certificate, get_tls_certificates, GetTlsCertificatesOpts, TlsCertificateOpts,
@@ -85,8 +87,8 @@ use gvm_gmp::responses::{
     GetScannersResponse, GetSchedulesResponse, GetSettingsResponse, GetTagsResponse,
     GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
     GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, HelpResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ReportExport, StartTaskResponse,
-    SyncConfigResponse, VerifyScannerResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ReportExport, ResumeTaskResponse,
+    StartTaskResponse, SyncConfigResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -386,6 +388,18 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn start_task(&mut self, task_id: &EntityId) -> Result<StartTaskResponse, GvmError> {
         let response = self.send(start_task(task_id)).await?;
         StartTaskResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `resume_task` request and return a typed [`ResumeTaskResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn resume_task(
+        &mut self,
+        task_id: &EntityId,
+    ) -> Result<ResumeTaskResponse, GvmError> {
+        let response = self.send(resume_task(task_id)).await?;
+        ResumeTaskResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Reports ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -505,6 +505,83 @@ async fn full_crud_lifecycle_succeeds() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn typed_resume_task_returns_report_id() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let target_response = client
+        .create_target(
+            "Typed Resume Target",
+            CreateTargetOpts {
+                hosts: vec!["127.0.0.1".to_string()],
+                ..CreateTargetOpts::default()
+            },
+        )
+        .await
+        .expect("create_target should succeed");
+    let target_id = target_response.id;
+
+    let config_id = "550e8400-e29b-41d4-a716-446655440001"
+        .parse()
+        .expect("entity id");
+    let scanner_id = "550e8400-e29b-41d4-a716-446655440002"
+        .parse()
+        .expect("entity id");
+
+    let task_response = client
+        .create_task(
+            "Typed Resume Task",
+            &config_id,
+            &target_id,
+            &scanner_id,
+            Default::default(),
+        )
+        .await
+        .expect("create_task should succeed");
+    let task_id = task_response.id;
+
+    let start_response = client
+        .start_task(&task_id)
+        .await
+        .expect("start_task should succeed");
+    assert_eq!(start_response.status, 202);
+    assert!(start_response.report_id.is_some());
+
+    client
+        .call(stop_task(&task_id))
+        .await
+        .expect("stop_task should succeed");
+
+    let resume_response = client
+        .resume_task(&task_id)
+        .await
+        .expect("resume_task should succeed");
+    assert_eq!(resume_response.status, 202);
+    assert!(resume_response.report_id.is_some());
+
+    client
+        .call(delete_task(&task_id, true))
+        .await
+        .expect("delete_task should succeed");
+    client
+        .call(delete_target(&target_id, true))
+        .await
+        .expect("delete_target should succeed");
+
+    server.shutdown().await;
+}
+
 async fn typed_scan_config_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
     let created_config = client
         .create_scan_config(

--- a/crates/gvm-gmp/src/responses/task.rs
+++ b/crates/gvm-gmp/src/responses/task.rs
@@ -69,6 +69,15 @@ pub struct StartTaskResponse {
     pub report_id: Option<EntityId>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ResumeTaskResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub report_id: Option<EntityId>,
+}
+
 impl Task {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
@@ -159,12 +168,7 @@ impl CreateTaskResponse {
 
 impl StartTaskResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
-        let (status, status_text) = status_from_response(response)?;
-        let root = parse_document(response.data())?;
-        let report_id = root
-            .optional_child_text("report_id")
-            .map(|value| parse_entity_id(&value, "report_id"))
-            .transpose()?;
+        let (status, status_text, report_id) = parse_task_action_response(response)?;
         Ok(Self {
             status,
             status_text,
@@ -173,8 +177,30 @@ impl StartTaskResponse {
     }
 }
 
+impl ResumeTaskResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text, report_id) = parse_task_action_response(response)?;
+        Ok(Self {
+            status,
+            status_text,
+            report_id,
+        })
+    }
+}
+
+fn parse_task_action_response(
+    response: &Response,
+) -> Result<(u16, String, Option<EntityId>), ParseError> {
+    let (status, status_text) = status_from_response(response)?;
+    let root = parse_document(response.data())?;
+    let report_id = root
+        .optional_child_text("report_id")
+        .map(|value| parse_entity_id(&value, "report_id"))
+        .transpose()?;
+    Ok((status, status_text, report_id))
+}
+
 pub type StopTaskResponse = ActionResponse;
-pub type ResumeTaskResponse = ActionResponse;
 pub type ModifyTaskResponse = ActionResponse;
 pub type DeleteTaskResponse = ActionResponse;
 pub type MoveTaskResponse = ActionResponse;
@@ -278,6 +304,21 @@ mod tests {
         assert_eq!(
             parsed.report_id.as_ref().map(EntityId::as_str),
             Some("rpt-new-1")
+        );
+    }
+
+    #[test]
+    fn parses_resume_task_response() {
+        let response = Response::from(
+            r#"<resume_task_response status="202" status_text="OK, request submitted"><report_id>rpt-new-2</report_id></resume_task_response>"#,
+        );
+
+        let parsed = ResumeTaskResponse::from_response(&response).expect("resume parses");
+
+        assert_eq!(parsed.status, 202);
+        assert_eq!(
+            parsed.report_id.as_ref().map(EntityId::as_str),
+            Some("rpt-new-2")
         );
     }
 


### PR DESCRIPTION
## Summary
- add typed `ResumeTaskResponse` parsing that preserves `report_id`
- add a typed `resume_task()` helper to `gvm-client`
- cover the new response shape in focused parser and client integration tests

## Validation
- `cargo test -p gvm-gmp parses_resume_task_response -- --nocapture`
- `cargo test -p gvm-gmp parses_start_task_response -- --nocapture`
- `cargo test -p gvm-client --features unix-socket-tests typed_resume_task_returns_report_id -- --nocapture`

Closes #206
