### PR TITLE
feat(client): add report vulnerabilities alias

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -389,6 +389,15 @@ pub trait GmpNextCommands {
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError>;
 
+    /// Get report vulnerability summaries using python-gvm's descriptive helper name.
+    async fn get_report_vulnerabilities(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<Response, GvmError> {
+        self.get_report_vulns(report_id, opts).await
+    }
+
     /// Get report TLS certificate summaries.
     async fn get_report_tls_certificates(
         &mut self,

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -39,8 +39,8 @@ use gvm_gmp::commands::report_formats::{
 };
 use gvm_gmp::commands::reports::{
     get_report_closed_cves, get_report_errors, get_report_export, get_report_export_with_opts,
-    get_report_tls_certificates, get_report_vulns, get_reports, GetReportDetailsOpts,
-    GetReportExportOpts, GetReportsOpts,
+    get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns, get_reports,
+    GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -427,6 +427,22 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportVulnsResponse, GvmError> {
         let response = self.send(get_report_vulns(report_id, opts)).await?;
+        GetReportVulnsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_vulns` request using python-gvm's descriptive helper
+    /// name and return a typed [`GetReportVulnsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_vulnerabilities(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportVulnsResponse, GvmError> {
+        let response = self
+            .send(get_report_vulnerabilities(report_id, opts))
+            .await?;
         GetReportVulnsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -7,7 +7,7 @@
 use gvm_client::{GmpClient, GmpNextCommands, GmpVersioned, GvmError};
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::authentication::authenticate;
-use gvm_gmp::commands::reports::get_report_hosts;
+use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
 use gvm_gmp::commands::scan_configs::ConfigOpts;
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::system::get_timezones;
@@ -18,16 +18,6 @@ use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, s
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn socket_path() -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("gvmc-{}-{unique}.sock", std::process::id()))
-}
 
 async fn stateful_server() -> Option<MockGmpServer> {
     stateful_server_with_version(MockVersion::V22_5).await
@@ -37,7 +27,7 @@ async fn stateful_server_with_version(version: MockVersion) -> Option<MockGmpSer
     match MockGmpServer::builder()
         .mode(ServerMode::Stateful)
         .version(version)
-        .unix_socket(socket_path())
+        .unix_socket_auto()
         .build()
         .await
     {
@@ -50,7 +40,7 @@ async fn stateful_server_with_version(version: MockVersion) -> Option<MockGmpSer
 async fn fixture_server_with_version_response(version_xml: &str) -> Option<MockGmpServer> {
     match MockGmpServer::builder()
         .mode(ServerMode::Fixture)
-        .unix_socket(socket_path())
+        .unix_socket_auto()
         .override_response(
             "get_version",
             &format!(
@@ -70,7 +60,7 @@ async fn fixture_server(version: MockVersion) -> Option<MockGmpServer> {
     match MockGmpServer::builder()
         .mode(ServerMode::Fixture)
         .version(version)
-        .unix_socket(socket_path())
+        .unix_socket_auto()
         .build()
         .await
     {
@@ -295,6 +285,22 @@ async fn unsupported_next_command_rejected_before_send() {
     }
 
     let error = client
+        .call(get_report_vulnerabilities(
+            &EntityId::new("report-1").expect("valid id"),
+            Default::default(),
+        ))
+        .await
+        .expect_err("22.7 should reject report vulnerabilities alias");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == "get_report_vulns"
+    ));
+
+    let error = client
         .call(get_timezones())
         .await
         .expect_err("22.7 should reject get_timezones");
@@ -363,6 +369,12 @@ async fn next_commands_work_on_v22_8() {
         .expect_err("missing report should return server error");
     assert!(matches!(helper_error, GvmError::Server { status: 404, .. }));
 
+    let alias_error = client
+        .get_report_vulnerabilities(&report_id, Default::default())
+        .await
+        .expect_err("missing report should return server error through alias");
+    assert!(matches!(alias_error, GvmError::Server { status: 404, .. }));
+
     server.shutdown().await;
 }
 
@@ -384,6 +396,13 @@ async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
         .expect("report vulns should parse");
     assert_eq!(vulns.items.len(), 1);
     assert_eq!(vulns.items[0].severity.as_deref(), Some("8.2"));
+
+    let vulnerabilities = client
+        .get_report_vulnerabilities(&report_id, Default::default())
+        .await
+        .expect("report vulnerabilities alias should parse");
+    assert_eq!(vulnerabilities.items.len(), 1);
+    assert_eq!(vulnerabilities.items[0].severity.as_deref(), Some("8.2"));
 
     let tls = client
         .get_report_tls_certificates(&report_id, Default::default())

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -232,6 +232,15 @@ pub fn get_report_vulns(report_id: &EntityId, opts: GetReportDetailsOpts) -> imp
     get_report_detail_command("get_report_vulns", report_id, opts)
 }
 
+/// Build a `get_report_vulns` request using python-gvm's descriptive helper name.
+#[must_use]
+pub fn get_report_vulnerabilities(
+    report_id: &EntityId,
+    opts: GetReportDetailsOpts,
+) -> impl Request {
+    get_report_vulns(report_id, opts)
+}
+
 /// Build a `get_report_tls_certificates` request.
 #[must_use]
 pub fn get_report_tls_certificates(
@@ -354,6 +363,16 @@ mod tests {
         assert_eq!(
             xml(get_report_vulns(&id("r1"), GetReportDetailsOpts::default())),
             "<get_report_vulns details=\"1\" report_id=\"r1\"/>"
+        );
+        assert_eq!(
+            xml(get_report_vulnerabilities(
+                &id("r1"),
+                GetReportDetailsOpts {
+                    filter_string: Some("name=foo".into()),
+                    ..Default::default()
+                },
+            )),
+            "<get_report_vulns details=\"1\" filter=\"name=foo\" report_id=\"r1\"/>"
         );
         assert_eq!(
             xml(get_report_tls_certificates(


### PR DESCRIPTION
## Summary
- add `get_report_vulnerabilities` as a python-gvm-compatible alias for the existing `get_report_vulns` wire command
- expose the alias through the raw GMP Next trait as a provided default method and through the typed client API
- cover XML parity, GMP 22.7 pre-send rejection, GMP 22.8 raw client behavior, typed parsing, and replace the client integration socket helper with the mock server auto-socket helper

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp report_helper_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -m unittest tests/test_sbom_postprocess.py`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `semgrep --config p/rust --config p/security-audit --config p/secrets .`
- targeted Semgrep over the changed files

Known baseline warnings: workspace tests still emit existing cfg-gated integration-test missing-docs warnings; `cargo deny check` reports existing unmatched allowlist/advisory warnings; `cargo audit` reports the existing allowed yanked `crypto-bigint 0.7.4` warning. Fuzzing was not run because this change is a command-builder/client alias plus integration-test helper cleanup and does not touch parser, transport framing, streaming, or fuzz-facing logic.