### PR TITLE
feat(gmp): align resource names command types

### DIFF
--- a/crates/gvm-gmp/src/commands/resource_names.rs
+++ b/crates/gvm-gmp/src/commands/resource_names.rs
@@ -3,24 +3,37 @@
 
 //! Resource-name command builders.
 
-/// Re-export of the system `get_resource_names` helpers.
-pub use crate::commands::system::{get_resource_names, GetResourceNamesOpts};
+/// Re-export of the system resource-name helpers.
+pub use crate::commands::system::{get_resource_name, get_resource_names, GetResourceNamesOpts};
+pub use crate::enums::ResourceType;
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::resource_names::{get_resource_names, GetResourceNamesOpts};
+    use crate::commands::resource_names::{
+        get_resource_name, get_resource_names, GetResourceNamesOpts, ResourceType,
+    };
     use crate::common::xml;
-    use crate::enums::EntityType;
     use crate::types::EntityId;
 
     #[test]
     fn resource_names_command_builds_xml() {
         let rendered = xml(get_resource_names(GetResourceNamesOpts {
-            resource_type: Some(EntityType::Target),
+            resource_type: Some(ResourceType::Target),
             resource_id: Some(EntityId::new("t1").expect("valid id")),
             ..Default::default()
         }));
-        assert!(rendered.contains("type=\"target\""));
+        assert!(rendered.contains("type=\"TARGET\""));
         assert!(rendered.contains("resource_id=\"t1\""));
+    }
+
+    #[test]
+    fn resource_name_command_builds_xml() {
+        assert_eq!(
+            xml(get_resource_name(
+                &EntityId::new("t1").expect("valid id"),
+                ResourceType::Task,
+            )),
+            "<get_resource_names resource_id=\"t1\" type=\"TASK\"/>"
+        );
     }
 }

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -6,7 +6,7 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::add_filter_attrs;
-use crate::enums::{AggregateStatistic, EntityType, FeedType, HelpFormat, InfoType, SortOrder};
+use crate::enums::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceType, SortOrder};
 use crate::types::EntityId;
 
 /// Options for `get_aggregates` requests.
