### PR TITLE
fix(gmp): preserve user host access mode

### DIFF
--- a/crates/gvm-gmp/src/commands/users.rs
+++ b/crates/gvm-gmp/src/commands/users.rs
@@ -16,12 +16,60 @@ pub struct UserOpts {
     pub comment: Option<String>,
     /// Optional password value.
     pub password: Option<String>,
-    /// Optional host-access restriction string.
-    pub host_access: Option<String>,
+    /// Optional host-access restrictions.
+    pub host_access: Option<UserHostAccess>,
     /// Role identifiers assigned to the user.
     pub role_ids: Vec<EntityId>,
     /// Optional user authentication type.
     pub auth_type: Option<UserAuthType>,
+}
+
+/// User host-access restrictions.
+///
+/// `hosts` is the comma-separated GMP host expression string accepted by gvmd.
+/// It may contain individual hosts, ranges, or CIDR expressions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UserHostAccess {
+    /// If true, allow only the listed hosts; otherwise forbid the listed hosts.
+    pub allow: bool,
+    /// Comma-separated GMP host expression list.
+    pub hosts: String,
+}
+
+impl UserHostAccess {
+    /// Create user host-access restrictions.
+    #[must_use]
+    pub fn new(allow: bool, hosts: impl Into<String>) -> Self {
+        Self {
+            allow,
+            hosts: hosts.into(),
+        }
+    }
+
+    /// Create an allow-list host-access restriction.
+    #[must_use]
+    pub fn allow(hosts: impl Into<String>) -> Self {
+        Self::new(true, hosts)
+    }
+
+    /// Create a deny-list host-access restriction.
+    #[must_use]
+    pub fn deny(hosts: impl Into<String>) -> Self {
+        Self::new(false, hosts)
+    }
+}
+
+impl From<String> for UserHostAccess {
+    fn from(hosts: String) -> Self {
+        Self::allow(hosts)
+    }
+}
+
+impl From<&str> for UserHostAccess {
+    fn from(hosts: &str) -> Self {
+        Self::allow(hosts)
+    }
 }
 
 /// Options for `get_users` requests.
@@ -93,7 +141,11 @@ pub fn delete_user(user_id: &EntityId, ultimate: bool) -> impl Request {
 fn add_user_body(cmd: &mut XmlCommand, opts: &UserOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     add_text_element(cmd, "password", opts.password.as_deref());
-    add_text_element(cmd, "hosts", opts.host_access.as_deref());
+    if let Some(host_access) = &opts.host_access {
+        cmd.add_element("hosts")
+            .set_attribute("allow", bool_str(host_access.allow))
+            .set_text(&host_access.hosts);
+    }
     if let Some(auth_type) = opts.auth_type {
         cmd.add_element_with_text("authentication", auth_type.as_gmp_str());
     }
@@ -157,5 +209,53 @@ mod tests {
         assert!(rendered.contains("<delete_user "));
         assert!(rendered.contains("user_id=\"u1\""));
         assert!(rendered.contains("ultimate=\"1\""));
+    }
+
+    #[test]
+    fn modify_user_emits_host_access_allow_mode() {
+        let rendered = xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::allow("192.0.2.0/24")),
+                ..Default::default()
+            },
+        ));
+
+        assert_eq!(
+            rendered,
+            "<modify_user user_id=\"u1\"><hosts allow=\"1\">192.0.2.0/24</hosts></modify_user>"
+        );
+    }
+
+    #[test]
+    fn modify_user_emits_host_access_deny_mode() {
+        let rendered = xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::deny("192.0.2.0/24")),
+                ..Default::default()
+            },
+        ));
+
+        assert_eq!(
+            rendered,
+            "<modify_user user_id=\"u1\"><hosts allow=\"0\">192.0.2.0/24</hosts></modify_user>"
+        );
+    }
+
+    #[test]
+    fn modify_user_emits_explicit_empty_host_access() {
+        let rendered = xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::deny("")),
+                ..Default::default()
+            },
+        ));
+
+        assert_eq!(
+            rendered,
+            "<modify_user user_id=\"u1\"><hosts allow=\"0\"></hosts></modify_user>"
+        );
     }
 }

