### PR TITLE
docs(journal): consolidate pending journal entries

### DIFF
--- a/journal/2026-05-26.md
+++ b/journal/2026-05-26.md
@@ -1,0 +1,24 @@
+# 2026-05-26 — `main` Churned Through MCP Docs, a Revert, and Automation Cleanup While the Real Feature Queue Stayed Open
+
+## Mainline & Merged Work
+
+### `main` moved several times after the 2026-05-24 journal baseline, but most of that movement was operational or corrective rather than new product delivery
+- PR #168 (`ci: add journal PR automation workflow`) finally landed on 2026-05-25, so the repo's long-running journal backlog is now at least backed by an automated path into review
+- PR #184 (`docs: make MCP a first-class gateway surface`) merged the same day, then PR #187 reverted it a little over an hour later, which means `main` briefly carried the wrong-repo MCP planning direction before explicitly backing it out
+- PR #182 also landed on 2026-05-25 with the actions-group dependency refresh, and PR #186 merged the pending journal backlog through 2026-05-24
+- The net effect is that `main` changed repeatedly, but only one of those moves improved repo operations materially; the rest either documented prior work or unwound a documentation mistake
+
+## Issues
+- No new issues were opened after the 2026-05-24 journal baseline
+- No issues were closed in the same window
+- So the backlog itself did not move; the story here is branch and automation churn, not tracker cleanup
+
+## Pull Request Queue
+- The real implementation lane is still PR #177 (`Add GMP REST support gap helpers`), which remains open alongside the older `quick-xml` bump in PR #165
+- Two fresh dependency PRs joined the queue on 2026-05-25: PR #180 (`serde_json`) and PR #181 (`russh`)
+- That leaves the repo in a familiar state: `main` absorbed maintenance and documentation movement, while the actual product-path follow-through is still waiting in review
+
+## CI Health
+- The 2026-05-25 `main` merges all validated cleanly: PRs #168, #182, #186, and the #187 revert each produced successful `CI`, `Security`, or `OpenSSF Scorecard` runs
+- `Dependabot Updates` on `main` also completed successfully on 2026-05-25, so the maintenance automation lane is currently healthy rather than noisy
+- Operationally, this repo looks stable; the main risk is still queue age on the feature work, not branch breakage

