### PR TITLE
feat(gmp): expose user auth and scan config type

### DIFF
--- a/crates/gvm-gmp/src/responses/scan_config.rs
+++ b/crates/gvm-gmp/src/responses/scan_config.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
-    ActionResponse, CountInfo, EntityMeta, ParseError,
+    count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,6 +16,7 @@ use crate::responses::common::{
 pub struct ScanConfig {
     pub meta: EntityMeta,
     pub usage_type: Option<String>,
+    pub type_: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +43,7 @@ impl ScanConfig {
         Ok(Self {
             meta: parse_entity_meta(node)?,
             usage_type: node.optional_child_text("usage_type"),
+            type_: optional_u32(node, "type", "type")?,
         })
     }
 }
@@ -103,10 +105,12 @@ mod tests {
                     <writable>1</writable>
                     <in_use>0</in_use>
                     <usage_type>scan</usage_type>
+                    <type>0</type>
                 </config>
                 <config id="cfg-2">
                     <name>Policy</name>
                     <usage_type>policy</usage_type>
+                    <type>7</type>
                 </config>
                 <config_count>2<filtered>2</filtered><page>1</page></config_count>
             </get_configs_response>"#,
@@ -118,6 +122,8 @@ mod tests {
         assert_eq!(parsed.counts.total, Some(2));
         assert_eq!(parsed.items[0].usage_type.as_deref(), Some("scan"));
         assert_eq!(parsed.items[1].usage_type.as_deref(), Some("policy"));
+        assert_eq!(parsed.items[0].type_, Some(0));
+        assert_eq!(parsed.items[1].type_, Some(7));
     }
 
     #[test]
@@ -174,6 +180,24 @@ mod tests {
 
         assert_eq!(config.meta.comment, None);
         assert_eq!(config.usage_type, None);
+        assert_eq!(config.type_, None);
         assert!(!config.meta.in_use);
+    }
+
+    #[test]
+    fn parses_known_and_unknown_scan_config_types() {
+        let response = Response::from(
+            r#"<get_configs_response status="200" status_text="OK">
+                <config id="cfg-1"><name>OpenVAS</name><type>0</type></config>
+                <config id="cfg-2"><name>OSP</name><type>1</type></config>
+                <config id="cfg-3"><name>Future</name><type>42</type></config>
+            </get_configs_response>"#,
+        );
+
+        let parsed = GetScanConfigsResponse::from_response(&response).expect("configs parse");
+
+        assert_eq!(parsed.items[0].type_, Some(0));
+        assert_eq!(parsed.items[1].type_, Some(1));
+        assert_eq!(parsed.items[2].type_, Some(42));
     }
 }

--- a/crates/gvm-gmp/src/responses/user.rs
+++ b/crates/gvm-gmp/src/responses/user.rs
@@ -82,7 +82,10 @@ impl User {
             groups,
             hosts_allow: node.optional_child_text("hosts_allow"),
             hosts: node.optional_child_text("hosts"),
-            authentication_type: node.optional_child_text("authentication"),
+            authentication_type: node
+                .child("sources")
+                .and_then(|sources| sources.optional_child_text("source"))
+                .or_else(|| node.optional_child_text("authentication")),
         })
     }
 }
