### PR TITLE
docs(journal): consolidate pending journal entries

### DIFF
--- a/journal/2026-05-26.md
+++ b/journal/2026-05-26.md
@@ -1,0 +1,24 @@
+# 2026-05-26 — `main` Churned Through MCP Docs, a Revert, and Automation Cleanup While the Real Feature Queue Stayed Open
+
+## Mainline & Merged Work
+
+### `main` moved several times after the 2026-05-24 journal baseline, but most of that movement was operational or corrective rather than new product delivery
+- PR #168 (`ci: add journal PR automation workflow`) finally landed on 2026-05-25, so the repo's long-running journal backlog is now at least backed by an automated path into review
+- PR #184 (`docs: make MCP a first-class gateway surface`) merged the same day, then PR #187 reverted it a little over an hour later, which means `main` briefly carried the wrong-repo MCP planning direction before explicitly backing it out
+- PR #182 also landed on 2026-05-25 with the actions-group dependency refresh, and PR #186 merged the pending journal backlog through 2026-05-24
+- The net effect is that `main` changed repeatedly, but only one of those moves improved repo operations materially; the rest either documented prior work or unwound a documentation mistake
+
+## Issues
+- No new issues were opened after the 2026-05-24 journal baseline
+- No issues were closed in the same window
+- So the backlog itself did not move; the story here is branch and automation churn, not tracker cleanup
+
+## Pull Request Queue
+- The real implementation lane is still PR #177 (`Add GMP REST support gap helpers`), which remains open alongside the older `quick-xml` bump in PR #165
+- Two fresh dependency PRs joined the queue on 2026-05-25: PR #180 (`serde_json`) and PR #181 (`russh`)
+- That leaves the repo in a familiar state: `main` absorbed maintenance and documentation movement, while the actual product-path follow-through is still waiting in review
+
+## CI Health
+- The 2026-05-25 `main` merges all validated cleanly: PRs #168, #182, #186, and the #187 revert each produced successful `CI`, `Security`, or `OpenSSF Scorecard` runs
+- `Dependabot Updates` on `main` also completed successfully on 2026-05-25, so the maintenance automation lane is currently healthy rather than noisy
+- Operationally, this repo looks stable; the main risk is still queue age on the feature work, not branch breakage

