### PR TITLE
docs(journal): add 2026-06-09 journal entry

### DIFF
--- a/journal/2026-06-09.md
+++ b/journal/2026-06-09.md
@@ -1,0 +1,24 @@
+# 2026-06-09 — Mainline Resumed GMP Surface Expansion, but the Queue Now Carries Two Fresh Contract Gaps and Some CI Drift
+
+## Mainline & Merged Work
+
+### `main` moved in two distinct phases after the 2026-05-24 baseline
+- The window opened with repository-maintenance churn on 2026-05-25: journal consolidation PR #186 landed, journal automation arrived in #168, the actions stack was bumped in #182, and an MCP-surface docs experiment landed in #184 before being reverted the same day by #187
+- Real library work resumed immediately after that pause. `main` then absorbed PR #191 (empty optional schedule IDs), PR #177 (GMP REST support gap helpers), PR #200 (typed report export support), PR #202 (typed enum compatibility with gvmd/python-gvm 22.7), PR #205 (self-closing report-export error preservation), PR #207 (typed `resume_task` responses), PR #210 (note and override result flags), and PR #218 (paginated filter builder support)
+- That sequence matters because the repo did not just keep nibbling at loose ends; it reopened the GMP parity lane and pushed through a coherent set of typed request/response, export, filtering, and helper improvements on `main`
+
+## Issues
+- Nine issues opened in this window: #190, #192, #199, #201, #204, #206, #209, #217, and #219
+- Seven of those already closed through merged work on `main`: #190, #199, #201, #204, #206, #209, and #217
+- Older gap-tracker work also burned down while the new slice landed: issues #173, #174, and #175 all closed on 2026-06-01 when PR #177 merged
+- The unresolved residue is now narrow rather than sprawling: #192 (capability detection/probing primitives) and #219 (typed NVT score helpers/modeling) are the clearest remaining product follow-ons from this burst
+
+## Pull Request Queue
+- The active implementation queue is concentrated in two substantive branches: PR #220 adds typed NVT score accessors, and PR #221 carries host-type compatibility output fixes
+- Maintenance pressure is still present around them: dependency PRs #214 and #215 are open, and the unmerged journal backlog now spans #188, #189, #193, #194, #195, #198, #203, #208, #211, #212, #213, and #216
+- That is a better queue shape than the repo had in late May because the product work is now explicit and reviewable, even if the documentation backlog is still clogging the front of the branch list
+
+## CI Health
+- `main` itself looks healthy in the latest window: the 2026-06-08 push cleared `CI`, `Security`, and `OpenSSF Scorecard`, and scheduled `Security` on `main` also succeeded the same day
+- The newest product branch signal is mixed rather than universally green. PR #220 passed both `CI` and `Security`, but PR #221 failed `CI` while still passing `Security`
+- Maintenance branches are also not perfectly clean: the latest actions bump PR (#215) failed `CI`, and the current cargo bump PR (#214) failed `Security` even though its `CI` run passed


### PR DESCRIPTION
## Summary
- add the 2026-06-09 journal entry covering post-2026-05-24 GMP/library activity
- capture the recent merged-work burst, issue burn-down, open queue, and CI signal

Agent: Thoth