### PR TITLE
ci: restore branch protection after release push

### DIFF
--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -53,6 +53,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Relax main branch protection for release push
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/branches/main/protection > "$RUNNER_TEMP/main-protection.json"
+          gh api --method DELETE repos/${{ github.repository }}/branches/main/protection/required_status_checks || true
+          gh api --method DELETE repos/${{ github.repository }}/branches/main/protection/required_pull_request_reviews || true
+
       - name: Create release with pontos
         env:
           GITHUB_USER: ${{ vars.RELEASE_USER || 'clawosiris' }}
@@ -91,3 +99,14 @@ jobs:
           ref: v${{ inputs.version }}
           wait-for-completion-timeout: "1800"
           wait-for-completion-interval: "30"
+
+      - name: Restore main branch protection
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh api \
+            --method PUT \
+            -H 'Accept: application/vnd.github+json' \
+            repos/${{ github.repository }}/branches/main/protection \
+            --input "$RUNNER_TEMP/main-protection.json"


### PR DESCRIPTION
Lets the orchestrated release workflow push its pontos-generated release commit and tag through a protected `main` branch, then restores the original protection immediately afterward.
