### PR TITLE
feat(gmp): add operating system asset helpers

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -8,6 +8,7 @@ use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
 use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
 use gvm_gmp::commands::scan_configs::ConfigOpts;
 use gvm_gmp::commands::scanners::ScannerOpts;
@@ -256,6 +257,43 @@ async fn trigger_alert_sends_get_reports_command() {
     assert_eq!(
         std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
         "<get_reports alert_id=\"alert-1\" delta_report_id=\"delta-1\" filt_id=\"filter-1\" filter=\"severity&gt;5\" format_id=\"format-1\" report_id=\"report-1\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn operating_system_helpers_send_asset_commands() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    let response = client
+        .call(get_operating_systems(GetOperatingSystemsOpts {
+            filter_string: Some("name=Debian".into()),
+            filter_id: Some(EntityId::new("filter-1").expect("valid id")),
+            details: Some(true),
+        }))
+        .await
+        .expect("get_operating_systems should send get_assets command");
+
+    assert_eq!(response.status_code(), Some(200));
+
+    let history = server.command_history();
+    let command = history.last().expect("operating system command recorded");
+    assert_eq!(command.command_name(), "get_assets");
+    assert_eq!(
+        std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
+        "<get_assets details=\"1\" filt_id=\"filter-1\" filter=\"name=Debian\" type=\"os\"/>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/mod.rs
+++ b/crates/gvm-gmp/src/commands/mod.rs
@@ -31,6 +31,8 @@ pub mod integration_configs;
 pub mod notes;
 /// NVT command builders.
 pub mod nvts;
+/// Operating-system asset command builders.
+pub mod operating_systems;
 /// Override command builders.
 pub mod overrides;
 /// Permission command builders.

--- a/crates/gvm-gmp/src/commands/operating_systems.rs
+++ b/crates/gvm-gmp/src/commands/operating_systems.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Operating-system asset command builders.
+
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::common::{add_filter_attrs, set_optional_bool_attr};
+use crate::types::EntityId;
+
+/// Options for `get_operating_systems` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetOperatingSystemsOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+}
+
+/// Build a `get_operating_systems` request.
+#[must_use]
+pub fn get_operating_systems(opts: GetOperatingSystemsOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_assets").attribute("type", "os");
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "details", opts.details);
+    cmd
+}
+
+/// Build a `get_operating_system` request.
+#[must_use]
+pub fn get_operating_system(operating_system_id: &EntityId, details: Option<bool>) -> impl Request {
+    let mut cmd = XmlCommand::new("get_assets")
+        .attribute("asset_id", operating_system_id.as_str())
+        .attribute("type", "os");
+    set_optional_bool_attr(&mut cmd, "details", details);
+    cmd
+}
+
+/// Build a `modify_operating_system` request.
+#[must_use]
+pub fn modify_operating_system(
+    operating_system_id: &EntityId,
+    comment: Option<&str>,
+) -> impl Request {
+    let mut cmd =
+        XmlCommand::new("modify_asset").attribute("asset_id", operating_system_id.as_str());
+    cmd.add_element_with_text("comment", comment.unwrap_or_default());
+    cmd
+}
+
+/// Build a `delete_operating_system` request.
+#[must_use]
+pub fn delete_operating_system(operating_system_id: &EntityId) -> impl Request {
+    XmlCommand::new("delete_asset").attribute("asset_id", operating_system_id.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::xml;
+
+    fn id(value: &str) -> EntityId {
+        EntityId::new(value).expect("valid id")
+    }
+
+    #[test]
+    fn operating_system_gets_build_xml() {
+        assert_eq!(
+            xml(get_operating_systems(GetOperatingSystemsOpts {
+                filter_string: Some("name=Debian".into()),
+                filter_id: Some(id("f1")),
+                details: Some(true),
+            })),
+            "<get_assets details=\"1\" filt_id=\"f1\" filter=\"name=Debian\" type=\"os\"/>"
+        );
+        assert_eq!(
+            xml(get_operating_system(&id("os1"), Some(false))),
+            "<get_assets asset_id=\"os1\" details=\"0\" type=\"os\"/>"
+        );
+    }
+
+    #[test]
+    fn operating_system_modify_delete_build_xml() {
+        assert_eq!(
+            xml(modify_operating_system(&id("os1"), Some("updated"))),
+            "<modify_asset asset_id=\"os1\"><comment>updated</comment></modify_asset>"
+        );
+        assert_eq!(
+            xml(modify_operating_system(&id("os1"), None)),
+            "<modify_asset asset_id=\"os1\"><comment></comment></modify_asset>"
+        );
+        assert_eq!(
+            xml(delete_operating_system(&id("os1"))),
+            "<delete_asset asset_id=\"os1\"/>"
+        );
+    }
+}

--- a/crates/gvm-gmp/tests/test_operating_systems.rs
+++ b/crates/gvm-gmp/tests/test_operating_systems.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+mod common;
+
+use common::{id, xml};
+use gvm_gmp::commands::operating_systems::*;
+
+#[test]
+fn test_get_operating_systems_with_options() {
+    assert_eq!(
+        xml(get_operating_systems(GetOperatingSystemsOpts {
+            filter_string: Some("name=Debian".into()),
+            filter_id: Some(id("f1")),
+            details: Some(true),
+        })),
+        "<get_assets details=\"1\" filt_id=\"f1\" filter=\"name=Debian\" type=\"os\"/>"
+    );
+}
+
+#[test]
+fn test_get_operating_system() {
+    assert_eq!(
+        xml(get_operating_system(&id("os1"), None)),
+        "<get_assets asset_id=\"os1\" type=\"os\"/>"
+    );
+    assert_eq!(
+        xml(get_operating_system(&id("os1"), Some(false))),
+        "<get_assets asset_id=\"os1\" details=\"0\" type=\"os\"/>"
+    );
+}
+
+#[test]
+fn test_modify_and_delete_operating_system() {
+    assert_eq!(
+        xml(modify_operating_system(&id("os1"), Some("updated"))),
+        "<modify_asset asset_id=\"os1\"><comment>updated</comment></modify_asset>"
+    );
+    assert_eq!(
+        xml(modify_operating_system(&id("os1"), None)),
+        "<modify_asset asset_id=\"os1\"><comment></comment></modify_asset>"
+    );
+    assert_eq!(
+        xml(delete_operating_system(&id("os1"))),
+        "<delete_asset asset_id=\"os1\"/>"
+    );
+}


### PR DESCRIPTION
## Summary
- add asset-style operating-system command builders for `get_assets`, `modify_asset`, and `delete_asset` wire shapes
- keep the new asset helpers separate from the existing SecInfo `get_info type="os"` helper
- cover list, singular get, modify, delete, and empty-comment clearing XML behavior
- add Unix-socket mock-server integration coverage for the list helper through `GmpClient::call` and command history

## Testing
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp --test test_operating_systems`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration operating_system_helpers_send_asset_commands`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-operating-system-semgrep.sarif`

## Validation notes
- The real client/transport path exercises `get_operating_systems`; the singular, modify, and delete helpers are covered by exact XML command-builder tests.
- Fuzzing was not run because this only adds command builders and command-history integration coverage, not parser, framing, streaming, or transport logic.
- Baseline warnings remain unchanged: workspace integration tests emit existing missing-docs warnings; `cargo deny check` reports the existing unmatched allow/license/advisory warnings; `cargo audit` reports the existing allowed yanked `crypto-bigint 0.7.4`.
