### PR TITLE
ci: align MSRV with SSH dependency stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, "1.79.0"]  # stable + MSRV
+        rust: [stable, "1.85.0"]  # stable + MSRV
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # master
         with:
-          toolchain: "1.79.0"
+          toolchain: "1.85.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo check --workspace --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 version = "0.3.3"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.85.0"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/clawosiris/rust-gvm"
 keywords = ["greenbone", "gvm", "gmp", "vulnerability", "security"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG RUST_VERSION=1.75.0
+ARG RUST_VERSION=1.85.0
 
 FROM rust:${RUST_VERSION}-bookworm AS builder
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ cargo build --release -p gvm-mock-server
 
 ### Requirements
 
-- Rust 1.79+ (MSRV)
+- Rust 1.85+ (MSRV)
 - Python 3.10+ with `python-gvm` (for integration tests only)
 
 ## CI/CD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,7 @@ Accepted advisories are documented in [`deny.toml`](deny.toml) with rationale:
 
 - `cargo clippy` with `-D warnings` in CI
 - `#[deny(unsafe_code)]` — no unsafe blocks in any crate
-- MSRV tested (currently Rust 1.75.0)
+- MSRV tested (currently Rust 1.85.0)
 - All XML parsing uses `quick-xml` with default limits (no unbounded expansion)
 
 ## Security-Relevant Architecture

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # rust-gvm Clippy configuration
 # See: https://doc.rust-lang.org/clippy/configuration.html
 
-msrv = "1.79.0"
+msrv = "1.85.0"
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 8
 type-complexity-threshold = 300

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -37,7 +37,7 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
 /// Return whether a command is supported by the negotiated version.
 #[must_use]
 pub fn command_supported(command_name: &str, version: GmpVersion) -> bool {
-    minimum_version_for_command(command_name).map_or(true, |minimum| version >= minimum)
+    minimum_version_for_command(command_name).is_none_or(|minimum| version >= minimum)
 }
 
 /// Human-readable minimum version label for a version-gated command.

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(missing_docs)]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::print_stderr, missing_docs)]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{Gmp226Commands, GmpNextCommands, GmpVersioned};
 use gvm_connection::UnixSocketConnection;

--- a/crates/gvm-connection/tests/large_response.rs
+++ b/crates/gvm-connection/tests/large_response.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "large-response-tests")]
 #![allow(clippy::unwrap_used, missing_docs)]
+#![cfg(feature = "large-response-tests")]
 
 use gvm_connection::{GvmConnection, UnixSocketConfig, UnixSocketConnection};
 use gvm_gmp::commands::reports::get_report;

--- a/crates/gvm-connection/tests/ssh_connection.rs
+++ b/crates/gvm-connection/tests/ssh_connection.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "ssh")]
 #![allow(missing_docs)]
+#![cfg(feature = "ssh")]
 
 use std::path::PathBuf;
 use std::time::Duration;

--- a/crates/gvm-connection/tests/ssh_e2e.rs
+++ b/crates/gvm-connection/tests/ssh_e2e.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(all(feature = "ssh", feature = "unix-socket-tests"))]
 #![allow(clippy::print_stdout, clippy::unwrap_used, missing_docs)]
+#![cfg(all(feature = "ssh", feature = "unix-socket-tests"))]
 
 use std::io::ErrorKind;
 

--- a/crates/gvm-connection/tests/unix_connection.rs
+++ b/crates/gvm-connection/tests/unix_connection.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::print_stdout, clippy::unwrap_used, missing_docs)]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_connection::{GvmConnection, UnixSocketConfig, UnixSocketConnection};
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};

--- a/crates/gvm-mock-server/tests/builder_coverage.rs
+++ b/crates/gvm-mock-server/tests/builder_coverage.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stdout,
     clippy::redundant_closure_for_method_calls,
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 

