### PR TITLE
feat(client): add singular secinfo helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -58,7 +58,8 @@ use gvm_gmp::commands::schedules::{
     create_schedule, get_schedules, GetSchedulesOpts, ScheduleOpts,
 };
 use gvm_gmp::commands::secinfo::{
-    get_cert_bund_advisories, get_cpes, get_cves, get_dfn_cert_advisories, GetSecInfoOpts,
+    get_cert_bund_advisories, get_cert_bund_advisory, get_cpe, get_cpes, get_cve, get_cves,
+    get_dfn_cert_advisories, get_dfn_cert_advisory, GetSecInfoOpts,
 };
 use gvm_gmp::commands::system::{describe_auth, get_settings, get_timezones, FilteredGetOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
@@ -593,12 +594,32 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         GetCvesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
+    /// Send a `get_info` request for a single CVE entry and return a typed
+    /// [`GetCvesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_cve(&mut self, cve_id: &str) -> Result<GetCvesResponse, GvmError> {
+        let response = self.send(get_cve(cve_id)).await?;
+        GetCvesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
     /// Send a `get_info` request for CPE entries and return a typed [`GetCpesResponse`].
     ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_cpes(&mut self, opts: GetSecInfoOpts) -> Result<GetCpesResponse, GvmError> {
         let response = self.send(get_cpes(opts)).await?;
+        GetCpesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_info` request for a single CPE entry and return a typed
+    /// [`GetCpesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_cpe(&mut self, cpe_id: &str) -> Result<GetCpesResponse, GvmError> {
+        let response = self.send(get_cpe(cpe_id)).await?;
         GetCpesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
@@ -615,6 +636,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         GetCertBundAdvisoriesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
+    /// Send a `get_info` request for a single CERT-Bund advisory and return a
+    /// typed [`GetCertBundAdvisoriesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_cert_bund_advisory(
+        &mut self,
+        cert_id: &str,
+    ) -> Result<GetCertBundAdvisoriesResponse, GvmError> {
+        let response = self.send(get_cert_bund_advisory(cert_id)).await?;
+        GetCertBundAdvisoriesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
     /// Send a `get_info` request for DFN-CERT advisories and return a typed
     /// [`GetDfnCertAdvisoriesResponse`].
     ///
@@ -625,6 +659,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: GetSecInfoOpts,
     ) -> Result<GetDfnCertAdvisoriesResponse, GvmError> {
         let response = self.send(get_dfn_cert_advisories(opts)).await?;
+        GetDfnCertAdvisoriesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_info` request for a single DFN-CERT advisory and return a
+    /// typed [`GetDfnCertAdvisoriesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_dfn_cert_advisory(
+        &mut self,
+        cert_id: &str,
+    ) -> Result<GetDfnCertAdvisoriesResponse, GvmError> {
+        let response = self.send(get_dfn_cert_advisory(cert_id)).await?;
         GetDfnCertAdvisoriesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -497,6 +497,55 @@ async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
 }
 
 #[tokio::test]
+async fn typed_secinfo_singular_helpers_fetch_one_entry() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let cve = client
+        .get_cve("CVE-2026-1000")
+        .await
+        .expect("single CVE should parse");
+    assert_eq!(cve.items.len(), 1);
+    assert_eq!(cve.items[0].id, "CVE-2026-1000");
+    assert_eq!(cve.items[0].name, "Mock CVE one");
+    assert_eq!(cve.counts.total, Some(1));
+
+    let cpe = client
+        .get_cpe("cpe:/a:greenbone:gvm")
+        .await
+        .expect("single CPE should parse");
+    assert_eq!(cpe.items.len(), 1);
+    assert_eq!(cpe.items[0].id, "cpe:/a:greenbone:gvm");
+    assert_eq!(cpe.items[0].name, "Greenbone GVM");
+
+    let cert = client
+        .get_cert_bund_advisory("CB-K26/001")
+        .await
+        .expect("single CERT-Bund advisory should parse");
+    assert_eq!(cert.items.len(), 1);
+    assert_eq!(cert.items[0].id, "CB-K26/001");
+
+    let dfn = client
+        .get_dfn_cert_advisory("DFN-2026-001")
+        .await
+        .expect("single DFN-CERT advisory should parse");
+    assert_eq!(dfn.items.len(), 1);
+    assert_eq!(dfn.items[0].id, "DFN-2026-001");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn full_crud_lifecycle_succeeds() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-gmp/src/commands/secinfo.rs
+++ b/crates/gvm-gmp/src/commands/secinfo.rs
@@ -29,10 +29,10 @@ impl InfoType {
     #[must_use]
     pub const fn as_gmp_str(self) -> &'static str {
         match self {
-            Self::Cpe => "cpe",
-            Self::Cve => "cve",
-            Self::CertBundAdvisory => "cert_bund_adv",
-            Self::DfnCertAdvisory => "dfn_cert_adv",
+            Self::Cpe => "CPE",
+            Self::Cve => "CVE",
+            Self::CertBundAdvisory => "CERT_BUND_ADV",
+            Self::DfnCertAdvisory => "DFN_CERT_ADV",
             Self::OperatingSystem => "os",
             Self::Vulnerability => "vuln",
         }
@@ -63,10 +63,24 @@ fn get_info(info_type: &str, opts: &GetSecInfoOpts) -> XmlCommand {
     cmd
 }
 
+fn get_info_by_id(info_type: InfoType, info_id: &str) -> XmlCommand {
+    let mut cmd = XmlCommand::new("get_info");
+    cmd.set_attribute("info_id", info_id);
+    cmd.set_attribute("type", info_type.as_gmp_str());
+    cmd.set_attribute("details", "1");
+    cmd
+}
+
 /// Build a `get_info` request for CPE entries.
 #[must_use]
 pub fn get_cpes(opts: GetSecInfoOpts) -> XmlCommand {
     get_info(InfoType::Cpe.as_gmp_str(), &opts)
+}
+
+/// Build a `get_info` request for a single CPE entry.
+#[must_use]
+pub fn get_cpe(cpe_id: &str) -> XmlCommand {
+    get_info_by_id(InfoType::Cpe, cpe_id)
 }
 
 /// Build a `get_info` request for CVE entries.
@@ -75,16 +89,34 @@ pub fn get_cves(opts: GetSecInfoOpts) -> XmlCommand {
     get_info(InfoType::Cve.as_gmp_str(), &opts)
 }
 
+/// Build a `get_info` request for a single CVE entry.
+#[must_use]
+pub fn get_cve(cve_id: &str) -> XmlCommand {
+    get_info_by_id(InfoType::Cve, cve_id)
+}
+
 /// Build a `get_info` request for CERT-Bund advisories.
 #[must_use]
 pub fn get_cert_bund_advisories(opts: GetSecInfoOpts) -> XmlCommand {
     get_info(InfoType::CertBundAdvisory.as_gmp_str(), &opts)
 }
 
+/// Build a `get_info` request for a single CERT-Bund advisory.
+#[must_use]
+pub fn get_cert_bund_advisory(cert_id: &str) -> XmlCommand {
+    get_info_by_id(InfoType::CertBundAdvisory, cert_id)
+}
+
 /// Build a `get_info` request for DFN-CERT advisories.
 #[must_use]
 pub fn get_dfn_cert_advisories(opts: GetSecInfoOpts) -> XmlCommand {
     get_info(InfoType::DfnCertAdvisory.as_gmp_str(), &opts)
+}
+
+/// Build a `get_info` request for a single DFN-CERT advisory.
+#[must_use]
+pub fn get_dfn_cert_advisory(cert_id: &str) -> XmlCommand {
+    get_info_by_id(InfoType::DfnCertAdvisory, cert_id)
 }
 
 /// Build a `get_info` request for operating-system entries.
@@ -102,17 +134,18 @@ pub fn get_vulnerabilities(opts: GetSecInfoOpts) -> XmlCommand {
 #[cfg(test)]
 mod tests {
     use crate::commands::secinfo::{
-        get_cert_bund_advisories, get_cpes, get_cves, get_dfn_cert_advisories,
-        get_operating_systems, get_vulnerabilities, GetSecInfoOpts, InfoType,
+        get_cert_bund_advisories, get_cert_bund_advisory, get_cpe, get_cpes, get_cve, get_cves,
+        get_dfn_cert_advisories, get_dfn_cert_advisory, get_operating_systems, get_vulnerabilities,
+        GetSecInfoOpts, InfoType,
     };
     use crate::common::xml;
 
     #[test]
     fn info_type_variants_map_to_wire_values() {
-        assert_eq!(InfoType::Cpe.as_gmp_str(), "cpe");
-        assert_eq!(InfoType::Cve.as_gmp_str(), "cve");
-        assert_eq!(InfoType::CertBundAdvisory.as_gmp_str(), "cert_bund_adv");
-        assert_eq!(InfoType::DfnCertAdvisory.as_gmp_str(), "dfn_cert_adv");
+        assert_eq!(InfoType::Cpe.as_gmp_str(), "CPE");
+        assert_eq!(InfoType::Cve.as_gmp_str(), "CVE");
+        assert_eq!(InfoType::CertBundAdvisory.as_gmp_str(), "CERT_BUND_ADV");
+        assert_eq!(InfoType::DfnCertAdvisory.as_gmp_str(), "DFN_CERT_ADV");
         assert_eq!(InfoType::OperatingSystem.as_gmp_str(), "os");
         assert_eq!(InfoType::Vulnerability.as_gmp_str(), "vuln");
     }
@@ -126,19 +159,19 @@ mod tests {
         };
         assert_eq!(
             xml(get_cpes(opts.clone())),
-            "<get_info details=\"1\" filt_id=\"f1\" filter=\"family=foo\" type=\"cpe\"/>"
+            "<get_info details=\"1\" filt_id=\"f1\" filter=\"family=foo\" type=\"CPE\"/>"
         );
         assert_eq!(
             xml(get_cves(GetSecInfoOpts::default())),
-            "<get_info type=\"cve\"/>"
+            "<get_info type=\"CVE\"/>"
         );
         assert_eq!(
             xml(get_cert_bund_advisories(GetSecInfoOpts::default())),
-            "<get_info type=\"cert_bund_adv\"/>"
+            "<get_info type=\"CERT_BUND_ADV\"/>"
         );
         assert_eq!(
             xml(get_dfn_cert_advisories(GetSecInfoOpts::default())),
-            "<get_info type=\"dfn_cert_adv\"/>"
+            "<get_info type=\"DFN_CERT_ADV\"/>"
         );
         assert_eq!(
             xml(get_operating_systems(GetSecInfoOpts::default())),
@@ -147,6 +180,22 @@ mod tests {
         assert_eq!(
             xml(get_vulnerabilities(GetSecInfoOpts::default())),
             "<get_info type=\"vuln\"/>"
+        );
+        assert_eq!(
+            xml(get_cpe("cpe:/a:greenbone:gvm")),
+            "<get_info details=\"1\" info_id=\"cpe:/a:greenbone:gvm\" type=\"CPE\"/>"
+        );
+        assert_eq!(
+            xml(get_cve("CVE-2026-1000")),
+            "<get_info details=\"1\" info_id=\"CVE-2026-1000\" type=\"CVE\"/>"
+        );
+        assert_eq!(
+            xml(get_cert_bund_advisory("CB-K26/001")),
+            "<get_info details=\"1\" info_id=\"CB-K26/001\" type=\"CERT_BUND_ADV\"/>"
+        );
+        assert_eq!(
+            xml(get_dfn_cert_advisory("DFN-2026-001")),
+            "<get_info details=\"1\" info_id=\"DFN-2026-001\" type=\"DFN_CERT_ADV\"/>"
         );
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -989,28 +989,28 @@ fn render_system_reports_response() -> Vec<u8> {
 fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
     let info_type = cmd.attr("type").unwrap_or("cve");
     let (element, entries) = match info_type {
-        "cpe" => (
+        "CPE" | "cpe" => (
             "cpe",
             vec![
                 ("cpe:/a:greenbone:gvm", "Greenbone GVM"),
                 ("cpe:/o:debian:debian_linux:12", "Debian 12"),
             ],
         ),
-        "cve" => (
+        "CVE" | "cve" => (
             "cve",
             vec![
                 ("CVE-2026-1000", "Mock CVE one"),
                 ("CVE-2026-1001", "Mock CVE two"),
             ],
         ),
-        "cert_bund_adv" => (
+        "CERT_BUND_ADV" | "cert_bund_adv" => (
             "cert_bund_adv",
             vec![
                 ("CB-K26/001", "CERT-Bund advisory one"),
                 ("CB-K26/002", "CERT-Bund advisory two"),
             ],
         ),
-        "dfn_cert_adv" => (
+        "DFN_CERT_ADV" | "dfn_cert_adv" => (
             "dfn_cert_adv",
             vec![
                 ("DFN-2026-001", "DFN-CERT advisory one"),
@@ -1031,12 +1031,18 @@ fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
         _ => ("info", vec![("info-1", "Generic info entry")]),
     };
 
+    let info_id = cmd.attr("info_id");
+    let entries: Vec<_> = entries
+        .into_iter()
+        .filter(|(id, _)| info_id.is_none_or(|wanted| wanted == *id))
+        .collect();
+    let count = entries.len();
     let items: String = entries
         .into_iter()
         .map(|(id, name)| format!("<{element} id=\"{id}\"><name>{name}</name></{element}>"))
         .collect();
     format!(
-        "<get_info_response status=\"200\" status_text=\"OK\">{items}<{element}_count>2<filtered>2</filtered></{element}_count></get_info_response>"
+        "<get_info_response status=\"200\" status_text=\"OK\">{items}<{element}_count>{count}<filtered>{count}</filtered></{element}_count></get_info_response>"
     )
     .into_bytes()
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -287,6 +287,29 @@ async fn stateful_secinfo_returns_typed_entries() {
 }
 
 #[tokio::test]
+async fn stateful_secinfo_accepts_uppercase_type_and_info_id() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let resp = send_recv(
+        &mut stream,
+        br#"<get_info details="1" info_id="CVE-2026-1000" type="CVE"/>"#,
+    )
+    .await;
+    assert_eq!(resp.status_code(), Some(200));
+    let text = resp.as_str().expect("utf8");
+    assert!(text.contains("<cve id=\"CVE-2026-1000\">"));
+    assert!(text.contains("Mock CVE one"));
+    assert!(text.contains("<cve_count>1<filtered>1</filtered></cve_count>"));
+    assert!(!text.contains("CVE-2026-1001"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn stateful_audit_reports_filter_by_usage_type() {
     let Some(server) = stateful_server().await else {
         return;


### PR DESCRIPTION
## Summary

- add singular `get_cpe`, `get_cve`, `get_cert_bund_advisory`, and `get_dfn_cert_advisory` GMP command builders and typed client helpers
- align SecInfo CPE/CVE/CERT-Bund/DFN-CERT `get_info` wire `type` values with python-gvm uppercase values
- teach the stateful mock server to accept uppercase SecInfo types, filter by `info_id`, and return dynamic counts
- add live Unix-socket mock-server tests for typed singular SecInfo calls and direct uppercase `get_info` filtering

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp secinfo`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_secinfo_singular_helpers_fetch_one_entry`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps stateful_secinfo_accepts_uppercase_type_and_info_id`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif --sarif-output /tmp/rust-gvm-secinfo-singular-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo +nightly fuzz run fuzz_response_parser -- -runs=1000`
- `git diff --check`

## Notes

- Source parity was checked against python-gvm `get_cpe`, `get_cve`, `get_cert_bund_advisory`, `get_dfn_cert_advisory`, and generic `get_info`: singular requests use `info_id`, uppercase SecInfo `type`, and `details="1"`.
- SecInfo IDs are plain strings, not UUID-only values; this matters for CPE and CVE identifiers.
- Existing list response parsers are reused because singular responses use the same `get_info_response` envelope with one typed child.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking cargo-geiger workspace unsafe gate passed with `used_unsafe=0` for workspace crates. The non-blocking geiger dependency reports wrote `target/geiger/*.txt` but emitted dependency parser/unscanned-file warnings, matching CI's non-blocking posture.
- `cargo vet` passed. `cargo vet --locked` was not used for the PR gate because upstream's workflow runs plain `cargo vet`; with cargo-vet 0.10.2, locked mode reports existing formatting drift in `supply-chain/imports.lock`.
