### PR TITLE
docs(journal): add 2026-06-28 journal entry

### DIFF
--- a/journal/2026-06-28.md
+++ b/journal/2026-06-28.md
@@ -1,0 +1,26 @@
+# 2026-06-28 — Typed GMP Coverage Surged into a 0.3.3 Release Push, Then Settled into a Much Smaller Follow-Through Queue
+
+## Mainline & Merged Work
+
+### The repo used the post-2026-05-14 window to burn down a large parity backlog instead of spreading effort across unrelated experiments
+- `main` first picked up the integration-config and report-helper parity work from PR #160, then added the journal automation lane in #168, dependency and workflow maintenance in #181, #182, and #168, and a short-lived docs detour in #184 that was explicitly reverted by #187
+- The real story started in early June: PRs #177, #191, #200, #202, #205, #207, #210, #218, #220, #221, #224, #227, #228, #230, #232, #235, #236, #239, #240, #244, #249, #252, #258, and #261 turned `rust-gvm` into a much more complete typed GMP surface for report export flows, filter composition, task detail parsing, target credentials, note and override handling, report metadata, user host access, and schedule timing
+- That run was substantial enough to carry the repo into the 0.3.3 release lane on 2026-06-18. The release itself needed immediate follow-through commits to repair artifact publishing and SBOM quality-score messaging, after which PR #265 restored the branch-protection posture
+- Compared with the 2026-05-14 baseline, `main` is no longer mostly about CI hygiene and queue triage. It shipped a real product-surface expansion and then did the release hardening work needed to keep that expansion publishable
+
+## Pull Request Queue
+- The open queue is far smaller in product terms than the raw PR count suggests. Nearly all visible open branches are journal backlog PRs #262 through #274
+- The only non-journal pull requests left in view are PR #165 (`quick-xml`), which is still unstable, and PR #215 (actions-group updates), which is also still unstable
+- That makes the repo's remaining review surface much narrower than it was in mid-May: the expensive work is no longer missing GMP coverage on `main`, but deciding when to spend time on dependency-repair branches versus the new follow-through issue work
+
+## Issues
+- This window opened a large issue wave because the parity push was driven explicitly through tracked GMP gaps: issues #175, #190, #192, #199, #201, #204, #206, #209, #217, #219, #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and #267 all appeared after the last journal entry
+- Most of that wave was immediately burned down on `main`. Everything from #175 through #260 closed in the same span except #247 and #251, which remain open as model-drift and `get_reports` follow-through items
+- The only brand-new unresolved issue after the release push is #267, which adds opt-in verbose GMP wire tracing on the client side
+- The remaining open backlog is therefore much more deliberate than the raw issue count implies: older strategic/security tickets still exist, but the parity-driven June spike mostly converted straight into shipped code
+
+## CI Health
+- CI and OpenSSF Scorecard stayed green through the 2026-06-18 release-repair sequence, and branch-protection restoration itself also landed with a clean push signal
+- The noisier lane is `Security`, not the general build/test surface. Release-related pushes on 2026-06-18 and the scheduled security run on 2026-06-22 both failed even while ordinary CI stayed green
+- Release automation was also not flat: the initial 0.3.3 release run failed, one repair run was cancelled, and the final warning-only fix landed before the repo returned to a more stable posture
+- The net picture is still healthier than the 2026-05-14 entry described. The repo's risk is no longer broad merge instability across default workflows; it is concentrated in security/release follow-through while the expanded GMP surface itself is already on `main`


### PR DESCRIPTION
## Summary
- add the 2026-06-28 journal entry
- capture repo activity since the last landed journal entry

## Testing
- not run (docs-only journal update)

Agent: Thoth
