### PR TITLE
docs(journal): add 2026-06-19 journal entry

### DIFF
--- a/journal/2026-06-19.md
+++ b/journal/2026-06-19.md
@@ -1,0 +1,23 @@
+# 2026-06-19 — Mainline Finished a Dense GMP Parity Burst, Cut `v0.3.3`, and Left the Queue Mostly as Journal Backlog Plus CI Maintenance
+
+## Mainline & Merged Work
+
+### `main` moved through one sustained product lane, then immediately rolled into release automation follow-through
+- Since the 2026-06-09 baseline, `main` absorbed PR #235 (user auth plus scan-config type exposure), #236 (validated GMP filter fragments), #239 and #240 (note/override parser fixes), #244 (missing typed GMP fields), #249 and #252 (report metadata scoping plus host-access-mode support), #258 (schedule run timestamps), #261 (report export options), and #265 (restore branch protection after the release push)
+- That set is coherent rather than scattered. The repo spent most of the window closing typed GMP surface and compatibility gaps, then used 2026-06-18 to turn that work into a `v0.3.3` release with follow-up fixes to artifact publishing and SBOM-quality reporting
+- The result is a repo that is materially further along its parity lane than the 2026-06-09 entry described: export configuration shipped, schedule metadata expanded, parser edge cases were cleaned up, and the release train actually moved instead of waiting on more backlog grooming
+
+## Issues
+- Eleven issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, and #260
+- Nine of those already closed through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- Older follow-through also burned down on the same lane: issue #192 closed on 2026-06-10 when filter-fragment validation landed
+- The unresolved residue from this burst is now narrow and concrete rather than sprawling: #247 (`GetReportsOpts::no_report` drift) and #251 (user host-access response-shape audit) are the main product leftovers from the latest GMP push
+
+## Pull Request Queue
+- The active queue is now mostly non-product backlog. Open PRs #262, #263, and #264 are all journal branches, while #214, #215, and #165 are dependency or workflow-maintenance branches
+- That is a healthier queue shape than the 2026-06-09 entry described because the substantive GMP work is already on `main`; what remains visible is review throughput on maintenance branches and accumulated journal automation output
+
+## CI Health
+- The 2026-06-18 release window was not uniformly green. `CI` and `OpenSSF Scorecard` succeeded on the release commits and the branch-protection restore follow-up, but `Security` failed repeatedly across the `v0.3.3` release and post-release fix pushes
+- Release automation itself also showed noise: the `Orchestrated Release` run on 2026-06-18 failed before the later release-fix commits and warning-only SBOM adjustment landed
+- Even with that noise, the repo's current signal is stronger than it looks at first glance. The mainline GMP work shipped and tagged successfully; the sharp edge now is release/security workflow stability rather than uncertainty about the product branch itself


### PR DESCRIPTION
## Summary
- add the 2026-06-19 journal entry
- cover the post-2026-06-09 GMP parity, release, and CI activity on main

Agent: Thoth
