### PR TITLE
feat(client): add policy getter helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -47,10 +47,10 @@ use gvm_gmp::commands::reports::{
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
-    clone_scan_config, create_scan_config, delete_scan_config, get_scan_config, get_scan_configs,
-    modify_policy_set_comment, modify_policy_set_name, modify_scan_config,
-    modify_scan_config_set_comment, modify_scan_config_set_name, sync_config, ConfigOpts,
-    GetScanConfigsOpts,
+    clone_scan_config, create_scan_config, delete_scan_config, get_policies, get_policy,
+    get_scan_config, get_scan_configs, modify_policy_set_comment, modify_policy_set_name,
+    modify_scan_config, modify_scan_config_set_comment, modify_scan_config_set_name, sync_config,
+    ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
     clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
@@ -193,6 +193,33 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         config_id: &EntityId,
     ) -> Result<GetScanConfigsResponse, GvmError> {
         let response = self.send(get_scan_config(config_id)).await?;
+        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a policy-scoped `get_configs` request and return a typed
+    /// [`GetScanConfigsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_policies(
+        &mut self,
+        opts: GetScanConfigsOpts,
+    ) -> Result<GetScanConfigsResponse, GvmError> {
+        let response = self.send(get_policies(opts)).await?;
+        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_configs` request for a single policy and return a typed
+    /// [`GetScanConfigsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_policy(
+        &mut self,
+        policy_id: &EntityId,
+        opts: GetPolicyOpts,
+    ) -> Result<GetScanConfigsResponse, GvmError> {
+        let response = self.send(get_policy(policy_id, opts)).await?;
         GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -15,7 +15,7 @@ use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSy
 use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
 use gvm_gmp::commands::scan_configs::{
     create_policy, get_policies, get_scan_config_preference, get_scan_config_preferences,
-    ConfigOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
+    ConfigOpts, GetPolicyOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::system::get_timezones;
@@ -855,6 +855,89 @@ async fn preference_getters_send_expected_mock_server_commands() {
     assert_eq!(
         commands[3],
         "<get_preferences nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_policy_getters_filter_stateful_mock_resources() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    client
+        .create_scan_config(
+            "Scan Config One",
+            None,
+            ConfigOpts {
+                usage_type: Some("scan".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("scan config should be created");
+
+    let response = client
+        .send(create_policy(
+            "Policy One",
+            ConfigOpts {
+                comment: Some("policy comment".into()),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("policy create request should succeed");
+    let policy = CreateScanConfigResponse::from_response(&response).expect("policy create parses");
+
+    server.clear_history();
+
+    let policies = client
+        .get_policies(GetScanConfigsOpts::default())
+        .await
+        .expect("policies should be fetched");
+    assert_eq!(policies.items.len(), 1);
+    assert_eq!(policies.items[0].meta.id, policy.id);
+    assert_eq!(policies.items[0].meta.name, "Policy One");
+    assert_eq!(policies.items[0].usage_type.as_deref(), Some("policy"));
+
+    let fetched = client
+        .get_policy(&policy.id, GetPolicyOpts { audits: Some(true) })
+        .await
+        .expect("policy should be fetched");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.id, policy.id);
+    assert_eq!(
+        fetched.items[0].meta.comment.as_deref(),
+        Some("policy comment")
+    );
+    assert_eq!(fetched.items[0].usage_type.as_deref(), Some("policy"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert!(history
+        .iter()
+        .all(|record| record.command_name() == "get_configs"));
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(commands[0], "<get_configs usage_type=\"policy\"/>");
+    assert_eq!(
+        commands[1],
+        format!(
+            "<get_configs config_id=\"{}\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>",
+            policy.id.as_str()
+        )
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -52,6 +52,13 @@ pub struct GetScanConfigPreferencesOpts {
     pub config_id: Option<EntityId>,
 }
 
+/// Options for singular policy `get_configs` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetPolicyOpts {
+    /// Whether to include audits using this policy.
+    pub audits: Option<bool>,
+}
+
 /// Build a clone request for an existing scan config.
 #[must_use]
 pub fn clone_scan_config(config_id: &EntityId) -> impl Request {
@@ -344,6 +351,17 @@ pub fn get_policies(opts: GetScanConfigsOpts) -> impl Request {
     get_configs_with_usage(opts, Some(UsageType::Policy))
 }
 
+/// Build a `get_configs` request for a single policy.
+#[must_use]
+pub fn get_policy(policy_id: &EntityId, opts: GetPolicyOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_configs")
+        .attribute("config_id", policy_id.as_str())
+        .attribute("usage_type", UsageType::Policy.as_gmp_str())
+        .attribute("details", "1");
+    set_optional_bool_attr(&mut cmd, "tasks", opts.audits);
+    cmd
+}
+
 /// Build a `modify_config` request scoped to policies.
 #[must_use]
 pub fn modify_policy(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
@@ -527,6 +545,14 @@ mod tests {
         assert_eq!(
             xml(get_policies(GetScanConfigsOpts::default())),
             "<get_configs usage_type=\"policy\"/>"
+        );
+        assert_eq!(
+            xml(get_policy(&id("p1"), GetPolicyOpts::default())),
+            "<get_configs config_id=\"p1\" details=\"1\" usage_type=\"policy\"/>"
+        );
+        assert_eq!(
+            xml(get_policy(&id("p1"), GetPolicyOpts { audits: Some(true) })),
+            "<get_configs config_id=\"p1\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>"
         );
         assert_eq!(
             xml(modify_policy(


### PR DESCRIPTION
## Summary

- add a singular policy `get_configs` command builder matching python-gvm's `get_policy` wire shape
- add typed `GmpClient::get_policies` and `GmpClient::get_policy` helpers returning `GetScanConfigsResponse`
- cover policy list/singular XML, including the python-gvm-compatible `audits` flag as `tasks`
- add live Unix-socket mock-server integration coverage that creates a scan config and policy, verifies policy-scoped filtering, fetches one policy, parses the response, and checks the exact GMP XML sent

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp policy_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_policy_getters_filter_stateful_mock_resources`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif-output /tmp/rust-gvm-policy-getters-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo geiger` reports for workspace crate manifests

## Notes

- Source parity was checked against python-gvm v224 policy request builders.
- Policy responses reuse rust-gvm's existing `GetScanConfigsResponse` because GMP returns policies as policy-scoped `get_configs_response` items.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking workspace unsafe gate passed with `used_unsafe=0` for workspace crates. Cargo-geiger dependency reports still emit baseline dependency unsafe warnings.
- `cargo vet` passed; generated `supply-chain/imports.lock` quote-normalization churn was restored.
- Fuzzing was not run because this change is command-builder/client-helper/live integration work and does not touch parser, transport framing, streaming, or fuzz-facing code.
