### PR TITLE
feat(gmp): add agent group commands

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -14,6 +14,10 @@ mod typed;
 mod version;
 
 use gvm_connection::GvmConnection;
+use gvm_gmp::commands::agent_groups::{
+    clone_agent_group, create_agent_group, delete_agent_group, get_agent_group, get_agent_groups,
+    modify_agent_group,
+};
 use gvm_gmp::commands::credentials::get_credential_stores;
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -33,6 +37,9 @@ use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
 pub use error::GvmError;
+pub use gvm_gmp::commands::agent_groups::{
+    CreateAgentGroupOpts, GetAgentGroupsOpts, ModifyAgentGroupOpts,
+};
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
@@ -197,6 +204,96 @@ impl<C: GvmConnection> GmpClient<C> {
             .await
     }
 
+    /// Create an agent group.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn create_agent_group(
+        &mut self,
+        name: &str,
+        agent_ids: &[EntityId],
+        scheduler_cron_time: &str,
+        opts: CreateAgentGroupOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(create_agent_group(
+            name,
+            agent_ids,
+            scheduler_cron_time,
+            opts,
+        ))
+        .await
+    }
+
+    /// Clone an agent group.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn clone_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<Response, GvmError> {
+        self.call(clone_agent_group(agent_group_id)).await
+    }
+
+    /// Get a single agent group.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<Response, GvmError> {
+        self.call(get_agent_group(agent_group_id)).await
+    }
+
+    /// List agent groups.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agent_groups(
+        &mut self,
+        opts: GetAgentGroupsOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_agent_groups(opts)).await
+    }
+
+    /// Modify an agent group.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn modify_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        scheduler_cron_time: &str,
+        opts: ModifyAgentGroupOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(modify_agent_group(
+            agent_group_id,
+            scheduler_cron_time,
+            opts,
+        ))
+        .await
+    }
+
+    /// Delete an agent group.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn delete_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<Response, GvmError> {
+        self.call(delete_agent_group(agent_group_id, ultimate))
+            .await
+    }
+
     /// Get host summaries for a report.
     ///
     /// # Errors
