### PR TITLE
feat(gmp): add preference getter helpers

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -10,10 +10,12 @@ use gvm_client::{
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::nvts::{get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts};
 use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
 use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
 use gvm_gmp::commands::scan_configs::{
-    create_policy, get_policies, ConfigOpts, GetScanConfigsOpts,
+    create_policy, get_policies, get_scan_config_preference, get_scan_config_preferences,
+    ConfigOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::system::get_timezones;
@@ -774,6 +776,86 @@ async fn typed_scan_config_field_helpers_modify_stateful_mock_resource() {
         .expect("modified policy should be returned");
     assert_eq!(policy.meta.name, "Renamed policy");
     assert_eq!(policy.meta.comment, None);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn preference_getters_send_expected_mock_server_commands() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let responses = [
+        client
+            .call(get_scan_config_preferences(GetScanConfigPreferencesOpts {
+                nvt_oid: Some("1.3.6.1".into()),
+                config_id: Some(EntityId::new("config-1").expect("valid id")),
+            }))
+            .await
+            .expect("scan-config preferences request should succeed"),
+        client
+            .call(get_scan_config_preference(
+                "timeout",
+                GetScanConfigPreferencesOpts {
+                    nvt_oid: Some("1.3.6.1".into()),
+                    config_id: Some(EntityId::new("config-1").expect("valid id")),
+                },
+            ))
+            .await
+            .expect("scan-config preference request should succeed"),
+        client
+            .call(get_nvt_preferences(GetNvtPreferencesOpts {
+                nvt_oid: Some("1.3.6.1".into()),
+            }))
+            .await
+            .expect("nvt preferences request should succeed"),
+        client
+            .call(get_nvt_preference(
+                "timeout",
+                GetNvtPreferencesOpts {
+                    nvt_oid: Some("1.3.6.1".into()),
+                },
+            ))
+            .await
+            .expect("nvt preference request should succeed"),
+    ];
+    assert!(responses
+        .iter()
+        .all(|response| response.status_code() == Some(200)));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 4);
+    assert!(history
+        .iter()
+        .all(|record| record.command_name() == "get_preferences"));
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands[0],
+        "<get_preferences config_id=\"config-1\" nvt_oid=\"1.3.6.1\"/>"
+    );
+    assert_eq!(
+        commands[1],
+        "<get_preferences config_id=\"config-1\" nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
+    );
+    assert_eq!(commands[2], "<get_preferences nvt_oid=\"1.3.6.1\"/>");
+    assert_eq!(
+        commands[3],
+        "<get_preferences nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/nvts.rs
+++ b/crates/gvm-gmp/src/commands/nvts.rs
@@ -19,6 +19,13 @@ pub struct GetNvtsOpts {
     pub details: Option<bool>,
 }
 
+/// Options for NVT `get_preferences` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetNvtPreferencesOpts {
+    /// Optional NVT OID to restrict preference lookup.
+    pub nvt_oid: Option<String>,
+}
+
 /// Build a `get_nvts` request.
 #[must_use]
 pub fn get_nvts(opts: GetNvtsOpts) -> impl Request {
@@ -38,6 +45,29 @@ pub fn get_nvt(nvt_oid: &str) -> impl Request {
     XmlCommand::new("get_nvts")
         .attribute("nvt_oid", nvt_oid)
         .attribute("details", "1")
+}
+
+/// Build a `get_preferences` request for NVT preferences.
+#[must_use]
+pub fn get_nvt_preferences(opts: GetNvtPreferencesOpts) -> impl Request {
+    get_preferences_with(None, opts.nvt_oid.as_deref())
+}
+
+/// Build a `get_preferences` request for a single NVT preference.
+#[must_use]
+pub fn get_nvt_preference(name: &str, opts: GetNvtPreferencesOpts) -> impl Request {
+    get_preferences_with(Some(name), opts.nvt_oid.as_deref())
+}
+
+fn get_preferences_with(preference: Option<&str>, nvt_oid: Option<&str>) -> XmlCommand {
+    let mut cmd = XmlCommand::new("get_preferences");
+    if let Some(preference) = preference {
+        cmd.set_attribute("preference", preference);
+    }
+    if let Some(nvt_oid) = nvt_oid {
+        cmd.set_attribute("nvt_oid", nvt_oid);
+    }
+    cmd
 }
 
 /// Build a `get_nvt_families` request.
@@ -67,6 +97,25 @@ mod tests {
         assert_eq!(
             xml(get_nvt("1.3.6.1")),
             "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1\"/>"
+        );
+        assert_eq!(
+            xml(get_nvt_preferences(GetNvtPreferencesOpts::default())),
+            "<get_preferences/>"
+        );
+        assert_eq!(
+            xml(get_nvt_preferences(GetNvtPreferencesOpts {
+                nvt_oid: Some("1.3.6.1".into())
+            })),
+            "<get_preferences nvt_oid=\"1.3.6.1\"/>"
+        );
+        assert_eq!(
+            xml(get_nvt_preference(
+                "timeout",
+                GetNvtPreferencesOpts {
+                    nvt_oid: Some("1.3.6.1".into())
+                }
+            )),
+            "<get_preferences nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
         );
         assert_eq!(xml(get_nvt_families()), "<get_nvt_families/>");
     }

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -43,6 +43,15 @@ pub struct NvtFamilySelection {
     pub all: bool,
 }
 
+/// Options for scan-config `get_preferences` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetScanConfigPreferencesOpts {
+    /// Optional NVT OID to restrict preference lookup.
+    pub nvt_oid: Option<String>,
+    /// Optional scan-config identifier to request configured values.
+    pub config_id: Option<EntityId>,
+}
+
 /// Build a clone request for an existing scan config.
 #[must_use]
 pub fn clone_scan_config(config_id: &EntityId) -> impl Request {
@@ -106,6 +115,44 @@ pub fn get_scan_config(config_id: &EntityId) -> impl Request {
     XmlCommand::new("get_configs")
         .attribute("config_id", config_id.as_str())
         .attribute("details", "1")
+}
+
+/// Build a `get_preferences` request for scan-config preferences.
+#[must_use]
+pub fn get_scan_config_preferences(opts: GetScanConfigPreferencesOpts) -> impl Request {
+    get_preferences_with(
+        None,
+        opts.nvt_oid.as_deref(),
+        opts.config_id.as_ref().map(EntityId::as_str),
+    )
+}
+
+/// Build a `get_preferences` request for a single scan-config preference.
+#[must_use]
+pub fn get_scan_config_preference(name: &str, opts: GetScanConfigPreferencesOpts) -> impl Request {
+    get_preferences_with(
+        Some(name),
+        opts.nvt_oid.as_deref(),
+        opts.config_id.as_ref().map(EntityId::as_str),
+    )
+}
+
+fn get_preferences_with(
+    preference: Option<&str>,
+    nvt_oid: Option<&str>,
+    config_id: Option<&str>,
+) -> XmlCommand {
+    let mut cmd = XmlCommand::new("get_preferences");
+    if let Some(preference) = preference {
+        cmd.set_attribute("preference", preference);
+    }
+    if let Some(nvt_oid) = nvt_oid {
+        cmd.set_attribute("nvt_oid", nvt_oid);
+    }
+    if let Some(config_id) = config_id {
+        cmd.set_attribute("config_id", config_id);
+    }
+    cmd
 }
 
 /// Build a `modify_scan_config` request.
@@ -396,6 +443,33 @@ mod tests {
         assert!(rendered.contains("<get_configs "));
         assert!(rendered.contains("config_id=\"c1\""));
         assert!(rendered.contains("details=\"1\""));
+    }
+
+    #[test]
+    fn scan_config_preference_commands_build_xml() {
+        assert_eq!(
+            xml(get_scan_config_preferences(
+                GetScanConfigPreferencesOpts::default()
+            )),
+            "<get_preferences/>"
+        );
+        assert_eq!(
+            xml(get_scan_config_preferences(GetScanConfigPreferencesOpts {
+                nvt_oid: Some("1.3.6.1".into()),
+                config_id: Some(id("c1")),
+            })),
+            "<get_preferences config_id=\"c1\" nvt_oid=\"1.3.6.1\"/>"
+        );
+        assert_eq!(
+            xml(get_scan_config_preference(
+                "timeout",
+                GetScanConfigPreferencesOpts {
+                    nvt_oid: Some("1.3.6.1".into()),
+                    config_id: Some(id("c1")),
+                }
+            )),
+            "<get_preferences config_id=\"c1\" nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add NVT `get_preferences` command builders matching python-gvm's optional `nvt_oid` and `preference` attributes
- add scan-config preference command builders matching python-gvm's optional `config_id`, `nvt_oid`, and `preference` attributes
- cover the new builders with XML characterization tests
- add live Unix-socket mock-server integration coverage that sends the commands through `GmpClient::call`, asserts successful responses, and verifies the raw GMP XML recorded by the mock server

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp scan_config_preference_commands_build_xml`
- `cargo test -p gvm-gmp nvt_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration preference_getters_send_expected_mock_server_commands`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif-output /tmp/rust-gvm-preference-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo geiger` reports for workspace crate manifests

## Notes

- Source parity was checked against python-gvm v224 scan-config and NVT preference request builders.
- This slice adds low-level command builders only; it does not add typed response parsing because the current rust-gvm client has no preference response model to return.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking workspace unsafe gate passed with `used_unsafe=0` for workspace crates. Cargo-geiger dependency reports still emit baseline dependency unsafe warnings.
- `cargo vet` passed; generated `supply-chain/imports.lock` quote-normalization churn was restored.
- Fuzzing was not run because this change is command-builder/live command-status verification work and does not touch parser, transport framing, streaming, or fuzz-facing code.