--- a/journal/2026-05-28.md
+++ b/journal/2026-05-28.md
@@ -1,0 +1,24 @@
+# 2026-05-28 — `main` Only Absorbed Automation and Docs Churn, While the Real GMP Follow-on Branch Fell Further Behind
+
+## Mainline & Merged Work
+
+### The default branch moved five times after the 2026-05-24 baseline, but none of that movement shipped new GMP client surface
+- PR #168 (`ci: add journal PR automation workflow`) merged on 2026-05-25 and is the only durable repository-level workflow change in this window
+- PR #182 (`ci(deps): bump the actions group across 1 directory with 9 updates`) also landed the same day, so the maintenance lane did move even though product work did not
+- The only contentful docs experiment, PR #184 (`docs: make MCP a first-class gateway surface`), was reverted within hours by PR #187, which means `main` ended the window with churn but not a net documentation expansion
+- PR #186 then consolidated the pending journal backlog through 2026-05-24, so the repo was active, but mostly operationally rather than through new library capability
+
+## Issues
+- No new issues were opened after the last journal entry
+- No issues were closed in the same window either
+- That leaves the repo in an unusual state for this project: branch and workflow activity continued, but the issue tracker effectively paused
+
+## Pull Request Queue
+- The main substantive branch is still PR #177 (`Add GMP REST support gap helpers`), but it is now behind `main` instead of moving toward merge
+- The maintenance queue is also aging rather than draining: dependency PRs #165, #180, and #181 are all behind the branch tip
+- The new journal lane is open as PR #188, but it is blocked rather than already folded into the default branch
+
+## CI Health
+- The important default-branch signal stayed clean: `CI` and `Security` both succeeded for the automation merge in PR #168 and for the actions-update merge in PR #182
+- `OpenSSF Scorecard` also passed on the post-merge pushes, including the fast doc add/revert pair (#184 and #187)
+- So the repo does not look unstable; it looks under-merged on feature work while routine automation and branch protection changes continue to land cleanly

--- a/journal/2026-05-29.md
+++ b/journal/2026-05-29.md
@@ -1,0 +1,25 @@
+# 2026-05-29 — `main` Finally Moved Again, But the Bigger Story Is That the GMP Parity Lane Turned Into a Fresh Discovery Backlog
+
+## Mainline & Merged Work
+
+### The default branch absorbed one real bug fix after the 2026-05-24 baseline, while the rest of the visible movement stayed in maintenance and docs lanes
+- PR #191 (`fix(gmp): allow empty optional schedule ids`) merged on 2026-05-28 and fixed `GetTasksResponse` handling for unscheduled tasks, so the only new product-facing `main` change in this window was a targeted parser/compatibility correction rather than another broad parity tranche
+- The repo also landed PR #168 for journal PR automation plus PR #182 for the actions-group bump, which means operational maintenance still advanced even while feature throughput stayed narrow
+- Docs churn was real but self-correcting: PR #184 briefly made MCP look like a first-class gateway surface in the wrong repository, then PR #187 reverted that direction the same day
+- Journal backlog PR #186 merged as well, but that mostly cleaned up reporting debt rather than changing repository behavior
+
+## Issues
+- Issue #148 closed when PR #160 landed on 2026-05-18, confirming that the integration-config and report-helper parity slice documented in the prior entry is now complete on `main`
+- Four follow-on backlog issues opened on 2026-05-21: #172 (remaining GMP coverage roadmap), #173 (report drill-down commands), #174 (timezone and credential-store discovery), and #175 (mock fixtures / coverage for the remaining REST-support gaps)
+- The repo also converted a fresh bug report quickly: issue #190 (`GetTasksResponse rejects unscheduled tasks with empty schedule id`) opened on 2026-05-28 and closed the same day with PR #191
+- A new forward-looking issue, #192, now tracks reusable gvmd capability detection and probing primitives, so the parity lane has shifted from one-off gaps into capability discovery and coverage planning
+
+## Pull Request Queue
+- The live implementation branch is PR #193 (`feat(client): add gvmd capability discovery helpers`), which is currently the clearest follow-through from issue #192
+- PR #177 (`Add GMP REST support gap helpers`) remains open alongside older dependency bumps #181, #180, and #165, so the queue still carries both product backlog and maintenance debt instead of collapsing to one lane
+- Journal backlog PRs #188 and #189 are also still open, which reinforces that documentation automation exists now but is not yet fully draining the queue by itself
+
+## CI Health
+- The important signal on `main` is clean: the 2026-05-28 push for PR #191 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The new product-facing branch PR #193 also cleared both `CI` and `Security` on 2026-05-28, so the capability-discovery follow-on work is starting from a stable verification base
+- Operationally this repo is healthier than it looked in mid-May: the current risk is not broad branch instability, but whether the newly expanded GMP backlog keeps moving faster than the open PR pile grows

--- a/journal/2026-05-31.md
+++ b/journal/2026-05-31.md
@@ -1,0 +1,23 @@
+# 2026-05-31 — `main` Took a Small Real GMP Fix, Landed the Journal Automation Lane, and Cleaned Up a Wrong-Turn Docs Detour
+
+## Mainline & Merged Work
+
+### The default branch moved several times after the 2026-05-24 entry, but only one merge materially changed runtime behavior
+- PR #191 (`fix(gmp): allow empty optional schedule ids`) merged on 2026-05-28 and fixed issue #190, so unscheduled tasks no longer break on empty schedule IDs
+- PR #168 added journal PR automation to `main`, which matters operationally because the repo is now generating the documentation backlog automatically instead of relying on manual catch-up
+- Maintenance also landed through PR #182 (actions-group updates), while the docs lane briefly took a wrong turn: PR #184 made MCP look like a first-class gateway surface in the wrong repository and PR #187 reverted it the same day
+- PR #186 merged the accumulated journal backlog through 2026-05-24, but the substantive story in this window is still that the repo shipped one targeted GMP fix and otherwise mostly reorganized its maintenance and docs lanes
+
+## Issues
+- Issue #190 (`GetTasksResponse rejects unscheduled tasks with empty schedule id`) opened and closed on 2026-05-28, which shows the latest runtime defect was identified and repaired in the same day
+- A new follow-on issue, #192, now tracks reusable gvmd capability detection and probing primitives, so the next product lane is moving toward environment discovery rather than another one-off bug fix
+
+## Pull Request Queue
+- The live implementation branch is PR #193 (`feat(client): add gvmd capability discovery helpers`), which is the clearest continuation of the newly opened capability-probing issue
+- Older feature and maintenance work is still sitting in queue behind it: PR #177 (GMP REST support gap helpers), dependency bumps #165, #180, and #181, plus the growing journal backlog in PRs #188, #189, and #194
+- That leaves the repo in a familiar shape: `main` is stable and moving, but the next meaningful feature slice is still waiting off-branch rather than already absorbed
+
+## CI Health
+- The push for PR #191 passed `CI`, `Security`, and `OpenSSF Scorecard` on 2026-05-28, so the one real product change in this window validated cleanly
+- Dependabot automation on `main` also looks healthier than noisy right now: visible `Dependabot Updates` runs on 2026-05-25 and 2026-05-29 all completed successfully
+- There is no fresh branch-wide failure signal in the recent `main` history; the pressure point remains review throughput on the open queue, not broken verification

--- a/journal/2026-06-01.md
+++ b/journal/2026-06-01.md
@@ -1,0 +1,22 @@
+# 2026-06-01 — Mainline Moved from the #148 Parity Drop into Follow-up GMP Fixes, Roadmap Expansion, and Journal Automation
+
+## Product Surface
+
+### The product-facing code that actually landed on `main` after the 2026-05-14 baseline was narrower than the issue queue that formed around it
+- PR #160 closed issue #148 on 2026-05-18 and carried the integration-config plus report-helper parity work from the prior journal entry onto `main`.
+- PR #191 then landed a targeted parser fix on 2026-05-28 so unscheduled tasks with empty optional schedule IDs no longer break `GetTasksResponse`, closing issue #190 the same day.
+- No larger follow-up parity slice merged yet, but the repository opened the next planning wave immediately afterward through issues #172, #173, #174, #175, and #192.
+
+## Documentation & Planning
+- The repo took a meaningful docs and planning detour on 2026-05-25: PR #184 briefly made MCP a first-class gateway surface, and PR #187 reverted it later the same day after the repo concluded that work belonged elsewhere.
+- PR #186 consolidated pending journal entries through 2026-05-24, which means the repo used `main` to catch up its narrative backlog before the next implementation lane.
+
+## Issues
+- Six issues opened after the 2026-05-14 journal baseline: #172, #173, #174, #175, #190, and #192.
+- Two issues closed in the same window: #148 when the integration-config/report-helper parity work merged, and #190 when the empty-schedule-id fix landed.
+- The backlog shape shifted from one concrete parity issue to a broader roadmap: report drill-down coverage, timezone and credential-store discovery, REST-supporting mock coverage, and reusable gvmd capability probing are now explicit tracked follow-ons instead of implied future work.
+
+## CI Health
+- CI itself changed materially even though only one new product fix landed: PR #168 added journal PR automation, and PR #182 refreshed the GitHub Actions dependency group.
+- `main` still produces mixed maintenance signals rather than an all-green wall. On 2026-06-01 the latest `Dependabot Updates` batch split between successful cargo updates and failures in the pip and GitHub Actions lanes.
+- The latest product push signal is still healthy: the 2026-05-28 `OpenSSF Scorecard` run for PR #191 completed successfully on `main`.

--- a/journal/2026-06-02.md
+++ b/journal/2026-06-02.md
@@ -1,0 +1,23 @@
+# 2026-06-02 — `main` Absorbed the REST-Gap Helper Slice, Landed Typed Report Export, and Immediately Spawned an Alert-Compatibility Follow-On
+
+## Mainline & Merged Work
+
+### The default branch actually moved in a product direction this time, not just through maintenance or docs
+- PR #177 (`Add GMP REST support gap helpers`) merged on 2026-06-01 and closed issues #173, #174, and #175 together, so the repo converted a broad compatibility/testing bundle into shipped `main` behavior in one push
+- PR #200 (`feat(gmp): add typed report export request and response support`) merged later the same day and added typed report-export coverage as a fresh runtime capability instead of only rounding off old GMP gaps
+- That leaves the last 24 hours looking materially different from the 2026-05-31 entry: the queue stopped being only potential energy and actually delivered two substantive feature slices to `main`
+
+## Issues
+- Issue #199 (`feat(gmp): add typed report export request and response support`) opened and closed on 2026-06-01, which shows the report-export lane was identified, implemented, and merged inside the same day
+- A new follow-on issue, #201 (`Own gvmd alert name compatibility in typed alert APIs`), opened just before PR #200 merged, so the next compatibility problem is already isolated instead of being left implicit in review comments or ad hoc fixes
+- The older GMP gap issues #173, #174, and #175 all closed when PR #177 landed, which is the clearest sign that the REST-support helper branch was more than a narrow code tweak
+
+## Pull Request Queue
+- The active front edge is now PR #202 (`fix(gmp): own gvmd alert name compatibility`), which reads like the direct continuation of newly opened issue #201 rather than a disconnected branch
+- The queue behind it is still mixed between real feature work and maintenance backlog: PR #193 (gvmd capability discovery), PRs #196, #197, #181, and #165 (dependency/CI updates), plus the still-open journal lane in PR #198
+- So the repo's posture improved relative to 2026-05-31 because `main` finally absorbed real product work, but review pressure still exists on both the capability-discovery branch and a familiar dependabot stack
+
+## CI Health
+- The pushes for PRs #177 and #200 each passed `CI`, `Security`, and `OpenSSF Scorecard` on 2026-06-01, so both substantive merges validated cleanly on the default branch
+- Scheduled `Security` on `main` also completed successfully earlier that day, which means the repo did not pay for the merge burst with an immediate baseline verification regression
+- The noisy signal in this window sits in maintenance automation rather than product verification: a `pip` dynamic update and a `github_actions` dynamic update both failed on 2026-06-01 while the cargo-oriented update lanes succeeded

--- a/journal/2026-06-03.md
+++ b/journal/2026-06-03.md
@@ -1,0 +1,20 @@
+# 2026-06-03 — Mainline Closed More GMP Parity Gaps, Added Typed Report Export Support, and Tightened Automation Around the Repo
+
+## Product Surface
+
+### The mainline story after the 2026-05-14 baseline is continued GMP surface expansion rather than one isolated fix
+- PR #160 closed issue #148 and landed the integration-config plus report-helper command family on `main`, extending the GMP builders, typed client traits, and mock-server coverage beyond what the 2026-05-14 entry had already staged conceptually
+- PR #177 followed by filling more of the REST-support gap with timezone discovery, credential-store discovery, and report drill-down support, and the associated issues (#173, #174, #175) were opened and closed immediately as that work merged
+- PR #200 then restored typed report-export request and response support on `main`, which matters because downstream repos are now depending on a stable export contract rather than carrying that shape only in issue form
+- The last two default-branch fixes in this window were narrower but still release-facing: PR #202 aligned typed enums with gvmd and python-gvm 22.7 behavior, and PR #205 preserved self-closing gvmd error status handling so export failures keep their semantics instead of collapsing to an empty-status edge case
+- PR #207 finally typed the `resume_task` response, including the `report_id` shape rust-gvm-api needs downstream, so the repo closed this window with another concrete compatibility gap removed
+
+## Backlog & Coordination
+- Most of the issues opened in this window were merge-and-close tracking issues tied directly to the landed GMP work: #190, #199, #201, #204, and #206 are all already closed, and #173 through #175 closed with the REST-support helper merge
+- Two planning items remain open and now stand out more clearly because so much nearby implementation already landed: #172 still tracks the broader remaining GMP coverage roadmap, and #192 keeps reusable gvmd capability detection/probing work on the queue
+- Journal automation also became first-class repo plumbing through PR #168, and `main` absorbed the backfilled journal consolidation commit from PR #186 after that workflow was introduced
+
+## CI & Automation
+- CI automation changed in two visible ways on `main`: PR #168 added the journal PR workflow, and PR #182 refreshed the GitHub Actions dependency set that supports the automation stack
+- The verification signal on landed product work stayed clean in the latest burst: `CI`, `Security`, and `OpenSSF Scorecard` all passed on the 2026-06-01 and 2026-06-02 `main` pushes tied to PRs #200, #205, and #207
+- The noisy lane is now concentrated in dependency branches rather than `main`: recent Dependabot and cargo update PRs have produced a mix of `CI` successes and `Security` failures, so the repo's baseline is healthy even though the maintenance queue is not uniformly green

--- a/journal/2026-06-04.md
+++ b/journal/2026-06-04.md
@@ -1,0 +1,23 @@
+# 2026-06-04 — Mainline Closed Most of the GMP REST Gap Burst and Kept the Verification Signal Clean
+
+## Mainline & Merged Work
+
+### `main` absorbed a real product burst rather than another narrow parity slice
+- Since the 2026-05-24 entry, `main` has taken a dense run of substantive merges: PR #177 landed the queued GMP REST gap helpers, PR #200 added typed report-export request and response support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 fixed self-closing gvmd report-export error handling, PR #207 typed `resume_task` responses, and PR #210 added note/override result-flag support
+- The window also carried two repo-operations changes with real impact: PR #168 added journal PR automation and PR #181 bumped `russh` on `main`, while PR #184's MCP-surface planning was explicitly reverted by PR #187 before it could turn into durable product direction
+- That combination matters because the repo is no longer just enumerating missing GMP surface area; it converted most of the 2026-05-21 follow-on issue cluster into shipped client behavior on `main`
+
+## Issues
+- The repo opened seven new tracking issues in this window: #190 (empty optional schedule IDs), #192 (capability probing helpers), #199 (typed report export), #201 (typed alert compatibility), #204 (report-export error preservation), #206 (`resume_task` typing for rust-gvm-api), and #209 (note/override result expansion)
+- Six of those issues already closed through merged work on `main`: #190, #199, #201, #204, #206, and #209
+- The earlier GMP gap backlog also burned down materially when issues #173, #174, and #175 all closed with PR #177, leaving #192 as the clearest remaining capability-discovery branch still waiting off `main`
+
+## Pull Request Queue
+- The queue is now much narrower and more specific than it was in late May: PR #193 carries the remaining gvmd capability-discovery helpers, while dependency work stays open in PRs #165, #196, and #197
+- Journal backlog continues to accumulate in parallel through open PRs #188, #189, #194, #195, #198, #203, and #208, but that is maintenance noise rather than a product blocker
+- Relative to the last entry, the important shift is that the repo's highest-value GMP/report-export work is now on `main`, and the remaining open branches are follow-through rather than the core gap itself
+
+## CI Health
+- Push verification stayed clean across the substantive June merges: `CI`, `Security`, and `OpenSSF Scorecard` all passed for PRs #177, #200, #202, #205, #207, and #210
+- Scheduled `Security` on `main` also succeeded on 2026-06-01, so the baseline branch signal remained green while product work was landing quickly
+- The only fresh mainline noise in this window came from automation rather than code regressions: a dynamic `pip` update failed on 2026-06-01 while the paired cargo update lanes completed successfully

--- a/journal/2026-06-06.md
+++ b/journal/2026-06-06.md
@@ -1,0 +1,23 @@
+# 2026-06-06 — Typed GMP Parity Accelerated, the REST Gap Slice Landed, and Mainline Stayed Green
+
+## Mainline & Merged Work
+
+### `main` moved from backlog cleanup into a real feature burst after the 2026-05-24 journal baseline
+- The 2026-05-25 landing set was mostly operational: PR #168 added journal PR automation, PR #182 refreshed the actions stack, PR #184 briefly pushed MCP gateway docs into the wrong repo, PR #187 reverted that mistake, and PR #186 merged the accumulated journal backlog
+- The substantive product lane then accelerated across 2026-05-28 through 2026-06-03: PR #177 landed the GMP REST support gap helpers, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd report-export errors, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- Dependency maintenance also crossed the line instead of lingering forever: PR #181 updated `russh` to 0.61.1 and carried the needed CI adjustments with it
+
+## Issues
+- The follow-on GMP backlog converted into actual closures instead of just queue growth: issues #173, #174, and #175 closed with PR #177 on 2026-06-01
+- New implementation issues #199, #201, #204, #206, and #209 all opened and closed quickly as their paired PRs merged between 2026-06-01 and 2026-06-03
+- The one notable issue that did not immediately resolve is #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`), opened on 2026-05-28 and still carrying the next deeper compatibility layer
+
+## Pull Request Queue
+- The open queue is still dominated by journal backlog PRs rather than product work: #188, #189, #194, #195, #198, #203, #208, and #211 are all journal branches waiting for review
+- The non-journal queue is narrow but not empty: PR #193 holds the gvmd capability-discovery work in a `DIRTY` state, while dependency PRs #165, #196, and #197 are all sitting `BEHIND`
+- So the repo's bottleneck has shifted from "missing implementation" toward "review and merge throughput"
+
+## CI Health
+- Push validation on the real product merges is clean: `CI`, `Security`, and `OpenSSF Scorecard` all completed successfully on 2026-06-02 and again on 2026-06-03
+- `Dependabot Updates` also completed successfully on 2026-06-02, so the maintenance lane is at least executing rather than failing by default
+- There is no fresh evidence of broad default-branch instability; the friction is in queue age, not in broken mainline checks

--- a/journal/2026-06-07.md
+++ b/journal/2026-06-07.md
@@ -1,0 +1,22 @@
+# 2026-06-07 — `main` Turned the REST-Support GMP Queue into Shipped Surface Area While the Backlog Stayed Busy
+
+## Mainline & Merged Work
+
+### `main` absorbed a real run of product-facing GMP work after the 2026-05-24 baseline
+- Seven substantive merges reached the default branch in this window: PR #177 added REST-support GMP gap helpers, PR #191 fixed empty optional schedule ids, PR #200 added typed report-export support, PR #202 aligned typed enums with gvmd and `python-gvm` 22.7, PR #205 preserved self-closing gvmd error status in report export flows, PR #207 typed `resume_task` responses for downstream consumers, and PR #210 added note/override result expansion support
+- That sequence is coherent rather than scattered churn: the repo first tightened compatibility and error-shape handling, then expanded the typed surface for report export, task resumption, and note/override result access
+- Non-product but still notable mainline changes also landed on 2026-05-25: PR #168 added journal PR automation, PR #182 updated GitHub Actions dependencies, and PRs #184 and #187 briefly added then reverted MCP planning that belonged in a different repository
+
+## Issues
+- New issues in this window were tightly coupled to merged work: #190 (empty schedule ids), #199 (typed report export), #201 (typed alert compatibility), #204 (self-closing gvmd error status), #206 (typed `resume_task` response), and #209 (note/override result expansion) all opened and then closed quickly as their matching PRs landed
+- One new capability follow-up remains open: #192 (`feat(gmp): add reusable gvmd capability detection and probing primitives`)
+- Older backlog also kept burning down as the new feature lane landed: issues #173, #174, and #175 all closed on 2026-06-01 when PR #177 merged, leaving the broader roadmap issue #172 plus the newer capability-probing thread #192 as the visible remaining GMP-gap anchors
+
+## Pull Request Queue
+- The queue is now split between one real feature follow-on and a large docs/maintenance tail: PR #193 carries capability discovery helpers, while dependency PRs #196 and #197 and the unmerged daily journal PRs from #188 through #212 keep the branch list noisy
+- That queue shape matters because `main` has already absorbed the most important typed-surface work; the unresolved risk is now review throughput and backlog cleanup more than missing core GMP primitives
+
+## CI Health
+- Mainline verification stayed strong for shipped work: the 2026-06-02 and 2026-06-03 pushes on `main` cleared `CI`, `Security`, and `OpenSSF Scorecard`
+- The cleanest negative signal is isolated to dependency maintenance rather than the core product lane: the `quick-xml` bump in PR #165 failed both `CI` and `Security` on 2026-06-02
+- In other words, the shipped GMP expansion work is validating cleanly, while maintenance branches are where the visible CI drag remains

--- a/journal/2026-06-08.md
+++ b/journal/2026-06-08.md
@@ -1,0 +1,23 @@
+# 2026-06-08 — `main` Expanded GMP Coverage Again While the Queue Split Between Real Follow-Through and Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` absorbed a real multi-PR GMP/API expansion after the 2026-05-24 baseline
+- Seven substantive merges landed on `main` in this window: PR #177 added REST-support gap helpers, PR #191 fixed empty optional schedule IDs, PR #200 added typed report export support, PR #202 aligned typed enums with gvmd/python-gvm 22.7, PR #205 preserved self-closing gvmd error status, PR #207 typed `resume_task` responses, and PR #210 added note/override result flags
+- That is a coherent implementation burst rather than unrelated churn: the repo filled several remaining GMP surface gaps, tightened typed behavior around gvmd edge cases, and added follow-through client ergonomics for downstream consumers
+- The only non-product merges on `main` in the same span were PR #168 (journal PR automation), PR #182 (actions updates), and the short-lived docs lane around PRs #184 and #187, so the dominant story here is still API and protocol coverage advancing materially
+
+## Issues
+- Seven issues opened after the 2026-05-24 entry: #190, #192, #199, #201, #204, #206, and #209
+- Six of those were opened and closed in the same window by shipped work on `main`: #190, #199, #201, #204, #206, and #209 all burned down immediately once the corresponding fixes landed
+- The remaining open thread is more architectural than bug-fix oriented: #192 keeps the capability-detection/probing lane alive while the older umbrella roadmap issue #172 also remains open
+
+## Pull Request Queue
+- The queue is now split sharply between real follow-through work and accumulated journal noise
+- PR #193 (`feat(client): add gvmd capability discovery helpers`) is the one obvious substantive open branch tied directly to the still-open capability-detection lane
+- Everything else near the front of the queue is maintenance or docs churn: dependency bumps #214 and #215, the older `quick-xml` bump #165, and a long stack of unmerged daily journal PRs from #188 through #213
+
+## CI Health
+- CI signal on shipped work stayed usable across this burst: the substantive merges that landed on `main` cleared `CI` and `Security`, and the repo did not show the kind of broad branch instability that would undercut the feature pace
+- The workflow surface itself changed in this window through PR #168 (journal automation) and PR #182 (actions updates), so some of the visible activity is automation evolution rather than library behavior
+- The freshest signal is mixed but contained: new dependency PRs on 2026-06-08 split between green and red checks, while scheduled `OpenSSF Scorecard` succeeded on 2026-06-07, so the current risk is queue throughput and dependency noise rather than a broken `main`

--- a/journal/2026-06-11.md
+++ b/journal/2026-06-11.md
@@ -1,0 +1,24 @@
+# 2026-06-11 — `main` Burned Down the Remaining GMP Follow-on Queue and Left Only Maintenance Branches Behind
+
+## Mainline & Merged Work
+
+### The repo turned the post-2026-06-09 parity queue into one tight two-day landing burst
+- `main` absorbed PR #220 (typed NVT score accessors), PR #221 (host-type compatibility attrs), PR #224 (target credential command fields), PR #227 (required feed-version parsing), PR #228 (typed task detail fields), PR #230 (target credential readback), PR #232 (typed report/result/port-list metadata), PR #235 (user auth and scan-config type fields), PR #236 (filter fragment validation), PR #239 (unnamed note/override parsing), and PR #240 (id-only note/override refs)
+- That is not random cleanup churn. It closes a coherent stretch of GMP compatibility work around typed metadata, target credentials, filter safety, and note/override response handling
+- The practical result is that the repo used this window to finish several of the contract slices that were still visibly blocking downstream `rust-gvm-api` work on 2026-06-09
+
+## Issues
+- Nine new issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, and #238
+- All nine closed through same-day or next-day merges on `main`
+- Older follow-on residue also cleared while this burst landed: #219 (typed NVT score helpers) and #192 (capability detection/probing primitives) both closed in the same window
+- The interesting shift is that this slice did not leave a fresh product backlog behind. The repo converted a visible GMP gap queue into merged code instead of just reshuffling it into more open issues
+
+## Pull Request Queue
+- The substantive implementation queue is effectively gone for now; there are no fresh product branches sitting in review after PR #240 merged
+- The remaining open PRs are maintenance and backlog cleanup rather than new GMP feature work: dependency bumps #214 and #215 plus older unmerged journal PRs such as #216
+- That is a healthier queue shape than the repo had on 2026-06-09 because the front of the line is no longer carrying unresolved contract work
+
+## CI Health
+- `main` ended the window green. The latest 2026-06-10 push passed `CI`, `Security`, and `OpenSSF Scorecard`
+- There was brief noise earlier the same day when the `main` push for PR #239 failed `CI`, but the later push for PR #240 cleared it immediately
+- The remaining instability is concentrated on maintenance branches rather than `main`: PR #215 is still failing `CI`, and PR #214 is still failing `Security` via `Cargo Vet`

--- a/journal/2026-06-12.md
+++ b/journal/2026-06-12.md
@@ -1,0 +1,23 @@
+# 2026-06-12 — `main` Finished the Current GMP Parity Burst and Left the Remaining Queue Mostly in Maintenance Mode
+
+## Mainline & Merged Work
+
+### The repo did not just keep adding scattered fields; it closed out an entire slice of typed GMP contract work in one sustained run
+- Since the 2026-06-09 journal entry, `main` absorbed PR #220 (typed NVT score helpers), PR #221 (host-type compatibility attrs), PR #224 (target credential command fields), PR #227 (required feed version), PR #228 (typed task detail fields), PR #230 (target credential refs in responses), PR #232 (typed report/result/port-list metadata), PR #235 (user auth and scan-config type exposure), PR #236 (filter fragment validation), PR #239 and #240 (note/override parser fixes), and PR #244 (missing target, alert, and report fields)
+- That matters because the June 9 through June 11 sequence looks less like opportunistic cleanup and more like a deliberate final pass over the remaining GMP surface mismatches that were blocking downstream typed consumers
+- The shape of `main` changed accordingly: the repo now reads like it has largely finished the current parity burst rather than merely making progress inside it
+
+## Issues
+- Ten new issues opened in this window and every one of them already closed through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, and #242
+- Older backlog also burned down while the same wave was landing. Most importantly, #219 closed when the typed NVT score work merged and #192 finally closed once the capability-detection/probing follow-on landed on 2026-06-10
+- The repo therefore moved from carrying a visible tail of contract gaps to carrying almost none of this specific class of work
+
+## Pull Request Queue
+- The open queue is now much narrower in product terms than it was three days ago
+- The only non-journal branches still open are dependency and maintenance items: PR #214 (cargo updates), PR #215 (actions updates), and PR #165 (the long-lived `quick-xml` bump)
+- The newest operational branch is PR #245, which consolidates the pending journal backlog rather than extending the library surface further
+
+## CI Health
+- Mainline verification stayed clean throughout the closing burst. The 2026-06-10 push after PR #240 and the 2026-06-11 push after PR #244 both passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The latest product PRs were also healthy before merge: PR #244 cleared both `CI` and `Security`, and the journal-consolidation PR #245 immediately passed `Security` as well
+- In other words, the repo's visible risk has shifted away from functional GMP correctness and toward ordinary maintenance throughput

--- a/journal/2026-06-13.md
+++ b/journal/2026-06-13.md
@@ -1,0 +1,24 @@
+# 2026-06-13 — Mainline Kept Burning Down Typed GMP Drift, but the Queue Has Now Collapsed into Two Open Bugs and Maintenance PRs
+
+## Mainline & Merged Work
+
+### `main` spent the rest of the week closing the next layer of typed GMP shape mismatches instead of reopening broad new surface area
+- Since the 2026-06-09 journal entry, `main` absorbed a dense follow-on burst: PR #221 fixed host-type compatibility attributes, #224 added typed target credential fields, #227 made feed versions required in responses, #228 and #230 filled task-detail and target-credential parsing gaps, #232 exposed typed report/result/port-list metadata, #235 added user-auth and scan-config type coverage, #236 added GMP filter-fragment validation, #239 and #240 hardened note and override parsing, #244 filled missing target/alert/report fields, #249 fixed scoped report-metadata fetches, and #252 preserved user host-access mode
+- That set is narrower than the previous parity burst but still materially important: the repo spent four days shaving off places where gvmd or downstream `rust-gvm-api` conversions were still encountering silent model drift, weak validation, or partial typed coverage
+- The result is that the repo no longer looks like it is missing a large product lane. It looks like it is grinding through the remaining edge-shape correctness work one focused branch at a time
+
+## Issues
+- Fourteen issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, and #251
+- Twelve of those already closed through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, and #250
+- Older follow-on debt also continued to burn down: issue #192 closed on 2026-06-10 while the new parsing and validation work landed
+- The unresolved residue is now crisp rather than sprawling: #247 tracks the nonexistent `no_report` option on `GetReportsOpts`, and #251 tracks remaining uncertainty around user host-access response modeling
+
+## Pull Request Queue
+- There are no open substantive product branches left in the queue right now
+- The open PR list has collapsed into maintenance and documentation pressure: dependency PRs #165, #214, and #215 are still waiting, while journal backlog PRs #245 and #246 remain open
+- That is a healthier shape than the repo had earlier in June because the unanswered questions are now concentrated in two open issues rather than spread across many half-finished implementation branches
+
+## CI Health
+- Most of the window stayed green: the merged feature branches for #249 and #252 both cleared `CI` and `Security` before landing, and the earlier `main` push for #249 also passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The newest signal is mixed rather than clean. The latest `main` push for PR #252 passed `Security` and `OpenSSF Scorecard` but failed `CI`
+- That means the repo's current operational risk is not broad instability across all lanes. It is a fresh `CI` regression on `main` after an otherwise steady typed-model cleanup run

--- a/journal/2026-06-14.md
+++ b/journal/2026-06-14.md
@@ -1,0 +1,23 @@
+# 2026-06-14 — Mainline Cleared a Tight GMP Follow-On Burst, but the Latest Fix Reopened CI and Left Two Model Gaps Behind
+
+## Mainline & Merged Work
+
+### `main` spent this window finishing a narrow but coherent round of GMP compatibility work
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), PR #236 (filter fragment validation), PR #239 (unnamed note/override parsing), PR #240 (id-only note/override refs), PR #244 (missing typed GMP target and alert fields), PR #249 (scoped report metadata fetches), and PR #252 (preserve user host access mode)
+- That sequence matters because the repository did not fan back out into broad feature work. It stayed focused on response-shape drift, parser resilience, and typed contract cleanup around concrete gvmd compatibility gaps
+- The result is a smaller but more disciplined burst than the earlier June expansion: fewer branches overall, but nearly all of them tighten mismatches between the typed surface and real server behavior
+
+## Issues
+- Eight issues opened in this window: #234, #237, #238, #242, #247, #248, #250, and #251
+- Six of those already closed directly through merged work on `main`: #234, #237, #238, #242, #248, and #250
+- The unresolved residue is now concentrated in two places rather than spread everywhere: #247 tracks the nonexistent `GetReportsOpts::no_report` path that gvmd ignores, and #251 keeps the broader user-host-access model audit open
+
+## Pull Request Queue
+- The active non-journal queue is mostly maintenance now: PR #214 (cargo dependency updates), PR #215 (GitHub Actions updates), and the older quick-xml bump PR #165 remain open
+- Journal backlog is still clogging the branch list via PRs #245, #246, and #253, so the repository's visible queue is noisier than the actual product queue
+- That is a healthier shape than early June because the substantive GMP follow-on work has mostly landed; what remains is mostly cleanup, dependency churn, and documentation lag
+
+## CI Health
+- Verification was mostly clean through the middle of the burst. The `main` push for PR #249 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The newest mainline merge regressed that clean picture: PR #252 landed with `Security` and `OpenSSF Scorecard` still green, but the `CI` workflow on `main` failed
+- The open maintenance queue is also mixed. PR #214 is failing `Cargo Vet` and `Security`, while PR #215 is failing `Test (all features)` even though the rest of its matrix is green

