### PR TITLE
feat(client): add report format import helpers

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -37,7 +37,8 @@ use gvm_gmp::commands::report_configs::{
     clone_report_config, get_report_configs_opts, GetReportConfigsOpts,
 };
 use gvm_gmp::commands::report_formats::{
-    create_report_format, get_report_formats, GetReportFormatsOpts, ReportFormatOpts,
+    clone_report_format, create_report_format, get_report_formats, import_report_format,
+    GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
     get_report_closed_cves, get_report_errors, get_report_export, get_report_export_with_opts,
@@ -1196,6 +1197,33 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: ReportFormatOpts,
     ) -> Result<CreateReportFormatResponse, GvmError> {
         let response = self.send(create_report_format(name, opts)).await?;
+        CreateReportFormatResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_report_format` request that clones an existing report
+    /// format and return a typed [`CreateReportFormatResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn clone_report_format(
+        &mut self,
+        report_format_id: &EntityId,
+    ) -> Result<CreateReportFormatResponse, GvmError> {
+        let response = self.send(clone_report_format(report_format_id)).await?;
+        CreateReportFormatResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_report_format` request that imports report-format XML and
+    /// return a typed [`CreateReportFormatResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn import_report_format(
+        &mut self,
+        report_format_xml: &str,
+    ) -> Result<CreateReportFormatResponse, GvmError> {
+        let request = import_report_format(report_format_xml)?;
+        let response = self.send(request).await?;
         CreateReportFormatResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -944,6 +944,57 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
 }
 
 #[tokio::test]
+async fn typed_report_format_import_and_clone_use_mock_server_create_command() {
+    let Some(server) = echo_server(MockVersion::V22_5).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let report_format_id = EntityId::new("rf1").expect("valid id");
+    let cloned = client
+        .clone_report_format(&report_format_id)
+        .await
+        .expect("report format clone should succeed");
+    assert_eq!(cloned.status, 201);
+
+    let report_format_xml = r#"<get_report_formats_response status="200" status_text="OK"><report_format id="rf1"><name>Imported</name></report_format></get_report_formats_response>"#;
+    let imported = client
+        .import_report_format(report_format_xml)
+        .await
+        .expect("report format import should succeed");
+    assert_eq!(imported.status, 201);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert!(history
+        .iter()
+        .all(|record| record.command_name() == "create_report_format"));
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands[0],
+        "<create_report_format><copy>rf1</copy></create_report_format>"
+    );
+    assert_eq!(
+        commands[1],
+        format!("<create_report_format>{report_format_xml}</create_report_format>")
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn full_crud_lifecycle_succeeds() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-gmp/src/commands/report_formats.rs
+++ b/crates/gvm-gmp/src/commands/report_formats.rs
@@ -4,9 +4,12 @@
 //! Report format command builders.
 
 use gvm_protocol::{Request, XmlCommand};
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
 use crate::enums::ReportFormatType;
+use crate::responses::ParseError;
 use crate::types::EntityId;
 
 /// Optional fields for report-format create and modify requests.
@@ -40,6 +43,28 @@ pub fn create_report_format(name: &str, opts: ReportFormatOpts) -> impl Request 
     cmd.add_element_with_text("name", name);
     add_report_format_body(&mut cmd, &opts);
     cmd
+}
+
+/// Build a `create_report_format` request that clones an existing report format.
+#[must_use]
+pub fn clone_report_format(report_format_id: &EntityId) -> impl Request {
+    XmlCommand::new("create_report_format").child_with_text("copy", report_format_id.as_str())
+}
+
+/// Build a `create_report_format` request that imports report-format XML.
+///
+/// # Errors
+/// Returns an error if `report_format_xml` is not a single well-formed XML
+/// document.
+pub fn import_report_format(report_format_xml: &str) -> Result<impl Request, ParseError> {
+    validate_single_xml_document(report_format_xml)?;
+    let mut request = Vec::with_capacity(
+        "<create_report_format></create_report_format>".len() + report_format_xml.len(),
+    );
+    request.extend_from_slice(b"<create_report_format>");
+    request.extend_from_slice(report_format_xml.as_bytes());
+    request.extend_from_slice(b"</create_report_format>");
+    Ok(request)
 }
 
 /// Build a `get_report_formats` request.
@@ -95,6 +120,82 @@ fn add_report_format_body(cmd: &mut XmlCommand, opts: &ReportFormatOpts) {
     }
 }
 
+fn validate_single_xml_document(xml: &str) -> Result<(), ParseError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut depth = 0usize;
+    let mut saw_root = false;
+    let mut completed_root = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(_) => {
+                if completed_root {
+                    return Err(ParseError::InvalidValue {
+                        field: "report_format_xml".to_string(),
+                        value: "multiple root elements".to_string(),
+                    });
+                }
+                saw_root = true;
+                depth += 1;
+            }
+            Event::Empty(_) => {
+                if completed_root {
+                    return Err(ParseError::InvalidValue {
+                        field: "report_format_xml".to_string(),
+                        value: "multiple root elements".to_string(),
+                    });
+                }
+                saw_root = true;
+                completed_root = true;
+            }
+            Event::End(_) => {
+                if depth == 0 {
+                    return Err(ParseError::InvalidValue {
+                        field: "report_format_xml".to_string(),
+                        value: "unmatched end tag".to_string(),
+                    });
+                }
+                depth -= 1;
+                if depth == 0 {
+                    completed_root = true;
+                }
+            }
+            Event::Text(event) => {
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
+                    return Err(ParseError::InvalidValue {
+                        field: "report_format_xml".to_string(),
+                        value: if completed_root {
+                            "text after root element"
+                        } else {
+                            "text before root element"
+                        }
+                        .to_string(),
+                    });
+                }
+            }
+            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
+                return Err(ParseError::InvalidValue {
+                    field: "report_format_xml".to_string(),
+                    value: "content outside root element".to_string(),
+                });
+            }
+            Event::Eof => {
+                if saw_root && depth == 0 {
+                    return Ok(());
+                }
+                return Err(ParseError::MissingElement("root".to_string()));
+            }
+            Event::Decl(_)
+            | Event::PI(_)
+            | Event::DocType(_)
+            | Event::Comment(_)
+            | Event::CData(_)
+            | Event::GeneralRef(_) => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,6 +215,30 @@ mod tests {
             },
         ));
         assert!(rendered.contains("<type>pdf</type>"));
