### PR TITLE
fix(gmp): parse id-only note and override refs

### DIFF
--- a/crates/gvm-gmp/src/responses/note.rs
+++ b/crates/gvm-gmp/src/responses/note.rs
@@ -7,7 +7,7 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
-    parse_entity_meta_optional_name, parse_named_entity, status_from_response, ActionResponse,
+    parse_entity_meta_optional_name, parse_entity_ref, status_from_response, ActionResponse,
     CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
@@ -61,8 +61,8 @@ impl Note {
                 .unwrap_or_default(),
             port: node.optional_child_text("port"),
             severity: node.optional_child_text("severity"),
-            task: parse_named_entity(node, "task")?,
-            result: parse_named_entity(node, "result")?,
+            task: parse_entity_ref(node, "task")?,
+            result: parse_entity_ref(node, "result")?,
             active: node
                 .optional_child_text("active")
                 .map(|value| parse_bool(&value, "active"))
@@ -288,5 +288,29 @@ mod tests {
         assert_eq!(note.severity, None);
         assert_eq!(note.task, None);
         assert_eq!(note.result, None);
+    }
+
+    #[test]
+    fn parses_note_with_id_only_task_and_result_refs() {
+        let response = Response::from(
+            r#"<get_notes_response status="200" status_text="OK">
+                <note id="n-1">
+                    <name>Note One</name>
+                    <task id="t-1"/>
+                    <result id="r-1"/>
+                </note>
+            </get_notes_response>"#,
+        );
+
+        let parsed = GetNotesResponse::from_response(&response).expect("note parses");
+        let note = &parsed.items[0];
+
+        let task = note.task.as_ref().expect("task ref");
+        assert_eq!(task.id.as_str(), "t-1");
+        assert_eq!(task.name, "");
+
+        let result = note.result.as_ref().expect("result ref");
+        assert_eq!(result.id.as_str(), "r-1");
+        assert_eq!(result.name, "");
     }
 }

--- a/crates/gvm-gmp/src/responses/override_.rs
+++ b/crates/gvm-gmp/src/responses/override_.rs
@@ -7,7 +7,7 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
-    parse_entity_meta_optional_name, parse_named_entity, status_from_response, ActionResponse,
+    parse_entity_meta_optional_name, parse_entity_ref, status_from_response, ActionResponse,
     CountInfo, EntityMeta, NamedEntity, ParseError,
 };
 
@@ -63,8 +63,8 @@ impl Override {
             port: node.optional_child_text("port"),
             severity: node.optional_child_text("severity"),
             new_severity: node.optional_child_text("new_severity"),
-            task: parse_named_entity(node, "task")?,
-            result: parse_named_entity(node, "result")?,
+            task: parse_entity_ref(node, "task")?,
+            result: parse_entity_ref(node, "result")?,
             active: node
                 .optional_child_text("active")
                 .map(|value| parse_bool(&value, "active"))
@@ -293,5 +293,29 @@ mod tests {
         assert_eq!(ov.new_severity.as_deref(), Some("0"));
         assert_eq!(ov.task, None);
         assert_eq!(ov.result, None);
+    }
+
+    #[test]
+    fn parses_override_with_id_only_task_and_result_refs() {
+        let response = Response::from(
+            r#"<get_overrides_response status="200" status_text="OK">
+                <override id="o-1">
+                    <name>Override One</name>
+                    <task id="t-1"/>
+                    <result id="r-1"/>
+                </override>
+            </get_overrides_response>"#,
+        );
+
+        let parsed = GetOverridesResponse::from_response(&response).expect("override parses");
+        let ov = &parsed.items[0];
+
+        let task = ov.task.as_ref().expect("task ref");
+        assert_eq!(task.id.as_str(), "t-1");
+        assert_eq!(task.name, "");
+
+        let result = ov.result.as_ref().expect("result ref");
+        assert_eq!(result.id.as_str(), "r-1");
+        assert_eq!(result.name, "");
     }
 }


### PR DESCRIPTION
## Summary
- Allow note and override task/result refs to parse when gvmd returns id-only XML elements
- Preserve the referenced IDs while using an empty name when gvmd omits nested <name>
- Add regression tests for id-only task and result refs

## Tests
- cargo test -p gvm-gmp
- cargo clippy -p gvm-gmp --all-targets -- -D warnings

Fixes #237