### PR TITLE
docs(journal): add 2026-06-08 journal entry

### DIFF
--- a/journal/2026-06-08.md
+++ b/journal/2026-06-08.md
@@ -1,0 +1,23 @@
+# 2026-06-08 — `main` Expanded GMP Coverage Again While the Queue Split Between Real Follow-Through and Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` absorbed a real multi-PR GMP/API expansion after the 2026-05-24 baseline
+- Seven substantive merges landed on `main` in this window: PR #177 added REST-support gap helpers, PR #191 fixed empty optional schedule IDs, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd error status, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- That is a coherent implementation burst rather than unrelated churn: the repo filled several remaining GMP surface gaps, tightened typed behavior around gvmd edge cases, and added follow-through client ergonomics for downstream consumers
+- The only non-product merges on `main` in the same span were PR #168 (journal PR automation), PR #182 (actions updates), and the short-lived docs lane around PRs #184 and #187, so the dominant story here is still API and protocol coverage advancing materially
+
+## Issues
+- Seven issues opened after the 2026-05-24 entry: #190, #192, #199, #201, #204, #206, and #209
+- Six of those were opened and closed in the same window by shipped work on `main`: #190, #199, #201, #204, #206, and #209 all burned down immediately once the corresponding fixes landed
+- The remaining open thread is more architectural than bug-fix oriented: #192 keeps the capability-detection/probing lane alive while the older umbrella roadmap issue #172 also remains open
+
+## Pull Request Queue
+- The queue is now split sharply between real follow-through work and accumulated journal noise
+- PR #193 (`feat(client): add gvmd capability discovery helpers`) is the one obvious substantive open branch tied directly to the still-open capability-detection lane
+- Everything else near the front of the queue is maintenance or docs churn: dependency bumps #214 and #215, the older `quick-xml` bump #165, and a long stack of unmerged daily journal PRs from #188 through #213
+
+## CI Health
+- CI signal on shipped work stayed usable across this burst: the substantive merges that landed on `main` cleared `CI` and `Security`, and the repo did not show the kind of broad branch instability that would undercut the feature pace
+- The workflow surface itself changed in this window through PR #168 (journal automation) and PR #182 (actions updates), so some of the visible activity is automation evolution rather than library behavior
+- The freshest signal is mixed but contained: new dependency PRs on 2026-06-08 split between green and red checks, while scheduled `OpenSSF Scorecard` succeeded on 2026-06-07, so the current risk is queue throughput and dependency noise rather than a broken `main`


### PR DESCRIPTION
## Summary
- add a 2026-06-08 journal entry covering post-2026-05-24 mainline GMP/client work
- capture issue churn, queue shape, and CI signal since the last merged journal baseline

## Testing
- not run (journal-only change)

Agent: Thoth