### PR TITLE
feat(gmp): add note and override result flags

### DIFF
--- a/crates/gvm-gmp/src/commands/notes.rs
+++ b/crates/gvm-gmp/src/commands/notes.rs
@@ -40,6 +40,8 @@ pub struct GetNotesOpts {
     pub trash: Option<bool>,
     /// Whether to request detailed output.
     pub details: Option<bool>,
+    /// Whether to include associated result references in the response.
+    pub result: Option<bool>,
 }
 
 /// Build a clone request for an existing note.
@@ -68,6 +70,7 @@ pub fn get_notes(opts: GetNotesOpts) -> impl Request {
     );
     set_optional_bool_attr(&mut cmd, "trash", opts.trash);
     set_optional_bool_attr(&mut cmd, "details", opts.details);
+    set_optional_bool_attr(&mut cmd, "result", opts.result);
     cmd
 }
 
@@ -156,9 +159,12 @@ mod tests {
         let rendered = xml(get_notes(GetNotesOpts {
             filter_string: Some("name=foo".into()),
             details: Some(true),
+            result: Some(true),
             ..Default::default()
         }));
         assert!(rendered.contains("filter=\"name=foo\""));
+        assert!(rendered.contains("details=\"1\""));
+        assert!(rendered.contains("result=\"1\""));
         let rendered = xml(modify_note(
             &id("n1"),
             NoteOpts {

--- a/crates/gvm-gmp/src/commands/overrides.rs
+++ b/crates/gvm-gmp/src/commands/overrides.rs
@@ -40,6 +40,8 @@ pub struct GetOverridesOpts {
     pub trash: Option<bool>,
     /// Whether to request detailed output.
     pub details: Option<bool>,
+    /// Whether to include associated result references in the response.
+    pub result: Option<bool>,
 }
 
 /// Build a clone request for an existing override.
@@ -68,6 +70,7 @@ pub fn get_overrides(opts: GetOverridesOpts) -> impl Request {
     );
     set_optional_bool_attr(&mut cmd, "trash", opts.trash);
     set_optional_bool_attr(&mut cmd, "details", opts.details);
+    set_optional_bool_attr(&mut cmd, "result", opts.result);
     cmd
 }
 
@@ -152,9 +155,11 @@ mod tests {
         let rendered = xml(get_overrides(GetOverridesOpts {
             filter_string: Some("name=foo".into()),
             details: Some(true),
+            result: Some(true),
             ..Default::default()
         }));
         assert!(rendered.contains("details=\"1\""));
+        assert!(rendered.contains("result=\"1\""));
         let rendered = xml(modify_override(
             &id("o1"),
             OverrideOpts {

--- a/crates/gvm-gmp/tests/test_notes.rs
+++ b/crates/gvm-gmp/tests/test_notes.rs
@@ -50,4 +50,12 @@ fn test_note_get_modify_delete() {
         xml(delete_note(&id("n1"), true)),
         "<delete_note note_id=\"n1\" ultimate=\"1\"/>"
     );
+    assert_eq!(
+        xml(get_notes(GetNotesOpts {
+            details: Some(true),
+            result: Some(true),
+            ..Default::default()
+        })),
+        "<get_notes details=\"1\" result=\"1\"/>"
+    );
 }

--- a/crates/gvm-gmp/tests/test_overrides.rs
+++ b/crates/gvm-gmp/tests/test_overrides.rs
@@ -50,4 +50,12 @@ fn test_override_get_modify_delete() {
         xml(delete_override(&id("o1"), false)),
         "<delete_override override_id=\"o1\" ultimate=\"0\"/>"
     );
+    assert_eq!(
+        xml(get_overrides(GetOverridesOpts {
+            details: Some(true),
+            result: Some(true),
+            ..Default::default()
+        })),
+        "<get_overrides details=\"1\" result=\"1\"/>"
+    );
 }


### PR DESCRIPTION
## Summary
- add an optional `result` flag to `GetNotesOpts` and `GetOverridesOpts`
- wire the new option into the GMP XML builders for bulk note and override reads
- extend builder/integration tests to assert `result="1"` is emitted when requested

## Testing
- cargo fmt --all
- cargo test -p gvm-gmp --test test_notes -- --nocapture
- cargo test -p gvm-gmp --test test_overrides -- --nocapture
- cargo test -p gvm-gmp --lib -- --nocapture

Closes #209

Agent: Thoth
