### PR TITLE
docs(journal): add 2026-06-07 journal entry

### DIFF
--- a/journal/2026-06-07.md
+++ b/journal/2026-06-07.md
@@ -1,0 +1,22 @@
+# 2026-06-07 — `main` Turned the REST-Support GMP Queue into Shipped Surface Area While the Backlog Stayed Busy
+
+## Mainline & Merged Work
+
+### `main` absorbed a real run of product-facing GMP work after the 2026-05-24 baseline
+- Seven substantive merges reached the default branch in this window: PR #177 added REST-support GMP gap helpers, PR #191 fixed empty optional schedule ids, PR #200 added typed report-export support, PR #202 aligned typed enums with gvmd and `python-gvm` 22.7, PR #205 preserved self-closing gvmd error status in report export flows, PR #207 typed `resume_task` responses for downstream consumers, and PR #210 added note/override result expansion support
+- That sequence is coherent rather than scattered churn: the repo first tightened compatibility and error-shape handling, then expanded the typed surface for report export, task resumption, and note/override result access
+- Non-product but still notable mainline changes also landed on 2026-05-25: PR #168 added journal PR automation, PR #182 updated GitHub Actions dependencies, and PRs #184 and #187 briefly added then reverted MCP planning that belonged in a different repository
+
+## Issues
+- New issues in this window were tightly coupled to merged work: #190 (empty schedule ids), #199 (typed report export), #201 (typed alert compatibility), #204 (self-closing gvmd error status), #206 (typed `resume_task` response), and #209 (note/override result expansion) all opened and then closed quickly as their matching PRs landed
+- One new capability follow-up remains open: #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`)
+- Older backlog also kept burning down as the new feature lane landed: issues #173, #174, and #175 all closed on 2026-06-01 when PR #177 merged, leaving the broader roadmap issue #172 plus the newer capability-probing thread #192 as the visible remaining GMP-gap anchors
+
+## Pull Request Queue
+- The queue is now split between one real feature follow-on and a large docs/maintenance tail: PR #193 carries capability discovery helpers, while dependency PRs #196 and #197 and the unmerged daily journal PRs from #188 through #212 keep the branch list noisy
+- That queue shape matters because `main` has already absorbed the most important typed-surface work; the unresolved risk is now review throughput and backlog cleanup more than missing core GMP primitives
+
+## CI Health
+- Mainline verification stayed strong for shipped work: the 2026-06-02 and 2026-06-03 pushes on `main` cleared `CI`, `Security`, and `OpenSSF Scorecard`
+- The cleanest negative signal is isolated to dependency maintenance rather than the core product lane: the `quick-xml` bump in PR #165 failed both `CI` and `Security` on 2026-06-02
+- In other words, the shipped GMP expansion work is validating cleanly, while maintenance branches are where the visible CI drag remains


### PR DESCRIPTION
## Summary
- add the 2026-06-07 journal entry
- capture repo activity since the previous journal baseline on main

## Notes
- generated from current main-branch activity and existing journal style

Agent: Thoth