--- a/journal/2026-06-15.md
+++ b/journal/2026-06-15.md
@@ -1,0 +1,24 @@
+# 2026-06-15 — `main` Finished a Dense GMP Typing Burst, Closed Most of Its Follow-On Gaps, and Cleared the Product Queue Back to Drift Cleanup
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-09 through 2026-06-12 pushing through one unusually dense stretch of typed GMP surface work
+- Since the 2026-06-09 journal entry, `main` absorbed PR #220 (typed NVT score accessors), #221 (host type compatibility attrs), #224 (target credential command fields), #227 (required feed version handling), #228 (typed task detail fields), #230 (target credential response refs), #232 (typed report/result/port-list metadata), #235 (user auth and scan-config type exposure), #236 (filter fragment validation), #239 and #240 (note/override parsing fixes), #244 (missing typed alert/target/report fields), #249 (ID-scoped report metadata fetches), and #252 (user host access mode preservation)
+- That sequence matters because the repo was not just polishing edges. It spent four days filling a long list of typed-response and request-shape gaps that had been blocking higher-level consumers, especially `rust-gvm-api`
+- The result is that the product queue is no longer dominated by broad GMP parity work. Most of the visible movement now comes from narrower drift cleanup rather than missing typed surface area
+
+## Issues
+- Fourteen issues opened in this window: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, and #251
+- Twelve of those closed quickly through merged work on `main`: #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, and #250
+- Older backlog also fell while the burst was landing: issue #219 closed with PR #220, and the long-running capability/probing gap in #192 closed on 2026-06-10
+- The unresolved residue is now sharply narrower than the queue described on 2026-06-09. The only fresh follow-on issues still open from this burst are #247 (`GetReportsOpts::no_report` drift) and #251 (user host access response-shape drift)
+
+## Pull Request Queue
+- There are no open product PRs right now
+- The remaining open queue is almost entirely maintenance and documentation pressure: dependency PRs #165, #214, and #215 are still open, and the journal backlog now spans #245, #246, #253, and #254
+- That is a healthier queue shape than the repo had a week ago because the implementation burst actually landed instead of stalling in review
+
+## CI Health
+- Verification was mostly healthy across the burst, but not perfectly clean. `main` pushes for PRs #236, #240, #244, and #249 passed `CI`, `Security`, and `OpenSSF Scorecard`
+- Two merges introduced the only obvious red `main` signal in this window: the pushes for PR #239 on 2026-06-10 and PR #252 on 2026-06-12 both failed `CI` while still passing `Security` and `OpenSSF Scorecard`
+- The repo-level maintenance signal is also mixed rather than fully green. The scheduled `OpenSSF Scorecard` run on `main` passed on 2026-06-14, and the open actions-update PR #215 is green in both `CI` and `Security`, but the latest dynamic update run on `main` failed for the GitHub Actions lane even while the cargo update lanes passed

