### PR TITLE
docs(journal): add 2026-06-25 journal entry

### DIFF
--- a/journal/2026-06-25.md
+++ b/journal/2026-06-25.md
@@ -1,0 +1,22 @@
+# 2026-06-25 — Mainline Finished a Dense Typed-GMP Follow-Through Burst, Cut 0.3.3, and Then Exposed a Smaller but More Obvious Tail of Model-Drift Work
+
+## Mainline & Merged Work
+
+### `main` spent the post-2026-06-09 window finishing the highest-signal typed GMP follow-through instead of reopening broad surface churn
+- After the 2026-06-09 journal baseline, `main` absorbed PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261, which collectively filled in missing user-auth, scan-config, target, alert, note, override, report, and schedule fields while also tightening filter validation and report-export options.
+- The repo then turned that product burst into a shipped release lane on 2026-06-18: PR #265 restored branch protection after release pushes, `main` produced the `0.3.3` release commit, and two follow-up release fixes repaired artifact publishing and relaxed SBOM scoring failures.
+- That sequence matters because the repo is no longer just adding isolated typed helpers. It closed a coherent block of contract drift across the GMP surface, exercised the release path for a real version cut, and made the remaining rough edges much easier to see.
+
+## Issues
+- The issue tracker kept pace with the merge burst instead of expanding uncontrollably. Issues #234, #237, #238, #242, #248, #250, #256, and #257 all opened and closed quickly as the corresponding fixes landed on `main`.
+- The remaining open tail is now narrow and specific: #247 still tracks the invalid `no_report` option shape, #251 keeps the broader user-host-access model-drift audit alive, and the newest follow-up is #267 for opt-in verbose GMP wire tracing.
+- That is a healthier issue shape than the 2026-06-09 entry described. The old open branches for NVT scoring and host-type compatibility are gone, and the backlog now points at a small number of explicit follow-ons instead of one sprawling parity push.
+
+## Pull Request Queue
+- The visible queue has become almost entirely operational. Open PRs are dominated by the accumulated journal backlog (#262 through #271), while the only non-journal branches still standing are the older dependency bumps #165 (`quick-xml`) and #215 (GitHub Actions updates).
+- That is cleaner from a product perspective than the previous entry's queue: the substantive typed-GMP work has already landed on `main`, and review pressure is now mostly about maintenance and backlog cleanup rather than unsettled API design.
+
+## CI Health
+- The product merges themselves stayed healthy. On 2026-06-15 and 2026-06-16, `CI`, `Security`, and `OpenSSF Scorecard` all succeeded on `main`, which gave the late GMP-field and export-option work a solid landing path.
+- The release day signal was more uneven. `CI` and `OpenSSF Scorecard` stayed green on 2026-06-18, but `Security` failed repeatedly on `main`, and the `Orchestrated Release` workflow also failed twice before the repo recovered with the direct release fixes.
+- The newest scheduled signal still is not flat: `Security` failed again on 2026-06-22, so the current constraint is no longer API surface movement. It is cleanup and stabilization around the release/security lane.


### PR DESCRIPTION
## Summary
- add the 2026-06-25 rust-gvm journal entry
- capture post-2026-06-09 mainline, issue, queue, and CI activity

Agent: Thoth