### PR TITLE
feat(client): add vulnerability helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -61,7 +61,9 @@ use gvm_gmp::commands::secinfo::{
     get_cert_bund_advisories, get_cert_bund_advisory, get_cpe, get_cpes, get_cve, get_cves,
     get_dfn_cert_advisories, get_dfn_cert_advisory, GetSecInfoOpts,
 };
-use gvm_gmp::commands::system::{describe_auth, get_settings, get_timezones, FilteredGetOpts};
+use gvm_gmp::commands::system::{
+    describe_auth, get_settings, get_timezones, get_vuln, get_vulns, FilteredGetOpts,
+};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
 use gvm_gmp::commands::tasks::{
@@ -92,8 +94,9 @@ use gvm_gmp::responses::{
     GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
     GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
-    HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse, ReportExport, RestoreResponse,
-    ResumeTaskResponse, StartTaskResponse, SyncConfigResponse, VerifyScannerResponse,
+    GetVulnerabilitiesResponse, HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse,
+    ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
+    VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -695,6 +698,32 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<GetDfnCertAdvisoriesResponse, GvmError> {
         let response = self.send(get_dfn_cert_advisory(cert_id)).await?;
         GetDfnCertAdvisoriesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_vulns` request for vulnerabilities and return a typed
+    /// [`GetVulnerabilitiesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_vulnerabilities(
+        &mut self,
+        opts: FilteredGetOpts,
+    ) -> Result<GetVulnerabilitiesResponse, GvmError> {
+        let response = self.send(get_vulns(opts)).await?;
+        GetVulnerabilitiesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_vulns` request for a single vulnerability and return a typed
+    /// [`GetVulnerabilitiesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_vulnerability(
+        &mut self,
+        vulnerability_id: &str,
+    ) -> Result<GetVulnerabilitiesResponse, GvmError> {
+        let response = self.send(get_vuln(vulnerability_id)).await?;
+        GetVulnerabilitiesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Alerts ────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -650,6 +650,40 @@ async fn typed_secinfo_singular_helpers_fetch_one_entry() {
 }
 
 #[tokio::test]
+async fn typed_vulnerability_helpers_parse_stateful_mock_response() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let vulnerabilities = client
+        .get_vulnerabilities(Default::default())
+        .await
+        .expect("vulnerabilities should parse");
+    assert_eq!(vulnerabilities.items.len(), 2);
+    assert_eq!(vulnerabilities.items[0].id, "vuln-1");
+
+    let vulnerability = client
+        .get_vulnerability("vuln-1")
+        .await
+        .expect("single vulnerability should parse");
+    assert_eq!(vulnerability.items.len(), 1);
+    assert_eq!(vulnerability.items[0].id, "vuln-1");
+    assert_eq!(vulnerability.items[0].name, "Outdated package");
+    assert_eq!(vulnerability.counts.total, Some(1));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn full_crud_lifecycle_succeeds() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -216,6 +216,12 @@ pub fn get_vulns(opts: FilteredGetOpts) -> impl Request {
     cmd
 }
 
+/// Build a `get_vulns` request for a single vulnerability entry.
+#[must_use]
+pub fn get_vuln(vuln_id: &str) -> impl Request {
+    XmlCommand::new("get_vulns").attribute("vuln_id", vuln_id)
+}
+
 /// Build a `get_license` request.
 #[must_use]
 pub fn get_license() -> impl Request {
@@ -315,6 +321,14 @@ mod tests {
             ..Default::default()
         }))
         .contains("resource_id=\"t1\""));
+        assert_eq!(
+            xml(get_vulns(FilteredGetOpts {
+                filter_string: Some("severity>5".into()),
+                filter_id: Some(id("filter-1")),
+            })),
+            "<get_vulns filt_id=\"filter-1\" filter=\"severity&gt;5\"/>"
+        );
+        assert_eq!(xml(get_vuln("vuln-1")), "<get_vulns vuln_id=\"vuln-1\"/>");
         assert_eq!(xml(modify_auth(true)), "<modify_auth enabled=\"1\"/>");
         assert_eq!(
             xml(modify_license("abc")),

--- a/crates/gvm-gmp/src/responses/secinfo.rs
+++ b/crates/gvm-gmp/src/responses/secinfo.rs
@@ -416,3 +416,28 @@ impl GetVulnerabilitiesResponse {
         })
     }
 }
+
+#[cfg(test)]
+mod additional_tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_get_vulns_response() {
+        let response = Response::from(
+            r#"<get_vulns_response status="200" status_text="OK">
+                <vuln id="vuln-1"><name>Outdated package</name></vuln>
+                <vuln_count>1<filtered>1</filtered></vuln_count>
+            </get_vulns_response>"#,
+        );
+
+        let parsed = GetVulnerabilitiesResponse::from_response(&response).expect("vulns parse");
+
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.items[0].id, "vuln-1");
+        assert_eq!(parsed.items[0].name, "Outdated package");
+        assert_eq!(parsed.counts.total, Some(1));
+    }
+}

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -409,6 +409,7 @@ impl SessionHandler {
             "get_aggregates" => return render_aggregates_response(cmd),
             "get_system_reports" => return render_system_reports_response(),
             "get_info" => return render_secinfo_response(cmd),
+            "get_vulns" => return render_vulnerabilities_response(cmd),
             "get_report_hosts"
             | "get_report_ports"
             | "get_report_applications"
@@ -1070,6 +1071,27 @@ fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
         .collect();
     format!(
         "<get_info_response status=\"200\" status_text=\"OK\">{items}<{element}_count>{count}<filtered>{count}</filtered></{element}_count></get_info_response>"
+    )
+    .into_bytes()
+}
+
+fn render_vulnerabilities_response(cmd: &ParsedCommand) -> Vec<u8> {
+    let entries = [
+        ("vuln-1", "Outdated package"),
+        ("vuln-2", "Weak configuration"),
+    ];
+    let vuln_id = cmd.attr("vuln_id");
+    let entries: Vec<_> = entries
+        .into_iter()
+        .filter(|(id, _)| vuln_id.is_none_or(|wanted| wanted == *id))
+        .collect();
+    let count = entries.len();
+    let items: String = entries
+        .into_iter()
+        .map(|(id, name)| format!("<vuln id=\"{id}\"><name>{name}</name></vuln>"))
+        .collect();
+    format!(
+        "<get_vulns_response status=\"200\" status_text=\"OK\">{items}<vuln_count>{count}<filtered>{count}</filtered></vuln_count></get_vulns_response>"
     )
     .into_bytes()
 }