@@ -52,7 +52,7 @@ pub struct GetInfoOpts {
 #[derive(Debug, Clone, Default)]
 pub struct GetResourceNamesOpts {
     /// Optional related resource type.
-    pub resource_type: Option<EntityType>,
+    pub resource_type: Option<ResourceType>,
     /// Optional related resource identifier.
     pub resource_id: Option<EntityId>,
     /// Optional inline filter expression.
@@ -195,6 +195,15 @@ pub fn get_resource_names(opts: GetResourceNamesOpts) -> impl Request {
     cmd
 }
 
+/// Build a `get_resource_names` request for a single resource.
+#[must_use]
+pub fn get_resource_name(resource_id: &EntityId, resource_type: ResourceType) -> impl Request {
+    let mut cmd = XmlCommand::new("get_resource_names");
+    cmd.set_attribute("resource_id", resource_id.as_str());
+    cmd.set_attribute("type", resource_type.as_gmp_str());
+    cmd
+}
+
 /// Build a `get_vulns` request.
 #[must_use]
 pub fn get_vulns(opts: FilteredGetOpts) -> impl Request {
@@ -301,7 +310,7 @@ mod tests {
         }))
         .contains("type=\"NVT\""));
         assert!(xml(get_resource_names(GetResourceNamesOpts {
-            resource_type: Some(EntityType::Task),
+            resource_type: Some(ResourceType::Task),
             resource_id: Some(id("t1")),
             ..Default::default()
         }))

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -410,6 +410,145 @@ gmp_enum!(EntityType {
     User => "user",
     Vulnerability => "vulnerability"
 });
+/// Resource types accepted by `get_resource_names`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ResourceType {
+    /// Alert resources.
+    Alert,
+    /// Audit resources are represented as tasks in GMP.
+    Audit,
+    /// Audit report resources are represented as reports in GMP.
+    AuditReport,
+    /// CERT-Bund advisory resources.
+    CertBundAdv,
+    /// Scan configuration resources.
+    Config,
+    /// CPE resources.
+    Cpe,
+    /// Credential resources.
+    Credential,
+    /// CVE resources.
+    Cve,
+    /// DFN-CERT advisory resources.
+    DfnCertAdv,
+    /// Filter resources.
+    Filter,
+    /// Group resources.
+    Group,
+    /// Host resources.
+    Host,
+    /// Note resources.
+    Note,
+    /// NVT resources.
+    Nvt,
+    /// Operating system resources.
+    OperatingSystem,
+    /// Override resources.
+    Override,
+    /// Permission resources.
+    Permission,
+    /// Port list resources.
+    PortList,
+    /// Report format resources.
+    ReportFormat,
+    /// Report resources.
+    Report,
+    /// Report config resources.
+    ReportConfig,
+    /// Result resources.
+    Result,
+    /// Role resources.
+    Role,
+    /// Scanner resources.
+    Scanner,
+    /// Schedule resources.
+    Schedule,
+    /// Target resources.
+    Target,
+    /// Task resources.
+    Task,
+    /// TLS certificate resources.
+    TlsCertificate,
+    /// User resources.
+    User,
+}
+
+impl ResourceType {
+    /// Returns the GMP wire-format string for this value.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Alert => "ALERT",
+            Self::Audit | Self::Task => "TASK",
+            Self::AuditReport | Self::Report => "REPORT",
+            Self::CertBundAdv => "CERT_BUND_ADV",
+            Self::Config => "CONFIG",
+            Self::Cpe => "CPE",
+            Self::Credential => "CREDENTIAL",
+            Self::Cve => "CVE",
+            Self::DfnCertAdv => "DFN_CERT_ADV",
+            Self::Filter => "FILTER",
+            Self::Group => "GROUP",
+            Self::Host => "HOST",
+            Self::Note => "NOTE",
+            Self::Nvt => "NVT",
+            Self::OperatingSystem => "OS",
+            Self::Override => "OVERRIDE",
+            Self::Permission => "PERMISSION",
+            Self::PortList => "PORT_LIST",
+            Self::ReportFormat => "REPORT_FORMAT",
+            Self::ReportConfig => "REPORT_CONFIG",
+            Self::Result => "RESULT",
+            Self::Role => "ROLE",
+            Self::Scanner => "SCANNER",
+            Self::Schedule => "SCHEDULE",
+            Self::Target => "TARGET",
+            Self::TlsCertificate => "TLS_CERTIFICATE",
+            Self::User => "USER",
+        }
+    }
+}
+
+impl FromStr for ResourceType {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ALERT" => Ok(Self::Alert),
+            "TASK" => Ok(Self::Task),
+            "REPORT" => Ok(Self::Report),
+            "CERT_BUND_ADV" => Ok(Self::CertBundAdv),
+            "CONFIG" => Ok(Self::Config),
+            "CPE" => Ok(Self::Cpe),
+            "CREDENTIAL" => Ok(Self::Credential),
+            "CVE" => Ok(Self::Cve),
+            "DFN_CERT_ADV" => Ok(Self::DfnCertAdv),
+            "FILTER" => Ok(Self::Filter),
+            "GROUP" => Ok(Self::Group),
+            "HOST" => Ok(Self::Host),
+            "NOTE" => Ok(Self::Note),
+            "NVT" => Ok(Self::Nvt),
+            "OS" => Ok(Self::OperatingSystem),
+            "OVERRIDE" => Ok(Self::Override),
+            "PERMISSION" => Ok(Self::Permission),
+            "PORT_LIST" => Ok(Self::PortList),
+            "REPORT_FORMAT" => Ok(Self::ReportFormat),
+            "REPORT_CONFIG" => Ok(Self::ReportConfig),
+            "RESULT" => Ok(Self::Result),
+            "ROLE" => Ok(Self::Role),
+            "SCANNER" => Ok(Self::Scanner),
+            "SCHEDULE" => Ok(Self::Schedule),
+            "TARGET" => Ok(Self::Target),
+            "TLS_CERTIFICATE" => Ok(Self::TlsCertificate),
+            "USER" => Ok(Self::User),
+            _ => Err(EnumParseError {
+                enum_name: "ResourceType",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(FeedType {
     Nvt => "NVT",
     Cert => "CERT",
@@ -690,6 +829,7 @@ mod tests {
         "up"
     );
     enum_round_trip_test!(entity_type_round_trip, EntityType, Task, "task");
+    enum_round_trip_test!(resource_type_round_trip, ResourceType, Task, "TASK");
     enum_round_trip_test!(feed_type_round_trip, FeedType, Nvt, "NVT");
     enum_round_trip_test!(filter_type_round_trip, FilterType, Task, "task");
     enum_round_trip_test!(help_format_round_trip, HelpFormat, Xml, "xml");

--- a/crates/gvm-gmp/tests/test_enums.rs
+++ b/crates/gvm-gmp/tests/test_enums.rs
@@ -1003,6 +1003,31 @@ fn test_entitytype_invalid_string_returns_error() {
 }
 
 #[test]
+fn test_resourcetype_task_as_gmp_str() {
+    assert_eq!(ResourceType::Task.as_gmp_str(), "TASK");
+}
+#[test]
+fn test_resourcetype_operatingsystem_as_gmp_str() {
+    assert_eq!(ResourceType::OperatingSystem.as_gmp_str(), "OS");
+}
+#[test]
+fn test_resourcetype_audit_aliases_as_gmp_str() {
+    assert_eq!(ResourceType::Audit.as_gmp_str(), "TASK");
+    assert_eq!(ResourceType::AuditReport.as_gmp_str(), "REPORT");
+}
+#[test]
+fn test_resourcetype_from_str() {
+    assert_eq!(
+        ResourceType::from_str("TLS_CERTIFICATE").unwrap(),
+        ResourceType::TlsCertificate
+    );
+}
+#[test]
+fn test_resourcetype_invalid_string_returns_error() {
+    assert!(ResourceType::from_str("task").is_err());
+}
+
+#[test]
 fn test_feedtype_nvt_as_gmp_str() {
     assert_eq!(FeedType::Nvt.as_gmp_str(), "NVT");
 }

--- a/crates/gvm-gmp/tests/test_resource_names.rs
+++ b/crates/gvm-gmp/tests/test_resource_names.rs
@@ -6,14 +6,18 @@
 mod common;
 
 use common::{id, xml};
-use gvm_gmp::commands::resource_names::{get_resource_names, GetResourceNamesOpts};
-use gvm_gmp::EntityType;
+use gvm_gmp::commands::resource_names::{
+    get_resource_name, get_resource_names, GetResourceNamesOpts, ResourceType,
+};
 
 #[test]
 fn test_get_resource_names_basic() {
     assert_eq!(
-        xml(get_resource_names(Default::default())),
-        "<get_resource_names/>"
+        xml(get_resource_names(GetResourceNamesOpts {
+            resource_type: Some(ResourceType::Task),
+            ..Default::default()
+        })),
+        "<get_resource_names type=\"TASK\"/>"
     );
 }
 
@@ -21,11 +25,19 @@ fn test_get_resource_names_basic() {
 fn test_get_resource_names_with_options() {
     assert_eq!(
         xml(get_resource_names(GetResourceNamesOpts {
-            resource_type: Some(EntityType::Task),
+            resource_type: Some(ResourceType::Task),
             resource_id: Some(id("t1")),
             filter_string: Some("name=foo".into()),
             filter_id: Some(id("f1")),
         })),
-        "<get_resource_names filt_id=\"f1\" filter=\"name=foo\" resource_id=\"t1\" type=\"task\"/>"
+        "<get_resource_names filt_id=\"f1\" filter=\"name=foo\" resource_id=\"t1\" type=\"TASK\"/>"
+    );
+}
+
+#[test]
+fn test_get_resource_name() {
+    assert_eq!(
+        xml(get_resource_name(&id("t1"), ResourceType::Task)),
+        "<get_resource_names resource_id=\"t1\" type=\"TASK\"/>"
     );
 }

--- a/crates/gvm-gmp/tests/test_system.rs
+++ b/crates/gvm-gmp/tests/test_system.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::{id, xml};
 use gvm_gmp::commands::system::*;
-use gvm_gmp::{AggregateStatistic, EntityType, FeedType, HelpFormat, InfoType, SortOrder};
+use gvm_gmp::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceType, SortOrder};
 
 #[test]
 fn test_system_help_and_feeds() {
@@ -72,12 +72,12 @@ fn test_system_aggregates_info_resource_names_and_mutations() {
     );
     assert_eq!(
         xml(get_resource_names(GetResourceNamesOpts {
-            resource_type: Some(EntityType::Task),
+            resource_type: Some(ResourceType::Task),
             resource_id: Some(id("t1")),
             filter_string: None,
             filter_id: None
         })),
-        "<get_resource_names resource_id=\"t1\" type=\"task\"/>"
+        "<get_resource_names resource_id=\"t1\" type=\"TASK\"/>"
     );
     assert_eq!(xml(get_license()), "<get_license/>");
     assert_eq!(xml(describe_auth()), "<describe_auth/>");


### PR DESCRIPTION
## Summary

- add a command-specific `ResourceType` for `get_resource_names`
- emit uppercase GMP resource-name type values matching python-gvm
- add `get_resource_name` as a singular helper for resource-id lookups
- update focused command and enum tests

## Stack / Review Note

This PR is stacked on #287 (`ci: align MSRV with SSH dependency stack`). Until #287 merges, this branch includes that base commit plus the resource-names commit.

Please review the top commit/diff after #287 when evaluating the resource-names change:

- `b6c0a75 feat(gmp): align resource names command types`

If stacked PRs are not preferred, I can rebase/resubmit this as a standalone PR after #287 is merged.

## Parity Evidence

- python-gvm v225/v226 `ResourceNames.get_resource_names(ResourceType.TASK)` emits `<get_resource_names type="TASK"/>`
- python-gvm `ResourceNames.get_resource_names(ResourceType.CPE, filter_string="foo=bar")` emits `<get_resource_names type="CPE" filter="foo=bar"/>`
- python-gvm `ResourceNames.get_resource_name(resource_id="t1", resource_type=ResourceType.TASK)` emits `<get_resource_names resource_id="t1" type="TASK"/>`

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-gmp resource_name`
- `cargo test -p gvm-gmp resourcetype`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `make test-integration`
- `git diff --check`

Additional local security validation:

- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-pr288-semgrep.sarif`
- `cargo deny check`
- `cargo audit`

Results: `cargo machete` found no unused dependencies; `cargo vet` succeeded; `scripts/check_workspace_unsafe.py` reported `used_unsafe=0` for all workspace crates; Semgrep scanned tracked files with zero findings.

Notes: `cargo deny check` still reports existing unused allow/ignore warnings; `cargo audit` still reports the existing allowed yanked `crypto-bigint 0.7.4` warning.