### PR TITLE
feat(gvm-gmp): add typed NVT score accessors

### DIFF
--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -258,6 +258,10 @@ pub(crate) fn parse_u32(value: &str, field: &str) -> Result<u32, ParseError> {
     })
 }
 
+pub(crate) fn parse_score(value: &str) -> Option<f64> {
+    value.parse::<f64>().ok()
+}
+
 pub(crate) fn optional_u16(
     node: &XmlNode,
     name: &str,

--- a/crates/gvm-gmp/src/responses/nvt.rs
+++ b/crates/gvm-gmp/src/responses/nvt.rs
@@ -6,7 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, status_from_response, CountInfo, ParseError,
+    count_info, optional_u32, parse_document, parse_score, status_from_response, CountInfo,
+    ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,6 +52,16 @@ pub struct GetNvtFamiliesResponse {
 }
 
 impl Nvt {
+    /// Returns `cvss_base` parsed as a numeric score when present and valid.
+    pub fn cvss_base_score(&self) -> Option<f64> {
+        self.cvss_base.as_deref().and_then(parse_score)
+    }
+
+    /// Returns `severity` parsed as a numeric score when present and valid.
+    pub fn severity_score(&self) -> Option<f64> {
+        self.severity.as_deref().and_then(parse_score)
+    }
+
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             oid: node
@@ -219,6 +230,48 @@ mod tests {
         assert_eq!(nvt.severity, None);
         assert_eq!(nvt.tags, None);
         assert_eq!(nvt.solution_type, None);
+        assert_eq!(nvt.cvss_base_score(), None);
+        assert_eq!(nvt.severity_score(), None);
+    }
+
+    #[test]
+    fn parses_typed_nvt_scores() {
+        let response = Response::from(
+            r#"<get_nvts_response status="200" status_text="OK">
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100001">
+                    <name>HTTP Detection</name>
+                    <cvss_base>7.5</cvss_base>
+                    <severity>9.8</severity>
+                </nvt>
+            </get_nvts_response>"#,
+        );
+
+        let parsed = GetNvtsResponse::from_response(&response).expect("nvts parse");
+        let nvt = &parsed.items[0];
+
+        assert_eq!(nvt.cvss_base_score(), Some(7.5));
+        assert_eq!(nvt.severity_score(), Some(9.8));
+    }
+
+    #[test]
+    fn malformed_typed_nvt_scores_degrade_to_none() {
+        let response = Response::from(
+            r#"<get_nvts_response status="200" status_text="OK">
+                <nvt oid="1.3.6.1.4.1.25623.1.0.100001">
+                    <name>HTTP Detection</name>
+                    <cvss_base>unknown</cvss_base>
+                    <severity>n/a</severity>
+                </nvt>
+            </get_nvts_response>"#,
+        );
+
+        let parsed = GetNvtsResponse::from_response(&response).expect("nvts parse");
+        let nvt = &parsed.items[0];
+
+        assert_eq!(nvt.cvss_base.as_deref(), Some("unknown"));
+        assert_eq!(nvt.severity.as_deref(), Some("n/a"));
+        assert_eq!(nvt.cvss_base_score(), None);
+        assert_eq!(nvt.severity_score(), None);
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/result.rs
+++ b/crates/gvm-gmp/src/responses/result.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, parse_entity_meta, status_from_response, CountInfo,
-    EntityMeta, ParseError,
+    count_info, optional_u32, parse_document, parse_entity_meta, parse_score, status_from_response,
+    CountInfo, EntityMeta, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -53,6 +53,11 @@ pub struct GetResultsResponse {
 }
 
 impl ScanResult {
+    /// Returns `severity` parsed as a numeric score when present and valid.
+    pub fn severity_score(&self) -> Option<f64> {
+        self.severity.as_deref().and_then(parse_score)
+    }
+
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
@@ -85,6 +90,13 @@ impl ScanResult {
                 .transpose()?,
             description: node.optional_child_text("description"),
         })
+    }
+}
+
+impl NvtRef {
+    /// Returns `cvss_base` parsed as a numeric score when present and valid.
+    pub fn cvss_base_score(&self) -> Option<f64> {
+        self.cvss_base.as_deref().and_then(parse_score)
     }
 }
 
@@ -155,6 +167,14 @@ mod tests {
         assert_eq!(
             parsed.items[0].qod.as_ref().and_then(|qod| qod.value),
             Some(80)
+        );
+        assert_eq!(parsed.items[0].severity_score(), Some(0.0));
+        assert_eq!(
+            parsed.items[0]
+                .nvt
+                .as_ref()
+                .and_then(NvtRef::cvss_base_score),
+            Some(0.0)
         );
         assert_eq!(parsed.items[1].port, None);
     }
@@ -231,5 +251,32 @@ mod tests {
         assert_eq!(result.nvt, None);
         assert_eq!(result.qod, None);
         assert_eq!(result.description, None);
+        assert_eq!(result.severity_score(), None);
+    }
+
+    #[test]
+    fn malformed_typed_result_scores_degrade_to_none() {
+        let response = Response::from(
+            r#"<get_results_response status="200" status_text="OK">
+                <result id="res-1">
+                    <name>Malformed Scores</name>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+                        <cvss_base>unknown</cvss_base>
+                    </nvt>
+                    <severity>n/a</severity>
+                </result>
+            </get_results_response>"#,
+        );
+
+        let parsed = GetResultsResponse::from_response(&response).expect("results parse");
+        let result = &parsed.items[0];
+
+        assert_eq!(result.severity.as_deref(), Some("n/a"));
+        assert_eq!(result.severity_score(), None);
+        assert_eq!(
+            result.nvt.as_ref().and_then(|nvt| nvt.cvss_base.as_deref()),
+            Some("unknown")
+        );
+        assert_eq!(result.nvt.as_ref().and_then(NvtRef::cvss_base_score), None);
     }
 }


### PR DESCRIPTION
## Summary
- add shared numeric score parsing for GMP response models without changing the raw wire fields
- expose typed score accessors on `gvm_gmp::responses::Nvt`, `gvm_gmp::responses::result::NvtRef`, and `gvm_gmp::responses::ScanResult`
- cover present, missing, and malformed score values in upstream response tests

## Verification
- cargo test -p gvm-gmp
- cargo test --workspace

Fixes #219.

Agent: Thoth