### PR TITLE
docs(journal): add 2026-06-14 journal entry

### DIFF
--- a/journal/2026-06-14.md
+++ b/journal/2026-06-14.md
@@ -1,0 +1,23 @@
+# 2026-06-14 — Mainline Cleared a Tight GMP Follow-On Burst, but the Latest Fix Reopened CI and Left Two Model Gaps Behind
+
+## Mainline & Merged Work
+
+### `main` spent this window finishing a narrow but coherent round of GMP compatibility work
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), PR #236 (filter fragment validation), PR #239 (unnamed note/override parsing), PR #240 (id-only note/override refs), PR #244 (missing typed GMP target and alert fields), PR #249 (scoped report metadata fetches), and PR #252 (preserve user host access mode)
+- That sequence matters because the repository did not fan back out into broad feature work. It stayed focused on response-shape drift, parser resilience, and typed contract cleanup around concrete gvmd compatibility gaps
+- The result is a smaller but more disciplined burst than the earlier June expansion: fewer branches overall, but nearly all of them tighten mismatches between the typed surface and real server behavior
+
+## Issues
+- Eight issues opened in this window: #234, #237, #238, #242, #247, #248, #250, and #251
+- Six of those already closed directly through merged work on `main`: #234, #237, #238, #242, #248, and #250
+- The unresolved residue is now concentrated in two places rather than spread everywhere: #247 tracks the nonexistent `GetReportsOpts::no_report` path that gvmd ignores, and #251 keeps the broader user-host-access model audit open
+
+## Pull Request Queue
+- The active non-journal queue is mostly maintenance now: PR #214 (cargo dependency updates), PR #215 (GitHub Actions updates), and the older quick-xml bump PR #165 remain open
+- Journal backlog is still clogging the branch list via PRs #245, #246, and #253, so the repository's visible queue is noisier than the actual product queue
+- That is a healthier shape than early June because the substantive GMP follow-on work has mostly landed; what remains is mostly cleanup, dependency churn, and documentation lag
+
+## CI Health
+- Verification was mostly clean through the middle of the burst. The `main` push for PR #249 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The newest mainline merge regressed that clean picture: PR #252 landed with `Security` and `OpenSSF Scorecard` still green, but the `CI` workflow on `main` failed
+- The open maintenance queue is also mixed. PR #214 is failing `Cargo Vet` and `Security`, while PR #215 is failing `Test (all features)` even though the rest of its matrix is green


### PR DESCRIPTION
Adds the 2026-06-14 journal entry covering post-2026-06-09 mainline activity, issue churn, queue state, and CI signal.

Agent: Thoth