--- a/journal/2026-05-28.md
+++ b/journal/2026-05-28.md
@@ -1,0 +1,24 @@
+# 2026-05-28 — `main` Only Absorbed Automation and Docs Churn, While the Real GMP Follow-on Branch Fell Further Behind
+
+## Mainline & Merged Work
+
+### The default branch moved five times after the 2026-05-24 baseline, but none of that movement shipped new GMP client surface
+- PR #168 (`ci: add journal PR automation workflow`) merged on 2026-05-25 and is the only durable repository-level workflow change in this window
+- PR #182 (`ci(deps): bump the actions group across 1 directory with 9 updates`) also landed the same day, so the maintenance lane did move even though product work did not
+- The only contentful docs experiment, PR #184 (`docs: make MCP a first-class gateway surface`), was reverted within hours by PR #187, which means `main` ended the window with churn but not a net documentation expansion
+- PR #186 then consolidated the pending journal backlog through 2026-05-24, so the repo was active, but mostly operationally rather than through new library capability
+
+## Issues
+- No new issues were opened after the last journal entry
+- No issues were closed in the same window either
+- That leaves the repo in an unusual state for this project: branch and workflow activity continued, but the issue tracker effectively paused
+
+## Pull Request Queue
+- The main substantive branch is still PR #177 (`Add GMP REST support gap helpers`), but it is now behind `main` instead of moving toward merge
+- The maintenance queue is also aging rather than draining: dependency PRs #165, #180, and #181 are all behind the branch tip
+- The new journal lane is open as PR #188, but it is blocked rather than already folded into the default branch
+
+## CI Health
+- The important default-branch signal stayed clean: `CI` and `Security` both succeeded for the automation merge in PR #168 and for the actions-update merge in PR #182
+- `OpenSSF Scorecard` also passed on the post-merge pushes, including the fast doc add/revert pair (#184 and #187)
+- So the repo does not look unstable; it looks under-merged on feature work while routine automation and branch protection changes continue to land cleanly

--- a/journal/2026-05-29.md
+++ b/journal/2026-05-29.md
@@ -1,0 +1,25 @@
+# 2026-05-29 — `main` Finally Moved Again, But the Bigger Story Is That the GMP Parity Lane Turned Into a Fresh Discovery Backlog
+
+## Mainline & Merged Work
+
+### The default branch absorbed one real bug fix after the 2026-05-24 baseline, while the rest of the visible movement stayed in maintenance and docs lanes
+- PR #191 (`fix(gmp): allow empty optional schedule ids`) merged on 2026-05-28 and fixed `GetTasksResponse` handling for unscheduled tasks, so the only new product-facing `main` change in this window was a targeted parser/compatibility correction rather than another broad parity tranche
+- The repo also landed PR #168 for journal PR automation plus PR #182 for the actions-group bump, which means operational maintenance still advanced even while feature throughput stayed narrow
+- Docs churn was real but self-correcting: PR #184 briefly made MCP look like a first-class gateway surface in the wrong repository, then PR #187 reverted that direction the same day
+- Journal backlog PR #186 merged as well, but that mostly cleaned up reporting debt rather than changing repository behavior
+
+## Issues
+- Issue #148 closed when PR #160 landed on 2026-05-18, confirming that the integration-config and report-helper parity slice documented in the prior entry is now complete on `main`
+- Four follow-on backlog issues opened on 2026-05-21: #172 (remaining GMP coverage roadmap), #173 (report drill-down commands), #174 (timezone and credential-store discovery), and #175 (mock fixtures / coverage for the remaining REST-support gaps)
+- The repo also converted a fresh bug report quickly: issue #190 (`GetTasksResponse rejects unscheduled tasks with empty schedule id`) opened on 2026-05-28 and closed the same day with PR #191
+- A new forward-looking issue, #192, now tracks reusable gvmd capability detection and probing primitives, so the parity lane has shifted from one-off gaps into capability discovery and coverage planning
+
+## Pull Request Queue
+- The live implementation branch is PR #193 (`feat(client): add gvmd capability discovery helpers`), which is currently the clearest follow-through from issue #192
+- PR #177 (`Add GMP REST support gap helpers`) remains open alongside older dependency bumps #181, #180, and #165, so the queue still carries both product backlog and maintenance debt instead of collapsing to one lane
+- Journal backlog PRs #188 and #189 are also still open, which reinforces that documentation automation exists now but is not yet fully draining the queue by itself
+
+## CI Health
+- The important signal on `main` is clean: the 2026-05-28 push for PR #191 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The new product-facing branch PR #193 also cleared both `CI` and `Security` on 2026-05-28, so the capability-discovery follow-on work is starting from a stable verification base
+- Operationally this repo is healthier than it looked in mid-May: the current risk is not broad branch instability, but whether the newly expanded GMP backlog keeps moving faster than the open PR pile grows

--- a/journal/2026-05-31.md
+++ b/journal/2026-05-31.md
@@ -1,0 +1,23 @@
+# 2026-05-31 — `main` Took a Small Real GMP Fix, Landed the Journal Automation Lane, and Cleaned Up a Wrong-Turn Docs Detour
+
+## Mainline & Merged Work
+
+### The default branch moved several times after the 2026-05-24 entry, but only one merge materially changed runtime behavior
+- PR #191 (`fix(gmp): allow empty optional schedule ids`) merged on 2026-05-28 and fixed issue #190, so unscheduled tasks no longer break on empty schedule IDs
+- PR #168 added journal PR automation to `main`, which matters operationally because the repo is now generating the documentation backlog automatically instead of relying on manual catch-up
+- Maintenance also landed through PR #182 (actions-group updates), while the docs lane briefly took a wrong turn: PR #184 made MCP look like a first-class gateway surface in the wrong repository and PR #187 reverted it the same day
+- PR #186 merged the accumulated journal backlog through 2026-05-24, but the substantive story in this window is still that the repo shipped one targeted GMP fix and otherwise mostly reorganized its maintenance and docs lanes
+
+## Issues
+- Issue #190 (`GetTasksResponse rejects unscheduled tasks with empty schedule id`) opened and closed on 2026-05-28, which shows the latest runtime defect was identified and repaired in the same day
+- A new follow-on issue, #192, now tracks reusable gvmd capability detection and probing primitives, so the next product lane is moving toward environment discovery rather than another one-off bug fix
+
+## Pull Request Queue
+- The live implementation branch is PR #193 (`feat(client): add gvmd capability discovery helpers`), which is the clearest continuation of the newly opened capability-probing issue
+- Older feature and maintenance work is still sitting in queue behind it: PR #177 (GMP REST support gap helpers), dependency bumps #165, #180, and #181, plus the growing journal backlog in PRs #188, #189, and #194
+- That leaves the repo in a familiar shape: `main` is stable and moving, but the next meaningful feature slice is still waiting off-branch rather than already absorbed
+
+## CI Health
+- The push for PR #191 passed `CI`, `Security`, and `OpenSSF Scorecard` on 2026-05-28, so the one real product change in this window validated cleanly
+- Dependabot automation on `main` also looks healthier than noisy right now: visible `Dependabot Updates` runs on 2026-05-25 and 2026-05-29 all completed successfully
+- There is no fresh branch-wide failure signal in the recent `main` history; the pressure point remains review throughput on the open queue, not broken verification

--- a/journal/2026-06-01.md
+++ b/journal/2026-06-01.md
@@ -1,0 +1,22 @@
+# 2026-06-01 — Mainline Moved from the #148 Parity Drop into Follow-up GMP Fixes, Roadmap Expansion, and Journal Automation
+
+## Product Surface
+
+### The product-facing code that actually landed on `main` after the 2026-05-14 baseline was narrower than the issue queue that formed around it
+- PR #160 closed issue #148 on 2026-05-18 and carried the integration-config plus report-helper parity work from the prior journal entry onto `main`.
+- PR #191 then landed a targeted parser fix on 2026-05-28 so unscheduled tasks with empty optional schedule IDs no longer break `GetTasksResponse`, closing issue #190 the same day.
+- No larger follow-up parity slice merged yet, but the repository opened the next planning wave immediately afterward through issues #172, #173, #174, #175, and #192.
+
+## Documentation & Planning
+- The repo took a meaningful docs and planning detour on 2026-05-25: PR #184 briefly made MCP a first-class gateway surface, and PR #187 reverted it later the same day after the repo concluded that work belonged elsewhere.
+- PR #186 consolidated pending journal entries through 2026-05-24, which means the repo used `main` to catch up its narrative backlog before the next implementation lane.
+
+## Issues
+- Six issues opened after the 2026-05-14 journal baseline: #172, #173, #174, #175, #190, and #192.
+- Two issues closed in the same window: #148 when the integration-config/report-helper parity work merged, and #190 when the empty-schedule-id fix landed.
+- The backlog shape shifted from one concrete parity issue to a broader roadmap: report drill-down coverage, timezone and credential-store discovery, REST-supporting mock coverage, and reusable gvmd capability probing are now explicit tracked follow-ons instead of implied future work.
+
+## CI Health
+- CI itself changed materially even though only one new product fix landed: PR #168 added journal PR automation, and PR #182 refreshed the GitHub Actions dependency group.
+- `main` still produces mixed maintenance signals rather than an all-green wall. On 2026-06-01 the latest `Dependabot Updates` batch split between successful cargo updates and failures in the pip and GitHub Actions lanes.
+- The latest product push signal is still healthy: the 2026-05-28 `OpenSSF Scorecard` run for PR #191 completed successfully on `main`.

--- a/journal/2026-06-02.md
+++ b/journal/2026-06-02.md
@@ -1,0 +1,23 @@
+# 2026-06-02 — `main` Absorbed the REST-Gap Helper Slice, Landed Typed Report Export, and Immediately Spawned an Alert-Compatibility Follow-On
+
+## Mainline & Merged Work
+
+### The default branch actually moved in a product direction this time, not just through maintenance or docs
+- PR #177 (`Add GMP REST support gap helpers`) merged on 2026-06-01 and closed issues #173, #174, and #175 together, so the repo converted a broad compatibility/testing bundle into shipped `main` behavior in one push
+- PR #200 (`feat(gmp): add typed report export request and response support`) merged later the same day and added typed report-export coverage as a fresh runtime capability instead of only rounding off old GMP gaps
+- That leaves the last 24 hours looking materially different from the 2026-05-31 entry: the queue stopped being only potential energy and actually delivered two substantive feature slices to `main`
+
+## Issues
+- Issue #199 (`feat(gmp): add typed report export request and response support`) opened and closed on 2026-06-01, which shows the report-export lane was identified, implemented, and merged inside the same day
+- A new follow-on issue, #201 (`Own gvmd alert name compatibility in typed alert APIs`), opened just before PR #200 merged, so the next compatibility problem is already isolated instead of being left implicit in review comments or ad hoc fixes
+- The older GMP gap issues #173, #174, and #175 all closed when PR #177 landed, which is the clearest sign that the REST-support helper branch was more than a narrow code tweak
+
+## Pull Request Queue
+- The active front edge is now PR #202 (`fix(gmp): own gvmd alert name compatibility`), which reads like the direct continuation of newly opened issue #201 rather than a disconnected branch
+- The queue behind it is still mixed between real feature work and maintenance backlog: PR #193 (gvmd capability discovery), PRs #196, #197, #181, and #165 (dependency/CI updates), plus the still-open journal lane in PR #198
+- So the repo's posture improved relative to 2026-05-31 because `main` finally absorbed real product work, but review pressure still exists on both the capability-discovery branch and a familiar dependabot stack
+
+## CI Health
+- The pushes for PRs #177 and #200 each passed `CI`, `Security`, and `OpenSSF Scorecard` on 2026-06-01, so both substantive merges validated cleanly on the default branch
+- Scheduled `Security` on `main` also completed successfully earlier that day, which means the repo did not pay for the merge burst with an immediate baseline verification regression
+- The noisy signal in this window sits in maintenance automation rather than product verification: a `pip` dynamic update and a `github_actions` dynamic update both failed on 2026-06-01 while the cargo-oriented update lanes succeeded

--- a/journal/2026-06-03.md
+++ b/journal/2026-06-03.md
@@ -1,0 +1,20 @@
+# 2026-06-03 — Mainline Closed More GMP Parity Gaps, Added Typed Report Export Support, and Tightened Automation Around the Repo
+
+## Product Surface
+
+### The mainline story after the 2026-05-14 baseline is continued GMP surface expansion rather than one isolated fix
+- PR #160 closed issue #148 and landed the integration-config plus report-helper command family on `main`, extending the GMP builders, typed client traits, and mock-server coverage beyond what the 2026-05-14 entry had already staged conceptually
+- PR #177 followed by filling more of the REST-support gap with timezone discovery, credential-store discovery, and report drill-down support, and the associated issues (#173, #174, #175) were opened and closed immediately as that work merged
+- PR #200 then restored typed report-export request and response support on `main`, which matters because downstream repos are now depending on a stable export contract rather than carrying that shape only in issue form
+- The last two default-branch fixes in this window were narrower but still release-facing: PR #202 aligned typed enums with gvmd and python-gvm 22.7 behavior, and PR #205 preserved self-closing gvmd error status handling so export failures keep their semantics instead of collapsing to an empty-status edge case
+- PR #207 finally typed the `resume_task` response, including the `report_id` shape rust-gvm-api needs downstream, so the repo closed this window with another concrete compatibility gap removed
+
+## Backlog & Coordination
+- Most of the issues opened in this window were merge-and-close tracking issues tied directly to the landed GMP work: #190, #199, #201, #204, and #206 are all already closed, and #173 through #175 closed with the REST-support helper merge
+- Two planning items remain open and now stand out more clearly because so much nearby implementation already landed: #172 still tracks the broader remaining GMP coverage roadmap, and #192 keeps reusable gvmd capability detection/probing work on the queue
+- Journal automation also became first-class repo plumbing through PR #168, and `main` absorbed the backfilled journal consolidation commit from PR #186 after that workflow was introduced
+
+## CI & Automation
+- CI automation changed in two visible ways on `main`: PR #168 added the journal PR workflow, and PR #182 refreshed the GitHub Actions dependency set that supports the automation stack
+- The verification signal on landed product work stayed clean in the latest burst: `CI`, `Security`, and `OpenSSF Scorecard` all passed on the 2026-06-01 and 2026-06-02 `main` pushes tied to PRs #200, #205, and #207
+- The noisy lane is now concentrated in dependency branches rather than `main`: recent Dependabot and cargo update PRs have produced a mix of `CI` successes and `Security` failures, so the repo's baseline is healthy even though the maintenance queue is not uniformly green

--- a/journal/2026-06-04.md
+++ b/journal/2026-06-04.md
@@ -1,0 +1,23 @@
+# 2026-06-04 — Mainline Closed Most of the GMP REST Gap Burst and Kept the Verification Signal Clean
+
+## Mainline & Merged Work
+
+### `main` absorbed a real product burst rather than another narrow parity slice
+- Since the 2026-05-24 entry, `main` has taken a dense run of substantive merges: PR #177 landed the queued GMP REST gap helpers, PR #200 added typed report-export request and response support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 fixed self-closing gvmd report-export error handling, PR #207 typed `resume_task` responses, and PR #210 added note/override result-flag support
+- The window also carried two repo-operations changes with real impact: PR #168 added journal PR automation and PR #181 bumped `russh` on `main`, while PR #184's MCP-surface planning was explicitly reverted by PR #187 before it could turn into durable product direction
+- That combination matters because the repo is no longer just enumerating missing GMP surface area; it converted most of the 2026-05-21 follow-on issue cluster into shipped client behavior on `main`
+
+## Issues
+- The repo opened seven new tracking issues in this window: #190 (empty optional schedule IDs), #192 (capability probing helpers), #199 (typed report export), #201 (typed alert compatibility), #204 (report-export error preservation), #206 (`resume_task` typing for rust-gvm-api), and #209 (note/override result expansion)
+- Six of those issues already closed through merged work on `main`: #190, #199, #201, #204, #206, and #209
+- The earlier GMP gap backlog also burned down materially when issues #173, #174, and #175 all closed with PR #177, leaving #192 as the clearest remaining capability-discovery branch still waiting off `main`
+
+## Pull Request Queue
+- The queue is now much narrower and more specific than it was in late May: PR #193 carries the remaining gvmd capability-discovery helpers, while dependency work stays open in PRs #165, #196, and #197
+- Journal backlog continues to accumulate in parallel through open PRs #188, #189, #194, #195, #198, #203, and #208, but that is maintenance noise rather than a product blocker
+- Relative to the last entry, the important shift is that the repo's highest-value GMP/report-export work is now on `main`, and the remaining open branches are follow-through rather than the core gap itself
+
+## CI Health
+- Push verification stayed clean across the substantive June merges: `CI`, `Security`, and `OpenSSF Scorecard` all passed for PRs #177, #200, #202, #205, #207, and #210
+- Scheduled `Security` on `main` also succeeded on 2026-06-01, so the baseline branch signal remained green while product work was landing quickly
+- The only fresh mainline noise in this window came from automation rather than code regressions: a dynamic `pip` update failed on 2026-06-01 while the paired cargo update lanes completed successfully

--- a/journal/2026-06-06.md
+++ b/journal/2026-06-06.md
@@ -1,0 +1,23 @@
+# 2026-06-06 — Typed GMP Parity Accelerated, the REST Gap Slice Landed, and Mainline Stayed Green
+
+## Mainline & Merged Work
+
+### `main` moved from backlog cleanup into a real feature burst after the 2026-05-24 journal baseline
+- The 2026-05-25 landing set was mostly operational: PR #168 added journal PR automation, PR #182 refreshed the actions stack, PR #184 briefly pushed MCP gateway docs into the wrong repo, PR #187 reverted that mistake, and PR #186 merged the accumulated journal backlog
+- The substantive product lane then accelerated across 2026-05-28 through 2026-06-03: PR #177 landed the GMP REST support gap helpers, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd report-export errors, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- Dependency maintenance also crossed the line instead of lingering forever: PR #181 updated `russh` to 0.61.1 and carried the needed CI adjustments with it
+
+## Issues
+- The follow-on GMP backlog converted into actual closures instead of just queue growth: issues #173, #174, and #175 closed with PR #177 on 2026-06-01
+- New implementation issues #199, #201, #204, #206, and #209 all opened and closed quickly as their paired PRs merged between 2026-06-01 and 2026-06-03
+- The one notable issue that did not immediately resolve is #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`), opened on 2026-05-28 and still carrying the next deeper compatibility layer
+
+## Pull Request Queue
+- The open queue is still dominated by journal backlog PRs rather than product work: #188, #189, #194, #195, #198, #203, #208, and #211 are all journal branches waiting for review
+- The non-journal queue is narrow but not empty: PR #193 holds the gvmd capability-discovery work in a `DIRTY` state, while dependency PRs #165, #196, and #197 are all sitting `BEHIND`
+- So the repo's bottleneck has shifted from "missing implementation" toward "review and merge throughput"
+
+## CI Health
+- Push validation on the real product merges is clean: `CI`, `Security`, and `OpenSSF Scorecard` all completed successfully on 2026-06-02 and again on 2026-06-03
+- `Dependabot Updates` also completed successfully on 2026-06-02, so the maintenance lane is at least executing rather than failing by default
+- There is no fresh evidence of broad default-branch instability; the friction is in queue age, not in broken mainline checks

--- a/journal/2026-06-07.md
+++ b/journal/2026-06-07.md
@@ -1,0 +1,22 @@
+# 2026-06-07 — `main` Turned the REST-Support GMP Queue into Shipped Surface Area While the Backlog Stayed Busy
+
+## Mainline & Merged Work
+
+### `main` absorbed a real run of product-facing GMP work after the 2026-05-24 baseline
+- Seven substantive merges reached the default branch in this window: PR #177 added REST-support GMP gap helpers, PR #191 fixed empty optional schedule ids, PR #200 added typed report-export support, PR #202 aligned typed enums with gvmd and `python-gvm` 22.7, PR #205 preserved self-closing gvmd error status in report export flows, PR #207 typed `resume_task` responses for downstream consumers, and PR #210 added note/override result expansion support
+- That sequence is coherent rather than scattered churn: the repo first tightened compatibility and error-shape handling, then expanded the typed surface for report export, task resumption, and note/override result access
+- Non-product but still notable mainline changes also landed on 2026-05-25: PR #168 added journal PR automation, PR #182 updated GitHub Actions dependencies, and PRs #184 and #187 briefly added then reverted MCP planning that belonged in a different repository
+
+## Issues
+- New issues in this window were tightly coupled to merged work: #190 (empty schedule ids), #199 (typed report export), #201 (typed alert compatibility), #204 (self-closing gvmd error status), #206 (typed `resume_task` response), and #209 (note/override result expansion) all opened and then closed quickly as their matching PRs landed
+- One new capability follow-up remains open: #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`)
+- Older backlog also kept burning down as the new feature lane landed: issues #173, #174, and #175 all closed on 2026-06-01 when PR #177 merged, leaving the broader roadmap issue #172 plus the newer capability-probing thread #192 as the visible remaining GMP-gap anchors
+
+## Pull Request Queue
+- The queue is now split between one real feature follow-on and a large docs/maintenance tail: PR #193 carries capability discovery helpers, while dependency PRs #196 and #197 and the unmerged daily journal PRs from #188 through #212 keep the branch list noisy
+- That queue shape matters because `main` has already absorbed the most important typed-surface work; the unresolved risk is now review throughput and backlog cleanup more than missing core GMP primitives
+
+## CI Health
+- Mainline verification stayed strong for shipped work: the 2026-06-02 and 2026-06-03 pushes on `main` cleared `CI`, `Security`, and `OpenSSF Scorecard`
+- The cleanest negative signal is isolated to dependency maintenance rather than the core product lane: the `quick-xml` bump in PR #165 failed both `CI` and `Security` on 2026-06-02
+- In other words, the shipped GMP expansion work is validating cleanly, while maintenance branches are where the visible CI drag remains

--- a/journal/2026-06-08.md
+++ b/journal/2026-06-08.md
@@ -1,0 +1,23 @@
+# 2026-06-08 — `main` Expanded GMP Coverage Again While the Queue Split Between Real Follow-Through and Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` absorbed a real multi-PR GMP/API expansion after the 2026-05-24 baseline
+- Seven substantive merges landed on `main` in this window: PR #177 added REST-support gap helpers, PR #191 fixed empty optional schedule IDs, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd error status, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- That is a coherent implementation burst rather than unrelated churn: the repo filled several remaining GMP surface gaps, tightened typed behavior around gvmd edge cases, and added follow-through client ergonomics for downstream consumers
+- The only non-product merges on `main` in the same span were PR #168 (journal PR automation), PR #182 (actions updates), and the short-lived docs lane around PRs #184 and #187, so the dominant story here is still API and protocol coverage advancing materially
+
+## Issues
+- Seven issues opened after the 2026-05-24 entry: #190, #192, #199, #201, #204, #206, and #209
+- Six of those were opened and closed in the same window by shipped work on `main`: #190, #199, #201, #204, #206, and #209 all burned down immediately once the corresponding fixes landed
+- The remaining open thread is more architectural than bug-fix oriented: #192 keeps the capability-detection/probing lane alive while the older umbrella roadmap issue #172 also remains open
+
+## Pull Request Queue
+- The queue is now split sharply between real follow-through work and accumulated journal noise
+- PR #193 (`feat(client): add gvmd capability discovery helpers`) is the one obvious substantive open branch tied directly to the still-open capability-detection lane
+- Everything else near the front of the queue is maintenance or docs churn: dependency bumps #214 and #215, the older `quick-xml` bump #165, and a long stack of unmerged daily journal PRs from #188 through #213
+
+## CI Health
+- CI signal on shipped work stayed usable across this burst: the substantive merges that landed on `main` cleared `CI` and `Security`, and the repo did not show the kind of broad branch instability that would undercut the feature pace
+- The workflow surface itself changed in this window through PR #168 (journal automation) and PR #182 (actions updates), so some of the visible activity is automation evolution rather than library behavior
+- The freshest signal is mixed but contained: new dependency PRs on 2026-06-08 split between green and red checks, while scheduled `OpenSSF Scorecard` succeeded on 2026-06-07, so the current risk is queue throughput and dependency noise rather than a broken `main`

--- a/journal/2026-06-11.md
+++ b/journal/2026-06-11.md
@@ -1,0 +1,24 @@
+# 2026-06-11 — `main` Burned Down the Remaining GMP Follow-on Queue and Left Only Maintenance Branches Behind
+
+## Mainline & Merged Work
+
+### The repo turned the post-2026-06-09 parity queue into one tight two-day landing burst
+- `main` absorbed PR #220 (typed NVT score accessors), PR #221 (host-type compatibility attrs), PR #224 (target credential command fields), PR #227 (required feed-version parsing), PR #228 (typed task detail fields), PR #230 (target credential readback), PR #232 (typed report/result/port-list metadata), PR #235 (user auth and scan-config type fields), PR #236 (filter fragment validation), PR #239 (unnamed note/override parsing), and PR #240 (id-only note/override refs)
+- That is not random cleanup churn. It closes a coherent stretch of GMP compatibility work around typed metadata, target credentials, filter safety, and note/override response handling
+- The practical result is that the repo used this window to finish several of the contract slices that were still visibly blocking downstream `rust-gvm-api` work on 2026-06-09
+
+## Issues
+- Nine new issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, and #238
+- All nine closed through same-day or next-day merges on `main`
+- Older follow-on residue also cleared while this burst landed: #219 (typed NVT score helpers) and #192 (capability detection/probing primitives) both closed in the same window
+- The interesting shift is that this slice did not leave a fresh product backlog behind. The repo converted a visible GMP gap queue into merged code instead of just reshuffling it into more open issues
+
+## Pull Request Queue
+- The substantive implementation queue is effectively gone for now; there are no fresh product branches sitting in review after PR #240 merged
+- The remaining open PRs are maintenance and backlog cleanup rather than new GMP feature work: dependency bumps #214 and #215 plus older unmerged journal PRs such as #216
+- That is a healthier queue shape than the repo had on 2026-06-09 because the front of the line is no longer carrying unresolved contract work
+
+## CI Health
+- `main` ended the window green. The latest 2026-06-10 push passed `CI`, `Security`, and `OpenSSF Scorecard`
+- There was brief noise earlier the same day when the `main` push for PR #239 failed `CI`, but the later push for PR #240 cleared it immediately
+- The remaining instability is concentrated on maintenance branches rather than `main`: PR #215 is still failing `CI`, and PR #214 is still failing `Security` via `Cargo Vet`

--- a/journal/2026-06-12.md
+++ b/journal/2026-06-12.md
@@ -1,0 +1,23 @@
+# 2026-06-12 — `main` Finished the Current GMP Parity Burst and Left the Remaining Queue Mostly in Maintenance Mode
+
+## Mainline & Merged Work
+
+### The repo did not just keep adding scattered fields; it closed out an entire slice of typed GMP contract work in one sustained run
+- Since the 2026-06-09 journal entry, `main` absorbed PR #220 (typed NVT score helpers), PR #221 (host-type compatibility attrs), PR #224 (target credential command fields), PR #227 (required feed version), PR #228 (typed task detail fields), PR #230 (target credential refs in responses), PR #232 (typed report/result/port-list metadata), PR #235 (user auth and scan-config type exposure), PR #236 (filter fragment validation), PR #239 and #240 (note/override parser fixes), and PR #244 (missing target, alert, and report fields)
+- That matters because the June 9 through June 11 sequence looks less like opportunistic cleanup and more like a deliberate final pass over the remaining GMP surface mismatches that were blocking downstream typed consumers
+- The shape of `main` changed accordingly: the repo now reads like it has largely finished the current parity burst rather than merely making progress inside it
+
+## Issues
+- Ten new issues opened in this window and every one of them already closed through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, and #242
+- Older backlog also burned down while the same wave was landing. Most importantly, #219 closed when the typed NVT score work merged and #192 finally closed once the capability-detection/probing follow-on landed on 2026-06-10
+- The repo therefore moved from carrying a visible tail of contract gaps to carrying almost none of this specific class of work
+
+## Pull Request Queue
+- The open queue is now much narrower in product terms than it was three days ago
+- The only non-journal branches still open are dependency and maintenance items: PR #214 (cargo updates), PR #215 (actions updates), and PR #165 (the long-lived `quick-xml` bump)
+- The newest operational branch is PR #245, which consolidates the pending journal backlog rather than extending the library surface further
+
+## CI Health
+- Mainline verification stayed clean throughout the closing burst. The 2026-06-10 push after PR #240 and the 2026-06-11 push after PR #244 both passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The latest product PRs were also healthy before merge: PR #244 cleared both `CI` and `Security`, and the journal-consolidation PR #245 immediately passed `Security` as well
+- In other words, the repo's visible risk has shifted away from functional GMP correctness and toward ordinary maintenance throughput

--- a/journal/2026-06-13.md
+++ b/journal/2026-06-13.md
@@ -1,0 +1,24 @@
+# 2026-06-13 — Mainline Kept Burning Down Typed GMP Drift, but the Queue Has Now Collapsed into Two Open Bugs and Maintenance PRs
+
+## Mainline & Merged Work
+
+### `main` spent the rest of the week closing the next layer of typed GMP shape mismatches instead of reopening broad new surface area
+- Since the 2026-06-09 journal entry, `main` absorbed a dense follow-on burst: PR #221 fixed host-type compatibility attributes, #224 added typed target credential fields, #227 made feed versions required in responses, #228 and #230 filled task-detail and target-credential parsing gaps, #232 exposed typed report/result/port-list metadata, #235 added user-auth and scan-config type coverage, #236 added GMP filter-fragment validation, #239 and #240 hardened note and override parsing, #244 filled missing target/alert/report fields, #249 fixed scoped report-metadata fetches, and #252 preserved user host-access mode
+- That set is narrower than the previous parity burst but still materially important: the repo spent four days shaving off places where gvmd or downstream `rust-gvm-api` conversions were still encountering silent model drift, weak validation, or partial typed coverage
+- The result is that the repo no longer looks like it is missing a large product lane. It looks like it is grinding through the remaining edge-shape correctness work one focused branch at a time
+
+## Issues
+- Fourteen issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, and #251
+- Twelve of those already closed through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, and #250
+- Older follow-on debt also continued to burn down: issue #192 closed on 2026-06-10 while the new parsing and validation work landed
+- The unresolved residue is now crisp rather than sprawling: #247 tracks the nonexistent `no_report` option on `GetReportsOpts`, and #251 tracks remaining uncertainty around user host-access response modeling
+
+## Pull Request Queue
+- There are no open substantive product branches left in the queue right now
+- The open PR list has collapsed into maintenance and documentation pressure: dependency PRs #165, #214, and #215 are still waiting, while journal backlog PRs #245 and #246 remain open
+- That is a healthier shape than the repo had earlier in June because the unanswered questions are now concentrated in two open issues rather than spread across many half-finished implementation branches
+
+## CI Health
+- Most of the window stayed green: the merged feature branches for #249 and #252 both cleared `CI` and `Security` before landing, and the earlier `main` push for #249 also passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The newest signal is mixed rather than clean. The latest `main` push for PR #252 passed `Security` and `OpenSSF Scorecard` but failed `CI`
+- That means the repo's current operational risk is not broad instability across all lanes. It is a fresh `CI` regression on `main` after an otherwise steady typed-model cleanup run

--- a/journal/2026-06-14.md
+++ b/journal/2026-06-14.md
@@ -1,0 +1,23 @@
+# 2026-06-14 — Mainline Cleared a Tight GMP Follow-On Burst, but the Latest Fix Reopened CI and Left Two Model Gaps Behind
+
+## Mainline & Merged Work
+
+### `main` spent this window finishing a narrow but coherent round of GMP compatibility work
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), PR #236 (filter fragment validation), PR #239 (unnamed note/override parsing), PR #240 (id-only note/override refs), PR #244 (missing typed GMP target and alert fields), PR #249 (scoped report metadata fetches), and PR #252 (preserve user host access mode)
+- That sequence matters because the repository did not fan back out into broad feature work. It stayed focused on response-shape drift, parser resilience, and typed contract cleanup around concrete gvmd compatibility gaps
+- The result is a smaller but more disciplined burst than the earlier June expansion: fewer branches overall, but nearly all of them tighten mismatches between the typed surface and real server behavior
+
+## Issues
+- Eight issues opened in this window: #234, #237, #238, #242, #247, #248, #250, and #251
+- Six of those already closed directly through merged work on `main`: #234, #237, #238, #242, #248, and #250
+- The unresolved residue is now concentrated in two places rather than spread everywhere: #247 tracks the nonexistent `GetReportsOpts::no_report` path that gvmd ignores, and #251 keeps the broader user-host-access model audit open
+
+## Pull Request Queue
+- The active non-journal queue is mostly maintenance now: PR #214 (cargo dependency updates), PR #215 (GitHub Actions updates), and the older quick-xml bump PR #165 remain open
+- Journal backlog is still clogging the branch list via PRs #245, #246, and #253, so the repository's visible queue is noisier than the actual product queue
+- That is a healthier shape than early June because the substantive GMP follow-on work has mostly landed; what remains is mostly cleanup, dependency churn, and documentation lag
+
+## CI Health
+- Verification was mostly clean through the middle of the burst. The `main` push for PR #249 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The newest mainline merge regressed that clean picture: PR #252 landed with `Security` and `OpenSSF Scorecard` still green, but the `CI` workflow on `main` failed
+- The open maintenance queue is also mixed. PR #214 is failing `Cargo Vet` and `Security`, while PR #215 is failing `Test (all features)` even though the rest of its matrix is green

