### PR TITLE
fix(deps): update quick-xml security release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,9 +1583,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -2254,7 +2254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 
 # XML
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # Error handling
 thiserror = "2"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -25,6 +25,12 @@ criteria = "safe-to-deploy"
 delta = "0.39.3 -> 0.39.4"
 notes = "Reviewed local diff: DTD parser guards avoid buffer overrun/panic paths when unknown markup exceeds the fixed lookahead window; no new capability or unsafe surface added."
 
+[[audits.quick-xml]]
+who = "Thoth"
+criteria = "safe-to-deploy"
+delta = "0.40.1 -> 0.41.0"
+notes = "Reviewed 0.40.1 to 0.41.0 security release diff for RUSTSEC-2026-0194 and RUSTSEC-2026-0195; changes bound duplicate-attribute and namespace-declaration DoS paths."
+
 [[audits.rustls]]
 who = "Thoth"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary
- update `quick-xml` to `0.41.0`
- refresh the lockfile so RustSec advisories RUSTSEC-2026-0194 and RUSTSEC-2026-0195 no longer apply

## Validation
- `cargo fmt --all -- --check`
- `cargo audit`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Agent: Thoth
