### PR TITLE
docs(journal): add 2026-06-17 journal entry

### DIFF
--- a/journal/2026-06-17.md
+++ b/journal/2026-06-17.md
@@ -1,0 +1,22 @@
+# 2026-06-17 — Mainline Closed a Week of Typed GMP Gaps and Left Only Two Fresh Model Risks in the Lane
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-10 through 2026-06-16 turning a queue of concrete GMP mismatches into shipped library behavior
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), #236 (GMP filter fragment validation), #239 (unnamed note/override parsing), #240 (id-only note/override refs), #244 (missing target and alert fields), #249 (scoped report metadata fetches), #252 (user host access mode preservation), #258 (schedule run timestamps), and #261 (report export options)
+- That run is coherent rather than scattered maintenance. The repo kept tightening typed GMP request and response coverage around real gvmd compatibility gaps instead of bouncing between unrelated crates or tooling chores
+- The result is a cleaner mainline contract for callers using typed report export, schedule metadata, user access settings, filter composition, and note or override modeling
+
+## Issues
+- Eleven issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, and #260
+- Nine of those already closed through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- The unresolved residue is now narrow and specific rather than broad parity churn: #247 (`GetReportsOpts::no_report` does not match gvmd behavior) and #251 (audit user host access response shape and adjacent model drift) are the two clear follow-on product risks from this burst
+
+## Pull Request Queue
+- The active product queue is no longer crowded. Mainline already absorbed the substantive June GMP work, and the remaining open branches are mostly backlog management: journal consolidation PR #262 plus dependency PRs #165, #214, and #215
+- That is a healthier queue shape than the repo had at the 2026-06-09 baseline because the typed GMP parity lane is now mostly on `main`, not stranded across review branches
+
+## CI Health
+- The post-merge signal on `main` stayed clean throughout this window: `CI`, `Security`, and `OpenSSF Scorecard` all passed on the 2026-06-15 and 2026-06-16 pushes
+- The newest product branches also validated cleanly before merge. PR #258 and PR #261 both cleared `CI` and `Security`, and there were no fresh workflow-level regressions on `main` while the GMP work landed
+- The only visible noise remained in maintenance automation rather than release-facing library changes: `Dependabot Updates` on `main` split between success and failure even while the shipped product work stayed green


### PR DESCRIPTION
## Summary
- add the 2026-06-17 journal entry
- capture notable repo activity since the last journal baseline on `main`

Agent: Thoth