--- a/journal/2026-06-15.md
+++ b/journal/2026-06-15.md
@@ -1,0 +1,24 @@
+# 2026-06-15 — `main` Finished a Dense GMP Typing Burst, Closed Most of Its Follow-On Gaps, and Cleared the Product Queue Back to Drift Cleanup
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-09 through 2026-06-12 pushing through one unusually dense stretch of typed GMP surface work
+- Since the 2026-06-09 journal entry, `main` absorbed PR #220 (typed NVT score accessors), #221 (host type compatibility attrs), #224 (target credential command fields), #227 (required feed version handling), #228 (typed task detail fields), #230 (target credential response refs), #232 (typed report/result/port-list metadata), #235 (user auth and scan-config type exposure), #236 (filter fragment validation), #239 and #240 (note/override parsing fixes), #244 (missing typed alert/target/report fields), #249 (ID-scoped report metadata fetches), and #252 (user host access mode preservation)
+- That sequence matters because the repo was not just polishing edges. It spent four days filling a long list of typed-response and request-shape gaps that had been blocking higher-level consumers, especially `rust-gvm-api`
+- The result is that the product queue is no longer dominated by broad GMP parity work. Most of the visible movement now comes from narrower drift cleanup rather than missing typed surface area
+
+## Issues
+- Fourteen issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, and #251
+- Twelve of those closed quickly through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, and #250
+- Older backlog also fell while the burst was landing: issue #219 closed with PR #220, and the long-running capability/probing gap in #192 closed on 2026-06-10
+- The unresolved residue is now sharply narrower than the queue described on 2026-06-09. The only fresh follow-on issues still open from this burst are #247 (`GetReportsOpts::no_report` drift) and #251 (user host access response-shape drift)
+
+## Pull Request Queue
+- There are no open product PRs right now
+- The remaining open queue is almost entirely maintenance and documentation pressure: dependency PRs #165, #214, and #215 are still open, and the journal backlog now spans #245, #246, #253, and #254
+- That is a healthier queue shape than the repo had a week ago because the implementation burst actually landed instead of stalling in review
+
+## CI Health
+- Verification was mostly healthy across the burst, but not perfectly clean. `main` pushes for PRs #236, #240, #244, and #249 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- Two merges introduced the only obvious red `main` signal in this window: the pushes for PR #239 on 2026-06-10 and PR #252 on 2026-06-12 both failed `CI` while still passing `Security` and `OpenSSF Scorecard`
+- The repo-level maintenance signal is also mixed rather than fully green. The scheduled `OpenSSF Scorecard` run on `main` passed on 2026-06-14, and the open actions-update PR #215 is green in both `CI` and `Security`, but the latest dynamic update run on `main` failed for the GitHub Actions lane even while the cargo update lanes passed