--- a/journal/2026-06-16.md
+++ b/journal/2026-06-16.md
@@ -1,0 +1,23 @@
+# 2026-06-16 — Mainline Cleared a Fast GMP Parity Slice, Leaving Mostly Maintenance and Journal Debt in the Queue
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-10 through 2026-06-15 closing a compact but coherent GMP model-correction burst
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config typing), #236 (filter fragment validation), #239 and #240 (note/override parser fixes), #244 (missing target and alert fields), #249 (scoped report metadata fetches), #252 (host-access mode preservation), and #258 (schedule first/next run timestamps)
+- That sequence matters because it was not random bug churn. Nearly every merge tightened typed GMP parity around filters, note and override parsing, report retrieval, user host-access semantics, and schedule modeling
+- The window also burned down older residue while it landed. PR #236 closed the long-lived capability/filter helper tracker #192, and the same burst resolved fresh issues #234, #237, #238, #242, #248, #250, and #257 directly on `main`
+
+## Issues
+- Ten issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, and #257
+- Eight of those already closed through merged work on `main`, and older tracker #192 also fell during the same slice
+- The unresolved residue is now narrow rather than diffuse: #247 (the `details=0` / `no_report` mismatch) and #251 (user host-access response/model drift) are the clearest remaining follow-ons from this burst
+
+## Pull Request Queue
+- Product branches have effectively cleared out of the immediate queue. The only non-journal open work is now dependency maintenance PRs #165, #214, and #215
+- Journal debt is still stacked ahead of them through PRs #245, #246, #253, #254, and #255
+- That is a healthier queue shape than the repo had on 2026-06-09 because the remaining visible work is mostly maintenance and documentation backlog, not unresolved GMP behavior gaps
+
+## CI Health
+- `main` is green in the latest visible window: the 2026-06-15 push for PR #258 cleared `CI`, `Security`, and `OpenSSF Scorecard`, and scheduled `Security` on `main` also passed the same day
+- The active actions bump PR #215 is fully green, but the dependency queue is not uniformly clean: PR #214 fails `Cargo Vet` and `Security`, while the older quick-xml bump PR #165 is broadly red across test, lint, and security lanes
+- Dependabot monitoring on `main` remains noisy as well, with one 2026-06-15 GitHub Actions update suggestion failing while sibling update detections succeeded

