### PR TITLE
feat(client): add trashcan restore helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -70,6 +70,7 @@ use gvm_gmp::commands::tickets::{create_ticket, get_tickets, GetTicketsOpts, Tic
 use gvm_gmp::commands::tls_certificates::{
     create_tls_certificate, get_tls_certificates, GetTlsCertificatesOpts, TlsCertificateOpts,
 };
+use gvm_gmp::commands::trashcan::{empty_trashcan, restore_from_trashcan};
 use gvm_gmp::commands::users::{create_user, get_users, GetUsersOpts, UserOpts};
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::responses::{
@@ -79,8 +80,8 @@ use gvm_gmp::responses::{
     CreateReportFormatResponse, CreateRoleResponse, CreateScanConfigResponse,
     CreateScannerResponse, CreateScheduleResponse, CreateTagResponse, CreateTargetResponse,
     CreateTaskResponse, CreateTicketResponse, CreateTlsCertificateResponse, CreateUserResponse,
-    DeleteScanConfigResponse, DeleteScannerResponse, DescribeAuthResponse, GetAlertsResponse,
-    GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
+    DeleteScanConfigResponse, DeleteScannerResponse, DescribeAuthResponse, EmptyTrashcanResponse,
+    GetAlertsResponse, GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
     GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
     GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
     GetNvtFamiliesResponse, GetNvtsResponse, GetOverridesResponse, GetPermissionsResponse,
@@ -90,7 +91,7 @@ use gvm_gmp::responses::{
     GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
     GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
-    HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse, ReportExport,
+    HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse, ReportExport, RestoreResponse,
     ResumeTaskResponse, StartTaskResponse, SyncConfigResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
@@ -403,6 +404,27 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<ResumeTaskResponse, GvmError> {
         let response = self.send(resume_task(task_id)).await?;
         ResumeTaskResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send an `empty_trashcan` request and return a typed [`EmptyTrashcanResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn empty_trashcan(&mut self) -> Result<EmptyTrashcanResponse, GvmError> {
+        let response = self.send(empty_trashcan()).await?;
+        EmptyTrashcanResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `restore` request and return a typed [`RestoreResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn restore_from_trashcan(
+        &mut self,
+        resource_id: &EntityId,
+    ) -> Result<RestoreResponse, GvmError> {
+        let response = self.send(restore_from_trashcan(resource_id)).await?;
+        RestoreResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Reports ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -581,6 +581,79 @@ async fn full_crud_lifecycle_succeeds() {
 }
 
 #[tokio::test]
+async fn typed_trashcan_helpers_restore_deleted_task() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let empty_response = client
+        .empty_trashcan()
+        .await
+        .expect("empty_trashcan should succeed");
+    assert_eq!(empty_response.status, 200);
+
+    let target_response = client
+        .create_target(
+            "Trashcan Target",
+            CreateTargetOpts {
+                hosts: vec!["127.0.0.1".to_string()],
+                ..CreateTargetOpts::default()
+            },
+        )
+        .await
+        .expect("create_target should succeed");
+    let target_id = target_response.id;
+    let config_id = "550e8400-e29b-41d4-a716-446655440001"
+        .parse()
+        .expect("entity id");
+    let scanner_id = "550e8400-e29b-41d4-a716-446655440002"
+        .parse()
+        .expect("entity id");
+
+    let task_response = client
+        .create_task(
+            "Trashcan Task",
+            &config_id,
+            &target_id,
+            &scanner_id,
+            Default::default(),
+        )
+        .await
+        .expect("create_task should succeed");
+    let task_id = task_response.id;
+
+    let delete_response = client
+        .call(delete_task(&task_id, false))
+        .await
+        .expect("delete_task should succeed");
+    assert_eq!(delete_response.status_code(), Some(200));
+
+    let restore_response = client
+        .restore_from_trashcan(&task_id)
+        .await
+        .expect("restore_from_trashcan should succeed");
+    assert_eq!(restore_response.status, 200);
+
+    let get_response = client
+        .call(get_task(&task_id))
+        .await
+        .expect("get_task should succeed");
+    let body = get_response.as_str().expect("utf8");
+    assert!(body.contains("Trashcan Task"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_resume_task_returns_report_id() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-gmp/src/commands/trashcan.rs
+++ b/crates/gvm-gmp/src/commands/trashcan.rs
@@ -19,6 +19,14 @@ pub fn restore(resource_id: &EntityId) -> impl Request {
     XmlCommand::new("restore").attribute("id", resource_id.as_str())
 }
 
+/// Build a `restore` request for a resource in the trashcan.
+///
+/// This is a python-gvm-compatible name for [`restore`].
+#[must_use]
+pub fn restore_from_trashcan(resource_id: &EntityId) -> impl Request {
+    restore(resource_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -30,6 +38,12 @@ mod tests {
         assert_eq!(xml(empty_trashcan()), "<empty_trashcan/>");
         assert_eq!(
             xml(restore(&EntityId::new("a1").expect("valid id"))),
+            "<restore id=\"a1\"/>"
+        );
+        assert_eq!(
+            xml(restore_from_trashcan(
+                &EntityId::new("a1").expect("valid id")
+            )),
             "<restore id=\"a1\"/>"
         );
     }


### PR DESCRIPTION
## Summary

- add `restore_from_trashcan(&EntityId)` as a python-gvm-compatible alias for the existing `restore` command builder
- add typed `GmpClient::empty_trashcan` and `GmpClient::restore_from_trashcan` helpers
- add a live stateful mock-server integration test that deletes a task to trash, restores it through the typed helper, and fetches the restored task

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp trashcan`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_trashcan_helpers_restore_deleted_task`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_mode stateful_trash_and_restore`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix matrix_tags_create_and_empty_trashcan`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix matrix_schedules_create_delete_to_trash_and_restore`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-trashcan-restore-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `git diff --check`

## Notes

- The first `make test-integration` attempt was run outside `.venv` and failed with `ModuleNotFoundError: No module named 'gvm'`; rerunning with `.venv` activated passed.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking cargo-geiger workspace unsafe gate passed with `used_unsafe=0` for workspace crates. The non-blocking geiger text-report command wrote `target/geiger/*.txt` but emitted dependency parser/unscanned-file warnings, matching CI's non-blocking posture.
- Fuzzing was not run because this change is an alias/client-helper/live integration slice and does not touch parser, streaming, transport, or fuzz-facing code.