--- a/crates/gvm-mock-server/tests/fault_per_session.rs
+++ b/crates/gvm-mock-server/tests/fault_per_session.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stdout,
     clippy::redundant_closure_for_method_calls,
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_mock_server::{Fault, FaultKind, GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::Response;

--- a/crates/gvm-mock-server/tests/scenario_mode.rs
+++ b/crates/gvm-mock-server/tests/scenario_mode.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stdout,
     clippy::redundant_closure_for_method_calls,
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_mock_server::{GmpVersion, MockGmpServer, ScenarioMode, ScenarioStep};
 use gvm_protocol::Response;

--- a/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
+++ b/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stdout,
     clippy::redundant_closure_for_method_calls,
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
 use gvm_protocol::Response;

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stderr,
     clippy::print_stdout,
@@ -9,6 +8,7 @@
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::features::get_features;

--- a/spec/openspec.md
+++ b/spec/openspec.md
@@ -607,7 +607,7 @@ Dev dependencies: `tokio-test`, `pretty_assertions`, `rstest`
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | Push/PR to main | Format, Clippy, Test (stable + MSRV 1.75), Test (all features), Documentation, Cargo Deny, Coverage, python-gvm integration |
+| `ci.yml` | Push/PR to main | Format, Clippy, Test (stable + MSRV 1.85), Test (all features), Documentation, Cargo Deny, Coverage, python-gvm integration |
 | `nightly.yml` | Daily 04:00 UTC + manual | Full CI + 5-target cross-platform binary builds |
 | `release.yml` | `v*` tag push | Test → 5-target builds → SBOM generation → GitHub Release with checksums |
 


### PR DESCRIPTION
## Description

Align the declared MSRV with the current all-features dependency graph.

The SSH feature uses `russh 0.61`, whose crate metadata requires Rust 1.85. With the current Rust 1.79 MSRV check, the all-features workspace check fails before `rust-gvm` compiles because transitive RustCrypto prerelease crates require Cargo edition-2024 support.

I also checked the alternative of downgrading `russh` to keep Rust 1.79 compatibility, but that path reintroduces high-severity RustSec advisories in `russh` / `russh-cryptovec`. This PR instead updates the MSRV contract to Rust 1.85.

Changes:
- update workspace `rust-version`, Clippy MSRV, CI MSRV jobs, README, and OpenSpec references to Rust 1.85
- apply one Clippy suggestion available at the new MSRV
- move cfg-gated integration-test `allow(...)` attrs before `cfg(...)` attrs so warning allowances apply correctly

Refs: none

## Type

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [ ] test: Adding/updating tests
- [x] docs: Documentation
- [x] ci: CI/CD changes
- [x] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated (if applicable)
- [x] New tests added for new functionality (N/A: no new functionality)
- [x] OpenSpec updated (if design changed)
- [ ] Journal entry updated

Journal entry not included; recent non-journal maintenance PRs do not appear to include journal files, and journal updates use a separate journal branch workflow.

## Testing

Tested locally with:

```sh
cargo fmt --all -- --check
cargo check --workspace
cargo +1.85.0 check --workspace --all-features
cargo test --workspace
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
cargo +1.85.0 test --workspace
cargo deny check
cargo audit
python3 -B -m unittest tests.test_sbom_postprocess -q
make test-integration
git diff --check
```

Additional local security validation:

```sh
cargo machete
cargo vet
python3 scripts/check_workspace_unsafe.py
semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-pr287-semgrep.sarif
cargo deny check
cargo audit
```

`make test-integration` builds `gvm-mock-server` and runs the Python `python-gvm` integration workflow against the mock server.

`cargo machete` found no unused dependencies. `cargo vet` succeeded. `scripts/check_workspace_unsafe.py` reported `used_unsafe=0` for all workspace crates. Semgrep scanned tracked files with zero findings.

`cargo deny check` exits successfully and reports the existing unused allow/ignore warnings in `deny.toml`. `cargo audit` exits successfully and reports the existing allowed yanked-crate warning for `crypto-bigint 0.7.4`.

Agent: Codex