--- a/journal/2026-06-17.md
+++ b/journal/2026-06-17.md
@@ -1,0 +1,22 @@
+# 2026-06-17 — Mainline Closed a Week of Typed GMP Gaps and Left Only Two Fresh Model Risks in the Lane
+
+## Mainline & Merged Work
+
+### `main` spent 2026-06-10 through 2026-06-16 turning a queue of concrete GMP mismatches into shipped library behavior
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), #236 (GMP filter fragment validation), #239 (unnamed note/override parsing), #240 (id-only note/override refs), #244 (missing target and alert fields), #249 (scoped report metadata fetches), #252 (user host access mode preservation), #258 (schedule run timestamps), and #261 (report export options)
+- That run is coherent rather than scattered maintenance. The repo kept tightening typed GMP request and response coverage around real gvmd compatibility gaps instead of bouncing between unrelated crates or tooling chores
+- The result is a cleaner mainline contract for callers using typed report export, schedule metadata, user access settings, filter composition, and note or override modeling
+
+## Issues
+- Eleven issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, and #260
+- Nine of those already closed through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- The unresolved residue is now narrow and specific rather than broad parity churn: #247 (`GetReportsOpts::no_report` does not match gvmd behavior) and #251 (audit user host access response shape and adjacent model drift) are the two clear follow-on product risks from this burst
+
+## Pull Request Queue
+- The active product queue is no longer crowded. Mainline already absorbed the substantive June GMP work, and the remaining open branches are mostly backlog management: journal consolidation PR #262 plus dependency PRs #165, #214, and #215
+- That is a healthier queue shape than the repo had at the 2026-06-09 baseline because the typed GMP parity lane is now mostly on `main`, not stranded across review branches
+
+## CI Health
+- The post-merge signal on `main` stayed clean throughout this window: `CI`, `Security`, and `OpenSSF Scorecard` all passed on the 2026-06-15 and 2026-06-16 pushes
+- The newest product branches also validated cleanly before merge. PR #258 and PR #261 both cleared `CI` and `Security`, and there were no fresh workflow-level regressions on `main` while the GMP work landed
+- The only visible noise remained in maintenance automation rather than release-facing library changes: `Dependabot Updates` on `main` split between success and failure even while the shipped product work stayed green

