### PR TITLE
build(deps): consolidate dependency and security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,15 +38,3 @@ updates:
     labels:
       - "dependencies"
       - "ci"
-
-  # Python dependencies (pip) — for integration tests
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: "test(deps)"
-    labels:
-      - "dependencies"
-      - "python"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt
@@ -44,7 +44,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, "1.75.0"]  # stable + MSRV
+        rust: [stable, "1.79.0"]  # stable + MSRV
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -75,7 +75,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --all-features
@@ -89,7 +89,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo doc --workspace --all-features --no-deps
@@ -101,7 +101,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: Run cargo deny
@@ -114,7 +114,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
@@ -135,10 +135,10 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - run: pip install python-gvm
@@ -152,10 +152,10 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
-          toolchain: "1.75.0"
+          toolchain: "1.79.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo check --workspace --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt
@@ -44,7 +44,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
@@ -61,7 +61,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
           toolchain: ${{ matrix.rust }}
@@ -75,7 +75,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --all-features
@@ -89,7 +89,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo doc --workspace --all-features --no-deps
@@ -101,7 +101,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
       - name: Run cargo deny
@@ -114,16 +114,16 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-llvm-cov
       - run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: lcov.info
           fail_ci_if_error: false
@@ -135,10 +135,10 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: pip install python-gvm
@@ -152,7 +152,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
           toolchain: "1.75.0"

--- a/.github/workflows/journal-pr-automation.yml
+++ b/.github/workflows/journal-pr-automation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate changed files are journal entries only
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -38,7 +38,7 @@ jobs:
               return;
             }
       - name: Enable squash auto-merge
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --all-features
@@ -45,10 +45,10 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -115,7 +115,7 @@ jobs:
         if: runner.os == 'Linux'
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
@@ -155,7 +155,7 @@ jobs:
           sha256sum ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.tar.gz.sha256
 
       - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: '${{ matrix.artifact }}.tar.gz'
 
@@ -176,11 +176,11 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-cyclonedx@${{ env.CARGO_CYCLONEDX_VERSION }}
 