@@ -327,6 +424,39 @@ pub trait Gmp226Commands {
 /// Commands available only in GMP 22.8 and later.
 #[async_trait::async_trait]
 pub trait GmpNextCommands {
+    /// Create an agent group.
+    async fn create_agent_group(
+        &mut self,
+        name: &str,
+        agent_ids: &[EntityId],
+        scheduler_cron_time: &str,
+        opts: CreateAgentGroupOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Clone an agent group.
+    async fn clone_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError>;
+
+    /// Get a single agent group.
+    async fn get_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError>;
+
+    /// List agent groups.
+    async fn get_agent_groups(&mut self, opts: GetAgentGroupsOpts) -> Result<Response, GvmError>;
+
+    /// Modify an agent group.
+    async fn modify_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        scheduler_cron_time: &str,
+        opts: ModifyAgentGroupOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Delete an agent group.
+    async fn delete_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<Response, GvmError>;
+
     /// Get a single integration configuration.
     async fn get_integration_config(
         &mut self,
@@ -543,6 +673,49 @@ impl_gmp226_commands!(GmpNext);
 
 #[async_trait::async_trait]
 impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
+    async fn create_agent_group(
+        &mut self,
+        name: &str,
+        agent_ids: &[EntityId],
+        scheduler_cron_time: &str,
+        opts: CreateAgentGroupOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .create_agent_group(name, agent_ids, scheduler_cron_time, opts)
+            .await
+    }
+
+    async fn clone_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError> {
+        self.0.clone_agent_group(agent_group_id).await
+    }
+
+    async fn get_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError> {
+        self.0.get_agent_group(agent_group_id).await
+    }
+
+    async fn get_agent_groups(&mut self, opts: GetAgentGroupsOpts) -> Result<Response, GvmError> {
+        self.0.get_agent_groups(opts).await
+    }
+
+    async fn modify_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        scheduler_cron_time: &str,
+        opts: ModifyAgentGroupOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .modify_agent_group(agent_group_id, scheduler_cron_time, opts)
+            .await
+    }
+
+    async fn delete_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<Response, GvmError> {
+        self.0.delete_agent_group(agent_group_id, ultimate).await
+    }
+
     async fn get_integration_config(
         &mut self,
         integration_config_id: &EntityId,

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -16,7 +16,11 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_report_configs"
         | "modify_report_config"
         | "get_features" => Some(GmpVersion(22, 6)),
-        "get_integration_configs"
+        "create_agent_group"
+        | "delete_agent_group"
+        | "get_agent_groups"
+        | "modify_agent_group"
+        | "get_integration_configs"
         | "modify_integration_config"
         | "get_report_hosts"
         | "get_report_ports"
@@ -195,6 +199,12 @@ mod tests {
         );
         assert_eq!(
             minimum_version_for_command("get_credential_stores"),
+            Some(GmpVersion(22, 8))
+        );
+        assert!(!command_supported("get_agent_groups", GmpVersion(22, 7)));
+        assert!(command_supported("get_agent_groups", GmpVersion(22, 8)));
+        assert_eq!(
+            minimum_version_for_command("create_agent_group"),
             Some(GmpVersion(22, 8))
         );
     }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::print_stderr, missing_docs)]
+#![cfg(feature = "unix-socket-tests")]
 
-use gvm_client::{Gmp226Commands, GmpNextCommands, GmpVersioned};
+use gvm_client::{
+    CreateAgentGroupOpts, Gmp226Commands, GmpNextCommands, GmpVersioned, ModifyAgentGroupOpts,
+};
 use gvm_connection::UnixSocketConnection;
+use gvm_gmp::types::EntityId;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 
 async fn stateful_server(version: MockVersion) -> Option<MockGmpServer> {
@@ -92,6 +95,112 @@ async fn next_client_exposes_next_trait_methods() {
         .await
         .expect("next-only command should succeed");
     assert_eq!(response.status_code(), Some(200));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_agent_groups_round_trip() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    let agent_ids = [
+        EntityId::new("agent-1").expect("valid id"),
+        EntityId::new("agent-2").expect("valid id"),
+    ];
+    let create_response = client
+        .create_agent_group(
+            "Client Agent Group",
+            &agent_ids,
+            "0 */5 * * *",
+            CreateAgentGroupOpts {
+                comment: Some("created through client".into()),
+            },
+        )
+        .await
+        .expect("create_agent_group should succeed");
+    assert_eq!(create_response.status_code(), Some(201));
+    let agent_group_id = EntityId::new(create_response.id().expect("created id"))
+        .expect("server id should be valid");
+
+    let clone_response = client
+        .clone_agent_group(&agent_group_id)
+        .await
+        .expect("clone_agent_group should succeed");
+    assert_eq!(clone_response.status_code(), Some(201));
+
+    let get_response = client
+        .get_agent_group(&agent_group_id)
+        .await
+        .expect("get_agent_group should succeed");
+    let get_text = get_response.as_str().expect("valid UTF-8 XML");
+    assert!(get_text.contains("Client Agent Group"));
+    assert!(get_text.contains("<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"));
+
+    let list_response = client
+        .get_agent_groups(Default::default())
+        .await
+        .expect("get_agent_groups should succeed");
+    assert_eq!(list_response.status_code(), Some(200));
+    assert!(list_response
+        .as_str()
+        .expect("valid UTF-8 XML")
+        .contains("<agent_group_count>2"));
+
+    let modify_response = client
+        .modify_agent_group(
+            &agent_group_id,
+            "0 */10 * * *",
+            ModifyAgentGroupOpts {
+                name: Some("Updated Agent Group".into()),
+                comment: Some("modified through client".into()),
+                agent_ids: vec![EntityId::new("agent-3").expect("valid id")],
+            },
+        )
+        .await
+        .expect("modify_agent_group should succeed");
+    assert_eq!(modify_response.status_code(), Some(200));
+
+    let updated_response = client
+        .get_agent_group(&agent_group_id)
+        .await
+        .expect("updated get_agent_group should succeed");
+    let updated_text = updated_response.as_str().expect("valid UTF-8 XML");
+    assert!(updated_text.contains("Updated Agent Group"));
+    assert!(updated_text.contains("<comment>modified through client</comment>"));
+    assert!(updated_text.contains("<scheduler_cron_time>0 */10 * * *</scheduler_cron_time>"));
+
+    let delete_response = client
+        .delete_agent_group(&agent_group_id, true)
+        .await
+        .expect("delete_agent_group should succeed");
+    assert_eq!(delete_response.status_code(), Some(200));
+
+    let error = client
+        .get_agent_group(&agent_group_id)
+        .await
+        .expect_err("deleted agent group should not be found");
+    assert!(matches!(
+        error,
+        gvm_client::GvmError::Server { status: 404, .. }
+    ));
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/agent_groups.rs
+++ b/crates/gvm-gmp/src/commands/agent_groups.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Agent group command builders.
+
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::types::EntityId;
+
+/// Optional fields for `create_agent_group` requests.
+#[derive(Debug, Clone, Default)]
+pub struct CreateAgentGroupOpts {
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+}
+
+/// Options for `get_agent_groups` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetAgentGroupsOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether to query trashcan resources.
+    pub trash: Option<bool>,
+}
+
+/// Optional fields for `modify_agent_group` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyAgentGroupOpts {
+    /// Optional resource name.
+    pub name: Option<String>,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional agent ids to set for the group.
+    pub agent_ids: Vec<EntityId>,
+}
+
+/// Build a clone request for an existing agent group.
+#[must_use]
+pub fn clone_agent_group(agent_group_id: &EntityId) -> impl Request {
+    XmlCommand::new("create_agent_group").child_with_text("copy", agent_group_id.as_str())
+}
+
+/// Build a `create_agent_group` request.
+#[must_use]
+pub fn create_agent_group(
+    name: &str,
+    agent_ids: &[EntityId],
+    scheduler_cron_time: &str,
+    opts: CreateAgentGroupOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("create_agent_group");
+    cmd.add_element_with_text("name", name);
+    cmd.add_element_with_text("scheduler_cron_time", scheduler_cron_time);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_agent_elements(&mut cmd, agent_ids);
+    cmd
+}
+
+/// Build a `get_agent_groups` request.
+#[must_use]
+pub fn get_agent_groups(opts: GetAgentGroupsOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_agent_groups");
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "trash", opts.trash);
+    cmd
+}
+
+/// Build a `get_agent_group` request.
+#[must_use]
+pub fn get_agent_group(agent_group_id: &EntityId) -> impl Request {
+    XmlCommand::new("get_agent_groups").attribute("agent_group_id", agent_group_id.as_str())
+}
+
+/// Build a `modify_agent_group` request.
+#[must_use]
+pub fn modify_agent_group(
+    agent_group_id: &EntityId,
+    scheduler_cron_time: &str,
+    opts: ModifyAgentGroupOpts,
+) -> impl Request {
+    let mut cmd =
+        XmlCommand::new("modify_agent_group").attribute("agent_group_id", agent_group_id.as_str());
+    cmd.add_element_with_text("scheduler_cron_time", scheduler_cron_time);
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_agent_elements(&mut cmd, &opts.agent_ids);
+    cmd
+}
+
+/// Build a `delete_agent_group` request.
+#[must_use]
+pub fn delete_agent_group(agent_group_id: &EntityId, ultimate: bool) -> impl Request {
+    XmlCommand::new("delete_agent_group")
+        .attribute("agent_group_id", agent_group_id.as_str())
+        .attribute("ultimate", bool_str(ultimate))
+}
+
+fn add_agent_elements(cmd: &mut XmlCommand, agent_ids: &[EntityId]) {
+    if agent_ids.is_empty() {
+        return;
+    }
+
+    let agents = cmd.add_element("agents");
+    for agent_id in agent_ids {
+        agents
+            .add_child("agent")
+            .set_attribute("id", agent_id.as_str());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::xml;
+
+    fn id(value: &str) -> EntityId {
+        EntityId::new(value).expect("valid id")
+    }
+
+    #[test]
+    fn agent_group_create_and_clone_build_xml() {
+        assert_eq!(
+            xml(create_agent_group(
+                "agents",
+                &[id("agent-1"), id("agent-2")],
+                "0 */5 * * *",
+                CreateAgentGroupOpts {
+                    comment: Some("scheduled".into()),
+                },
+            )),
+            "<create_agent_group><name>agents</name><scheduler_cron_time>0 */5 * * *</scheduler_cron_time><comment>scheduled</comment><agents><agent id=\"agent-1\"/><agent id=\"agent-2\"/></agents></create_agent_group>"
+        );
+        assert_eq!(
+            xml(clone_agent_group(&id("group-1"))),
+            "<create_agent_group><copy>group-1</copy></create_agent_group>"
+        );
+    }
+
+    #[test]
+    fn agent_group_get_builds_xml() {
+        assert_eq!(
+            xml(get_agent_groups(GetAgentGroupsOpts {
+                filter_string: Some("name=agents".into()),
+                filter_id: Some(id("filter-1")),
+                trash: Some(true),
+            })),
+            "<get_agent_groups filt_id=\"filter-1\" filter=\"name=agents\" trash=\"1\"/>"
+        );
+        assert_eq!(
+            xml(get_agent_group(&id("group-1"))),
+            "<get_agent_groups agent_group_id=\"group-1\"/>"
+        );
+    }
+
+    #[test]
+    fn agent_group_modify_and_delete_build_xml() {
+        assert_eq!(
+            xml(modify_agent_group(
+                &id("group-1"),
+                "0 */10 * * *",
+                ModifyAgentGroupOpts {
+                    name: Some("updated".into()),
+                    comment: Some("changed".into()),
+                    agent_ids: vec![id("agent-3")],
+                },
+            )),
+            "<modify_agent_group agent_group_id=\"group-1\"><scheduler_cron_time>0 */10 * * *</scheduler_cron_time><name>updated</name><comment>changed</comment><agents><agent id=\"agent-3\"/></agents></modify_agent_group>"
+        );
+        assert_eq!(
+            xml(delete_agent_group(&id("group-1"), false)),
+            "<delete_agent_group agent_group_id=\"group-1\" ultimate=\"0\"/>"
+        );
+    }
+}

--- a/crates/gvm-gmp/src/commands/mod.rs
+++ b/crates/gvm-gmp/src/commands/mod.rs
@@ -3,6 +3,8 @@
 
 //! GMP command builders.
 
+/// Agent group command builders.
+pub mod agent_groups;
 /// Aggregate command builders.
 pub mod aggregates;
 /// Alert command builders.

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -288,6 +288,9 @@ impl SessionHandler {
         if let Some(comment) = parse_element_text(raw_xml, "comment") {
             resource.comment = comment;
         }
+        if let Some(scheduler_cron_time) = parse_element_text(raw_xml, "scheduler_cron_time") {
+            resource.set_attr("scheduler_cron_time", &scheduler_cron_time);
+        }
 
         if matches!(resource_type, "config" | "task") {
             if let Some(usage_type) = parse_element_text(raw_xml, "usage_type") {
@@ -503,6 +506,7 @@ impl SessionHandler {
         let new_host = parse_element_text(raw_xml, "host");
         let new_hosts = parse_element_text(raw_xml, "hosts");
         let new_status = parse_element_text(raw_xml, "status");
+        let new_scheduler_cron_time = parse_element_text(raw_xml, "scheduler_cron_time");
         let new_nvt_oid = parse_element_text(raw_xml, "nvt_oid")
             .or_else(|| cmd.child_attr("nvt", "oid").map(str::to_string));
         let new_result_id = parse_element_text(raw_xml, "result_id")
@@ -590,6 +594,9 @@ impl SessionHandler {
             }
             if let Some(ref oidc_client_secret) = new_oidc_client_secret {
                 r.set_attr("oidc_provider_client_secret", oidc_client_secret);
+            }
+            if let Some(ref scheduler_cron_time) = new_scheduler_cron_time {
+                r.set_attr("scheduler_cron_time", scheduler_cron_time);
             }
             if resource_type == "ticket" {
                 if let Some(ref status) = new_status {

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -43,6 +43,7 @@ impl Default for LargeReportConfig {
 /// Known GMP commands that the mock server recognizes.
 pub static KNOWN_COMMANDS: &[&str] = &[
     "authenticate",
+    "create_agent_group",
     "create_alert",
     "create_asset",
     "create_config",
@@ -65,6 +66,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "create_ticket",
     "create_tls_certificate",
     "create_user",
+    "delete_agent_group",
     "delete_alert",
     "delete_asset",
     "delete_config",
@@ -88,6 +90,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "delete_user",
     "describe_auth",
     "empty_trashcan",
+    "get_agent_groups",
     "get_aggregates",
     "get_alerts",
     "get_assets",
@@ -123,6 +126,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "get_version",
     "get_vulns",
     "help",
+    "modify_agent_group",
     "modify_alert",
     "modify_asset",
     "modify_auth",

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -49,8 +49,12 @@ const GMP_22_6_COMMANDS: &[&str] = &[
 
 /// Commands only available in GMP 22.8+ / GMP Next.
 const GMP_22_8_COMMANDS: &[&str] = &[
+    "create_agent_group",
+    "delete_agent_group",
+    "get_agent_groups",
     "get_integration_configs",
     "modify_integration_config",
+    "modify_agent_group",
     "get_report_hosts",
     "get_report_ports",
     "get_report_applications",
@@ -172,5 +176,9 @@ mod tests {
             "get_credential_stores",
             GmpVersion::V22_8
         ));
+        assert!(!command_available("get_agent_groups", GmpVersion::V22_7));
+        assert!(command_available("get_agent_groups", GmpVersion::V22_8));
+        assert!(!command_available("create_agent_group", GmpVersion::V22_6));
+        assert!(command_available("create_agent_group", GmpVersion::V22_8));
     }
 }

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
-#![cfg(feature = "unix-socket-tests")]
 #![allow(
     clippy::print_stderr,
     clippy::print_stdout,
@@ -9,7 +8,9 @@
     clippy::unwrap_used,
     missing_docs
 )]
+#![cfg(feature = "unix-socket-tests")]
 
+use gvm_gmp::commands::agent_groups::{create_agent_group, get_agent_groups, CreateAgentGroupOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -199,6 +200,10 @@ async fn version_22_7_rejects_next_commands() {
         .unwrap()
         .contains("get_integration_configs"));
 
+    let response = send_recv(&mut stream, get_agent_groups(Default::default())).await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("get_agent_groups"));
+
     let response = send_recv(
         &mut stream,
         get_report_hosts(
@@ -234,6 +239,25 @@ async fn version_22_8_accepts_next_commands() {
         .as_str()
         .expect("utf8")
         .contains("Default Integration Config"));
+
+    let agent_group_response = send_recv(
+        &mut stream,
+        create_agent_group(
+            "Version Gated Agent Group",
+            &[id("agent-1")],
+            "0 */5 * * *",
+            CreateAgentGroupOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(agent_group_response.status_code(), Some(201));
+
+    let agent_groups_response = send_recv(&mut stream, get_agent_groups(Default::default())).await;
+    assert_eq!(agent_groups_response.status_code(), Some(200));
+    assert!(agent_groups_response
+        .as_str()
+        .expect("utf8")
+        .contains("Version Gated Agent Group"));
 
     let modify_response = send_recv(
         &mut stream,


### PR DESCRIPTION
## Summary

- add GMP Next `agent_groups` command builders for create, clone, get/list, modify, and delete
- expose agent-group helpers through the Next versioned client surface
- register the commands in client/mock-server 22.8 gating and mock echo/stateful handling
- add exact XML builder tests plus real Unix-socket mock-server lifecycle coverage

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp`
- `cargo test -p gvm-client --features unix-socket-tests`
- `cargo test -p gvm-mock-server --features unix-socket-tests`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `. .venv/bin/activate && python3 -B -m unittest tests.test_sbom_postprocess -q`
- `. .venv/bin/activate && make test-integration`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-agent-groups-semgrep.sarif`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --sarif --output /tmp/rust-gvm-agent-groups-changed-semgrep.sarif <changed files>`

Notes: `cargo deny check` reported only existing unmatched allowlist/advisory warnings; `cargo audit` reported the existing allowed yanked `crypto-bigint` warning; MSRV/default workspace tests still print existing cfg-gated integration-test missing-doc warnings outside this slice. Fuzzing was not run because this changes command builders/client dispatch/mock CRUD handling, not parser/framing/fuzz-facing behavior.