+        assert_eq!(
+            xml(clone_report_format(&id("rf1"))),
+            "<create_report_format><copy>rf1</copy></create_report_format>"
+        );
+        assert_eq!(
+            xml(import_report_format(
+                r#"<get_report_formats_response status="200" status_text="OK"><report_format id="rf1"><name>Imported</name></report_format></get_report_formats_response>"#
+            )
+            .expect("valid report format XML")),
+            r#"<create_report_format><get_report_formats_response status="200" status_text="OK"><report_format id="rf1"><name>Imported</name></report_format></get_report_formats_response></create_report_format>"#
+        );
+        assert!(import_report_format(
+            r#"<get_report_formats_response status="200" status_text="OK"/></create_report_format><delete_task/>"#
+        )
+        .is_err());
+        assert!(import_report_format(
+            r#"prefix<get_report_formats_response status="200" status_text="OK"/>"#
+        )
+        .is_err());
+        assert!(import_report_format(
+            r#"<get_report_formats_response status="200" status_text="OK"/>suffix"#
+        )
+        .is_err());
+        assert!(import_report_format("").is_err());
         assert_eq!(
             xml(get_report_format(&id("rf1"))),
             "<get_report_formats details=\"1\" report_format_id=\"rf1\"/>"


### PR DESCRIPTION
## Summary

- add `clone_report_format` and `import_report_format` command builders matching python-gvm's `create_report_format` wire shapes
- validate imported report-format XML as a single well-formed XML document before wrapping it in `create_report_format`
- add typed `GmpClient::clone_report_format` and `GmpClient::import_report_format` helpers returning `CreateReportFormatResponse`
- add live Unix-socket mock-server integration coverage for both helpers and exact command history XML

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp report_format_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_report_format_import_and_clone_use_mock_server_create_command`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif-output /tmp/rust-gvm-report-format-semgrep.sarif`
- `cargo deny check`
- `cargo audit`
- `cargo geiger` reports for workspace crate manifests

## Notes

- Source parity was checked against python-gvm v224 report-format request builders/tests.
- Echo mode is used for the live mock-server command-surface test because stateful mode recognizes `create_report_format` but does not model report-format resource storage/cloning.
- `import_report_format` intentionally validates input as one XML document before wrapping it, preventing wrapper breakout or multiple-root command injection.
- `cargo deny check` passed with existing baseline unused allow/ignore warnings.
- `cargo audit` passed with the known allowed yanked `crypto-bigint 0.7.4` warning.
- The blocking workspace unsafe gate passed with `used_unsafe=0` for workspace crates. Cargo-geiger dependency reports still emit baseline dependency unsafe warnings.
- `cargo vet` passed; generated `supply-chain/imports.lock` quote-normalization churn was restored.
- Fuzzing was not run because existing fuzz targets do not exercise this command-builder/import-validator path; malformed import XML is covered by focused unit tests.
