### PR TITLE
docs(journal): add 2026-07-03 journal entry

### DIFF
--- a/journal/2026-07-03.md
+++ b/journal/2026-07-03.md
@@ -1,0 +1,23 @@
+# 2026-07-03 — Mainline Turned a Long GMP Parity Run into a 0.3.3 Release, a Report-Export Fix, and a New Fully-Green Follow-On Queue
+
+## Mainline & Merged Work
+
+### The repo did not just accumulate small fixes after the 2026-05-14 baseline; it shipped a broad GMP surface expansion and then tightened the release lane on top of it
+- `main` absorbed a long sequence of typed GMP work in this window: report drill-down helpers and REST-support gaps, typed report export support, enum alignment, resume-task/report-export fixes, note and override expansion flags, paginated filter builders, NVT score helpers, target credential fields, task detail parsing, report/result/port-list metadata, report metadata scoping, host access updates, schedule timestamps, and report export options
+- That run culminated in the 2026-06-18 `0.3.3` release sequence, including the automatic release commit, an artifact-publishing repair, and a branch-protection follow-up
+- Mainline then kept moving on 2026-07-01 and 2026-07-02 with a merged dependency/security bundle, the report-export decoding fix from PR #282, a `quick-xml` security update, and the journal backlog roll-up
+
+## Issues
+- The issue tracker was very active through June and then narrowed instead of spreading. The repo opened a large batch of short-lived parity and bug tickets across the typed GMP surface, and most of them closed immediately through the matching mainline PRs
+- Closed work in this window includes #173, #174, #175, #190, #192, #199, #201, #204, #206, #209, #217, #219, #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, #260, and the same-day report-export fix in #281
+- The remaining open issue set is now much smaller and easier to describe: #172 still tracks the broad parity roadmap, #247 and #251 track remaining response-shape drift, and #267 adds opt-in verbose GMP wire tracing
+
+## Pull Request Queue
+- The queue shape flipped completely by the end of the window. Instead of mostly journal and maintenance follow-up, the repo now has a fresh batch of ten open product branches: PRs #287 through #296
+- Those branches are coherent rather than random. They cover MSRV alignment plus another parity wave around resource-name alignment, redacted wire tracing, trashcan restore helpers, singular secinfo helpers, vulnerability helpers, scan-config fields, preference getters, policy getters, and report-format import helpers
+- That makes the current queue the clearest signal about where the repo is going next: the 0.3.3 cleanup is shipped, and another client/parity expansion batch is already staged
+
+## CI Health
+- The validation signal is stronger than the 2026-05-14 baseline left behind. The 2026-07-02 push to `main` passed `CI`, `Security`, and `OpenSSF Scorecard`
+- The entire new PR wave also started clean: every visible `CI` and `Security` run for PRs #287 through #296 completed successfully on 2026-07-02
+- Right now the repo's limiting factor is review throughput, not test instability. Both mainline and the newly opened feature queue are green


### PR DESCRIPTION
## Summary
- add the 2026-07-03 journal entry covering activity since the 2026-05-14 baseline
- capture the 0.3.3 release wave, follow-on report-export fix, queue reset, and green CI picture

Agent: Thoth