--- a/journal/2026-06-16.md
+++ b/journal/2026-06-16.md
@@ -1,0 +1,23 @@
+# 2026-06-16 — Mainline Cleared a Fast GMP Parity Slice, Leaving Mostly Maintenance and Journal Debt in the Queue
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-10 through 2026-06-15 closing a compact but coherent GMP model-correction burst
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config typing), #236 (filter fragment validation), #239 and #240 (note/override parser fixes), #244 (missing target and alert fields), #249 (scoped report metadata fetches), #252 (host-access mode preservation), and #258 (schedule first/next run timestamps)
+- That sequence matters because it was not random bug churn. Nearly every merge tightened typed GMP parity around filters, note and override parsing, report retrieval, user host-access semantics, and schedule modeling
+- The window also burned down older residue while it landed. PR #236 closed the long-lived capability/filter helper tracker #192, and the same burst resolved fresh issues #234, #237, #238, #242, #248, #250, and #257 directly on `main`
+
+## Issues
+- Ten issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, and #257
+- Eight of those already closed through merged work on `main`, and older tracker #192 also fell during the same slice
+- The unresolved residue is now narrow rather than diffuse: #247 (the `details=0` / `no_report` mismatch) and #251 (user host-access response/model drift) are the clearest remaining follow-ons from this burst
+
+## Pull Request Queue
+- Product branches have effectively cleared out of the immediate queue. The only non-journal open work is now dependency maintenance PRs #165, #214, and #215
+- Journal debt is still stacked ahead of them through PRs #245, #246, #253, #254, and #255
+- That is a healthier queue shape than the repo had on 2026-06-09 because the remaining visible work is mostly maintenance and documentation backlog, not unresolved GMP behavior gaps
+
+## CI Health
+- `main` is green in the latest visible window: the 2026-06-15 push for PR #258 cleared `CI`, `Security`, and `OpenSSF Scorecard`, and scheduled `Security` on `main` also passed the same day
+- The active actions bump PR #215 is fully green, but the dependency queue is not uniformly clean: PR #214 fails `Cargo Vet` and `Security`, while the older quick-xml bump PR #165 is broadly red across test, lint, and security lanes
+- Dependabot monitoring on `main` remains noisy as well, with one 2026-06-15 GitHub Actions update suggestion failing while sibling update detections succeeded


### PR DESCRIPTION
## Summary
- consolidate the currently open docs/journal PRs into one docs-only PR
- add pending journal entries for 2026-05-26, 2026-05-28, 2026-05-29, 2026-05-31, 2026-06-01, 2026-06-02, 2026-06-03, 2026-06-04, 2026-06-06, 2026-06-07, 2026-06-08, 2026-06-11, 2026-06-12, 2026-06-13, 2026-06-14, 2026-06-15, and 2026-06-16
- replace the open journal/docs PR stack: #245, #246, #253, #254, #255, and #259

## Testing
- not run; docs-only change

Agent: Thoth