### PR DESCRIPTION
## Summary

- add typed `GmpClient::get_vulnerabilities` and `GmpClient::get_vulnerability` helpers backed by the existing `get_vulns` GMP command
- add singular `get_vuln` command-builder support while keeping the existing `get_vulns` list builder as the low-level API
- teach the stateful mock server to return `get_vulns_response` fixtures and filter by `vuln_id`
- add parser and live Unix-socket mock-server coverage for vulnerability list and singular lookup behavior

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp system_commands_build_xml`
- `cargo test -p gvm-gmp system_filtered_mutation_commands_build_xml`
- `cargo test -p gvm-gmp parses_get_vulns_response`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_vulnerability_helpers_parse_stateful_mock_response`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif-output /tmp/rust-gvm-vulnerability-helpers-semgrep-profile.sarif`
- `semgrep scan --config auto --sarif-output /tmp/rust-gvm-vulnerability-helpers-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo geiger` reports for workspace crate manifests
- `cargo +nightly fuzz run fuzz_response_parser -- -runs=1000`

## Notes

- Source parity was checked against python-gvm: `get_vulnerabilities()` emits `get_vulns`, and `get_vulnerability(...)` emits `get_vulns` with `vuln_id`.
- The implementation reuses the existing `commands::system::get_vulns` builder instead of adding a second list builder with overlapping semantics.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking workspace unsafe gate passed with `used_unsafe=0` for workspace crates. Cargo-geiger dependency reports still emit baseline dependency unsafe warnings.
- The narrower Semgrep PR profile reported 0 findings. Broad Semgrep auto reported existing repo-level workflow/Dockerfile/dependabot findings unrelated to this slice.
- `cargo vet` passed; generated `supply-chain/imports.lock` quote-normalization churn was restored.
- Cargo-fuzz passed 1000 response-parser runs; generated `fuzz/Cargo.lock` version churn was restored.
