### PR TITLE
fix: parse unnamed notes and overrides (fixes #238)

### DIFF
--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -351,14 +351,24 @@ pub(crate) fn parse_entity_ref(
         .map(Option::flatten)
 }
 
-pub(crate) fn parse_entity_meta(node: &XmlNode) -> Result<EntityMeta, ParseError> {
+fn parse_entity_meta_with_name(
+    node: &XmlNode,
+    name_required: bool,
+) -> Result<EntityMeta, ParseError> {
+    let id = parse_entity_id(
+        node.attr("id")
+            .ok_or_else(|| ParseError::MissingElement(format!("{}.id", node.name)))?,
+        &format!("{}.id", node.name),
+    )?;
+    let name = if name_required {
+        node.required_child_text("name")?
+    } else {
+        node.optional_child_text("name").unwrap_or_default()
+    };
+
     Ok(EntityMeta {
-        id: parse_entity_id(
-            node.attr("id")
-                .ok_or_else(|| ParseError::MissingElement(format!("{}.id", node.name)))?,
-            &format!("{}.id", node.name),
-        )?,
-        name: node.required_child_text("name")?,
+        id,
+        name,
         comment: node.optional_child_text("comment"),
         creation_time: node.optional_child_text("creation_time"),
         modification_time: node.optional_child_text("modification_time"),
@@ -374,6 +384,14 @@ pub(crate) fn parse_entity_meta(node: &XmlNode) -> Result<EntityMeta, ParseError
             .transpose()?
             .unwrap_or(false),
     })
+}
+
+pub(crate) fn parse_entity_meta(node: &XmlNode) -> Result<EntityMeta, ParseError> {
+    parse_entity_meta_with_name(node, true)
+}
+
+pub(crate) fn parse_entity_meta_optional_name(node: &XmlNode) -> Result<EntityMeta, ParseError> {
+    parse_entity_meta_with_name(node, false)
 }
 
 #[cfg(test)]

--- a/crates/gvm-gmp/src/responses/note.rs
+++ b/crates/gvm-gmp/src/responses/note.rs
@@ -6,9 +6,9 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
-    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
-    ParseError,
+    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
+    parse_entity_meta_optional_name, parse_named_entity, status_from_response, ActionResponse,
+    CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,7 +49,7 @@ pub struct CreateNoteResponse {
 impl Note {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
-            meta: parse_entity_meta(node)?,
+            meta: parse_entity_meta_optional_name(node)?,
             text: node.optional_child_text("text"),
             nvt_oid: node
                 .child("nvt")
@@ -230,5 +230,63 @@ mod tests {
         assert!(note.hosts.is_empty());
         assert_eq!(note.task, None);
         assert!(!note.active);
+    }
+
+    #[test]
+    fn parses_gvmd_note_without_top_level_name() {
+        let response = Response::from(
+            r#"<get_notes_response status="200" status_text="OK">
+                <note id="139bd467-d6dc-46a6-9297-0f2bbaec342a">
+                    <permissions><permission><name>Everything</name></permission></permissions>
+                    <owner><name>admin</name></owner>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.12288"><name>Global variable settings</name><type>nvt</type></nvt>
+                    <creation_time>2026-06-10T12:41:51Z</creation_time>
+                    <modification_time>2026-06-10T12:41:51Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <active>1</active>
+                    <end_time>2026-06-11T12:41:51Z</end_time>
+                    <text>raw gmp parser repro</text>
+                    <hosts></hosts>
+                    <port></port>
+                    <severity></severity>
+                    <task id=""><name></name><trash>0</trash></task>
+                    <orphan>0</orphan>
+                    <result id=""/>
+                </note>
+            </get_notes_response>"#,
+        );
+
+        let parsed = GetNotesResponse::from_response(&response).expect("note parses");
+        let note = &parsed.items[0];
+
+        assert_eq!(
+            note.meta.id.as_str(),
+            "139bd467-d6dc-46a6-9297-0f2bbaec342a"
+        );
+        assert_eq!(note.meta.name, "");
+        assert_eq!(
+            note.meta.owner.as_ref().map(|owner| owner.name.as_str()),
+            Some("admin")
+        );
+        assert_eq!(
+            note.meta.creation_time.as_deref(),
+            Some("2026-06-10T12:41:51Z")
+        );
+        assert_eq!(
+            note.meta.modification_time.as_deref(),
+            Some("2026-06-10T12:41:51Z")
+        );
+        assert!(note.meta.writable);
+        assert!(!note.meta.in_use);
+        assert!(note.active);
+        assert_eq!(note.end_time.as_deref(), Some("2026-06-11T12:41:51Z"));
+        assert_eq!(note.text.as_deref(), Some("raw gmp parser repro"));
+        assert_eq!(note.nvt_oid.as_deref(), Some("1.3.6.1.4.1.25623.1.0.12288"));
+        assert!(note.hosts.is_empty());
+        assert_eq!(note.port, None);
+        assert_eq!(note.severity, None);
+        assert_eq!(note.task, None);
+        assert_eq!(note.result, None);
     }
 }

--- a/crates/gvm-gmp/src/responses/override_.rs
+++ b/crates/gvm-gmp/src/responses/override_.rs
@@ -6,9 +6,9 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
-    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
-    ParseError,
+    count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
+    parse_entity_meta_optional_name, parse_named_entity, status_from_response, ActionResponse,
+    CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,7 +50,7 @@ pub struct CreateOverrideResponse {
 impl Override {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
-            meta: parse_entity_meta(node)?,
+            meta: parse_entity_meta_optional_name(node)?,
             text: node.optional_child_text("text"),
             nvt_oid: node
                 .child("nvt")
@@ -234,5 +234,64 @@ mod tests {
         assert_eq!(ov.new_severity, None);
         assert_eq!(ov.task, None);
         assert!(!ov.active);
+    }
+
+    #[test]
+    fn parses_gvmd_override_without_top_level_name() {
+        let response = Response::from(
+            r#"<get_overrides_response status="200" status_text="OK">
+                <override id="6a9710b1-7ac3-4140-a212-25a0aa504979">
+                    <permissions><permission><name>Everything</name></permission></permissions>
+                    <owner><name>admin</name></owner>
+                    <nvt oid="1.3.6.1.4.1.25623.1.0.12288"><name>Global variable settings</name><type>nvt</type></nvt>
+                    <creation_time>2026-06-10T12:42:24Z</creation_time>
+                    <modification_time>2026-06-10T12:42:24Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <active>1</active>
+                    <end_time>2026-06-11T12:42:24Z</end_time>
+                    <text>raw gmp override parser repro</text>
+                    <hosts></hosts>
+                    <port></port>
+                    <threat></threat>
+                    <severity></severity>
+                    <new_threat>Log</new_threat>
+                    <new_severity>0</new_severity>
+                    <task id=""><name></name><trash>0</trash></task>
+                    <orphan>0</orphan>
+                    <result id=""/>
+                </override>
+            </get_overrides_response>"#,
+        );
+
+        let parsed = GetOverridesResponse::from_response(&response).expect("override parses");
+        let ov = &parsed.items[0];
+
+        assert_eq!(ov.meta.id.as_str(), "6a9710b1-7ac3-4140-a212-25a0aa504979");
+        assert_eq!(ov.meta.name, "");
+        assert_eq!(
+            ov.meta.owner.as_ref().map(|owner| owner.name.as_str()),
+            Some("admin")
+        );
+        assert_eq!(
+            ov.meta.creation_time.as_deref(),
+            Some("2026-06-10T12:42:24Z")
+        );
+        assert_eq!(
+            ov.meta.modification_time.as_deref(),
+            Some("2026-06-10T12:42:24Z")
+        );
+        assert!(ov.meta.writable);
+        assert!(!ov.meta.in_use);
+        assert!(ov.active);
+        assert_eq!(ov.end_time.as_deref(), Some("2026-06-11T12:42:24Z"));
+        assert_eq!(ov.text.as_deref(), Some("raw gmp override parser repro"));
+        assert_eq!(ov.nvt_oid.as_deref(), Some("1.3.6.1.4.1.25623.1.0.12288"));
+        assert!(ov.hosts.is_empty());
+        assert_eq!(ov.port, None);
+        assert_eq!(ov.severity, None);
+        assert_eq!(ov.new_severity.as_deref(), Some("0"));
+        assert_eq!(ov.task, None);
+        assert_eq!(ov.result, None);
     }
 }


### PR DESCRIPTION
Fixes #238

## Summary
- tolerate gvmd note and override resources without a top-level name
- keep strict name parsing for other resource metadata
- add gvmd-shape regression tests for notes and overrides

## Tests
- cargo test -p gvm-gmp parses_gvmd_
- cargo test -p gvm-gmp