### PR TITLE
docs(journal): add 2026-06-06 journal entry

### DIFF
--- a/journal/2026-06-06.md
+++ b/journal/2026-06-06.md
@@ -1,0 +1,23 @@
+# 2026-06-06 — Typed GMP Parity Accelerated, the REST Gap Slice Landed, and Mainline Stayed Green
+
+## Mainline & Merged Work
+
+### `main` moved from backlog cleanup into a real feature burst after the 2026-05-24 journal baseline
+- The 2026-05-25 landing set was mostly operational: PR #168 added journal PR automation, PR #182 refreshed the actions stack, PR #184 briefly pushed MCP gateway docs into the wrong repo, PR #187 reverted that mistake, and PR #186 merged the accumulated journal backlog
+- The substantive product lane then accelerated across 2026-05-28 through 2026-06-03: PR #177 landed the GMP REST support gap helpers, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd report-export errors, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- Dependency maintenance also crossed the line instead of lingering forever: PR #181 updated `russh` to 0.61.1 and carried the needed CI adjustments with it
+
+## Issues
+- The follow-on GMP backlog converted into actual closures instead of just queue growth: issues #173, #174, and #175 closed with PR #177 on 2026-06-01
+- New implementation issues #199, #201, #204, #206, and #209 all opened and closed quickly as their paired PRs merged between 2026-06-01 and 2026-06-03
+- The one notable issue that did not immediately resolve is #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`), opened on 2026-05-28 and still carrying the next deeper compatibility layer
+
+## Pull Request Queue
+- The open queue is still dominated by journal backlog PRs rather than product work: #188, #189, #194, #195, #198, #203, #208, and #211 are all journal branches waiting for review
+- The non-journal queue is narrow but not empty: PR #193 holds the gvmd capability-discovery work in a `DIRTY` state, while dependency PRs #165, #196, and #197 are all sitting `BEHIND`
+- So the repo's bottleneck has shifted from "missing implementation" toward "review and merge throughput"
+
+## CI Health
+- Push validation on the real product merges is clean: `CI`, `Security`, and `OpenSSF Scorecard` all completed successfully on 2026-06-02 and again on 2026-06-03
+- `Dependabot Updates` also completed successfully on 2026-06-02, so the maintenance lane is at least executing rather than failing by default
+- There is no fresh evidence of broad default-branch instability; the friction is in queue age, not in broken mainline checks


### PR DESCRIPTION
## Summary
- add the 2026-06-06 journal entry
- capture repo activity since the previous journal baseline

Agent: Thoth
