### PR TITLE
Add missing typed GMP fields

### DIFF
--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -74,6 +74,10 @@ pub struct ModifyTargetOpts {
     pub esxi_credential_id: Option<EntityId>,
     /// Optional SNMP credential identifier.
     pub snmp_credential_id: Option<EntityId>,
+    /// Whether reverse lookup only should be enabled.
+    pub reverse_lookup_only: Option<bool>,
+    /// Whether reverse-lookup unification should be enabled.
+    pub reverse_lookup_unify: Option<bool>,
 }
 
 /// Build a clone request for an existing target.
@@ -147,6 +151,12 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
     }
     add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
     add_target_credentials(&mut cmd, &opts);
+    if let Some(value) = opts.reverse_lookup_only {
+        cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
+    }
+    if let Some(value) = opts.reverse_lookup_unify {
+        cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
+    }
     cmd
 }
 
@@ -272,6 +282,8 @@ mod tests {
                 smb_credential_id: Some(id("smb1")),
                 esxi_credential_id: Some(id("esxi1")),
                 snmp_credential_id: Some(id("snmp1")),
+                reverse_lookup_only: Some(true),
+                reverse_lookup_unify: Some(false),
                 ..Default::default()
             },
         ));
@@ -281,6 +293,8 @@ mod tests {
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
+        assert!(rendered.contains("<reverse_lookup_only>1</reverse_lookup_only>"));
+        assert!(rendered.contains("<reverse_lookup_unify>0</reverse_lookup_unify>"));
         assert_eq!(
             xml(delete_target(&id("t1"), false)),
             "<delete_target target_id=\"t1\" ultimate=\"0\"/>"

--- a/crates/gvm-gmp/src/responses/alert.rs
+++ b/crates/gvm-gmp/src/responses/alert.rs
@@ -3,6 +3,7 @@
 
 //! Alert response models.
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use gvm_protocol::Response;
@@ -19,8 +20,11 @@ use crate::{AlertCondition, AlertEvent, AlertMethod};
 pub struct Alert {
     pub meta: EntityMeta,
     pub event: Option<String>,
+    pub event_data: HashMap<String, String>,
     pub condition: Option<String>,
+    pub condition_data: HashMap<String, String>,
     pub method: Option<String>,
+    pub method_data: HashMap<String, String>,
     pub filter: Option<NamedEntity>,
     pub active: bool,
 }
@@ -48,13 +52,18 @@ impl Alert {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
             meta: parse_entity_meta(node)?,
-            event: node.optional_child_text("event").map(normalize_alert_event),
+            event: alert_field_text(node, "event").map(normalize_alert_event),
+            event_data: alert_data(node, "event"),
             condition: node
-                .optional_child_text("condition")
+                .child("condition")
+                .and_then(alert_field_value)
                 .map(normalize_alert_condition),
+            condition_data: alert_data(node, "condition"),
             method: node
-                .optional_child_text("method")
+                .child("method")
+                .and_then(alert_field_value)
                 .map(normalize_alert_method),
+            method_data: alert_data(node, "method"),
             filter: parse_named_entity(node, "filter")?,
             active: node
                 .optional_child_text("active")
@@ -101,6 +110,40 @@ impl CreateAlertResponse {
 
 pub type ModifyAlertResponse = ActionResponse;
 pub type DeleteAlertResponse = ActionResponse;
+
+fn alert_field_text(node: &crate::responses::common::XmlNode, field: &str) -> Option<String> {
+    node.child(field).and_then(alert_field_value)
+}
+
+fn alert_field_value(node: &crate::responses::common::XmlNode) -> Option<String> {
+    node.optional_child_text("name")
+        .or_else(|| (!node.text.is_empty()).then(|| node.text.clone()))
+}
+
+fn alert_data(node: &crate::responses::common::XmlNode, field: &str) -> HashMap<String, String> {
+    node.child(field).map(parse_alert_data).unwrap_or_default()
+}
+
+fn parse_alert_data(node: &crate::responses::common::XmlNode) -> HashMap<String, String> {
+    let mut data = HashMap::new();
+    for item in node.children_named("data") {
+        let Some(name) = item
+            .attr("name")
+            .map(ToString::to_string)
+            .or_else(|| item.child_text("name"))
+        else {
+            continue;
+        };
+        let value = item
+            .attr("value")
+            .map(ToString::to_string)
+            .or_else(|| item.child_text("value"))
+            .or_else(|| item.child_text("data"))
+            .unwrap_or_else(|| item.text.clone());
+        data.insert(name, value);
+    }
+    data
+}
 
 fn normalize_alert_event(value: String) -> String {
     AlertEvent::from_str(&value)
@@ -260,9 +303,54 @@ mod tests {
 
         assert_eq!(alert.meta.comment, None);
         assert_eq!(alert.event, None);
+        assert!(alert.event_data.is_empty());
         assert_eq!(alert.condition, None);
+        assert!(alert.condition_data.is_empty());
         assert_eq!(alert.method, None);
+        assert!(alert.method_data.is_empty());
         assert_eq!(alert.filter, None);
         assert!(!alert.active);
+    }
+
+    #[test]
+    fn parses_alert_data_maps() {
+        let response = Response::from(
+            r#"<get_alerts_response status="200" status_text="OK">
+                <alert id="a-1">
+                    <name>Data Alert</name>
+                    <event>
+                        <name>Task run status changed</name>
+                        <data><name>status</name>Done</data>
+                    </event>
+                    <condition>
+                        Severity at least
+                        <data><name>severity</name>5.0</data>
+                    </condition>
+                    <method>
+                        Email
+                        <data><name>to_address</name>ops@example.com</data>
+                    </method>
+                </alert>
+            </get_alerts_response>"#,
+        );
+
+        let parsed = GetAlertsResponse::from_response(&response).expect("alerts parse");
+        let alert = &parsed.items[0];
+
+        assert_eq!(alert.event.as_deref(), Some("task_run_status_changed"));
+        assert_eq!(
+            alert.event_data.get("status").map(String::as_str),
+            Some("Done")
+        );
+        assert_eq!(alert.condition.as_deref(), Some("severity_at_least"));
+        assert_eq!(
+            alert.condition_data.get("severity").map(String::as_str),
+            Some("5.0")
+        );
+        assert_eq!(alert.method.as_deref(), Some("email"));
+        assert_eq!(
+            alert.method_data.get("to_address").map(String::as_str),
+            Some("ops@example.com")
+        );
     }
 }

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -91,6 +91,7 @@ pub struct ReportTlsCertificate {
     pub subject: Option<String>,
     pub issuer: Option<String>,
     pub serial: Option<String>,
+    pub sha256_fingerprint: Option<String>,
     pub activation_time: Option<String>,
     pub expiration_time: Option<String>,
 }
@@ -275,11 +276,22 @@ impl ReportTlsCertificate {
         Self {
             id: node.attr("id").map(ToString::to_string),
             name: node.optional_child_text("name"),
-            host: node.optional_child_text("host"),
-            port: node.optional_child_text("port"),
-            subject: node.optional_child_text("subject"),
-            issuer: node.optional_child_text("issuer"),
+            host: node
+                .child("host")
+                .and_then(|host| host.optional_child_text("ip"))
+                .or_else(|| node.optional_child_text("host")),
+            port: node
+                .child("ports")
+                .and_then(|ports| ports.optional_child_text("port"))
+                .or_else(|| node.optional_child_text("port")),
+            subject: node
+                .optional_child_text("subject_dn")
+                .or_else(|| node.optional_child_text("subject")),
+            issuer: node
+                .optional_child_text("issuer_dn")
+                .or_else(|| node.optional_child_text("issuer")),
             serial: node.optional_child_text("serial"),
+            sha256_fingerprint: node.optional_child_text("sha256_fingerprint"),
             activation_time: node.optional_child_text("activation_time"),
             expiration_time: node.optional_child_text("expiration_time"),
         }
@@ -343,12 +355,6 @@ impl_report_detail_response!(
     "vuln_count"
 );
 impl_report_detail_response!(
-    GetReportTlsCertificatesResponse,
-    ReportTlsCertificate,
-    ["tls_certificate", "certificate"],
-    "tls_certificate_count"
-);
-impl_report_detail_response!(
     GetReportErrorsResponse,
     ReportError,
     ["error"],
@@ -360,6 +366,52 @@ impl_report_detail_response!(
     ["closed_cve", "cve"],
     "closed_cve_count"
 );
+
+impl GetReportTlsCertificatesResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let container = root.child("tls_certificates");
+        let mut items = Vec::new();
+        items.extend(
+            root.children_named("tls_certificate")
+                .map(ReportTlsCertificate::from_node),
+        );
+        if let Some(container) = container {
+            items.extend(
+                container
+                    .children_named("tls_certificate")
+                    .map(ReportTlsCertificate::from_node),
+            );
+        }
+
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: report_tls_certificate_count_info(&root, container)?,
+        })
+    }
+}
+
+fn report_tls_certificate_count_info(
+    root: &crate::responses::common::XmlNode,
+    container: Option<&crate::responses::common::XmlNode>,
+) -> Result<CountInfo, ParseError> {
+    let legacy_counts = count_info(root, "tls_certificate_count")?;
+    if legacy_counts != CountInfo::default() {
+        return Ok(legacy_counts);
+    }
+
+    Ok(CountInfo {
+        total: container
+            .map(|node| optional_u32(node, "count", "tls_certificates.count"))
+            .transpose()?
+            .flatten(),
+        filtered: None,
+        page: None,
+    })
+}
 
 impl ReportExport {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
@@ -731,16 +783,18 @@ mod tests {
     fn parses_report_tls_certificates_response() {
         let response = Response::from(
             r#"<get_report_tls_certificates_response status="200" status_text="OK">
-                <tls_certificate id="tls-1">
-                    <name>example.com</name>
-                    <host>192.0.2.10</host>
-                    <port>443/tcp</port>
-                    <subject>CN=example.com</subject>
-                    <issuer>CN=Example CA</issuer>
-                    <serial>01</serial>
-                    <expiration_time>2027-01-01T00:00:00Z</expiration_time>
-                </tls_certificate>
-                <tls_certificate_count>1<filtered>1</filtered></tls_certificate_count>
+                <tls_certificates>
+                    <tls_certificate>
+                        <name>ee:ff:00:11</name>
+                        <host><ip>192.0.2.10</ip><hostname>example.com</hostname></host>
+                        <ports><port>443/tcp</port></ports>
+                        <subject_dn>CN=example.com</subject_dn>
+                        <issuer_dn>CN=Example CA</issuer_dn>
+                        <serial>01</serial>
+                        <sha256_fingerprint>ee:ff:00:11</sha256_fingerprint>
+                        <expiration_time>2027-01-01T00:00:00Z</expiration_time>
+                    </tls_certificate>
+                </tls_certificates>
             </get_report_tls_certificates_response>"#,
         );
 
@@ -748,10 +802,17 @@ mod tests {
             .expect("tls certificates parse");
 
         assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].host.as_deref(), Some("192.0.2.10"));
+        assert_eq!(parsed.items[0].port.as_deref(), Some("443/tcp"));
+        assert_eq!(parsed.items[0].subject.as_deref(), Some("CN=example.com"));
         assert_eq!(parsed.items[0].issuer.as_deref(), Some("CN=Example CA"));
         assert_eq!(
             parsed.items[0].expiration_time.as_deref(),
             Some("2027-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            parsed.items[0].sha256_fingerprint.as_deref(),
+            Some("ee:ff:00:11")
         );
     }
 


### PR DESCRIPTION
## Summary
- add reverse lookup flags to modify_target options and XML emission
- expose alert event, condition, and method data maps from GMP alert responses
- expose SHA-256 fingerprints for report TLS certificates and parse gvmd's tls_certificates wrapper shape

Fixes #242

## Verification
- cargo test -p gvm-gmp
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features

## Notes
- Reviewed against current gvmd/GMP XML shapes for alert data and report TLS certificates.