### PR TITLE
feat(gmp): support report export options

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -37,7 +37,7 @@ pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
-pub use gvm_gmp::commands::reports::GetReportDetailsOpts;
+pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts};
 pub use version::{
     command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
     required_version_label,

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -38,8 +38,9 @@ use gvm_gmp::commands::report_formats::{
     create_report_format, get_report_formats, GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    get_report_closed_cves, get_report_errors, get_report_export, get_report_tls_certificates,
-    get_report_vulns, get_reports, GetReportDetailsOpts, GetReportsOpts,
+    get_report_closed_cves, get_report_errors, get_report_export, get_report_export_with_opts,
+    get_report_tls_certificates, get_report_vulns, get_reports, GetReportDetailsOpts,
+    GetReportExportOpts, GetReportsOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -481,6 +482,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<ReportExport, GvmError> {
         let response = self
             .send(get_report_export(report_id, report_format_id))
+            .await?;
+        ReportExport::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_reports` export request with export options and return a typed [`ReportExport`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_export_with_opts(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportExportOpts,
+    ) -> Result<ReportExport, GvmError> {
+        let response = self
+            .send(get_report_export_with_opts(report_id, opts))
             .await?;
         ReportExport::from_response(&response).map_err(GvmError::Parse)
     }

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -35,6 +35,35 @@ pub struct GetReportsOpts {
     pub ignore_pagination: Option<bool>,
 }
 
+/// Options for `get_reports` report-format export requests.
+#[derive(Debug, Clone)]
+pub struct GetReportExportOpts {
+    /// Required report format identifier.
+    pub report_format_id: EntityId,
+    /// Optional report configuration identifier.
+    pub report_config_id: Option<EntityId>,
+    /// Optional inline result filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved result filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether pagination should be ignored. Defaults to true when omitted.
+    pub ignore_pagination: Option<bool>,
+}
+
+impl GetReportExportOpts {
+    /// Create export options for a report format.
+    #[must_use]
+    pub fn new(report_format_id: EntityId) -> Self {
+        Self {
+            report_format_id,
+            report_config_id: None,
+            filter_string: None,
+            filter_id: None,
+            ignore_pagination: None,
+        }
+    }
+}
+
 /// Shared options for `get_report_*` helper requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetReportDetailsOpts {
@@ -97,11 +126,35 @@ pub fn get_report(report_id: &EntityId) -> impl Request {
 /// Build a `get_reports` export request for a specific report format.
 #[must_use]
 pub fn get_report_export(report_id: &EntityId, report_format_id: &EntityId) -> impl Request {
-    XmlCommand::new("get_reports")
+    get_report_export_with_opts(
+        report_id,
+        GetReportExportOpts::new(report_format_id.clone()),
+    )
+}
+
+/// Build a `get_reports` export request with report format export options.
+#[must_use]
+pub fn get_report_export_with_opts(
+    report_id: &EntityId,
+    opts: GetReportExportOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("get_reports")
         .attribute("report_id", report_id.as_str())
-        .attribute("format_id", report_format_id.as_str())
+        .attribute("format_id", opts.report_format_id.as_str())
         .attribute("details", "1")
-        .attribute("ignore_pagination", "1")
+        .attribute(
+            "ignore_pagination",
+            bool_str(opts.ignore_pagination.unwrap_or(true)),
+        );
+    if let Some(report_config_id) = opts.report_config_id {
+        cmd.set_attribute("config_id", report_config_id.as_str());
+    }
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    cmd
 }
 
 /// Build a `delete_report` request.

--- a/crates/gvm-gmp/tests/test_reports.rs
+++ b/crates/gvm-gmp/tests/test_reports.rs
@@ -38,6 +38,10 @@ fn test_report_get_and_delete() {
         "<get_reports details=\"1\" report_id=\"r1\"/>"
     );
     assert_eq!(
+        xml(get_report_export(&id("r1"), &id("rf1"))),
+        "<get_reports details=\"1\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+    );
+    assert_eq!(
         xml(get_reports(GetReportsOpts {
             report_id: Some(id("r1")),
             details: Some(false),
@@ -48,6 +52,52 @@ fn test_report_get_and_delete() {
     assert_eq!(
         xml(delete_report(&id("r1"), false)),
         "<delete_report report_id=\"r1\" ultimate=\"0\"/>"
+    );
+}
+
+#[test]
+fn test_report_export_with_report_config() {
+    let mut opts = GetReportExportOpts::new(id("rf1"));
+    opts.report_config_id = Some(id("rc1"));
+
+    assert_eq!(
+        xml(get_report_export_with_opts(&id("r1"), opts)),
+        "<get_reports config_id=\"rc1\" details=\"1\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+    );
+}
+
+#[test]
+fn test_report_export_with_filter_string() {
+    let mut opts = GetReportExportOpts::new(id("rf1"));
+    opts.filter_string = Some("severity>5".into());
+
+    assert_eq!(
+        xml(get_report_export_with_opts(&id("r1"), opts)),
+        "<get_reports details=\"1\" filter=\"severity&gt;5\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+    );
+}
+
+#[test]
+fn test_report_export_with_filter_id() {
+    let mut opts = GetReportExportOpts::new(id("rf1"));
+    opts.filter_id = Some(id("f1"));
+
+    assert_eq!(
+        xml(get_report_export_with_opts(&id("r1"), opts)),
+        "<get_reports details=\"1\" filt_id=\"f1\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
+    );
+}
+
+#[test]
+fn test_report_export_with_combined_options() {
+    let mut opts = GetReportExportOpts::new(id("rf1"));
+    opts.report_config_id = Some(id("rc1"));
+    opts.filter_string = Some("severity>5".into());
+    opts.filter_id = Some(id("f1"));
+
+    assert_eq!(
+        xml(get_report_export_with_opts(&id("r1"), opts)),
+        "<get_reports config_id=\"rc1\" details=\"1\" filt_id=\"f1\" filter=\"severity&gt;5\" format_id=\"rf1\" ignore_pagination=\"1\" report_id=\"r1\"/>"
     );
 }
 


### PR DESCRIPTION
## Summary

- add export-specific `GetReportExportOpts` for report-format `get_reports` exports
- emit optional `config_id`, inline `filter`, and saved `filt_id` while preserving the existing two-argument helper
- expose the options-based export helper from the typed client and cover each optional XML field

Fixes #260.

## Validation

- `cargo fmt --check` passed
- `git diff --check HEAD~1..HEAD` passed
- `cargo test -p gvm-gmp --test test_reports` passed, 8 tests
- `cargo test -p gvm-client --lib` passed, 12 tests
- `cargo clippy -p gvm-gmp -p gvm-client --all-targets` passed with existing missing-doc warnings in cfg-gated `gvm-client` integration test crates
