### PR TITLE
feat(gmp): add alert trigger helper

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -6,6 +6,7 @@
 
 use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
+use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::reports::get_report_hosts;
 use gvm_gmp::commands::scan_configs::ConfigOpts;
@@ -69,6 +70,20 @@ async fn fixture_server_with_version_response(version_xml: &str) -> Option<MockG
 async fn fixture_server(version: MockVersion) -> Option<MockGmpServer> {
     match MockGmpServer::builder()
         .mode(ServerMode::Fixture)
+        .version(version)
+        .unix_socket(socket_path())
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+async fn echo_server(version: MockVersion) -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Echo)
         .version(version)
         .unix_socket(socket_path())
         .build()
@@ -211,6 +226,47 @@ async fn create_target_and_get_targets_succeed() {
         .as_str()
         .expect("valid UTF-8 XML")
         .contains("Integration Target"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn trigger_alert_sends_get_reports_command() {
+    let Some(server) = echo_server(MockVersion::V22_4).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let response = client
+        .call(trigger_alert(
+            &EntityId::new("alert-1").expect("valid id"),
+            &EntityId::new("report-1").expect("valid id"),
+            TriggerAlertOpts {
+                filter_string: Some("severity>5".into()),
+                filter_id: Some(EntityId::new("filter-1").expect("valid id")),
+                report_format_id: Some(EntityId::new("format-1").expect("valid id")),
+                delta_report_id: Some(EntityId::new("delta-1").expect("valid id")),
+            },
+        ))
+        .await
+        .expect("trigger_alert should send get_reports command");
+
+    assert_eq!(response.status_code(), Some(200));
+    assert_eq!(
+        response.root_element_name().as_deref(),
+        Some("get_reports_response")
+    );
+
+    let history = server.command_history();
+    let command = history.last().expect("trigger command recorded");
+    assert_eq!(command.command_name(), "get_reports");
+    assert_eq!(
+        std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
+        "<get_reports alert_id=\"alert-1\" delta_report_id=\"delta-1\" filt_id=\"filter-1\" filter=\"severity&gt;5\" format_id=\"format-1\" report_id=\"report-1\"/>"
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -37,6 +37,19 @@ pub struct GetAlertsOpts {
     pub details: Option<bool>,
 }
 
+/// Options for `trigger_alert` requests.
+#[derive(Debug, Clone, Default)]
+pub struct TriggerAlertOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Optional report format identifier.
+    pub report_format_id: Option<EntityId>,
+    /// Optional delta report identifier.
+    pub delta_report_id: Option<EntityId>,
+}
+
 /// Build a clone request for an existing alert.
 #[must_use]
 pub fn clone_alert(alert_id: &EntityId) -> impl Request {
@@ -94,6 +107,30 @@ pub fn delete_alert(alert_id: &EntityId, ultimate: bool) -> impl Request {
 #[must_use]
 pub fn test_alert(alert_id: &EntityId) -> impl Request {
     XmlCommand::new("test_alert").attribute("alert_id", alert_id.as_str())
+}
+
+/// Build a `trigger_alert` request.
+#[must_use]
+pub fn trigger_alert(
+    alert_id: &EntityId,
+    report_id: &EntityId,
+    opts: TriggerAlertOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("get_reports")
+        .attribute("report_id", report_id.as_str())
+        .attribute("alert_id", alert_id.as_str());
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    if let Some(report_format_id) = opts.report_format_id.as_ref() {
+        cmd = cmd.attribute("format_id", report_format_id.as_str());
+    }
+    if let Some(delta_report_id) = opts.delta_report_id.as_ref() {
+        cmd = cmd.attribute("delta_report_id", delta_report_id.as_str());
+    }
+    cmd
 }
 
 fn add_alert_body(cmd: &mut XmlCommand, opts: &AlertOpts) {
@@ -172,5 +209,13 @@ mod tests {
             "<delete_alert alert_id=\"a1\" ultimate=\"0\"/>"
         );
         assert_eq!(xml(test_alert(&id("a1"))), "<test_alert alert_id=\"a1\"/>");
+        assert_eq!(
+            xml(trigger_alert(
+                &id("a1"),
+                &id("r1"),
+                TriggerAlertOpts::default()
+            )),
+            "<get_reports alert_id=\"a1\" report_id=\"r1\"/>"
+        );
     }
 }

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -62,3 +62,20 @@ fn test_alert_get_modify_delete_and_test() {
     );
     assert_eq!(xml(test_alert(&id("a1"))), "<test_alert alert_id=\"a1\"/>");
 }
+
+#[test]
+fn test_trigger_alert_builds_get_reports_command() {
+    assert_eq!(
+        xml(trigger_alert(
+            &id("a1"),
+            &id("r1"),
+            TriggerAlertOpts {
+                filter_string: Some("severity>5".into()),
+                filter_id: Some(id("f1")),
+                report_format_id: Some(id("rf1")),
+                delta_report_id: Some(id("dr1")),
+            }
+        )),
+        "<get_reports alert_id=\"a1\" delta_report_id=\"dr1\" filt_id=\"f1\" filter=\"severity&gt;5\" format_id=\"rf1\" report_id=\"r1\"/>"
+    );
+}


### PR DESCRIPTION
## Summary
- add a `trigger_alert` command builder matching python-gvm's specialized `get_reports` request shape
- cover the basic and fully-optioned XML request shapes, including filter, saved filter, report format, and delta report attributes
- add a Unix-socket client/mock-server integration test that sends the helper through the real transport path and verifies the recorded GMP XML

Refs parity with python-gvm v224 `trigger_alert`.

## Testing
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp --test test_alerts`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration trigger_alert_sends_get_reports_command`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check` (passed with baseline unmatched allow/license/advisory warnings)
- `cargo audit` (passed with the known allowed yanked `crypto-bigint 0.7.4` warning)
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-alert-trigger-semgrep.sarif`

## Validation Notes
- `trigger_alert` is exposed in the alert command module for python-gvm API parity, but its GMP wire command is `get_reports`.
- The mock-server integration test uses echo mode to verify the real client/transport path and exact recorded XML. It does not add new stateful alert-trigger semantics because the current mock server does not model alert execution.
- Fuzzing was not run because this slice only adds a command builder and command-history integration coverage; it does not touch parsers, transport framing, streaming, or fuzz-facing code.