### PR TITLE
docs(journal): add 2026-07-01 journal entry

### DIFF
--- a/journal/2026-07-01.md
+++ b/journal/2026-07-01.md
@@ -1,0 +1,23 @@
+# 2026-07-01 — Mainline Rushed Through a Dense GMP Fix Burst, Then Cut 0.3.3 While the Queue Turned Mostly into Backlog and Dependency Drift
+
+## Mainline & Merged Work
+
+### `main` did real library work immediately after the 2026-06-09 baseline, then pivoted into release mechanics instead of starting another broad feature wave
+- The product-heavy stretch landed fast on 2026-06-10 through 2026-06-16: PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261 added typed user-auth and scan-config coverage, filter validation, note/override parser fixes, missing GMP field support, scoped report metadata fetches, user host access mode handling, schedule run timestamps, and report export options.
+- That burst was followed by release-facing work rather than more parity expansion. PR #265 restored branch protection after the 0.3.3 release push, and `main` also picked up the direct 0.3.3 automation commits that repaired artifact publishing and added an SBOM quality-score warning.
+- The sequence matters because the repo's post-2026-06-09 story is not random churn. It shipped a concentrated typed-GMP correction lane, then immediately spent its next motion on getting the release path back into a safer shape.
+
+## Issues
+- Twelve issues opened in this window: #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, #266, and #267.
+- Eleven of those already closed, mostly by the same merged work that hit `main`: #237, #238, #242, #248, #250, #256, #257, and #260 all burned down quickly, and the brief docs/journal tracker #266 also closed.
+- The remaining fresh residue is small but clear. #247 tracks the invalid `no_report` option, #251 keeps the broader user-host-access model audit open, and #267 opens a new client-side verbose GMP wire-tracing request.
+
+## Pull Request Queue
+- The queue is now far less about product implementation than the 2026-06-09 entry suggested. The only clearly active non-journal branches are dependency maintenance PRs #276, #277, #278, plus the much older `quick-xml` bump in #165.
+- Everything else visible at the top of the queue is journal backlog: open PRs now span the consolidation branch #262 and daily entries #263 through #279, with only a few dates already merged away.
+- That leaves the repo in an awkward shape. The important GMP fixes and the 0.3.3 release are already on `main`, but the review surface is now dominated by automation residue and maintenance follow-ons rather than the next substantive library slice.
+
+## CI Health
+- The latest `main` push signal was mostly good, not perfectly clean. `CI` succeeded on nine post-baseline push runs and failed once, while `Security` succeeded seven times and failed three times across the same stretch.
+- The release lane was visibly noisy: the `Release` workflow around `v0.3.3` recorded failure, cancellation, and eventual success, and two manual `Orchestrated Release` runs failed before the branch-protection repair merged.
+- Scheduled posture also softened compared with the earlier entry. `OpenSSF Scorecard` stayed green, but scheduled `Security` split between one success and two failures, and the newer dependency plus journal PRs accumulated a long tail of failing `Security` pull-request runs late in the month.


### PR DESCRIPTION
## Summary
- add the 2026-07-01 journal entry covering post-2026-06-09 mainline, issue, queue, and CI activity

## Testing
- not run (journal-only change)

Agent: Thoth