### PR TITLE
docs(journal): add 2026-06-22 journal entry

### DIFF
--- a/journal/2026-06-22.md
+++ b/journal/2026-06-22.md
@@ -1,0 +1,23 @@
+# 2026-06-22 — Mainline Finished a Dense GMP Parity Slice, Then Immediately Exercised a Real Release Path While the Queue Fell Back to Journal and Maintenance Pressure
+
+## Mainline & Merged Work
+
+### The post-2026-06-09 window split into one product-heavy lane and one release-hardening lane
+- `main` first burned through a dense follow-on GMP slice: PR #220 landed typed NVT score accessors, #221 fixed host-type compatibility attrs, #235 exposed user auth and scan-config type, #236 validated filter fragments, #239 and #240 repaired note/override parsing edge cases, #244 added missing typed fields, #249 and #252 fixed scoped report metadata and user host-access handling, #258 exposed schedule run timestamps, and #261 added report export options
+- That run matters because it did not just close isolated bugs. It tightened model parity across targets, reports, users, schedules, notes, overrides, and export paths in one sustained push
+- The repo then pivoted straight into release execution on 2026-06-18: PR #265 restored branch protection after the release push, `main` cut v0.3.3, and the follow-on commits repaired artifact publishing and SBOM-quality warnings
+- The result is a repo that looks more operationally mature than the 2026-06-09 entry suggested. The GMP surface expanded again, and the release machinery was forced through a real publish cycle instead of staying theoretical
+
+## Issues
+- Seventeen issues opened on or after 2026-06-09, and most of them were short-lived contract gaps tied directly to the merged GMP work: #223, #225, #226, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, and #260 all closed quickly once the corresponding PRs landed
+- Older backlog also burned down in this window: issue #219 closed when typed NVT score helpers landed, and #192 closed when the capability-detection lane was resolved
+- The remaining fresh issue residue is now narrow but real: #247 (the silently ignored `no_report` flag), #251 (user host-access/model drift audit), and #267 (opt-in verbose wire tracing) are the visible follow-ons still open
+
+## Pull Request Queue
+- The open queue is no longer centered on product work. It is now mostly journal backlog plus two maintenance branches: dependency PR #165 and actions bump #215
+- That is a healthier shape than the 2026-06-09 entry described because the big GMP follow-on branches are no longer waiting for review, but it also means the visible queue is noisier than the actual remaining engineering risk
+
+## CI Health
+- The real release-day signal on 2026-06-18 was strong: the release workflow succeeded on `v0.3.3`, the corresponding `main` push cleared `OpenSSF Scorecard`, and the latest scheduled scorecard run on 2026-06-21 also stayed green
+- The maintenance lane is less clean. PR #215 passed `CI` on 2026-06-22 but failed `Security`, and that same date's dynamic `Dependabot Updates` runs on `main` split between success and failure instead of presenting one consistent result
+- Journal automation is still noisy in a specific, repetitive way: Security failed on journal PRs #266, #268, and #269 across 2026-06-19 through 2026-06-21 even though those branches are documentation-only backlog


### PR DESCRIPTION
## Summary
- add the 2026-06-22 journal entry
- cover GMP follow-on work, release execution, and current queue/CI state

Agent: Thoth