### PR TITLE
Parse typed report, result, and port-list metadata

### DIFF
--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -331,6 +331,26 @@ pub(crate) fn parse_named_entity(
         .map(Option::flatten)
 }
 
+pub(crate) fn parse_entity_ref(
+    node: &XmlNode,
+    field: &str,
+) -> Result<Option<NamedEntity>, ParseError> {
+    node.child(field)
+        .map(|child| {
+            let Some(raw_id) = child.attr("id") else {
+                return Err(ParseError::MissingElement(format!("{field}.id")));
+            };
+            if raw_id.is_empty() {
+                return Ok(None);
+            }
+            let id = parse_entity_id(raw_id, &format!("{field}.id"))?;
+            let name = child.optional_child_text("name").unwrap_or_default();
+            Ok(Some(NamedEntity { id, name }))
+        })
+        .transpose()
+        .map(Option::flatten)
+}
+
 pub(crate) fn parse_entity_meta(node: &XmlNode) -> Result<EntityMeta, ParseError> {
     Ok(EntityMeta {
         id: parse_entity_id(

--- a/crates/gvm-gmp/src/responses/port_list.rs
+++ b/crates/gvm-gmp/src/responses/port_list.rs
@@ -42,13 +42,43 @@ pub struct CreatePortListResponse {
 
 impl PortList {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let port_count_node = node.child("port_count");
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            port_count: optional_u32(node, "port_count", "port_count")?,
-            tcp_count: optional_u32(node, "tcp_count", "tcp_count")?,
-            udp_count: optional_u32(node, "udp_count", "udp_count")?,
+            port_count: port_count_node
+                .map(parse_total_port_count)
+                .transpose()?
+                .flatten(),
+            tcp_count: port_count_node
+                .map(|count| optional_u32(count, "tcp", "port_count.tcp"))
+                .transpose()?
+                .flatten(),
+            udp_count: port_count_node
+                .map(|count| optional_u32(count, "udp", "port_count.udp"))
+                .transpose()?
+                .flatten(),
             port_range: node.optional_child_text("port_range"),
         })
+    }
+}
+
+fn parse_total_port_count(
+    node: &crate::responses::common::XmlNode,
+) -> Result<Option<u32>, ParseError> {
+    if let Some(total) = optional_u32(node, "all", "port_count.all")? {
+        return Ok(Some(total));
+    }
+
+    if node.text.is_empty() {
+        Ok(None)
+    } else {
+        node.text
+            .parse::<u32>()
+            .map(Some)
+            .map_err(|_| ParseError::InvalidValue {
+                field: "port_count".to_string(),
+                value: node.text.clone(),
+            })
     }
 }
 
@@ -107,9 +137,11 @@ mod tests {
                     <modification_time>2026-01-02T00:00:00Z</modification_time>
                     <writable>1</writable>
                     <in_use>0</in_use>
-                    <port_count>65535</port_count>
-                    <tcp_count>65535</tcp_count>
-                    <udp_count>0</udp_count>
+                    <port_count>
+                        <all>65535</all>
+                        <tcp>65535</tcp>
+                        <udp>0</udp>
+                    </port_count>
                     <port_range>T:1-65535</port_range>
                 </port_list>
                 <port_list id="pl-2">
@@ -127,6 +159,25 @@ mod tests {
         assert_eq!(parsed.items[0].tcp_count, Some(65535));
         assert_eq!(parsed.items[0].udp_count, Some(0));
         assert_eq!(parsed.items[0].port_range.as_deref(), Some("T:1-65535"));
+    }
+
+    #[test]
+    fn parses_flat_total_port_count_without_protocol_breakdown() {
+        let response = Response::from(
+            r#"<get_port_lists_response status="200" status_text="OK">
+                <port_list id="pl-1">
+                    <name>Legacy Port Count</name>
+                    <port_count>3</port_count>
+                </port_list>
+            </get_port_lists_response>"#,
+        );
+
+        let parsed = GetPortListsResponse::from_response(&response).expect("port lists parse");
+        let port_list = &parsed.items[0];
+
+        assert_eq!(port_list.port_count, Some(3));
+        assert_eq!(port_list.tcp_count, None);
+        assert_eq!(port_list.udp_count, None);
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/port_list.rs
+++ b/crates/gvm-gmp/src/responses/port_list.rs
@@ -16,6 +16,8 @@ use crate::responses::common::{
 pub struct PortList {
     pub meta: EntityMeta,
     pub port_count: Option<u32>,
+    pub tcp_count: Option<u32>,
+    pub udp_count: Option<u32>,
     pub port_range: Option<String>,
 }
 
@@ -43,6 +45,8 @@ impl PortList {
         Ok(Self {
             meta: parse_entity_meta(node)?,
             port_count: optional_u32(node, "port_count", "port_count")?,
+            tcp_count: optional_u32(node, "tcp_count", "tcp_count")?,
+            udp_count: optional_u32(node, "udp_count", "udp_count")?,
             port_range: node.optional_child_text("port_range"),
         })
     }
@@ -104,6 +108,8 @@ mod tests {
                     <writable>1</writable>
                     <in_use>0</in_use>
                     <port_count>65535</port_count>
+                    <tcp_count>65535</tcp_count>
+                    <udp_count>0</udp_count>
                     <port_range>T:1-65535</port_range>
                 </port_list>
                 <port_list id="pl-2">
@@ -118,6 +124,8 @@ mod tests {
         assert_eq!(parsed.items.len(), 2);
         assert_eq!(parsed.counts.page, Some(1));
         assert_eq!(parsed.items[0].port_count, Some(65535));
+        assert_eq!(parsed.items[0].tcp_count, Some(65535));
+        assert_eq!(parsed.items[0].udp_count, Some(0));
         assert_eq!(parsed.items[0].port_range.as_deref(), Some("T:1-65535"));
     }
 
@@ -175,6 +183,8 @@ mod tests {
 
         assert_eq!(port_list.meta.comment, None);
         assert_eq!(port_list.port_count, None);
+        assert_eq!(port_list.tcp_count, None);
+        assert_eq!(port_list.udp_count, None);
         assert_eq!(port_list.port_range, None);
     }
 }

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -32,6 +32,19 @@ pub struct Report {
 pub struct ResultCount {
     pub full: Option<u32>,
     pub filtered: Option<u32>,
+    pub high: Option<SeverityCount>,
+    pub medium: Option<SeverityCount>,
+    pub low: Option<SeverityCount>,
+    pub log: Option<SeverityCount>,
+    pub false_positive: Option<SeverityCount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SeverityCount {
+    pub full: Option<u32>,
+    pub filtered: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -175,6 +188,11 @@ impl Report {
                             })
                             .transpose()?,
                         filtered: optional_u32(count, "filtered", "result_count.filtered")?,
+                        high: parse_severity_count(count, &["high", "hole"])?,
+                        medium: parse_severity_count(count, &["medium", "warning"])?,
+                        low: parse_severity_count(count, &["low", "info"])?,
+                        log: parse_severity_count(count, &["log"])?,
+                        false_positive: parse_severity_count(count, &["false_positive"])?,
                     })
                 })
                 .transpose()?,
@@ -191,6 +209,28 @@ impl Report {
                 .flatten(),
         })
     }
+}
+
+fn parse_severity_count(
+    node: &crate::responses::common::XmlNode,
+    field_names: &[&str],
+) -> Result<Option<SeverityCount>, ParseError> {
+    let Some(bucket) = field_names.iter().find_map(|name| node.child(name)) else {
+        return Ok(None);
+    };
+
+    Ok(Some(SeverityCount {
+        full: bucket
+            .optional_child_text("full")
+            .map(|value| {
+                value.parse::<u32>().map_err(|_| ParseError::InvalidValue {
+                    field: format!("{}.full", field_names[0]),
+                    value,
+                })
+            })
+            .transpose()?,
+        filtered: optional_u32(bucket, "filtered", &format!("{}.filtered", field_names[0]))?,
+    }))
 }
 
 impl GetReportsResponse {
@@ -574,6 +614,48 @@ mod tests {
             Some("9.8")
         );
         assert_eq!(report.host_count, Some(2));
+    }
+
+    #[test]
+    fn parses_report_result_count_severity_buckets() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK">
+                <report id="rpt-1">
+                    <name>Bucketed Report</name>
+                    <report id="rpt-1">
+                        <result_count>
+                            <full>11</full>
+                            <filtered>8</filtered>
+                            <hole><full>2</full><filtered>1</filtered></hole>
+                            <warning><full>3</full><filtered>2</filtered></warning>
+                            <info><full>4</full><filtered>3</filtered></info>
+                            <log><full>1</full><filtered>1</filtered></log>
+                            <false_positive><full>1</full><filtered>1</filtered></false_positive>
+                        </result_count>
+                    </report>
+                </report>
+            </get_reports_response>"#,
+        );
+
+        let parsed = GetReportsResponse::from_response(&response).expect("reports parse");
+        let count = parsed.items[0].result_count.as_ref().expect("result count");
+
+        assert_eq!(count.full, Some(11));
+        assert_eq!(count.filtered, Some(8));
+        assert_eq!(count.high.as_ref().and_then(|bucket| bucket.full), Some(2));
+        assert_eq!(
+            count.medium.as_ref().and_then(|bucket| bucket.filtered),
+            Some(2)
+        );
+        assert_eq!(count.low.as_ref().and_then(|bucket| bucket.full), Some(4));
+        assert_eq!(count.log.as_ref().and_then(|bucket| bucket.full), Some(1));
+        assert_eq!(
+            count
+                .false_positive
+                .as_ref()
+                .and_then(|bucket| bucket.filtered),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -36,6 +36,7 @@ pub struct ResultCount {
     pub medium: Option<SeverityCount>,
     pub low: Option<SeverityCount>,
     pub log: Option<SeverityCount>,
+    pub debug: Option<SeverityCount>,
     pub false_positive: Option<SeverityCount>,
 }
 
@@ -192,6 +193,7 @@ impl Report {
                         medium: parse_severity_count(count, &["medium", "warning"])?,
                         low: parse_severity_count(count, &["low", "info"])?,
                         log: parse_severity_count(count, &["log"])?,
+                        debug: parse_severity_count(count, &["debug"])?,
                         false_positive: parse_severity_count(count, &["false_positive"])?,
                     })
                 })