--- a/crates/gvm-gmp/src/responses/user.rs
+++ b/crates/gvm-gmp/src/responses/user.rs
@@ -5,6 +5,7 @@
 
 use gvm_protocol::Response;
 
+use crate::commands::users::UserHostAccess;
 use crate::responses::common::{
     count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
     ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
@@ -42,6 +43,21 @@ pub struct CreateUserResponse {
 }
 
 impl User {
+    /// Return host-access restrictions in the form accepted by `modify_user`.
+    ///
+    /// gvmd represents the host list as a comma-separated string. A missing
+    /// `allow` value defaults to allow mode, matching gvmd's command parser.
+    #[must_use]
+    pub fn host_access(&self) -> Option<UserHostAccess> {
+        let hosts = self.hosts.clone()?;
+        let allow = self
+            .hosts_allow
+            .as_deref()
+            .map(|value| !matches!(value, "0" | "false"))
+            .unwrap_or(true);
+        Some(UserHostAccess::new(allow, hosts))
+    }
+
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         let roles = node
             .children_named("role")
@@ -80,8 +96,12 @@ impl User {
             meta: parse_entity_meta(node)?,
             roles,
             groups,
-            hosts_allow: node.optional_child_text("hosts_allow"),
-            hosts: node.optional_child_text("hosts"),
+            hosts_allow: node.optional_child_text("hosts_allow").or_else(|| {
+                node.child("hosts")
+                    .and_then(|hosts| hosts.attr("allow"))
+                    .map(ToString::to_string)
+            }),
+            hosts: node.child_text("hosts"),
             authentication_type: node
                 .child("sources")
                 .and_then(|sources| sources.optional_child_text("source"))
@@ -129,7 +149,9 @@ pub type DeleteUserResponse = ActionResponse;
 
 #[cfg(test)]
 mod tests {
-    use gvm_protocol::Response;
+    use gvm_protocol::{Request, Response};
+
+    use crate::commands::users::{modify_user, UserOpts};
 
     use super::*;
 
@@ -177,6 +199,10 @@ mod tests {
         assert_eq!(parsed.items[0].groups[0].name, "Group One");
         assert_eq!(parsed.items[0].hosts_allow.as_deref(), Some("0"));
         assert_eq!(parsed.items[0].hosts.as_deref(), Some("192.168.1.0/24"));
+        assert_eq!(
+            parsed.items[0].host_access(),
+            Some(UserHostAccess::deny("192.168.1.0/24"))
+        );
         assert_eq!(parsed.items[0].authentication_type.as_deref(), Some("file"));
         assert_eq!(
             parsed.items[1].authentication_type.as_deref(),
@@ -242,7 +268,125 @@ mod tests {
         assert!(user.groups.is_empty());
         assert_eq!(user.hosts_allow, None);
         assert_eq!(user.hosts, None);
+        assert_eq!(user.host_access(), None);
         assert_eq!(user.authentication_type, None);
+    }
+
+    #[test]
+    fn parses_hosts_allow_attribute_shape() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>User One</name>
+                    <hosts allow="1">192.168.1.0/24, 192.168.2.0/24</hosts>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+
+        assert_eq!(user.hosts_allow.as_deref(), Some("1"));
+        assert_eq!(
+            user.hosts.as_deref(),
+            Some("192.168.1.0/24, 192.168.2.0/24")
+        );
+        assert_eq!(
+            user.host_access(),
+            Some(UserHostAccess::allow("192.168.1.0/24, 192.168.2.0/24"))
+        );
+    }
+
+    #[test]
+    fn round_trips_hosts_allow_attribute_to_modify_user() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>User One</name>
+                    <hosts allow="0">192.168.1.0/24</hosts>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+        let rendered = String::from_utf8(
+            modify_user(
+                &user.meta.id,
+                UserOpts {
+                    comment: Some("updated".into()),
+                    host_access: user.host_access(),
+                    ..Default::default()
+                },
+            )
+            .to_bytes(),
+        )
+        .expect("request XML should be UTF-8");
+
+        assert_eq!(
+            rendered,
+            "<modify_user user_id=\"u-1\"><comment>updated</comment><hosts allow=\"0\">192.168.1.0/24</hosts></modify_user>"
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_empty_hosts_for_round_trip() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>User One</name>
+                    <hosts allow="0"></hosts>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+
+        assert_eq!(user.hosts_allow.as_deref(), Some("0"));
+        assert_eq!(user.hosts.as_deref(), Some(""));
+        assert_eq!(user.host_access(), Some(UserHostAccess::deny("")));
+    }
+
+    #[test]
+    fn parses_false_hosts_allow_sibling_as_deny_mode() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>User One</name>
+                    <hosts_allow>false</hosts_allow>
+                    <hosts>192.168.1.0/24</hosts>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+
+        assert_eq!(
+            user.host_access(),
+            Some(UserHostAccess::deny("192.168.1.0/24"))
+        );
+    }
+
+    #[test]
+    fn parses_false_hosts_allow_attribute_as_deny_mode() {
+        let response = Response::from(
+            r#"<get_users_response status="200" status_text="OK">
+                <user id="u-1">
+                    <name>User One</name>
+                    <hosts allow="false">192.168.1.0/24</hosts>
+                </user>
+            </get_users_response>"#,
+        );
+
+        let parsed = GetUsersResponse::from_response(&response).expect("users parse");
+        let user = &parsed.items[0];
+
+        assert_eq!(
+            user.host_access(),
+            Some(UserHostAccess::deny("192.168.1.0/24"))
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_users.rs
+++ b/crates/gvm-gmp/tests/test_users.rs
@@ -30,7 +30,41 @@ fn test_create_user_with_optionals() {
                 auth_type: Some(UserAuthType::File),
             }
         )),
-        "<create_user><name>alice</name><comment>c</comment><password>secret</password><hosts>127.0.0.1</hosts><authentication>file</authentication><role id=\"r1\"/><role id=\"r2\"/></create_user>"
+        "<create_user><name>alice</name><comment>c</comment><password>secret</password><hosts allow=\"1\">127.0.0.1</hosts><authentication>file</authentication><role id=\"r1\"/><role id=\"r2\"/></create_user>"
+    );
+}
+
+#[test]
+fn test_modify_user_with_host_access_modes() {
+    assert_eq!(
+        xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::allow("192.0.2.0/24")),
+                ..Default::default()
+            }
+        )),
+        "<modify_user user_id=\"u1\"><hosts allow=\"1\">192.0.2.0/24</hosts></modify_user>"
+    );
+    assert_eq!(
+        xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::deny("192.0.2.0/24")),
+                ..Default::default()
+            }
+        )),
+        "<modify_user user_id=\"u1\"><hosts allow=\"0\">192.0.2.0/24</hosts></modify_user>"
+    );
+    assert_eq!(
+        xml(modify_user(
+            &id("u1"),
+            UserOpts {
+                host_access: Some(UserHostAccess::deny("")),
+                ..Default::default()
+            }
+        )),
+        "<modify_user user_id=\"u1\"><hosts allow=\"0\"></hosts></modify_user>"
     );
 }
 


### PR DESCRIPTION
## Summary
- add typed `UserHostAccess` support for user create/modify command builders
- emit `<hosts allow="0|1">...</hosts>` including explicit empty host lists
- parse both legacy `<hosts_allow>` siblings and current `<hosts allow="...">` response shapes for round-trip use

Fixes #250
References #251

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p gvm-gmp`
- `cargo test --workspace`

`cargo test --workspace` passes with existing missing-doc warnings in test crates.