### PR TITLE
feat(gmp): add typed alert data and target reverse lookup support

### DIFF
--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -3,9 +3,13 @@
 
 //! Alert command builders.
 
+use std::collections::HashMap;
+
 use gvm_protocol::{Request, XmlCommand};
 
-use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::common::{
+    add_filter_attrs, add_named_data_map, add_text_element, bool_str, set_optional_bool_attr,
+};
 use crate::enums::{AlertCondition, AlertEvent, AlertMethod};
 use crate::types::EntityId;
 
@@ -20,6 +24,12 @@ pub struct AlertOpts {
     pub condition: Option<AlertCondition>,
     /// Optional alert delivery method.
     pub method: Option<AlertMethod>,
+    /// Optional alert event metadata map.
+    pub event_data: HashMap<String, String>,
+    /// Optional alert condition metadata map.
+    pub condition_data: HashMap<String, String>,
+    /// Optional alert method metadata map.
+    pub method_data: HashMap<String, String>,
     /// Optional saved filter identifier.
     pub filter_id: Option<EntityId>,
 }
@@ -99,13 +109,19 @@ pub fn test_alert(alert_id: &EntityId) -> impl Request {
 fn add_alert_body(cmd: &mut XmlCommand, opts: &AlertOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     if let Some(event) = opts.event {
-        cmd.add_element_with_text("event", event.as_alert_name());
+        let event_node = cmd.add_element("event");
+        event_node.set_text(event.as_alert_name());
+        add_named_data_map(event_node, &opts.event_data);
     }
     if let Some(condition) = opts.condition {
-        cmd.add_element_with_text("condition", condition.as_alert_name());
+        let condition_node = cmd.add_element("condition");
+        condition_node.set_text(condition.as_alert_name());
+        add_named_data_map(condition_node, &opts.condition_data);
     }
     if let Some(method) = opts.method {
-        cmd.add_element_with_text("method", method.as_alert_name());
+        let method_node = cmd.add_element("method");
+        method_node.set_text(method.as_alert_name());
+        add_named_data_map(method_node, &opts.method_data);
     }
     if let Some(filter_id) = opts.filter_id.as_ref() {
         cmd.add_element("filter")
@@ -128,15 +144,32 @@ mod tests {
             "alert",
             AlertOpts {
                 event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: HashMap::from([(
+                    String::from("event_key"),
+                    String::from("event_value"),
+                )]),
                 condition: Some(AlertCondition::Always),
+                condition_data: HashMap::from([(
+                    String::from("condition_key"),
+                    String::from("condition_value"),
+                )]),
                 method: Some(AlertMethod::Email),
+                method_data: HashMap::from([(
+                    String::from("method_key"),
+                    String::from("method_value"),
+                )]),
                 filter_id: Some(id("f1")),
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<event>Task run status changed</event>"));
-        assert!(rendered.contains("<condition>Always</condition>"));
-        assert!(rendered.contains("<method>Email</method>"));
+        assert!(rendered.contains(
+            "<event>Task run status changed<data>event_value<name>event_key</name></data></event>"
+        ));
+        assert!(rendered.contains(
+            "<condition>Always<data>condition_value<name>condition_key</name></data></condition>"
+        ));
+        assert!(rendered
+            .contains("<method>Email<data>method_value<name>method_key</name></data></method>"));
         assert!(rendered.contains("<filter id=\"f1\"/>"));
         assert_eq!(
             xml(clone_alert(&id("a1"))),
@@ -160,12 +193,13 @@ mod tests {
             AlertOpts {
                 comment: Some("updated".into()),
                 method: Some(AlertMethod::SysLog),
+                method_data: HashMap::from([(String::from("foo"), String::from("bar"))]),
                 ..Default::default()
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>Syslog</method></modify_alert>"
+            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>Syslog<data>bar<name>foo</name></data></method></modify_alert>"
         );
         assert_eq!(
             xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -74,6 +74,10 @@ pub struct ModifyTargetOpts {
     pub esxi_credential_id: Option<EntityId>,
     /// Optional SNMP credential identifier.
     pub snmp_credential_id: Option<EntityId>,
+    /// Whether reverse lookup only should be enabled.
+    pub reverse_lookup_only: Option<bool>,
+    /// Whether reverse-lookup unification should be enabled.
+    pub reverse_lookup_unify: Option<bool>,
 }
 
 /// Build a clone request for an existing target.
@@ -147,6 +151,12 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
     }
     add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
     add_target_credentials(&mut cmd, &opts);
+    if let Some(value) = opts.reverse_lookup_only {
+        cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
+    }
+    if let Some(value) = opts.reverse_lookup_unify {
+        cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
+    }
     cmd
 }
 
@@ -272,6 +282,8 @@ mod tests {
                 smb_credential_id: Some(id("smb1")),
                 esxi_credential_id: Some(id("esxi1")),
                 snmp_credential_id: Some(id("snmp1")),
+                reverse_lookup_only: Some(false),
+                reverse_lookup_unify: Some(true),
                 ..Default::default()
             },
         ));
@@ -281,6 +293,8 @@ mod tests {
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
+        assert!(rendered.contains("<reverse_lookup_only>0</reverse_lookup_only>"));
+        assert!(rendered.contains("<reverse_lookup_unify>1</reverse_lookup_unify>"));
         assert_eq!(
             xml(delete_target(&id("t1"), false)),
             "<delete_target target_id=\"t1\" ultimate=\"0\"/>"

--- a/crates/gvm-gmp/src/common.rs
+++ b/crates/gvm-gmp/src/common.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
+use gvm_protocol::xml_command::XmlElement;
 use gvm_protocol::XmlCommand;
 
 use crate::types::EntityId;
+use std::collections::HashMap;
 
 pub(crate) fn bool_str(value: bool) -> &'static str {
     if value {
@@ -62,6 +64,14 @@ pub(crate) fn add_string_list(cmd: &mut XmlCommand, parent: &str, child: &str, v
     let root = cmd.add_element(parent);
     for value in values {
         root.add_child_with_text(child, value);
+    }
+}
+
+pub(crate) fn add_named_data_map(parent: &mut XmlElement, values: &HashMap<String, String>) {
+    for (key, value) in values {
+        let data = parent.add_child("data");
+        data.set_text(value);
+        data.add_child_with_text("name", key);
     }
 }
 

--- a/crates/gvm-gmp/src/responses/alert.rs
+++ b/crates/gvm-gmp/src/responses/alert.rs
@@ -3,13 +3,15 @@
 
 //! Alert response models.
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta, parse_named_entity,
-    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
+    parse_named_data_map, parse_named_entity, status_from_response, ActionResponse, CountInfo,
+    EntityMeta, NamedEntity, ParseError,
 };
 use crate::{AlertCondition, AlertEvent, AlertMethod};
 
@@ -21,6 +23,9 @@ pub struct Alert {
     pub event: Option<String>,
     pub condition: Option<String>,
     pub method: Option<String>,
+    pub event_data: HashMap<String, String>,
+    pub condition_data: HashMap<String, String>,
+    pub method_data: HashMap<String, String>,
     pub filter: Option<NamedEntity>,
     pub active: bool,
 }
@@ -48,13 +53,30 @@ impl Alert {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            event: node.optional_child_text("event").map(normalize_alert_event),
+            event: node
+                .child("event")
+                .map(|event| normalize_alert_event(event.text.clone())),
             condition: node
-                .optional_child_text("condition")
-                .map(normalize_alert_condition),
+                .child("condition")
+                .map(|condition| normalize_alert_condition(condition.text.clone())),
             method: node
-                .optional_child_text("method")
-                .map(normalize_alert_method),
+                .child("method")
+                .map(|method| normalize_alert_method(method.text.clone())),
+            event_data: node
+                .child("event")
+                .map(|event| parse_named_data_map(event, "event"))
+                .transpose()?
+                .unwrap_or_default(),
+            condition_data: node
+                .child("condition")
+                .map(|condition| parse_named_data_map(condition, "condition"))
+                .transpose()?
+                .unwrap_or_default(),
+            method_data: node
+                .child("method")
+                .map(|method| parse_named_data_map(method, "method"))
+                .transpose()?
+                .unwrap_or_default(),
             filter: parse_named_entity(node, "filter")?,
             active: node
                 .optional_child_text("active")
@@ -141,9 +163,9 @@ mod tests {
                     <modification_time>2026-01-02T00:00:00Z</modification_time>
                     <writable>1</writable>
                     <in_use>0</in_use>
-                    <event>task_run_status_changed</event>
-                    <condition>always</condition>
-                    <method>email</method>
+                    <event>task_run_status_changed<data>scan<name>status</name></data></event>
+                    <condition>always<data>9.5<name>severity</name></data></condition>
+                    <method>email<data>ops@example.com<name>to_address</name></data></method>
                     <filter id="f-1"><name>My Filter</name></filter>
                     <active>1</active>
                 </alert>
@@ -167,8 +189,26 @@ mod tests {
             parsed.items[0].event.as_deref(),
             Some("task_run_status_changed")
         );
+        assert_eq!(
+            parsed.items[0].event_data.get("status").map(String::as_str),
+            Some("scan")
+        );
         assert_eq!(parsed.items[0].condition.as_deref(), Some("always"));
+        assert_eq!(
+            parsed.items[0]
+                .condition_data
+                .get("severity")
+                .map(String::as_str),
+            Some("9.5")
+        );
         assert_eq!(parsed.items[0].method.as_deref(), Some("email"));
+        assert_eq!(
+            parsed.items[0]
+                .method_data
+                .get("to_address")
+                .map(String::as_str),
+            Some("ops@example.com")
+        );
         assert_eq!(
             parsed.items[0].filter.as_ref().map(|f| f.name.as_str()),
             Some("My Filter")
@@ -262,6 +302,9 @@ mod tests {
         assert_eq!(alert.event, None);
         assert_eq!(alert.condition, None);
         assert_eq!(alert.method, None);
+        assert!(alert.event_data.is_empty());
+        assert!(alert.condition_data.is_empty());
+        assert!(alert.method_data.is_empty());
         assert_eq!(alert.filter, None);
         assert!(!alert.active);
     }

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -258,6 +258,20 @@ pub(crate) fn parse_u32(value: &str, field: &str) -> Result<u32, ParseError> {
     })
 }
 
+pub(crate) fn parse_named_data_map(
+    node: &XmlNode,
+    field: &str,
+) -> Result<HashMap<String, String>, ParseError> {
+    let mut values = HashMap::new();
+    for data in node.children_named("data") {
+        let name = data
+            .optional_child_text("name")
+            .ok_or_else(|| ParseError::MissingElement(format!("{field}.data.name")))?;
+        values.insert(name, data.text.clone());
+    }
+    Ok(values)
+}
+
 pub(crate) fn parse_score(value: &str) -> Option<f64> {
     value.parse::<f64>().ok().filter(|score| score.is_finite())
 }

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -93,6 +93,7 @@ pub struct ReportTlsCertificate {
     pub serial: Option<String>,
     pub activation_time: Option<String>,
     pub expiration_time: Option<String>,
+    pub sha256_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -282,6 +283,7 @@ impl ReportTlsCertificate {
             serial: node.optional_child_text("serial"),
             activation_time: node.optional_child_text("activation_time"),
             expiration_time: node.optional_child_text("expiration_time"),
+            sha256_fingerprint: node.optional_child_text("sha256_fingerprint"),
         }
     }
 }
@@ -738,6 +740,7 @@ mod tests {
                     <subject>CN=example.com</subject>
                     <issuer>CN=Example CA</issuer>
                     <serial>01</serial>
+                    <sha256_fingerprint>ee:ff:00:11</sha256_fingerprint>
                     <expiration_time>2027-01-01T00:00:00Z</expiration_time>
                 </tls_certificate>
                 <tls_certificate_count>1<filtered>1</filtered></tls_certificate_count>
@@ -749,6 +752,10 @@ mod tests {
 
         assert_eq!(parsed.items.len(), 1);
         assert_eq!(parsed.items[0].issuer.as_deref(), Some("CN=Example CA"));
+        assert_eq!(
+            parsed.items[0].sha256_fingerprint.as_deref(),
+            Some("ee:ff:00:11")
+        );
         assert_eq!(
             parsed.items[0].expiration_time.as_deref(),
             Some("2027-01-01T00:00:00Z")

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -5,6 +5,8 @@
 
 mod common;
 
+use std::collections::HashMap;
+
 use common::{id, xml};
 use gvm_gmp::commands::alerts::*;
 use gvm_gmp::{AlertCondition, AlertEvent, AlertMethod};
@@ -25,12 +27,18 @@ fn test_create_alert_with_all_optionals() {
             AlertOpts {
                 comment: Some("c".into()),
                 event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: HashMap::from([(String::from("event_key"), String::from("event_value"))]),
                 condition: Some(AlertCondition::Always),
+                condition_data: HashMap::from([(
+                    String::from("condition_key"),
+                    String::from("condition_value"),
+                )]),
                 method: Some(AlertMethod::Email),
+                method_data: HashMap::from([(String::from("method_key"), String::from("method_value"))]),
                 filter_id: Some(id("f1")),
             }
         )),
-        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed</event><condition>Always</condition><method>Email</method><filter id=\"f1\"/></create_alert>"
+        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed<data>event_value<name>event_key</name></data></event><condition>Always<data>condition_value<name>condition_key</name></data></condition><method>Email<data>method_value<name>method_key</name></data></method><filter id=\"f1\"/></create_alert>"
     );
 }
 
@@ -49,12 +57,15 @@ fn test_alert_get_modify_delete_and_test() {
             &id("a1"),
             AlertOpts {
                 event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: HashMap::from([(String::from("status"), String::from("scan"))]),
                 condition: Some(AlertCondition::Always),
+                condition_data: HashMap::from([(String::from("threshold"), String::from("9.5"))]),
                 method: Some(AlertMethod::SysLog),
+                method_data: HashMap::from([(String::from("facility"), String::from("local0"))]),
                 ..Default::default()
             }
         )),
-        "<modify_alert alert_id=\"a1\"><event>Task run status changed</event><condition>Always</condition><method>Syslog</method></modify_alert>"
+        "<modify_alert alert_id=\"a1\"><event>Task run status changed<data>scan<name>status</name></data></event><condition>Always<data>9.5<name>threshold</name></data></condition><method>Syslog<data>local0<name>facility</name></data></method></modify_alert>"
     );
     assert_eq!(
         xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -48,6 +48,17 @@ fn test_target_get_modify_delete() {
         "<get_targets details=\"1\" target_id=\"t1\"/>"
     );
     assert_eq!(
+        xml(modify_target(
+            &id("t1"),
+            ModifyTargetOpts {
+                reverse_lookup_only: Some(false),
+                reverse_lookup_unify: Some(true),
+                ..Default::default()
+            }
+        )),
+        "<modify_target target_id=\"t1\"><reverse_lookup_only>0</reverse_lookup_only><reverse_lookup_unify>1</reverse_lookup_unify></modify_target>"
+    );
+    assert_eq!(
         xml(delete_target(&id("t1"), false)),
         "<delete_target target_id=\"t1\" ultimate=\"0\"/>"
     );


### PR DESCRIPTION
## Summary
- add `ModifyTargetOpts` support for `reverse_lookup_only` and `reverse_lookup_unify`
- add typed alert `event_data`, `condition_data`, and `method_data` support on both GMP command builders and response parsing
- expose `sha256_fingerprint` on `ReportTlsCertificate`

## Verification
- `cargo test -p gvm-gmp`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`

Closes #242

Agent: Thoth