@@ -149,13 +152,13 @@ mod tests {
                     </groups>
                     <hosts_allow>0</hosts_allow>
                     <hosts>192.168.1.0/24</hosts>
-                    <authentication>file</authentication>
+                    <sources><source>file</source></sources>
                 </user>
                 <user id="u-2">
                     <name>User Two</name>
                     <writable>0</writable>
                     <in_use>1</in_use>
-                    <authentication>future_auth_backend</authentication>
+                    <sources><source>future_auth_backend</source></sources>
                 </user>
                 <user_count>2<filtered>2</filtered><page>1</page></user_count>
             </get_users_response>"#,
@@ -246,9 +249,9 @@ mod tests {
     fn parses_known_user_authentication_types() {
         let response = Response::from(
             r#"<get_users_response status="200" status_text="OK">
-                <user id="u-1"><name>Alice</name><authentication>file</authentication></user>
-                <user id="u-2"><name>Bob</name><authentication>ldap_connect</authentication></user>
-                <user id="u-3"><name>Carol</name><authentication>radius_connect</authentication></user>
+                <user id="u-1"><name>Alice</name><sources><source>file</source></sources></user>
+                <user id="u-2"><name>Bob</name><sources><source>ldap_connect</source></sources></user>
+                <user id="u-3"><name>Carol</name><sources><source>radius_connect</source></sources></user>
             </get_users_response>"#,
         );
 
@@ -263,5 +266,18 @@ mod tests {
             parsed.items[2].authentication_type.as_deref(),
             Some("radius_connect")
         );
+    }
+
+    #[test]
+    fn falls_back_to_top_level_authentication_when_sources_are_absent() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1"><name>Alice</name><authentication>file</authentication></user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+
+        assert_eq!(parsed.items[0].authentication_type.as_deref(), Some("file"));
     }
 }

--- a/crates/gvm-gmp/src/responses/user.rs
+++ b/crates/gvm-gmp/src/responses/user.rs
@@ -19,6 +19,7 @@ pub struct User {
     pub groups: Vec<NamedEntity>,
     pub hosts_allow: Option<String>,
     pub hosts: Option<String>,
+    pub authentication_type: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,6 +82,7 @@ impl User {
             groups,
             hosts_allow: node.optional_child_text("hosts_allow"),
             hosts: node.optional_child_text("hosts"),
+            authentication_type: node.optional_child_text("authentication"),
         })
     }
 }
@@ -147,11 +149,13 @@ mod tests {
                     </groups>
                     <hosts_allow>0</hosts_allow>
                     <hosts>192.168.1.0/24</hosts>
+                    <authentication>file</authentication>
                 </user>
                 <user id="u-2">
                     <name>User Two</name>
                     <writable>0</writable>
                     <in_use>1</in_use>
+                    <authentication>future_auth_backend</authentication>
                 </user>
                 <user_count>2<filtered>2</filtered><page>1</page></user_count>
             </get_users_response>"#,
@@ -170,6 +174,11 @@ mod tests {
         assert_eq!(parsed.items[0].groups[0].name, "Group One");
         assert_eq!(parsed.items[0].hosts_allow.as_deref(), Some("0"));
         assert_eq!(parsed.items[0].hosts.as_deref(), Some("192.168.1.0/24"));
+        assert_eq!(parsed.items[0].authentication_type.as_deref(), Some("file"));
+        assert_eq!(
+            parsed.items[1].authentication_type.as_deref(),
+            Some("future_auth_backend")
+        );
         assert!(parsed.items[1].meta.in_use);
     }
 
@@ -230,5 +239,29 @@ mod tests {
         assert!(user.groups.is_empty());
         assert_eq!(user.hosts_allow, None);
         assert_eq!(user.hosts, None);
+        assert_eq!(user.authentication_type, None);
+    }
+
+    #[test]
+    fn parses_known_user_authentication_types() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1"><name>Alice</name><authentication>file</authentication></user>
+                <user id="u-2"><name>Bob</name><authentication>ldap_connect</authentication></user>
+                <user id="u-3"><name>Carol</name><authentication>radius_connect</authentication></user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+
+        assert_eq!(parsed.items[0].authentication_type.as_deref(), Some("file"));
+        assert_eq!(
+            parsed.items[1].authentication_type.as_deref(),
+            Some("ldap_connect")
+        );
+        assert_eq!(
+            parsed.items[2].authentication_type.as_deref(),
+            Some("radius_connect")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- expose `User.authentication_type` from `<authentication>` in `get_users` responses while preserving unknown future backend values verbatim
- expose `ScanConfig.type_` from `<type>` in `get_configs` responses as `Option<u32>`, keeping it distinct from `usage_type`
- add parser coverage for known values and unknown future values on both response paths

Closes #234

## Verification
- `cargo test -p gvm-gmp responses::user -- --nocapture`
- `cargo test -p gvm-gmp responses::scan_config -- --nocapture`
- `cargo test -p gvm-gmp`

Agent: Thoth