--- a/journal/2026-06-18.md
+++ b/journal/2026-06-18.md
@@ -1,0 +1,23 @@
+# 2026-06-18 — Mainline Closed Most of the Typed GMP Follow-Through Queue and Ended the Sprint with Report Export Support Plus Only Two Open Edge Cases
+
+## Mainline & Merged Work
+
+### `main` spent the post-2026-06-09 window turning parser drift and missing typed surface coverage into a concentrated closure sweep
+- Since the 2026-06-09 journal baseline, `main` absorbed PR #235 (user auth and scan-config type fields), #236 (GMP filter fragment validation), #239 (unnamed note and override parsing), #240 (id-only note and override refs), #244 (missing typed target, alert, and report fields), #249 (scoped report metadata fetches), #252 (user host access mode preservation), #258 (schedule run timestamps), and #261 (report export options)
+- That sequence matters because the repo did not just keep adding isolated accessors. It systematically burned down the remaining typed GMP mismatches around filters, notes and overrides, target and alert metadata, report retrieval semantics, user modeling, and export controls
+- By 2026-06-16 the queue had shifted from "many small contract gaps" to "a mostly closed parity lane with only a couple of stubborn edge cases still open"
+
+## Issues
+- Eleven issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, and #260
+- Nine of those were opened and closed in the same sweep through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- Older follow-through also cleared while the sweep landed: #233 and the longer-running #192 both closed on 2026-06-10
+- The remaining issue residue is now narrow and explicit rather than sprawling: #247 tracks the invalid `no_report` option surface, and #251 tracks remaining user-host-access shape drift
+
+## Pull Request Queue
+- The repo currently has no open product implementation branches. The remaining open PRs are dependency maintenance (#214 and #215) plus journal backlog cleanup (#262 and #263)
+- That is a healthier queue shape than the 2026-06-09 entry described because the substantive GMP follow-through work is now on `main`, not waiting in review
+
+## CI Health
+- `main` finished the sprint green: the 2026-06-15 and 2026-06-16 pushes both cleared `CI`, `Security`, and `OpenSSF Scorecard`
+- The window was not perfectly flat. `CI` failed on two earlier pushes during the 2026-06-10 to 2026-06-12 burst, even while `Security` and `OpenSSF Scorecard` stayed green
+- Scheduled and maintenance automation stayed mostly healthy as well, with scheduled `Security` green on 2026-06-15 and only one mixed Dependabot lane failure left visible in the recent run history

--- a/journal/2026-06-19.md
+++ b/journal/2026-06-19.md
@@ -1,0 +1,23 @@
+# 2026-06-19 — Mainline Finished a Dense GMP Parity Burst, Cut `v0.3.3`, and Left the Queue Mostly as Journal Backlog Plus CI Maintenance
+
+## Mainline & Merged Work
+
+### `main` moved through one sustained product lane, then immediately rolled into release automation follow-through
+- Since the 2026-06-09 baseline, `main` absorbed PR #235 (user auth plus scan-config type exposure), #236 (validated GMP filter fragments), #239 and #240 (note/override parser fixes), #244 (missing typed GMP fields), #249 and #252 (report metadata scoping plus host-access-mode support), #258 (schedule run timestamps), #261 (report export options), and #265 (restore branch protection after the release push)
+- That set is coherent rather than scattered. The repo spent most of the window closing typed GMP surface and compatibility gaps, then used 2026-06-18 to turn that work into a `v0.3.3` release with follow-up fixes to artifact publishing and SBOM-quality reporting
+- The result is a repo that is materially further along its parity lane than the 2026-06-09 entry described: export configuration shipped, schedule metadata expanded, parser edge cases were cleaned up, and the release train actually moved instead of waiting on more backlog grooming
+
+## Issues
+- Eleven issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, and #260
+- Nine of those already closed through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- Older follow-through also burned down on the same lane: issue #192 closed on 2026-06-10 when filter-fragment validation landed
+- The unresolved residue from this burst is now narrow and concrete rather than sprawling: #247 (`GetReportsOpts::no_report` drift) and #251 (user host-access response-shape audit) are the main product leftovers from the latest GMP push
+
+## Pull Request Queue
+- The active queue is now mostly non-product backlog. Open PRs #262, #263, and #264 are all journal branches, while #214, #215, and #165 are dependency or workflow-maintenance branches
+- That is a healthier queue shape than the 2026-06-09 entry described because the substantive GMP work is already on `main`; what remains visible is review throughput on maintenance branches and accumulated journal automation output
+
+## CI Health
+- The 2026-06-18 release window was not uniformly green. `CI` and `OpenSSF Scorecard` succeeded on the release commits and the branch-protection restore follow-up, but `Security` failed repeatedly across the `v0.3.3` release and post-release fix pushes
+- Release automation itself also showed noise: the `Orchestrated Release` run on 2026-06-18 failed before the later release-fix commits and warning-only SBOM adjustment landed
+- Even with that noise, the repo's current signal is stronger than it looks at first glance. The mainline GMP work shipped and tagged successfully; the sharp edge now is release/security workflow stability rather than uncertainty about the product branch itself

--- a/journal/2026-06-20.md
+++ b/journal/2026-06-20.md
@@ -1,0 +1,22 @@
+# 2026-06-20 — Mainline Finished a Dense GMP Parity Sprint, Cut v0.3.3, and Then Exposed the Remaining Gaps Much More Narrowly
+
+## Mainline & Merged Work
+
+### `main` carried one coherent GMP expansion wave all the way into a release instead of stalling in partial parity
+- After the 2026-06-09 journal baseline, `main` absorbed PR #221 (host-type compatibility attributes), #224 (target credential command fields), #227 (feed-version enforcement), #228 (task detail parsing), #230 and #232 (typed credential/report metadata), #235 and #236 (user auth, scan-config typing, and filter validation), #239 and #240 (note/override parser fixes), #244 (missing typed GMP fields), #249 and #252 (report metadata scoping plus user host-access fixes), #258 (schedule run timestamps), and #261 (report export options).
+- The repo then turned that library work into a release lane on 2026-06-18: `main` produced v0.3.3, repaired artifact publishing, warned on SBOM quality score, and restored branch protection in PR #265 after the release push.
+- That sequence matters because it was not random API churn. The repo pushed through a tightly related run of typed GMP surface completion work, then immediately exercised the packaging path hard enough to reveal and fix release-process gaps.
+
+## Issues
+- Seventeen issues opened after the 2026-06-09 baseline, and sixteen of them already closed through merged work on `main`.
+- The fast closures map directly to the code that landed: parser fixes closed #237 and #238, field and response-shape work closed #242, #248, and #250, feed-sync and schedule fixes closed #256 and #257, and report export follow-through closed #260.
+- The remaining open backlog is now sharply bounded instead of sprawling: #247 tracks the invalid `no_report` option drift, #251 tracks additional user-host-access response audit work, and the newest follow-up #267 asks for opt-in verbose GMP wire tracing.
+
+## Pull Request Queue
+- The open queue is no longer product-heavy. The unresolved non-journal branches are maintenance PRs #165, #214, and #215, while journal backlog PRs #262 through #266 still sit in front of them.
+- That is a different queue shape from the 2026-06-09 entry: the substantive GMP parity work has already landed on `main`, and the visible queue is now mostly maintenance plus documentation automation residue.
+
+## CI Health
+- The release-day push signal was mixed rather than uniformly green. `CI` and `OpenSSF Scorecard` succeeded on the 2026-06-18 mainline pushes, but `Security` flipped between success and failure during the release choreography.
+- Operational workflows also showed some noise on the same day: `Orchestrated Release` and `Dependabot Updates` both recorded failures while the release fixes were being worked through.
+- The important distinction is that product work continued to land cleanly on `main`; the instability was concentrated in release and maintenance automation rather than in the GMP feature branches themselves.

--- a/journal/2026-06-21.md
+++ b/journal/2026-06-21.md
@@ -1,0 +1,22 @@
+# 2026-06-21 — Mainline Closed Most of the Typed GMP Follow-Ons, Then Drove a Real 0.3.3 Release Through a Slightly Messy Automation Lane
+
+## Mainline & Merged Work
+
+### `main` spent this window finishing the contract gaps that were still open on 2026-06-09, then immediately exercised the release path for real
+- The product lane moved first. `main` absorbed PRs #220 and #221 right after the previous entry, then kept going with #224, #227, #228, #230, #232, #235, #236, #239, #240, #244, #249, #252, #258, and #261.
+- That is a coherent burst rather than a random pile of patches. The repo filled in typed task detail fields, target credential handling, report and port-list metadata, note and override parsing, user host-access behavior, schedule timing, and report export options across the GMP surface.
+- The second phase was release-shaped instead of feature-shaped. On 2026-06-18, `main` ran an actual `0.3.3` release, restored branch protection in PR #265, and followed the generated release commit with two more release-path fixes to repair artifact publishing and improve SBOM-score handling.
+
+## Issues
+- The issue tracker mirrored the implementation burst: short-lived gap tickets #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, and #260 all opened and then closed as their matching fixes landed on `main`.
+- Older roadmap residue also kept burning down. Issue #148 closed when the integration-config and report-helper work shipped, and issues #173, #174, #175, #190, #199, #201, #204, #206, #209, #217, and #219 are no longer hanging around from the earlier parity push either.
+- What remains is much narrower: the long-running roadmap tracker #172 is still open, contract-audit follow-up #251 is still open, `GetReportsOpts::no_report` mismatch #247 is still open, and the newest request is #267 for opt-in verbose GMP wire tracing.
+
+## Pull Request Queue
+- The open queue is no longer carrying visible product work. What is left is journal backlog in PRs #262, #263, #264, #266, and #268 plus maintenance branches #165, #214, and #215.
+- That is a cleaner queue shape than the 2026-06-09 entry described. The repo converted the substantive GMP follow-on work into merged mainline commits, and the remaining clutter is mostly automation and dependency upkeep rather than unresolved feature design.
+
+## CI Health
+- Mainline push health stayed mostly strong while the parity fixes were landing. The 2026-06-15 and 2026-06-16 product merges cleared `CI`, `Security`, and `OpenSSF Scorecard`, and the 2026-06-18 branch-protection restoration merge in PR #265 also ran clean across those lanes.
+- The release lane itself was noisier than the normal mainline signal. Both visible `Orchestrated Release` runs on 2026-06-18 failed, and `Security` failed on the generated `0.3.3` release commit as well as on the two follow-up release-fix commits later that day.
+- Even so, the repo did not fall into a fully broken state. The corrective pushes on 2026-06-18 still kept `CI` and `OpenSSF Scorecard` green, which makes the remaining problem look isolated to release-path and security-workflow handling rather than a broad regression in the library.

--- a/journal/2026-06-22.md
+++ b/journal/2026-06-22.md
@@ -1,0 +1,23 @@
+# 2026-06-22 — Mainline Finished a Dense GMP Parity Slice, Then Immediately Exercised a Real Release Path While the Queue Fell Back to Journal and Maintenance Pressure
+
+## Mainline & Merged Work
+
+### The post-2026-06-09 window split into one product-heavy lane and one release-hardening lane
+- `main` first burned through a dense follow-on GMP slice: PR #220 landed typed NVT score accessors, #221 fixed host-type compatibility attrs, #235 exposed user auth and scan-config type, #236 validated filter fragments, #239 and #240 repaired note/override parsing edge cases, #244 added missing typed fields, #249 and #252 fixed scoped report metadata and user host-access handling, #258 exposed schedule run timestamps, and #261 added report export options
+- That run matters because it did not just close isolated bugs. It tightened model parity across targets, reports, users, schedules, notes, overrides, and export paths in one sustained push
+- The repo then pivoted straight into release execution on 2026-06-18: PR #265 restored branch protection after the release push, `main` cut v0.3.3, and the follow-on commits repaired artifact publishing and SBOM-quality warnings
+- The result is a repo that looks more operationally mature than the 2026-06-09 entry suggested. The GMP surface expanded again, and the release machinery was forced through a real publish cycle instead of staying theoretical
+
+## Issues
+- Seventeen issues opened on or after 2026-06-09, and most of them were short-lived contract gaps tied directly to the merged GMP work: #223, #225, #226, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, and #260 all closed quickly once the corresponding PRs landed
+- Older backlog also burned down in this window: issue #219 closed when typed NVT score helpers landed, and #192 closed when the capability-detection lane was resolved
+- The remaining fresh issue residue is now narrow but real: #247 (the silently ignored `no_report` flag), #251 (user host-access/model drift audit), and #267 (opt-in verbose wire tracing) are the visible follow-ons still open
+
+## Pull Request Queue
+- The open queue is no longer centered on product work. It is now mostly journal backlog plus two maintenance branches: dependency PR #165 and actions bump #215
+- That is a healthier shape than the 2026-06-09 entry described because the big GMP follow-on branches are no longer waiting for review, but it also means the visible queue is noisier than the actual remaining engineering risk
+
+## CI Health
+- The real release-day signal on 2026-06-18 was strong: the release workflow succeeded on `v0.3.3`, the corresponding `main` push cleared `OpenSSF Scorecard`, and the latest scheduled scorecard run on 2026-06-21 also stayed green
+- The maintenance lane is less clean. PR #215 passed `CI` on 2026-06-22 but failed `Security`, and that same date's dynamic `Dependabot Updates` runs on `main` split between success and failure instead of presenting one consistent result
+- Journal automation is still noisy in a specific, repetitive way: Security failed on journal PRs #266, #268, and #269 across 2026-06-19 through 2026-06-21 even though those branches are documentation-only backlog

--- a/journal/2026-06-23.md
+++ b/journal/2026-06-23.md
@@ -1,0 +1,22 @@
+# 2026-06-23 — Typed GMP Coverage Expanded Rapidly, Then the Repo Cut and Repaired a 0.3.3 Release While Leaving Only a Small Parsing Backlog Open
+
+## Mainline & Merged Work
+
+### The repo spent the post-2026-06-09 window shipping a dense typed-GMP correction wave before pivoting straight into release mechanics
+- `main` absorbed a tight sequence of user-facing typed surface work: target credential command fields (#224), required feed-version parsing (#227), typed task detail fields (#228), target credential readback (#230), typed report/result/port-list metadata (#232), safe filter-fragment validation (#236), user auth plus scan-config type fields (#235), note/override parser fixes (#239 and #240), additional target and alert fields (#244), scoped report metadata fetches (#249), user host access mode preservation (#252), schedule run timestamps (#258), and report export options (#261).
+- That is not random API churn. The branch systematically closed the gaps that had been blocking higher-level callers, especially `rust-gvm-api` conversions and richer typed export/report flows.
+- After the feature and parser lane landed, the repo immediately cut `v0.3.3`, then followed with release-only fixes to restore branch protection, repair artifact publishing, and emit an SBOM quality-score warning instead of failing the lane outright.
+
+## Issues
+- The issue tracker mirrored the implementation wave very closely: most new issues in this window were opened and closed the same day as the matching merges, including #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, #250, #257, and #260.
+- Only three fresh issues remained open after that burst: #247 (`GetReportsOpts::no_report` drift), #251 (audit user host-access response shape and related model drift), and #267 (opt-in verbose GMP wire tracing).
+- That leaves the backlog noticeably narrower than it was on 2026-06-09. The remaining work is now about correctness follow-through and observability, not missing core typed surface area.
+
+## Pull Request Queue
+- The open queue is now mostly automation-shaped rather than feature-shaped. Open journal PRs span #262 through #270, while the only non-journal branches in view are Dependabot PR #165 (`quick-xml`) and #215 (GitHub Actions updates).
+- That is a healthier queue shape than the one implied by the raw implementation volume. The substantive GMP surface work already landed on `main`; what remains open is mostly maintenance and backlog housekeeping.
+
+## CI Health
+- Normal feature merges stayed clean: the `CI`, `Security`, and `OpenSSF Scorecard` workflows succeeded on the mainline implementation PRs through #261.
+- The 0.3.3 release cut was noisier. `Orchestrated Release`, `Release`, and several `Security` runs failed during the initial release/publish attempts before the follow-up fixes produced a successful final `Release` run for `v0.3.3`.
+- The current risk signal is no longer core test breakage. It is workflow stability around release/security automation: scheduled `Security` failed again on 2026-06-22 even after the release lane itself was repaired.

--- a/journal/2026-06-25.md
+++ b/journal/2026-06-25.md
@@ -1,0 +1,22 @@
+# 2026-06-25 — Mainline Finished a Dense Typed-GMP Follow-Through Burst, Cut 0.3.3, and Then Exposed a Smaller but More Obvious Tail of Model-Drift Work
+
+## Mainline & Merged Work
+
+### `main` spent the post-2026-06-09 window finishing the highest-signal typed GMP follow-through instead of reopening broad surface churn
+- After the 2026-06-09 journal baseline, `main` absorbed PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261, which collectively filled in missing user-auth, scan-config, target, alert, note, override, report, and schedule fields while also tightening filter validation and report-export options.
+- The repo then turned that product burst into a shipped release lane on 2026-06-18: PR #265 restored branch protection after release pushes, `main` produced the `0.3.3` release commit, and two follow-up release fixes repaired artifact publishing and relaxed SBOM scoring failures.
+- That sequence matters because the repo is no longer just adding isolated typed helpers. It closed a coherent block of contract drift across the GMP surface, exercised the release path for a real version cut, and made the remaining rough edges much easier to see.
+
+## Issues
+- The issue tracker kept pace with the merge burst instead of expanding uncontrollably. Issues #234, #237, #238, #242, #248, #250, #256, and #257 all opened and closed quickly as the corresponding fixes landed on `main`.
+- The remaining open tail is now narrow and specific: #247 still tracks the invalid `no_report` option shape, #251 keeps the broader user-host-access model-drift audit alive, and the newest follow-up is #267 for opt-in verbose GMP wire tracing.
+- That is a healthier issue shape than the 2026-06-09 entry described. The old open branches for NVT scoring and host-type compatibility are gone, and the backlog now points at a small number of explicit follow-ons instead of one sprawling parity push.
+
+## Pull Request Queue
+- The visible queue has become almost entirely operational. Open PRs are dominated by the accumulated journal backlog (#262 through #271), while the only non-journal branches still standing are the older dependency bumps #165 (`quick-xml`) and #215 (GitHub Actions updates).
+- That is cleaner from a product perspective than the previous entry's queue: the substantive typed-GMP work has already landed on `main`, and review pressure is now mostly about maintenance and backlog cleanup rather than unsettled API design.
+
+## CI Health
+- The product merges themselves stayed healthy. On 2026-06-15 and 2026-06-16, `CI`, `Security`, and `OpenSSF Scorecard` all succeeded on `main`, which gave the late GMP-field and export-option work a solid landing path.
+- The release day signal was more uneven. `CI` and `OpenSSF Scorecard` stayed green on 2026-06-18, but `Security` failed repeatedly on `main`, and the `Orchestrated Release` workflow also failed twice before the repo recovered with the direct release fixes.
+- The newest scheduled signal still is not flat: `Security` failed again on 2026-06-22, so the current constraint is no longer API surface movement. It is cleanup and stabilization around the release/security lane.

--- a/journal/2026-06-26.md
+++ b/journal/2026-06-26.md
@@ -1,0 +1,25 @@
+# 2026-06-26 — Mainline Finished the June GMP Cleanup Burst, Cut 0.3.3, and Left a Much Smaller Product Queue Behind the Journal Backlog
+
+## Mainline & Merged Work
+
+### `main` kept moving immediately after the 2026-06-09 baseline and the work was still concentrated in one coherent GMP/reporting lane
+- The repo absorbed PR #235 (user auth plus scan-config typing), #236 (validated GMP filter fragments), #239 and #240 (note/override parser fixes), #244 (missing typed target and alert fields), #249 and #252 (report metadata scoping plus user host-access compatibility), #258 (schedule run timestamps), #261 (report export options), and #265 (restore branch protection after the release push)
+- That merge train matters because it did not fragment into unrelated cleanup. It kept narrowing real gvmd and `python-gvm` parity gaps around typed filters, report exports, response compatibility, and scheduler metadata
+- The branch then converted that work into a shipped release on 2026-06-18: `main` produced v0.3.3, followed by two release-path fixes to repair artifact publishing and downgrade SBOM-score handling from a hard failure to a warning
+- The result is a repo that looks more release-shaped than it did on 2026-06-09. The GMP/reporting burst is now on `main`, the release path has been exercised end-to-end, and the remaining product queue is much narrower
+
+## Issues
+- Twelve issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and the later follow-up #267
+- Nine of those already closed through same-window merges: #234, #237, #238, #242, #248, #250, #256, #257, and #260
+- Older work also burned down in the same stretch: issue #233 closed when filter-fragment validation shipped, and the long-running capability-probing issue #192 finally closed on 2026-06-10
+- The unresolved residue is now specific rather than diffuse: #247 tracks the non-existent `no_report` option, #251 tracks remaining user-host-access model drift, and #267 adds opt-in verbose GMP wire tracing
+
+## Pull Request Queue
+- The substantive open queue is down to three non-journal branches: PR #221 fixes host-type compatibility output, while dependency PRs #215 and #165 still sit open
+- Everything else visible at the top of the queue is journal backlog: PRs #262 through #272 cover the accumulated daily entries that still have not merged
+- That is a better product queue shape than the 2026-06-09 entry described. The implementation backlog shrank, but review pressure is still getting hidden behind automation-generated journal volume
+
+## CI Health
+- The release day was not perfectly flat, but it was informative rather than chaotic. `CI` and `OpenSSF Scorecard` passed on the 2026-06-18 `main` push, while `Security` failed on the same push and on the 2026-06-22 scheduled run
+- The release workflow itself eventually completed successfully for v0.3.3 after one cancelled attempt during the artifact-publishing repair sequence
+- Branch-level health is mixed but usable: the latest visible actions-bump PR passed `CI` but failed `Security`, and the repeated journal PRs are also consistently tripping `Security`

--- a/journal/2026-06-27.md
+++ b/journal/2026-06-27.md
@@ -1,0 +1,25 @@
+# 2026-06-27 — Mainline Closed a Thick Stack of Typed GMP Gaps, Then Exercised the Release Lane Hard Enough to Expose Workflow Rough Edges
+
+## Mainline & Merged Work
+
+### `main` did not drift gradually after the 2026-06-09 baseline; it moved in one dense GMP-fix burst and then immediately rolled into release work
+- From 2026-06-10 through 2026-06-16, `main` absorbed PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261. That batch filled in typed GMP surface gaps around user auth and scan-config typing, safe filter-fragment validation, note and override parsing, missing target and alert fields, report metadata fetches, user host access mode, schedule run timestamps, and report export options.
+- The repo then shifted from product-surface repair into release execution on 2026-06-18. `main` picked up PR #265, cut the `0.3.3` release commit, and followed it with two direct release-path fixes for artifact publishing and SBOM quality-score handling.
+- That sequence matters because it shows the repo doing more than ordinary backlog trimming. The typed GMP lane kept moving fast enough to close a long set of correctness gaps, and the team immediately ran the release machinery against the new baseline instead of letting that work sit unexercised.
+
+## Issues
+- Twelve issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and #267.
+- Most of that intake was converted straight into merged `main` work. Issues #234, #237, #238, #242, #248, #250, #256, #257, and #260 all closed in the same slice as the corresponding GMP fixes landed.
+- Older capability and filter follow-through also continued to contract: #192 and #233 both closed during the 2026-06-10 burst.
+- The remaining open residue is now narrow and easy to name: #247 tracks a `GetReportsOpts::no_report` mismatch, #251 tracks broader user-host-access response drift, and #267 asks for opt-in verbose GMP wire tracing.
+
+## Pull Request Queue
+- The visible non-journal queue is small but still not empty. PR #215 (actions updates) and PR #165 (`quick-xml` bump) remain open beside the journal backlog.
+- The journal queue itself has continued to pile up after the release burst: open PRs now span #262 through #273, with today's entry extending that automation lane rather than clearing it.
+- That is a better shape than the repo had earlier in June on the product side, because the unresolved work is mostly maintenance and documentation churn rather than a large set of half-finished GMP feature branches.
+
+## CI Health
+- The mainline validation story was mostly strong during the GMP-fix burst. Push-time `CI`, `Security`, and `OpenSSF Scorecard` all passed for PRs #240, #244, #249, #258, and #261, and the 2026-06-15 scheduled `Security` run also succeeded.
+- The signal was not perfectly flat. `CI` failed on PR #239 and again on PR #252 before recovering on later merges.
+- Release execution on 2026-06-18 is the noisier part of the story. The release commit and its follow-up fixes kept `CI` green, but `Security` failed on the release commit and both immediate release-fix pushes. The `Orchestrated Release` workflow also failed twice that day before the branch-protection restore PR landed.
+- Post-release maintenance remains mixed rather than broken. Scheduled `Security` failed on 2026-06-22, while scheduled `OpenSSF Scorecard` stayed green and Dependabot runs split between clean cargo lanes and failing GitHub Actions bumps.

--- a/journal/2026-06-28.md
+++ b/journal/2026-06-28.md
@@ -1,0 +1,26 @@
+# 2026-06-28 — Typed GMP Coverage Surged into a 0.3.3 Release Push, Then Settled into a Much Smaller Follow-Through Queue
+
+## Mainline & Merged Work
+
+### The repo used the post-2026-05-14 window to burn down a large parity backlog instead of spreading effort across unrelated experiments
+- `main` first picked up the integration-config and report-helper parity work from PR #160, then added the journal automation lane in #168, dependency and workflow maintenance in #181, #182, and #168, and a short-lived docs detour in #184 that was explicitly reverted by #187
+- The real story started in early June: PRs #177, #191, #200, #202, #205, #207, #210, #218, #220, #221, #224, #227, #228, #230, #232, #235, #236, #239, #240, #244, #249, #252, #258, and #261 turned `rust-gvm` into a much more complete typed GMP surface for report export flows, filter composition, task detail parsing, target credentials, note and override handling, report metadata, user host access, and schedule timing
+- That run was substantial enough to carry the repo into the 0.3.3 release lane on 2026-06-18. The release itself needed immediate follow-through commits to repair artifact publishing and SBOM quality-score messaging, after which PR #265 restored the branch-protection posture
+- Compared with the 2026-05-14 baseline, `main` is no longer mostly about CI hygiene and queue triage. It shipped a real product-surface expansion and then did the release hardening work needed to keep that expansion publishable
+
+## Pull Request Queue
+- The open queue is far smaller in product terms than the raw PR count suggests. Nearly all visible open branches are journal backlog PRs #262 through #274
+- The only non-journal pull requests left in view are PR #165 (`quick-xml`), which is still unstable, and PR #215 (actions-group updates), which is also still unstable
+- That makes the repo's remaining review surface much narrower than it was in mid-May: the expensive work is no longer missing GMP coverage on `main`, but deciding when to spend time on dependency-repair branches versus the new follow-through issue work
+
+## Issues
+- This window opened a large issue wave because the parity push was driven explicitly through tracked GMP gaps: issues #175, #190, #192, #199, #201, #204, #206, #209, #217, #219, #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and #267 all appeared after the last journal entry
+- Most of that wave was immediately burned down on `main`. Everything from #175 through #260 closed in the same span except #247 and #251, which remain open as model-drift and `get_reports` follow-through items
+- The only brand-new unresolved issue after the release push is #267, which adds opt-in verbose GMP wire tracing on the client side
+- The remaining open backlog is therefore much more deliberate than the raw issue count implies: older strategic/security tickets still exist, but the parity-driven June spike mostly converted straight into shipped code
+
+## CI Health
+- CI and OpenSSF Scorecard stayed green through the 2026-06-18 release-repair sequence, and branch-protection restoration itself also landed with a clean push signal
+- The noisier lane is `Security`, not the general build/test surface. Release-related pushes on 2026-06-18 and the scheduled security run on 2026-06-22 both failed even while ordinary CI stayed green
+- Release automation was also not flat: the initial 0.3.3 release run failed, one repair run was cancelled, and the final warning-only fix landed before the repo returned to a more stable posture
+- The net picture is still healthier than the 2026-05-14 entry described. The repo's risk is no longer broad merge instability across default workflows; it is concentrated in security/release follow-through while the expanded GMP surface itself is already on `main`

--- a/journal/2026-06-29.md
+++ b/journal/2026-06-29.md
@@ -1,0 +1,25 @@
+# 2026-06-29 — Mainline Closed a Dense GMP Hardening Burst, Then Had to Exercise the 0.3.3 Release Path for Real
+
+## Mainline & Merged Work
+
+### The repo used the post-2026-06-09 window to finish one concentrated typed-GMP hardening pass before flipping into release mechanics
+- `main` absorbed PR #235 (user auth plus scan-config type coverage), #236 (filter fragment validation), #239 and #240 (note and override parser fixes), #244 (missing typed target and alert fields), #249 (ID-scoped report metadata fetches), #252 (user host access mode preservation), #258 (schedule run timestamps), and #261 (report export options).
+- That sequence matters because it was not random follow-up cleanup. The library kept closing the specific contract and parsing gaps that had been left visible in the 2026-06-09 entry, especially around report exports, report fetch scoping, typed response fidelity, and note or override edge cases.
+- After that product burst, `main` shifted into release-path work on 2026-06-18: PR #265 restored branch protection after the release push, GitHub Actions cut the `0.3.3` release commit directly onto `main`, and two immediate follow-up commits repaired artifact publishing and downgraded SBOM score regressions from hard failures to warnings.
+- The result is a repo whose recent movement is split cleanly into two phases: first the GMP surface got sharper, then the release lane got tested under pressure and fixed in-place instead of remaining a hypothetical automation path.
+
+## Issues
+- Twelve issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, and #267.
+- Nine of those closed quickly through same-window merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, and #260.
+- Older follow-through also burned down in the same stretch when issue #192 finally closed on 2026-06-10 after the filter-validation work shipped.
+- The remaining open residue is now much narrower than the raw issue count suggests: #247 tracks `GetReportsOpts::no_report` drift, #251 keeps the user-host-access model audit open, and #267 adds a fresh opt-in verbose GMP wire-tracing request on the client side.
+
+## Pull Request Queue
+- The visible queue is now dominated by backlog rather than fresh product branches. Open journal PRs span #262 through #275, with only one much older non-journal branch still hanging around from the earlier maintenance lane: dependency PR #165.
+- Fresh dependency churn arrived right before this entry as well: PRs #276, #277, and #278 all opened on 2026-06-29 and are already marked `UNSTABLE`.
+- That is a noisier queue shape than the mainline story itself. The interesting GMP and release work is already merged, while review pressure is now concentrated in automation backlog and unstable dependency branches rather than feature delivery.
+
+## CI Health
+- The mainline signal stayed mostly usable through this window, but it was not perfectly flat. Push-based `CI`, `Security`, and `OpenSSF Scorecard` mostly succeeded, yet each lane also recorded failures, and scheduled `Security` failed once after previously passing.
+- The clearest concentrated instability came from the release lane: `Orchestrated Release` failed twice before the follow-up commits on 2026-06-18 repaired artifact publishing behavior and softened the SBOM-quality gate.
+- Dependabot maintenance remains mixed rather than healthy. Dynamic `Dependabot Updates` runs split between success and failure across the same period, and the three newest dependency PRs all start life in an `UNSTABLE` state instead of extending the clean mainline story.

--- a/journal/2026-07-01.md
+++ b/journal/2026-07-01.md
@@ -1,0 +1,23 @@
+# 2026-07-01 — Mainline Rushed Through a Dense GMP Fix Burst, Then Cut 0.3.3 While the Queue Turned Mostly into Backlog and Dependency Drift
+
+## Mainline & Merged Work
+
+### `main` did real library work immediately after the 2026-06-09 baseline, then pivoted into release mechanics instead of starting another broad feature wave
+- The product-heavy stretch landed fast on 2026-06-10 through 2026-06-16: PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261 added typed user-auth and scan-config coverage, filter validation, note/override parser fixes, missing GMP field support, scoped report metadata fetches, user host access mode handling, schedule run timestamps, and report export options.
+- That burst was followed by release-facing work rather than more parity expansion. PR #265 restored branch protection after the 0.3.3 release push, and `main` also picked up the direct 0.3.3 automation commits that repaired artifact publishing and added an SBOM quality-score warning.
+- The sequence matters because the repo's post-2026-06-09 story is not random churn. It shipped a concentrated typed-GMP correction lane, then immediately spent its next motion on getting the release path back into a safer shape.
+
+## Issues
+- Twelve issues opened in this window: #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, #266, and #267.
+- Eleven of those already closed, mostly by the same merged work that hit `main`: #237, #238, #242, #248, #250, #256, #257, and #260 all burned down quickly, and the brief docs/journal tracker #266 also closed.
+- The remaining fresh residue is small but clear. #247 tracks the invalid `no_report` option, #251 keeps the broader user-host-access model audit open, and #267 opens a new client-side verbose GMP wire-tracing request.
+
+## Pull Request Queue
+- The queue is now far less about product implementation than the 2026-06-09 entry suggested. The only clearly active non-journal branches are dependency maintenance PRs #276, #277, #278, plus the much older `quick-xml` bump in #165.
+- Everything else visible at the top of the queue is journal backlog: open PRs now span the consolidation branch #262 and daily entries #263 through #279, with only a few dates already merged away.
+- That leaves the repo in an awkward shape. The important GMP fixes and the 0.3.3 release are already on `main`, but the review surface is now dominated by automation residue and maintenance follow-ons rather than the next substantive library slice.
+
+## CI Health
+- The latest `main` push signal was mostly good, not perfectly clean. `CI` succeeded on nine post-baseline push runs and failed once, while `Security` succeeded seven times and failed three times across the same stretch.
+- The release lane was visibly noisy: the `Release` workflow around `v0.3.3` recorded failure, cancellation, and eventual success, and two manual `Orchestrated Release` runs failed before the branch-protection repair merged.
+- Scheduled posture also softened compared with the earlier entry. `OpenSSF Scorecard` stayed green, but scheduled `Security` split between one success and two failures, and the newer dependency plus journal PRs accumulated a long tail of failing `Security` pull-request runs late in the month.

--- a/journal/2026-07-02.md
+++ b/journal/2026-07-02.md
@@ -1,0 +1,23 @@
+# 2026-07-02 — Mainline Pushed Through a Dense Mid-June GMP Compatibility Burst, Shipped 0.3.3, and Ended the Window with One More Report-Export Fix
+
+## Mainline & Merged Work
+
+### The repo's post-2026-06-09 movement came in three clear waves instead of one continuous trickle
+- The first wave was a concentrated GMP contract and parser hardening burst on 2026-06-10 through 2026-06-16: `main` absorbed PRs #235, #236, #239, #240, #244, #249, #252, #258, and #261, covering missing auth and scan-config fields, filter validation, note/override parsing, typed target and alert fields, scoped report metadata fetches, user host access handling, schedule timestamps, and report export options.
+- The second wave was release machinery. On 2026-06-18 the repo cut `0.3.3`, repaired the artifact publish path, added an SBOM-quality warning, and restored branch protection through PR #265 plus the release commits that immediately followed it.
+- The last wave only arrived on 2026-07-01, when `main` took PR #282 to decode report exports correctly after metadata handling and PR #283 to consolidate dependency and security updates. That sequence matters because it shows the repo largely closed the mid-June GMP gap burst, then revisited the export lane once real release behavior exposed a final edge.
+
+## Issues
+- Thirteen issues opened in this window: #234, #237, #238, #242, #247, #248, #250, #251, #256, #257, #260, #267, and #281.
+- Most of that issue burst already burned down through merged work on `main`: #234, #237, #238, #242, #248, #250, #256, #257, #260, and #281 all closed, and older follow-through issue #192 also finally closed on 2026-06-10.
+- The remaining open residue is much narrower than the issue creation spike suggests. The live product questions are now #247 (`GetReportsOpts::no_report` drift), #251 (user host access response-shape audit), and #267 (opt-in verbose GMP wire tracing), while older roadmap/security items remain parked outside this slice.
+
+## Pull Request Queue
+- The implementation queue is now surprisingly thin relative to how much landed on `main`. The only fresh non-journal branch in view is PR #284, an actions-group maintenance bump that is currently `CLEAN`.
+- Everything else is documentation backlog: open journal PRs span the still-unmerged 2026-06-16 through 2026-07-01 entries, including the older consolidation branch #262 and the daily branches #263, #264, #266, and #268 through #280.
+- That is an inverted queue shape from the 2026-06-09 baseline. Product work did get merged; review debt is now concentrated in journal automation rather than in unresolved GMP implementation branches.
+
+## CI Health
+- The latest mainline signal is clean. Both 2026-07-01 pushes passed `CI`, `Security`, and `OpenSSF Scorecard`, so the repo did not end this window in a broken shipped state.
+- The scheduled security lane was not equally calm earlier in the span: `Security` on `main` failed on 2026-06-22 and again on 2026-06-29 before the later green push runs.
+- Branch validation is still mixed around the edges. The current dependency PR #284 is clean, but recent dependency and journal branches repeatedly tripped `Security`, and dynamic Dependabot update runs continue to alternate between success and failure instead of presenting one flat maintenance signal.


### PR DESCRIPTION
## Summary
- Consolidates the pending journal-entry PRs into one clean branch.
- Adds 31 journal files from 2026-05-26 through 2026-07-02.
- Supersedes #262, #263, #264, #266, #268, #269, #270, #271, #272, #273, #274, #275, #279, #280, and #285.

## Verification
- `git diff --cached --check` before commit
- Confirmed the combined diff is journal file additions only