@@ -203,7 +203,7 @@ jobs:
         run: |
           python3 scripts/sbom_postprocess.py --cargo-toml Cargo.toml sbom-artifacts/*.cdx.json
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --workspace --all-features
@@ -45,7 +45,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -115,7 +115,7 @@ jobs:
         if: runner.os == 'Linux'
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
@@ -176,7 +176,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
@@ -203,7 +203,7 @@ jobs:
         run: |
           python3 scripts/sbom_postprocess.py --cargo-toml Cargo.toml sbom-artifacts/*.cdx.json
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: stable
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -37,6 +37,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
@@ -46,7 +46,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
@@ -59,7 +59,7 @@ jobs:
     name: Cargo Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-vet
         with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-geiger
         with:
@@ -102,7 +102,7 @@ jobs:
     name: Cargo Geiger Workspace Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-geiger
         with:
@@ -123,7 +123,7 @@ jobs:
   #     - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
   #       with:
   #         egress-policy: audit
-  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
   #       with:
   #         persist-credentials: false
   #     - name: Run Scorecard
@@ -147,7 +147,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run Semgrep
         uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-audit@0.22.1
       - name: Run cargo-audit
@@ -46,9 +46,9 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # v2
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2
         with:
           tool: cargo-machete@0.9.1
       - name: Run cargo-machete
@@ -59,9 +59,9 @@ jobs:
     name: Cargo Vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # cargo-vet
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-vet
         with:
           tool: cargo-vet
       - name: Run cargo-vet
@@ -73,9 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # cargo-geiger
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-geiger
         with:
           tool: cargo-geiger
       - name: Generate geiger reports (all workspace crates)
@@ -102,9 +102,9 @@ jobs:
     name: Cargo Geiger Workspace Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: taiki-e/install-action@d9be7d8cda89035c9c843f78bd44d4f72d8403d4 # cargo-geiger
+      - uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # cargo-geiger
         with:
           tool: cargo-geiger
       - name: Fail if workspace crates use unsafe
@@ -123,7 +123,7 @@ jobs:
   #     - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
   #       with:
   #         egress-policy: audit
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  #     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
   #       with:
   #         persist-credentials: false
   #     - name: Run Scorecard
@@ -147,7 +147,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - name: Run Semgrep
         uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         env:
@@ -164,7 +164,7 @@ jobs:
         # Making this non-blocking until code scanning is enabled.
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: semgrep.sarif
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ name = "gvm-connection"
 version = "0.3.3"
 dependencies = [
  "async-trait",
- "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "gvm-gmp",
  "gvm-mock-server",
  "gvm-protocol",
@@ -961,7 +961,7 @@ name = "gvm-mock-server"
 version = "0.3.3"
 dependencies = [
  "clap",
- "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "gvm-gmp",
  "gvm-protocol",
  "pretty_assertions",
@@ -1583,9 +1583,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2254,7 +2254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2488,9 +2488,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 version = "0.3.3"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.79.0"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/clawosiris/rust-gvm"
 keywords = ["greenbone", "gvm", "gmp", "vulnerability", "security"]
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 
 # XML
-quick-xml = { version = "0.39", features = ["serialize"] }
+quick-xml = { version = "0.40", features = ["serialize"] }
 
 # Error handling
 thiserror = "2"
@@ -48,7 +48,7 @@ rustls-pemfile = "2"
 
 # SSH (feature-gated)
 russh = "0.61"
-getrandom = "0.2"
+getrandom = "0.4"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ cargo build --release -p gvm-mock-server
 
 ### Requirements
 
-- Rust 1.75+ (MSRV)
+- Rust 1.79+ (MSRV)
 - Python 3.10+ with `python-gvm` (for integration tests only)
 
 ## CI/CD

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # rust-gvm Clippy configuration
 # See: https://doc.rust-lang.org/clippy/configuration.html
 
-msrv = "1.75.0"
+msrv = "1.79.0"
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 8
 type-complexity-threshold = 300

--- a/crates/gvm-connection/src/ssh.rs
+++ b/crates/gvm-connection/src/ssh.rs
@@ -493,18 +493,18 @@ mod tests {
 
         fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
             let mut bytes = [0_u8; 4];
-            getrandom::getrandom(&mut bytes).map_err(map_getrandom_error)?;
+            getrandom::fill(&mut bytes).map_err(map_getrandom_error)?;
             Ok(u32::from_le_bytes(bytes))
         }
 
         fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
             let mut bytes = [0_u8; 8];
-            getrandom::getrandom(&mut bytes).map_err(map_getrandom_error)?;
+            getrandom::fill(&mut bytes).map_err(map_getrandom_error)?;
             Ok(u64::from_le_bytes(bytes))
         }
 
         fn try_fill_bytes(&mut self, dst: &mut [u8]) -> std::result::Result<(), Self::Error> {
-            getrandom::getrandom(dst).map_err(map_getrandom_error)
+            getrandom::fill(dst).map_err(map_getrandom_error)
         }
     }
 

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -8,7 +8,7 @@ use std::str;
 
 use gvm_protocol::Response;
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 
 use crate::EntityId;
 
@@ -210,7 +210,7 @@ fn collect_attributes(
         attributes.insert(
             str::from_utf8(attribute.key.as_ref())?.to_string(),
             attribute
-                .decode_and_unescape_value(event.decoder())?
+                .decoded_and_normalized_value(XmlVersion::Implicit1_0, event.decoder())?
                 .into_owned(),
         );
     }

--- a/crates/gvm-mock-server/src/command_parser.rs
+++ b/crates/gvm-mock-server/src/command_parser.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 
 /// A parsed GMP command extracted from incoming XML.
 #[derive(Debug, Clone)]
@@ -136,7 +136,7 @@ fn parse_children(
                 });
             }
             Ok(Event::Text(ref t)) => {
-                if let Ok(unescaped) = t.xml_content() {
+                if let Ok(unescaped) = t.xml_content(XmlVersion::Implicit1_0) {
                     current_text.push_str(&unescaped);
                 }
             }
@@ -179,7 +179,7 @@ pub fn parse_element_text(xml: &[u8], element_name: &str) -> Option<String> {
                 }
             }
             Ok(Event::Text(ref t)) if inside => {
-                if let Ok(unescaped) = t.xml_content() {
+                if let Ok(unescaped) = t.xml_content(XmlVersion::Implicit1_0) {
                     result.push_str(&unescaped);
                 }
             }
@@ -202,7 +202,8 @@ fn extract_attributes(e: &quick_xml::events::BytesStart<'_>) -> HashMap<String, 
     for attr in e.attributes().flatten() {
         if let (Ok(key), Ok(val)) = (
             std::str::from_utf8(attr.key.as_ref()),
-            attr.unescape_value().map(|v| v.into_owned()),
+            attr.normalized_value(XmlVersion::Implicit1_0)
+                .map(|v| v.into_owned()),
         ) {
             map.insert(key.to_string(), val);
         }

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -342,7 +342,7 @@ fn threat_for_severity(severity: &str) -> &'static str {
 mod tests {
     use super::*;
     use quick_xml::events::Event;
-    use quick_xml::Reader;
+    use quick_xml::{Reader, XmlVersion};
 
     fn extract_descriptions(xml: &str) -> Vec<String> {
         let mut reader = Reader::from_str(xml);
@@ -356,7 +356,7 @@ mod tests {
                 }
                 Ok(Event::Text(text)) if in_description => {
                     descriptions.push(
-                        text.xml_content()
+                        text.xml_content(XmlVersion::Implicit1_0)
                             .expect("description text should decode")
                             .into_owned(),
                     );

--- a/crates/gvm-mock-server/src/ssh_listener.rs
+++ b/crates/gvm-mock-server/src/ssh_listener.rs
@@ -52,18 +52,18 @@ impl TryRng for SystemRng {
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut bytes = [0_u8; 4];
-        getrandom::getrandom(&mut bytes).map_err(map_getrandom_error)?;
+        getrandom::fill(&mut bytes).map_err(map_getrandom_error)?;
         Ok(u32::from_le_bytes(bytes))
     }
 
     fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut bytes = [0_u8; 8];
-        getrandom::getrandom(&mut bytes).map_err(map_getrandom_error)?;
+        getrandom::fill(&mut bytes).map_err(map_getrandom_error)?;
         Ok(u64::from_le_bytes(bytes))
     }
 
     fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-        getrandom::getrandom(dst).map_err(map_getrandom_error)
+        getrandom::fill(dst).map_err(map_getrandom_error)
     }
 }
 

--- a/crates/gvm-protocol/src/response.rs
+++ b/crates/gvm-protocol/src/response.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 
 use crate::error::ProtocolError;
 
@@ -214,13 +214,13 @@ impl Response {
                     child_texts.entry(name.to_string()).or_default();
                 }
                 Ok(Event::Text(ref text)) if current_child_name.is_some() => {
-                    let Ok(unescaped) = text.xml_content() else {
+                    let Ok(unescaped) = text.xml_content(XmlVersion::Implicit1_0) else {
                         return HashMap::new();
                     };
                     current_text.push_str(&unescaped);
                 }
                 Ok(Event::CData(ref text)) if current_child_name.is_some() => {
-                    let Ok(unescaped) = text.xml_content() else {
+                    let Ok(unescaped) = text.xml_content(XmlVersion::Implicit1_0) else {
                         return HashMap::new();
                     };
                     current_text.push_str(&unescaped);

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -11,23 +11,11 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
 [[exemptions.aead]]
-version = "0.5.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.aead]]
-version = "0.6.0-rc.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.aes]]
-version = "0.8.4"
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.aes]]
 version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.aes-gcm]]
-version = "0.10.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.aes-gcm]]
@@ -39,19 +27,11 @@ version = "1.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstream]]
-version = "0.6.21"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstream]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstyle]]
 version = "1.0.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.anstyle-parse]]
-version = "0.2.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.anstyle-parse]]
@@ -66,14 +46,6 @@ criteria = "safe-to-deploy"
 version = "3.0.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.anyhow]]
-version = "1.0.102"
-criteria = "safe-to-deploy"
-
-[[exemptions.argon2]]
-version = "0.5.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.argon2]]
 version = "0.6.0-rc.8"
 criteria = "safe-to-deploy"
@@ -83,23 +55,15 @@ version = "0.1.89"
 criteria = "safe-to-deploy"
 
 [[exemptions.autocfg]]
-version = "1.5.0"
+version = "1.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.aws-lc-rs]]
-version = "1.16.2"
+version = "1.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.aws-lc-sys]]
-version = "0.39.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.aws-lc-sys]]
-version = "0.39.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.base16ct]]
-version = "0.2.0"
+version = "0.41.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.base16ct]]
@@ -111,19 +75,11 @@ version = "1.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.bcrypt-pbkdf]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.bcrypt-pbkdf]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
-version = "2.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.blake2]]
-version = "0.10.6"
+version = "2.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.blake2]]
@@ -131,15 +87,7 @@ version = "0.11.0-rc.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.block-buffer]]
-version = "0.10.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.block-buffer]]
-version = "0.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.block-padding]]
-version = "0.3.3"
+version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.block-padding]]
@@ -147,23 +95,15 @@ version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.blowfish]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.blowfish]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bumpalo]]
-version = "3.20.2"
+version = "3.20.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
-version = "1.11.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cbc]]
-version = "0.1.2"
+version = "1.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cbc]]
@@ -171,11 +111,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.57"
-criteria = "safe-to-deploy"
-
-[[exemptions.cc]]
-version = "1.2.58"
+version = "1.2.64"
 criteria = "safe-to-deploy"
 
 [[exemptions.cfg-if]]
@@ -187,19 +123,11 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.chacha20]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]
-version = "0.4.44"
-criteria = "safe-to-deploy"
-
-[[exemptions.cipher]]
-version = "0.4.4"
+version = "0.4.45"
 criteria = "safe-to-deploy"
 
 [[exemptions.cipher]]
@@ -211,10 +139,6 @@ version = "4.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.5.48"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_builder]]
 version = "4.6.0"
 criteria = "safe-to-deploy"
 
@@ -223,23 +147,11 @@ version = "4.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
-version = "0.7.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_lex]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cmake]]
-version = "0.1.57"
-criteria = "safe-to-deploy"
-
-[[exemptions.cmake]]
 version = "0.1.58"
-criteria = "safe-to-deploy"
-
-[[exemptions.cmov]]
-version = "0.5.0-pre.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cmov]]
@@ -251,19 +163,11 @@ version = "1.0.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.const-oid]]
-version = "0.9.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.const-oid]]
 version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.cpubits]]
 version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.cpufeatures]]
-version = "0.2.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.cpufeatures]]
@@ -275,23 +179,7 @@ version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-bigint]]
-version = "0.5.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-bigint]]
-version = "0.7.0-rc.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-bigint]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-common]]
-version = "0.1.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-common]]
-version = "0.2.1"
+version = "0.7.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-common]]
@@ -299,15 +187,7 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.crypto-primes]]
-version = "0.7.0-pre.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-primes]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ctr]]
-version = "0.9.2"
+version = "0.7.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ctr]]
@@ -315,19 +195,11 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ctutils]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.ctutils]]
 version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek]]
-version = "4.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.curve25519-dalek]]
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek-derive]]
@@ -335,15 +207,11 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.data-encoding]]
-version = "2.10.0"
+version = "2.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.delegate]]
 version = "0.13.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.der]]
-version = "0.7.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.der]]
@@ -359,11 +227,7 @@ version = "0.1.13"
 criteria = "safe-to-run"
 
 [[exemptions.digest]]
-version = "0.10.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.digest]]
-version = "0.11.2"
+version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.dunce]]
@@ -371,15 +235,7 @@ version = "1.0.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.ecdsa]]
-version = "0.16.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.ecdsa]]
 version = "0.17.0-rc.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.ed25519]]
-version = "2.2.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.ed25519]]
@@ -387,19 +243,11 @@ version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ed25519-dalek]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ed25519-dalek]]
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.elliptic-curve]]
-version = "0.13.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.elliptic-curve]]
-version = "0.14.0-rc.32"
+version = "0.14.0-rc.33"
 criteria = "safe-to-deploy"
 
 [[exemptions.enum_dispatch]]
@@ -411,15 +259,11 @@ version = "0.3.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
-version = "2.3.0"
+version = "2.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ff]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.fiat-crypto]]
-version = "0.2.9"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fiat-crypto]]
@@ -471,7 +315,7 @@ version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-timer]]
-version = "3.0.3"
+version = "3.0.4"
 criteria = "safe-to-run"
 
 [[exemptions.futures-util]]
@@ -479,11 +323,11 @@ version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.generic-array]]
-version = "0.14.7"
+version = "0.14.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.generic-array]]
-version = "1.3.5"
+version = "1.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
@@ -495,11 +339,7 @@ version = "0.3.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
-version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.ghash]]
-version = "0.5.1"
+version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.ghash]]
@@ -511,23 +351,15 @@ version = "0.3.3"
 criteria = "safe-to-run"
 
 [[exemptions.group]]
-version = "0.13.0"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hashbrown]]
 version = "0.15.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.hashbrown]]
-version = "0.16.1"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.heck]]
 version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hex-literal]]
-version = "0.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.hex-literal]]
@@ -535,15 +367,7 @@ version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hkdf]]
-version = "0.12.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.hkdf]]
 version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hmac]]
-version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.hmac]]
@@ -551,19 +375,7 @@ version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hybrid-array]]
-version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.hybrid-array]]
-version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.hybrid-array]]
-version = "0.4.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.hybrid-array]]
-version = "0.4.10"
+version = "0.4.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.iana-time-zone]]
@@ -574,28 +386,12 @@ criteria = "safe-to-deploy"
 version = "0.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.id-arena]]
-version = "2.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.indexmap]]
-version = "2.11.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.indexmap]]
-version = "2.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.inout]]
-version = "0.1.4"
-criteria = "safe-to-deploy"
+version = "2.14.0"
+criteria = "safe-to-run"
 
 [[exemptions.inout]]
 version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.internal-russh-forked-ssh-key]]
-version = "0.6.16+upstream-0.6.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.internal-russh-num-bigint]]
@@ -606,24 +402,12 @@ criteria = "safe-to-deploy"
 version = "1.70.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.itoa]]
-version = "1.0.18"
-criteria = "safe-to-deploy"
-
 [[exemptions.jobserver]]
 version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.91"
-criteria = "safe-to-deploy"
-
-[[exemptions.js-sys]]
-version = "0.3.94"
-criteria = "safe-to-deploy"
-
-[[exemptions.keccak]]
-version = "0.1.6"
+version = "0.3.102"
 criteria = "safe-to-deploy"
 
 [[exemptions.keccak]]
@@ -631,27 +415,11 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.kem]]
-version = "0.3.0-pre.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.kem]]
 version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.leb128fmt]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.libc]]
-version = "0.2.183"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
 version = "0.2.186"
-criteria = "safe-to-deploy"
-
-[[exemptions.libm]]
-version = "0.2.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
@@ -662,16 +430,20 @@ criteria = "safe-to-deploy"
 version = "0.4.14"
 criteria = "safe-to-deploy"
 
+[[exemptions.log]]
+version = "0.4.32"
+criteria = "safe-to-deploy"
+
 [[exemptions.matchers]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.md5]]
-version = "0.7.0"
+version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.memchr]]
-version = "2.8.0"
+version = "2.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.miniz_oxide]]
@@ -679,15 +451,7 @@ version = "0.8.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.mio]]
-version = "1.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.mio]]
-version = "1.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ml-kem]]
-version = "0.2.3"
+version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ml-kem]]
@@ -696,10 +460,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.module-lattice]]
 version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.nix]]
-version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.nix]]
@@ -714,14 +474,6 @@ criteria = "safe-to-deploy"
 version = "0.4.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-bigint-dig]]
-version = "0.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-iter]]
-version = "0.1.45"
-criteria = "safe-to-deploy"
-
 [[exemptions.once_cell]]
 version = "1.21.4"
 criteria = "safe-to-deploy"
@@ -730,36 +482,20 @@ criteria = "safe-to-deploy"
 version = "1.70.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.opaque-debug]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.p256]]
-version = "0.13.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.p256]]
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.p384]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.p384]]
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.p521]]
-version = "0.13.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.p521]]
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.pageant]]
-version = "0.2.0"
+version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.parking_lot]]
@@ -771,23 +507,11 @@ version = "0.9.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.password-hash]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.password-hash]]
 version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.pbkdf2]]
-version = "0.12.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.pbkdf2]]
 version = "0.13.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.pem-rfc7468]]
-version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pem-rfc7468]]
@@ -807,19 +531,7 @@ version = "0.8.0-rc.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkcs5]]
-version = "0.7.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs5]]
 version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs8]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs8]]
-version = "0.11.0-rc.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkcs8]]
@@ -827,63 +539,27 @@ version = "0.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.poly1305]]
-version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.poly1305]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.polyval]]
-version = "0.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.polyval]]
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.ppv-lite86]]
-version = "0.2.21"
-criteria = "safe-to-deploy"
-
 [[exemptions.pretty_assertions]]
 version = "1.4.1"
 criteria = "safe-to-run"
 
-[[exemptions.prettyplease]]
-version = "0.2.37"
-criteria = "safe-to-deploy"
-
 [[exemptions.primefield]]
-version = "0.14.0-rc.9"
+version = "0.14.0-rc.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.primeorder]]
-version = "0.13.6"
+version = "0.14.0-rc.10"
 criteria = "safe-to-deploy"
-
-[[exemptions.primeorder]]
-version = "0.14.0-rc.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.proc-macro-crate]]
-version = "3.2.0"
-criteria = "safe-to-run"
-
-[[exemptions.proc-macro-crate]]
-version = "3.4.0"
-criteria = "safe-to-run"
 
 [[exemptions.proc-macro-crate]]
 version = "3.5.0"
-criteria = "safe-to-run"
-
-[[exemptions.proc-macro2]]
-version = "1.0.106"
-criteria = "safe-to-deploy"
-
-[[exemptions.proptest]]
-version = "1.6.0"
 criteria = "safe-to-run"
 
 [[exemptions.proptest]]
@@ -891,11 +567,7 @@ version = "1.11.0"
 criteria = "safe-to-run"
 
 [[exemptions.quick-xml]]
-version = "0.39.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.quote]]
-version = "1.0.45"
+version = "0.40.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]
@@ -907,12 +579,8 @@ version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
-version = "0.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand]]
-version = "0.9.2"
-criteria = "safe-to-deploy"
+version = "0.9.4"
+criteria = "safe-to-run"
 
 [[exemptions.rand]]
 version = "0.10.1"
@@ -920,23 +588,15 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand_chacha]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.rand_core]]
 version = "0.9.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_core]]
-version = "0.10.0-rc-3"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.rand_core]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
-
-[[exemptions.rand_xorshift]]
-version = "0.3.0"
-criteria = "safe-to-run"
 
 [[exemptions.rand_xorshift]]
 version = "0.4.0"
@@ -946,16 +606,16 @@ criteria = "safe-to-run"
 version = "0.5.18"
 criteria = "safe-to-deploy"
 
+[[exemptions.regex]]
+version = "1.12.4"
+criteria = "safe-to-run"
+
 [[exemptions.regex-automata]]
 version = "0.4.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
-version = "0.8.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.rfc6979]]
-version = "0.4.0"
+version = "0.8.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.rfc6979]]
@@ -964,10 +624,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ring]]
 version = "0.17.14"
-criteria = "safe-to-deploy"
-
-[[exemptions.rsa]]
-version = "0.10.0-rc.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.rsa]]
@@ -983,15 +639,7 @@ version = "0.26.1"
 criteria = "safe-to-run"
 
 [[exemptions.russh]]
-version = "0.58.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh]]
-version = "0.61.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh-cryptovec]]
-version = "0.58.0"
+version = "0.61.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.russh-cryptovec]]
@@ -1006,20 +654,12 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustcrypto-ff]]
-version = "0.14.0-rc.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustcrypto-group]]
-version = "0.14.0-rc.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustix]]
 version = "1.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
-version = "0.23.37"
+version = "0.23.41"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pemfile]]
@@ -1027,11 +667,7 @@ version = "2.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pki-types]]
-version = "1.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-webpki]]
-version = "0.103.10"
+version = "1.14.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
@@ -1047,10 +683,6 @@ version = "0.3.1"
 criteria = "safe-to-run"
 
 [[exemptions.salsa20]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.salsa20]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
@@ -1059,15 +691,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.scrypt]]
-version = "0.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.scrypt]]
 version = "0.12.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sec1]]
-version = "0.7.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.sec1]]
@@ -1075,7 +699,7 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.semver]]
-version = "1.0.27"
+version = "1.0.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde]]
@@ -1090,16 +714,8 @@ criteria = "safe-to-deploy"
 version = "1.0.228"
 criteria = "safe-to-deploy"
 
-[[exemptions.serde_json]]
-version = "1.0.149"
-criteria = "safe-to-deploy"
-
 [[exemptions.serdect]]
-version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha1]]
-version = "0.10.6"
+version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha1]]
@@ -1111,23 +727,7 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
-version = "0.10.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha2]]
-version = "0.11.0-rc.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha2]]
 version = "0.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha3]]
-version = "0.10.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.sha3]]
-version = "0.10.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha3]]
@@ -1139,7 +739,7 @@ version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.shlex]]
-version = "1.3.0"
+version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.signal-hook-registry]]
@@ -1147,19 +747,7 @@ version = "1.4.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.signature]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.signature]]
-version = "3.0.0-rc.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.signature]]
 version = "3.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.simd-adler32]]
-version = "0.3.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.simd-adler32]]
@@ -1171,19 +759,7 @@ version = "0.4.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
-version = "0.6.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.spin]]
-version = "0.9.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.spki]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.spki]]
-version = "0.8.0-rc.4"
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]
@@ -1191,15 +767,7 @@ version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ssh-cipher]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ssh-cipher]]
 version = "0.3.0-rc.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.ssh-encoding]]
-version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ssh-encoding]]
@@ -1215,11 +783,7 @@ version = "2.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "2.0.117"
-criteria = "safe-to-deploy"
-
-[[exemptions.tempfile]]
-version = "3.20.0"
+version = "2.0.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
@@ -1227,15 +791,7 @@ version = "3.27.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "1.0.69"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror]]
 version = "2.0.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "1.0.69"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
@@ -1267,47 +823,15 @@ version = "0.4.5"
 criteria = "safe-to-run"
 
 [[exemptions.toml_datetime]]
-version = "0.6.11"
-criteria = "safe-to-run"
-
-[[exemptions.toml_datetime]]
-version = "0.7.5+spec-1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_datetime]]
-version = "1.1.0+spec-1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_datetime]]
 version = "1.1.1+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_edit]]
-version = "0.22.27"
-criteria = "safe-to-run"
-
-[[exemptions.toml_edit]]
-version = "0.23.10+spec-1.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_edit]]
-version = "0.25.8+spec-1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_edit]]
-version = "0.25.9+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.toml_parser]]
-version = "1.1.0+spec-1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_parser]]
-version = "1.1.1+spec-1.1.0"
-criteria = "safe-to-run"
-
-[[exemptions.toml_write]]
-version = "0.1.2"
+version = "1.1.2+spec-1.1.0"
 criteria = "safe-to-run"
 
 [[exemptions.tracing]]
@@ -1331,7 +855,7 @@ version = "0.3.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.typenum]]
-version = "1.19.0"
+version = "1.20.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.unarray]]
@@ -1340,10 +864,6 @@ criteria = "safe-to-run"
 
 [[exemptions.unicode-ident]]
 version = "1.0.24"
-criteria = "safe-to-deploy"
-
-[[exemptions.universal-hash]]
-version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.universal-hash]]
@@ -1359,7 +879,7 @@ version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.23.0"
+version = "1.23.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.valuable]]
@@ -1375,67 +895,27 @@ version = "0.11.1+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasip2]]
-version = "1.0.2+wasi-0.2.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasip3]]
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+version = "1.0.4+wasi-0.2.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.114"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen]]
-version = "0.2.117"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.64"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-futures]]
-version = "0.4.67"
+version = "0.4.75"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.114"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-macro]]
-version = "0.2.117"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.114"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.117"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.114"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-shared]]
-version = "0.2.117"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-encoder]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-metadata]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasmparser]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.web-sys]]
-version = "0.3.91"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows]]
@@ -1483,10 +963,6 @@ version = "0.52.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
-version = "0.59.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
 version = "0.61.2"
 criteria = "safe-to-deploy"
 
@@ -1531,39 +1007,11 @@ version = "0.52.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]
-version = "0.7.15"
-criteria = "safe-to-run"
-
-[[exemptions.winnow]]
-version = "1.0.0"
-criteria = "safe-to-run"
-
-[[exemptions.winnow]]
-version = "1.0.1"
+version = "1.0.3"
 criteria = "safe-to-run"
 
 [[exemptions.wit-bindgen]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-core]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-rust]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-bindgen-rust-macro]]
-version = "0.51.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-component]]
-version = "0.244.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wit-parser]]
-version = "0.244.0"
+version = "0.57.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.yansi]]
@@ -1571,25 +1019,13 @@ version = "1.0.1"
 criteria = "safe-to-run"
 
 [[exemptions.zerocopy]]
-version = "0.8.47"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy]]
-version = "0.8.48"
-criteria = "safe-to-deploy"
+version = "0.8.52"
+criteria = "safe-to-run"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.47"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy-derive]]
-version = "0.8.48"
-criteria = "safe-to-deploy"
+version = "0.8.52"
+criteria = "safe-to-run"
 
 [[exemptions.zeroize]]
-version = "1.8.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.zmij]]
-version = "1.0.21"
+version = "1.9.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,13 +1,6 @@
 
 # cargo-vet imports lock
 
-[[publisher.unicode-xid]]
-version = "0.2.6"
-when = "2024-09-19"
-user-id = 1139
-user-login = "Manishearth"
-user-name = "Manish Goregaokar"
-
 [[audits.google.audits.adler2]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -56,32 +49,6 @@ delta = "1.0.1 -> 1.0.2"
 notes = "No changes to any .rs files or Rust code."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.foldhash]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "0.1.3"
-notes = """
-`ub-risk-2` review notes can be found in https://crrev.com/c/6071306/5/third_party/rust/chromium_crates_io/vendor/foldhash-0.1.3/src/seed.rs
-
-`does-not-implement-crypto` based on `README.md` which explicitly says that
-"Foldhash is **not appropriate for any cryptographic purpose**."
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.foldhash]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.3 -> 0.1.4"
-notes = "No changes to safety-relevant code"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.foldhash]]
-who = "Chris Palmer <palmer@google.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.4 -> 0.1.5"
-notes = "No new `unsafe`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.lazy_static]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -103,32 +70,6 @@ delta = "1.4.0 -> 1.5.0"
 notes = "Unsafe review notes: https://crrev.com/c/5650836"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.log]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-version = "0.4.22"
-notes = """
-Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
-
-Unsafety is generally very well-documented, with one exception, which we
-describe in the review doc.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.log]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.22 -> 0.4.25"
-notes = "No impact on `unsafe` usage in `lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.log]]
-who = "Daniel Cheng <dcheng@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "0.4.25 -> 0.4.26"
-notes = "Only trivial code and documentation changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.num-integer]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -143,44 +84,204 @@ version = "0.2.19"
 notes = "Contains a single line of float-to-int unsafe with decent safety comments"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.ppv-lite86]]
+who = "danakj@chromium.org"
+criteria = "safe-to-run"
+version = "0.2.17"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ppv-lite86]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.2.17 -> 0.2.20"
+notes = "Using zerocopy to reduce unsafe usage."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.ppv-lite86]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-run"
+delta = "0.2.20 -> 0.2.21"
+notes = """
+The delta mostly corresponds to @joshlf's
+https://github.com/cryptocorrosion/cryptocorrosion/pull/85 which started
+using an undocumented API that `zerocopy` has provided specifically for
+`ppv-lite86` in https://github.com/google/zerocopy/pull/2418.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.78"
+notes = """
+Grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for a benign \"fs\" hit in a doc comment)
+
+Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.79"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
+notes = """
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.86 -> 1.0.87"
+notes = "No new unsafe interactions."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Liza Burakova <liza@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.87 -> 1.0.89"
+notes = """
+Biggest change is adding error handling in build.rs.
+Some config related changes in wrapper.rs.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.89 -> 1.0.92"
+notes = """
+I looked at the delta and the previous discussion at
+https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
+and the changes look okay to me (including the `unsafe fn from_str_unchecked`
+changes in `wrapper.rs`).
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.92 -> 1.0.93"
+notes = "No `unsafe`-related changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.93 -> 1.0.94"
+notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.quick-error]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "1.2.3"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.rand]]
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "0.8.5"
+version = "1.0.35"
 notes = """
-For more detailed unsafe review notes please see https://crrev.com/c/6362797
+Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.rand_chacha]]
+[[audits.google.audits.quote]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.35 -> 1.0.36"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "0.3.1"
+delta = "1.0.36 -> 1.0.37"
 notes = """
-For more detailed unsafe review notes please see https://crrev.com/c/6362797
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.rand_core]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
+[[audits.google.audits.quote]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
 criteria = "safe-to-deploy"
-version = "0.6.4"
-notes = """
-For more detailed unsafe review notes please see https://crrev.com/c/6362797
-"""
+delta = "1.0.37 -> 1.0.38"
+notes = "Still no unsafe"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.regex]]
-who = "Justin Green <greenjustin@google.com>"
-criteria = "safe-to-run"
-version = "1.11.1"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+[[audits.google.audits.quote]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+notes = "Only minor changes for clippy lints and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.39 -> 1.0.40"
+notes = """
+The delta is just a simplification of how `tokens.extend(...)` call is made.
+Still no `unsafe` anywhere.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.relative-path]]
 who = "danakj <danakj@chromium.org>"
@@ -237,15 +338,6 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.2.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.mozilla.wildcard-audits.unicode-xid]]
-who = "Manish Goregaokar <manishsmail@gmail.com>"
-criteria = "safe-to-deploy"
-user-id = 1139 # Manish Goregaokar (Manishearth)
-start = "2019-07-25"
-end = "2027-04-23"
-notes = "All code written or reviewed by Manish"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.adler2]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
@@ -323,42 +415,58 @@ version = "1.0.7"
 notes = "Simple hasher implementation with no unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.5 -> 0.16.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.0 -> 0.16.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.16.1 -> 0.17.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.hex]]
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.log]]
-who = "Erich Gubler <erichdongubler@gmail.com>"
+[[audits.mozilla.audits.proc-macro2]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-delta = "0.4.26 -> 0.4.29"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+delta = "1.0.94 -> 1.0.106"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.proc-macro-error-attr2]]
-who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
-version = "2.0.0"
-notes = "No unsafe block."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.proc-macro-error2]]
-who = "Kagami Sascha Rosylight <saschanaz@outlook.com>"
-criteria = "safe-to-deploy"
-version = "2.0.1"
-notes = "No unsafe block with a lovely `#![forbid(unsafe_code)]`."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.regex]]
-who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.11.1 -> 1.12.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+delta = "1.0.40 -> 1.0.45"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.smallvec]]
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.15.1 -> 1.15.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.strsim]]


### PR DESCRIPTION
## Summary
- Consolidates the open dependency update set: Cargo group (#276), getrandom (#277), GitHub Actions (#278), and quick-xml (#165).
- Updates quick-xml to 0.40.1, getrandom to 0.4.3, rustls to 0.23.41, and uuid to 1.23.4; raises the repo MSRV to Rust 1.79 for quick-xml 0.40.
- Adapts quick-xml/getrandom API usage, refreshes cargo-vet metadata, and removes the stale pip Dependabot entry that has no manifest to update.
- Keeps the Dependabot GitHub Actions pin updates and corrects the inline action version comments.

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- cargo test --workspace --all-features
- cargo audit (passes; reports one allowed yanked warning from the existing russh/crypto-bigint chain)
- cargo vet

Agent: Thoth