### PR TITLE
feat(gmp): add audit clone and get helpers

### DIFF
--- a/crates/gvm-client/tests/audit_integration.rs
+++ b/crates/gvm-client/tests/audit_integration.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(missing_docs)]
+
+use gvm_client::GmpClient;
+use gvm_connection::UnixSocketConnection;
+use gvm_gmp::commands::tasks::get_audit;
+use gvm_gmp::types::EntityId;
+use gvm_mock_server::{MockGmpServer, ServerMode};
+
+async fn echo_server() -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Echo)
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
+    UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
+}
+
+#[tokio::test]
+async fn get_audit_sends_audit_scoped_get_tasks_command() {
+    let Some(server) = echo_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let response = client
+        .call(get_audit(&EntityId::new("audit1").expect("valid id")))
+        .await
+        .expect("get_audit should send get_tasks command");
+
+    assert_eq!(response.status_code(), Some(200));
+
+    let history = server.command_history();
+    let command = history.last().expect("audit get command recorded");
+    assert_eq!(command.command_name(), "get_tasks");
+    assert_eq!(
+        std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
+        "<get_tasks details=\"1\" task_id=\"audit1\" usage_type=\"audit\"/>"
+    );
+
+    server.shutdown().await;
+}

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -282,6 +282,21 @@ pub fn get_audits(opts: GetTasksOpts) -> impl Request {
     get_tasks_with_usage(opts, UsageType::Audit)
 }
 
+/// Build a clone request for an existing audit.
+#[must_use]
+pub fn clone_audit(task_id: &EntityId) -> impl Request {
+    clone_task(task_id)
+}
+
+/// Build a `get_tasks` request for a single audit.
+#[must_use]
+pub fn get_audit(task_id: &EntityId) -> impl Request {
+    XmlCommand::new("get_tasks")
+        .attribute("task_id", task_id.as_str())
+        .attribute("usage_type", UsageType::Audit.as_gmp_str())
+        .attribute("details", "1")
+}
+
 /// Build a `start_task` request for an audit.
 #[must_use]
 pub fn start_audit(task_id: &EntityId) -> impl Request {
@@ -424,6 +439,14 @@ mod tests {
         assert_eq!(
             xml(get_audits(GetTasksOpts::default())),
             "<get_tasks usage_type=\"audit\"/>"
+        );
+        assert_eq!(
+            xml(clone_audit(&id("a1"))),
+            "<create_task><copy>a1</copy></create_task>"
+        );
+        assert_eq!(
+            xml(get_audit(&id("a1"))),
+            "<get_tasks details=\"1\" task_id=\"a1\" usage_type=\"audit\"/>"
         );
         assert_eq!(
             xml(modify_audit(

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -47,12 +47,20 @@ fn test_task_mutation_and_actions() {
         "<create_task><copy>a1</copy></create_task>"
     );
     assert_eq!(
+        xml(clone_audit(&id("a1"))),
+        "<create_task><copy>a1</copy></create_task>"
+    );
+    assert_eq!(
         xml(create_container_task("foo", Some("bar"))),
         "<create_task><name>foo</name><comment>bar</comment><target id=\"0\"/></create_task>"
     );
     assert_eq!(
         xml(get_task(&id("a1"))),
         "<get_tasks details=\"1\" task_id=\"a1\" usage_type=\"scan\"/>"
+    );
+    assert_eq!(
+        xml(get_audit(&id("a1"))),
+        "<get_tasks details=\"1\" task_id=\"a1\" usage_type=\"audit\"/>"
     );
     assert_eq!(
         xml(move_task(&id("a1"), Some(&id("s1")))),


### PR DESCRIPTION
## Summary
- add `clone_audit` and `get_audit` helpers for python-gvm audit command parity
- keep the wire commands aligned with audit-as-task GMP semantics: `create_task` with `<copy>` and `get_tasks` with `usage_type="audit"`
- cover exact XML in task command tests
- add Unix-socket mock-server client coverage for `get_audit` through `GmpClient::call` and command history

## Testing
- `cargo fmt --all`
- `cargo test -p gvm-gmp --test test_tasks test_task_mutation_and_actions`
- `cargo test -p gvm-gmp audit_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test audit_integration`
- `cargo test -p gvm-gmp --test test_tasks`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-client --features unix-socket-tests --test audit_integration`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy -p gvm-gmp --all-targets --all-features -- -D warnings`
- `cargo clippy -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-audit-helpers-semgrep.sarif`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-audit-helpers-new-test-semgrep.sarif crates/gvm-client/tests/audit_integration.rs`

## Notes
- The client integration test uses mock-server echo mode to verify request construction, transport, and command history for the exact `get_tasks` audit wire command.
- Fuzzing was not run because this adds command-builder/client command-history coverage only, with no parser, framing, streaming, or fuzz-facing changes.
- Baseline warnings observed but unchanged: integration-test missing-docs warnings, existing `cargo deny` unmatched allow/license/advisory warnings, and the existing allowed yanked `crypto-bigint` audit warning. `cargo vet` quote-normalization churn in `supply-chain/imports.lock` was inspected and restored.
