### PR TITLE
feat(client): add scan config field helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -48,7 +48,9 @@ use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
     clone_scan_config, create_scan_config, delete_scan_config, get_scan_config, get_scan_configs,
-    modify_scan_config, sync_config, ConfigOpts, GetScanConfigsOpts,
+    modify_policy_set_comment, modify_policy_set_name, modify_scan_config,
+    modify_scan_config_set_comment, modify_scan_config_set_name, sync_config, ConfigOpts,
+    GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
     clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
@@ -204,6 +206,68 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: ConfigOpts,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
         let response = self.send(modify_scan_config(config_id, opts)).await?;
+        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_config` request to set a scan-config name and return a
+    /// typed [`ModifyScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_scan_config_set_name(
+        &mut self,
+        config_id: &EntityId,
+        name: &str,
+    ) -> Result<ModifyScanConfigResponse, GvmError> {
+        let response = self
+            .send(modify_scan_config_set_name(config_id, name))
+            .await?;
+        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_config` request to set or clear a scan-config comment and
+    /// return a typed [`ModifyScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_scan_config_set_comment(
+        &mut self,
+        config_id: &EntityId,
+        comment: Option<&str>,
+    ) -> Result<ModifyScanConfigResponse, GvmError> {
+        let response = self
+            .send(modify_scan_config_set_comment(config_id, comment))
+            .await?;
+        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_config` request to set a policy name and return a typed
+    /// [`ModifyScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_policy_set_name(
+        &mut self,
+        policy_id: &EntityId,
+        name: &str,
+    ) -> Result<ModifyScanConfigResponse, GvmError> {
+        let response = self.send(modify_policy_set_name(policy_id, name)).await?;
+        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_config` request to set or clear a policy comment and
+    /// return a typed [`ModifyScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_policy_set_comment(
+        &mut self,
+        policy_id: &EntityId,
+        comment: Option<&str>,
+    ) -> Result<ModifyScanConfigResponse, GvmError> {
+        let response = self
+            .send(modify_policy_set_comment(policy_id, comment))
+            .await?;
         ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -12,13 +12,16 @@ use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
 use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
-use gvm_gmp::commands::scan_configs::ConfigOpts;
+use gvm_gmp::commands::scan_configs::{
+    create_policy, get_policies, ConfigOpts, GetScanConfigsOpts,
+};
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
+use gvm_gmp::responses::{CreateScanConfigResponse, GetScanConfigsResponse};
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
@@ -679,6 +682,98 @@ async fn typed_vulnerability_helpers_parse_stateful_mock_response() {
     assert_eq!(vulnerability.items[0].id, "vuln-1");
     assert_eq!(vulnerability.items[0].name, "Outdated package");
     assert_eq!(vulnerability.counts.total, Some(1));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_scan_config_field_helpers_modify_stateful_mock_resource() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created = client
+        .create_scan_config(
+            "Original config",
+            None,
+            ConfigOpts {
+                comment: Some("initial comment".into()),
+                usage_type: Some("scan".into()),
+            },
+        )
+        .await
+        .expect("scan config should be created");
+
+    let fetched = client
+        .get_scan_config(&created.id)
+        .await
+        .expect("created scan config should be fetched");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.name, "Original config");
+    assert_eq!(
+        fetched.items[0].meta.comment.as_deref(),
+        Some("initial comment")
+    );
+
+    client
+        .modify_scan_config_set_name(&created.id, "Renamed config")
+        .await
+        .expect("scan config name should be modified");
+    client
+        .modify_scan_config_set_comment(&created.id, None)
+        .await
+        .expect("scan config comment should be cleared");
+
+    let fetched = client
+        .get_scan_config(&created.id)
+        .await
+        .expect("scan config should be fetched");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.name, "Renamed config");
+    assert_eq!(fetched.items[0].meta.comment, None);
+
+    let response = client
+        .send(create_policy(
+            "Original policy",
+            ConfigOpts {
+                comment: Some("initial policy comment".into()),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("policy create request should succeed");
+    let policy = CreateScanConfigResponse::from_response(&response).expect("policy create parses");
+
+    client
+        .modify_policy_set_name(&policy.id, "Renamed policy")
+        .await
+        .expect("policy name should be modified");
+    client
+        .modify_policy_set_comment(&policy.id, None)
+        .await
+        .expect("policy comment should be cleared");
+
+    let response = client
+        .send(get_policies(GetScanConfigsOpts::default()))
+        .await
+        .expect("policies should be fetched");
+    let policies = GetScanConfigsResponse::from_response(&response).expect("policies parse");
+    let policy = policies
+        .items
+        .iter()
+        .find(|item| item.meta.id == policy.id)
+        .expect("modified policy should be returned");
+    assert_eq!(policy.meta.name, "Renamed policy");
+    assert_eq!(policy.meta.comment, None);
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -161,6 +161,18 @@ pub fn modify_scan_config_set_family_selection(
     modify_config_set_family_selection(config_id, families, auto_add_new_families)
 }
 
+/// Build a `modify_config` request that sets a scan-config name.
+#[must_use]
+pub fn modify_scan_config_set_name(config_id: &EntityId, name: &str) -> impl Request {
+    modify_config_set_name(config_id, name)
+}
+
+/// Build a `modify_config` request that sets or clears a scan-config comment.
+#[must_use]
+pub fn modify_scan_config_set_comment(config_id: &EntityId, comment: Option<&str>) -> impl Request {
+    modify_config_set_comment(config_id, comment)
+}
+
 fn modify_config_with_usage(
     config_id: &EntityId,
     opts: ConfigOpts,
@@ -239,6 +251,18 @@ fn add_encoded_preference_value(preference: &mut XmlElement, value: Option<&str>
         let encoded = base64::engine::general_purpose::STANDARD.encode(value.as_bytes());
         preference.add_child_with_text("value", &encoded);
     }
+}
+
+fn modify_config_set_name(config_id: &EntityId, name: &str) -> XmlCommand {
+    XmlCommand::new("modify_config")
+        .attribute("config_id", config_id.as_str())
+        .child_with_text("name", name)
+}
+
+fn modify_config_set_comment(config_id: &EntityId, comment: Option<&str>) -> XmlCommand {
+    XmlCommand::new("modify_config")
+        .attribute("config_id", config_id.as_str())
+        .child_with_text("comment", comment.unwrap_or_default())
 }
 
 /// Build a `delete_scan_config` request.
@@ -326,6 +350,18 @@ pub fn modify_policy_set_family_selection(
     modify_config_set_family_selection(policy_id, families, auto_add_new_families)
 }
 
+/// Build a `modify_config` request that sets a policy name.
+#[must_use]
+pub fn modify_policy_set_name(policy_id: &EntityId, name: &str) -> impl Request {
+    modify_config_set_name(policy_id, name)
+}
+
+/// Build a `modify_config` request that sets or clears a policy comment.
+#[must_use]
+pub fn modify_policy_set_comment(policy_id: &EntityId, comment: Option<&str>) -> impl Request {
+    modify_config_set_comment(policy_id, comment)
+}
+
 /// Build a `delete_config` request for a policy.
 #[must_use]
 pub fn delete_policy(config_id: &EntityId) -> impl Request {
@@ -381,6 +417,18 @@ mod tests {
             "<modify_config config_id=\"c1\"><comment>updated</comment></modify_config>"
         );
         assert_eq!(
+            xml(modify_scan_config_set_name(&id("c1"), "renamed")),
+            "<modify_config config_id=\"c1\"><name>renamed</name></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_scan_config_set_comment(&id("c1"), Some("updated"))),
+            "<modify_config config_id=\"c1\"><comment>updated</comment></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_scan_config_set_comment(&id("c1"), None)),
+            "<modify_config config_id=\"c1\"><comment></comment></modify_config>"
+        );
+        assert_eq!(
             xml(delete_scan_config(&id("c1"), false)),
             "<delete_config config_id=\"c1\" ultimate=\"0\"/>"
         );
@@ -415,6 +463,18 @@ mod tests {
                 }
             )),
             "<modify_config config_id=\"p1\"><comment>updated</comment><usage_type>policy</usage_type></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_policy_set_name(&id("p1"), "renamed")),
+            "<modify_config config_id=\"p1\"><name>renamed</name></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_policy_set_comment(&id("p1"), Some("updated"))),
+            "<modify_config config_id=\"p1\"><comment>updated</comment></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_policy_set_comment(&id("p1"), None)),
+            "<modify_config config_id=\"p1\"><comment></comment></modify_config>"
         );
         assert_eq!(
             xml(delete_policy(&id("p1"))),


### PR DESCRIPTION
## Summary

- add scan-config and policy `set_name` / `set_comment` command builders matching python-gvm's targeted `modify_config` requests
- add typed client helpers for those four field updates
- cover comment clearing by emitting an empty `<comment>` element when no comment is supplied
- add live stateful mock-server integration coverage for scan-config and policy rename/comment-clear behavior

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp scan_config_get_modify_delete_sync_build_xml`
- `cargo test -p gvm-gmp policy_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_scan_config_field_helpers_modify_stateful_mock_resource`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif-output /tmp/rust-gvm-scan-policy-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo geiger` reports for workspace crate manifests

## Notes

- Source parity was checked against python-gvm v224 scan-config and policy request builders.
- The remaining scan-config/policy preference, import, family-selection, and NVT-selection helpers are intentionally left out for smaller follow-up slices.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking workspace unsafe gate passed with `used_unsafe=0` for workspace crates. Cargo-geiger dependency reports still emit baseline dependency unsafe warnings.
- `cargo vet` passed; generated `supply-chain/imports.lock` quote-normalization churn was restored.
- Fuzzing was not run because this change is command-builder/client-helper/live integration work and does not touch parser, transport framing, streaming, or fuzz-facing code.