@@ -630,6 +632,7 @@ mod tests {
                             <warning><full>3</full><filtered>2</filtered></warning>
                             <info><full>4</full><filtered>3</filtered></info>
                             <log><full>1</full><filtered>1</filtered></log>
+                            <debug><full>5</full><filtered>4</filtered></debug>
                             <false_positive><full>1</full><filtered>1</filtered></false_positive>
                         </result_count>
                     </report>
@@ -649,6 +652,10 @@ mod tests {
         );
         assert_eq!(count.low.as_ref().and_then(|bucket| bucket.full), Some(4));
         assert_eq!(count.log.as_ref().and_then(|bucket| bucket.full), Some(1));
+        assert_eq!(
+            count.debug.as_ref().and_then(|bucket| bucket.filtered),
+            Some(4)
+        );
         assert_eq!(
             count
                 .false_positive

--- a/crates/gvm-gmp/src/responses/result.rs
+++ b/crates/gvm-gmp/src/responses/result.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, parse_entity_meta, parse_score, status_from_response,
-    CountInfo, EntityMeta, ParseError,
+    count_info, optional_u32, parse_document, parse_entity_meta, parse_named_entity, parse_score,
+    status_from_response, CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,6 +17,8 @@ pub struct ScanResult {
     pub meta: EntityMeta,
     pub host: Option<String>,
     pub port: Option<String>,
+    pub task: Option<NamedEntity>,
+    pub report: Option<NamedEntity>,
     pub nvt: Option<NvtRef>,
     pub threat: Option<String>,
     pub severity: Option<String>,
@@ -32,6 +34,8 @@ pub struct NvtRef {
     pub name: Option<String>,
     pub family: Option<String>,
     pub cvss_base: Option<String>,
+    pub cves: Vec<String>,
+    pub tags: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,6 +67,8 @@ impl ScanResult {
             meta: parse_entity_meta(node)?,
             host: node.optional_child_text("host"),
             port: node.optional_child_text("port"),
+            task: parse_named_entity(node, "task")?,
+            report: parse_named_entity(node, "report")?,
             nvt: node
                 .child("nvt")
                 .map(|nvt| -> Result<NvtRef, ParseError> {
@@ -74,6 +80,8 @@ impl ScanResult {
                         name: nvt.optional_child_text("name"),
                         family: nvt.optional_child_text("family"),
                         cvss_base: nvt.optional_child_text("cvss_base"),
+                        cves: parse_nvt_cves(nvt),
+                        tags: nvt.optional_child_text("tags"),
                     })
                 })
                 .transpose()?,
@@ -98,6 +106,29 @@ impl NvtRef {
     pub fn cvss_base_score(&self) -> Option<f64> {
         self.cvss_base.as_deref().and_then(parse_score)
     }
+}
+
+fn parse_nvt_cves(node: &crate::responses::common::XmlNode) -> Vec<String> {
+    let mut cves = node
+        .children_named("cve")
+        .map(|cve| cve.text.clone())
+        .filter(|cve| !cve.is_empty())
+        .collect::<Vec<_>>();
+
+    if let Some(refs) = node.child("refs") {
+        cves.extend(
+            refs.children_named("ref")
+                .filter(|reference| reference.attr("type") == Some("cve"))
+                .filter_map(|reference| {
+                    reference
+                        .attr("id")
+                        .map(ToString::to_string)
+                        .or_else(|| (!reference.text.is_empty()).then(|| reference.text.clone()))
+                }),
+        );
+    }
+
+    cves
 }
 
 impl GetResultsResponse {
@@ -136,10 +167,15 @@ mod tests {
                     <in_use>0</in_use>
                     <host>192.168.1.1</host>
                     <port>80/tcp</port>
+                    <task id="task-1"><name>Discovery Scan</name></task>
+                    <report id="report-1"><name>Daily Report</name></report>
                     <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
                         <name>HTTP Server Detection</name>
                         <family>Service detection</family>
                         <cvss_base>0.0</cvss_base>
+                        <cve>CVE-2026-0001</cve>
+                        <refs><ref type="cve" id="CVE-2026-0002"/></refs>
+                        <tags>summary=Detects HTTP server</tags>
                     </nvt>
                     <threat>Log</threat>
                     <severity>0.0</severity>
@@ -161,8 +197,34 @@ mod tests {
         assert_eq!(parsed.counts.page, Some(1));
         assert_eq!(parsed.items[0].host.as_deref(), Some("192.168.1.1"));
         assert_eq!(
+            parsed.items[0].task.as_ref().map(|task| task.name.as_str()),
+            Some("Discovery Scan")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .report
+                .as_ref()
+                .map(|report| report.name.as_str()),
+            Some("Daily Report")
+        );
+        assert_eq!(
             parsed.items[0].nvt.as_ref().map(|nvt| nvt.oid.as_str()),
             Some("1.3.6.1.4.1.25623.1.0.100315")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .nvt
+                .as_ref()
+                .map(|nvt| nvt.cves.clone())
+                .unwrap_or_default(),
+            vec!["CVE-2026-0001".to_string(), "CVE-2026-0002".to_string()]
+        );
+        assert_eq!(
+            parsed.items[0]
+                .nvt
+                .as_ref()
+                .and_then(|nvt| nvt.tags.as_deref()),
+            Some("summary=Detects HTTP server")
         );
         assert_eq!(
             parsed.items[0].qod.as_ref().and_then(|qod| qod.value),
@@ -248,6 +310,8 @@ mod tests {
 
         assert_eq!(result.meta.comment, None);
         assert_eq!(result.host, None);
+        assert_eq!(result.task, None);
+        assert_eq!(result.report, None);
         assert_eq!(result.nvt, None);
         assert_eq!(result.qod, None);
         assert_eq!(result.description, None);

--- a/crates/gvm-gmp/src/responses/result.rs
+++ b/crates/gvm-gmp/src/responses/result.rs
@@ -6,7 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, parse_entity_meta, parse_named_entity, parse_score,
+    count_info, optional_u32, parse_document, parse_entity_meta, parse_entity_ref, parse_score,
     status_from_response, CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
@@ -67,8 +67,8 @@ impl ScanResult {
             meta: parse_entity_meta(node)?,
             host: node.optional_child_text("host"),
             port: node.optional_child_text("port"),
-            task: parse_named_entity(node, "task")?,
-            report: parse_named_entity(node, "report")?,
+            task: parse_entity_ref(node, "task")?,
+            report: parse_entity_ref(node, "report")?,
             nvt: node
                 .child("nvt")
                 .map(|nvt| -> Result<NvtRef, ParseError> {


### PR DESCRIPTION
## Summary
- parse normalized report severity buckets from typed report result counts
- expose result task/report refs plus NVT CVEs and tags in typed result responses
- expose explicit TCP/UDP counts in typed port-list responses

This gives `rust-gvm-api` the typed response data it needs for `#229` without local GMP XML parsing or protocol-count heuristics.

Closes #231.

## Testing
- `cargo test -p gvm-gmp`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`

Agent: Thoth
