### PR TITLE
feat(gmp): add TLS certificate clone helper

### DIFF
--- a/crates/gvm-client/tests/tls_certificate_integration.rs
+++ b/crates/gvm-client/tests/tls_certificate_integration.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(missing_docs)]
+
+use gvm_client::GmpClient;
+use gvm_connection::UnixSocketConnection;
+use gvm_gmp::commands::tls_certificates::clone_tls_certificate;
+use gvm_gmp::types::EntityId;
+use gvm_mock_server::{MockGmpServer, ServerMode};
+
+async fn echo_server() -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Echo)
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
+    UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
+}
+
+#[tokio::test]
+async fn clone_tls_certificate_sends_create_copy_command() {
+    let Some(server) = echo_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let response = client
+        .call(clone_tls_certificate(
+            &EntityId::new("tls1").expect("valid id"),
+        ))
+        .await
+        .expect("clone_tls_certificate should send create command");
+
+    assert_eq!(response.status_code(), Some(201));
+
+    let history = server.command_history();
+    let command = history.last().expect("TLS clone command recorded");
+    assert_eq!(command.command_name(), "create_tls_certificate");
+    assert_eq!(
+        std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
+        "<create_tls_certificate><copy>tls1</copy></create_tls_certificate>"
+    );
+
+    server.shutdown().await;
+}

--- a/crates/gvm-gmp/src/commands/tls_certificates.rs
+++ b/crates/gvm-gmp/src/commands/tls_certificates.rs
@@ -41,6 +41,14 @@ pub fn create_tls_certificate(name: &str, opts: TlsCertificateOpts) -> impl Requ
     cmd
 }
 
+/// Build a `clone_tls_certificate` request.
+#[must_use]
+pub fn clone_tls_certificate(tls_certificate_id: &EntityId) -> impl Request {
+    let mut cmd = XmlCommand::new("create_tls_certificate");
+    cmd.add_element_with_text("copy", tls_certificate_id.as_str());
+    cmd
+}
+
 /// Build a `get_tls_certificates` request.
 #[must_use]
 pub fn get_tls_certificates(opts: GetTlsCertificatesOpts) -> impl Request {
@@ -108,6 +116,10 @@ mod tests {
             },
         ));
         assert!(rendered.contains("<certificate>cert</certificate>"));
+        assert_eq!(
+            xml(clone_tls_certificate(&id("tls1"))),
+            "<create_tls_certificate><copy>tls1</copy></create_tls_certificate>"
+        );
         assert_eq!(
             xml(get_tls_certificate(&id("tls1"))),
             "<get_tls_certificates details=\"1\" tls_certificate_id=\"tls1\"/>"

--- a/crates/gvm-gmp/tests/test_tls_certificates.rs
+++ b/crates/gvm-gmp/tests/test_tls_certificates.rs
@@ -32,6 +32,14 @@ fn test_create_tls_certificate_with_optionals() {
 }
 
 #[test]
+fn test_clone_tls_certificate() {
+    assert_eq!(
+        xml(clone_tls_certificate(&id("tls1"))),
+        "<create_tls_certificate><copy>tls1</copy></create_tls_certificate>"
+    );
+}
+
+#[test]
 fn test_tls_certificate_get_modify_delete() {
     assert_eq!(
         xml(get_tls_certificate(&id("tls1"))),


### PR DESCRIPTION
## Summary
- add `clone_tls_certificate` for GMP TLS certificate copy requests
- cover the exact `<create_tls_certificate><copy>...</copy></create_tls_certificate>` XML in GMP command tests
- add Unix-socket mock-server client coverage for the helper through `GmpClient::call` and command history

## Testing
- `cargo fmt --all`
- `cargo test -p gvm-gmp --test test_tls_certificates test_clone_tls_certificate`
- `cargo test -p gvm-client --features unix-socket-tests --test tls_certificate_integration`
- `cargo test -p gvm-gmp --test test_tls_certificates`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-client --features unix-socket-tests --test tls_certificate_integration`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-tls-clone-semgrep.sarif`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-tls-clone-new-test-semgrep.sarif crates/gvm-client/tests/tls_certificate_integration.rs`

## Notes
- The client integration test uses mock-server echo mode because stateful mode interprets the clone request and returns 404 when the source TLS certificate does not exist. This PR verifies request construction, transport, and command history rather than stateful TLS certificate storage semantics.
- Fuzzing was not run because this is command-builder/client command-history coverage only, with no parser, framing, streaming, or fuzz-facing changes.
- Baseline warnings observed but unchanged: integration-test missing-docs warnings, existing `cargo deny` unmatched allow/license/advisory warnings, and the existing allowed yanked `crypto-bigint` audit warning. `cargo vet` quote-normalization churn in `supply-chain/imports.lock` was inspected and restored.
