### PR TITLE
docs(journal): add 2026-06-27 journal entry

### DIFF
--- a/journal/2026-06-27.md
+++ b/journal/2026-06-27.md
@@ -1,0 +1,25 @@
+# 2026-06-27 — Mainline Closed a Thick Stack of Typed GMP Gaps, Then Exercised the Release Lane Hard Enough to Expose Workflow Rough Edges
+
+## Mainline & Merged Work
+
+### `main` did not drift gradually after the 2026-06-09 baseline; it moved in one dense GMP-fix burst and then immediately rolled into release work
+- From 2026-06-10 through 2026-06-16, `main` absorbed PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261. That batch filled in typed GMP surface gaps around user auth and scan-config typing, safe filter-fragment validation, note and override parsing, missing target and alert fields, report metadata fetches, user host access mode, schedule run timestamps, and report export options.
+- The repo then shifted from product-surface repair into release execution on 2026-06-18. `main` picked up PR #265, cut the `0.3.3` release commit, and followed it with two direct release-path fixes for artifact publishing and SBOM quality-score handling.
+- That sequence matters because it shows the repo doing more than ordinary backlog trimming. The typed GMP lane kept moving fast enough to close a long set of correctness gaps, and the team immediately ran the release machinery against the new baseline instead of letting that work sit unexercised.
+
+## Issues
+- Twelve issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and #267.
+- Most of that intake was converted straight into merged `main` work. Issues #234, #237, #238, #242, #248, #250, #256, #257, and #260 all closed in the same slice as the corresponding GMP fixes landed.
+- Older capability and filter follow-through also continued to contract: #192 and #233 both closed during the 2026-06-10 burst.
+- The remaining open residue is now narrow and easy to name: #247 tracks a `GetReportsOpts::no_report` mismatch, #251 tracks broader user-host-access response drift, and #267 asks for opt-in verbose GMP wire tracing.
+
+## Pull Request Queue
+- The visible non-journal queue is small but still not empty. PR #215 (actions updates) and PR #165 (`quick-xml` bump) remain open beside the journal backlog.
+- The journal queue itself has continued to pile up after the release burst: open PRs now span #262 through #273, with today's entry extending that automation lane rather than clearing it.
+- That is a better shape than the repo had earlier in June on the product side, because the unresolved work is mostly maintenance and documentation churn rather than a large set of half-finished GMP feature branches.
+
+## CI Health
+- The mainline validation story was mostly strong during the GMP-fix burst. Push-time `CI`, `Security`, and `OpenSSF Scorecard` all passed for PRs #240, #244, #249, #258, and #261, and the 2026-06-15 scheduled `Security` run also succeeded.
+- The signal was not perfectly flat. `CI` failed on PR #239 and again on PR #252 before recovering on later merges.
+- Release execution on 2026-06-18 is the noisier part of the story. The release commit and its follow-up fixes kept `CI` green, but `Security` failed on the release commit and both immediate release-fix pushes. The `Orchestrated Release` workflow also failed twice that day before the branch-protection restore PR landed.
+- Post-release maintenance remains mixed rather than broken. Scheduled `Security` failed on 2026-06-22, while scheduled `OpenSSF Scorecard` stayed green and Dependabot runs split between clean cargo lanes and failing GitHub Actions bumps.


### PR DESCRIPTION
## Summary
- add the 2026-06-27 journal entry
- capture repo activity since the previous journal baseline

Agent: Thoth
