### PR TITLE
docs(journal): add 2026-07-04 journal entry

### DIFF
--- a/journal/2026-07-04.md
+++ b/journal/2026-07-04.md
@@ -1,0 +1,24 @@
+# 2026-07-04 — Mainline Absorbed the Big GMP Parity Wave, Cut the 0.3.3 Release, and Still Left a Fast-Moving Devel Lane Behind It
+
+## Mainline & Release Work
+
+### The quiet 2026-05-14 baseline did not last; `main` turned into a long parity-and-hardening lane before shipping 0.3.3
+- The first visible step after the previous journal was PR #160 on 2026-05-18, which landed the integration-config and report-helper GMP parity work that the 2026-05-14 entry was teeing up.
+- From late May through mid-June, `main` kept stacking high-signal GMP and typed-client work: REST support gap helpers in PR #177, typed report export support in PR #200, enum and response-shape repairs in PRs #202, #205, #221, #227, #239, #240, and #252, task and metadata typing in PRs #207, #228, #230, and #232, plus command-surface expansion in PRs #210, #218, #220, #224, #235, #236, #244, #249, #258, and #261.
+- That lane then turned into release work instead of stalling. `main` restored branch protection in PR #265 on 2026-06-18, cut the automatic `0.3.3` release the same day, and immediately followed with two release-pipeline repair commits to artifact publishing and SBOM warning behavior.
+- The early-July follow-through stayed practical rather than flashy: PR #282 fixed report-export decoding, PR #283 consolidated dependency and security updates, PR #286 pulled in the `quick-xml` security release, PR #284 bumped `taiki-e/install-action`, and PR #287 aligned the MSRV with the newer SSH dependency stack.
+
+## Development Queue
+- The visible queue on GitHub is actually empty right now: there are no open pull requests waiting for review.
+- That does not mean development stopped. It means the July 3-4 burst merged fast into `devel` instead of accumulating backlog. PRs #288 through #309 added or refined resource-name alignment, redacted GMP wire tracing, restore helpers, secinfo and vulnerability helpers, policy and preference getters, report-format import helpers, operating-system and feed helpers, web-application and OCI image target commands, agent-group commands, report-config cloning, and a report-vulnerabilities alias.
+- So the repo now has a split personality in a healthy way: `main` already shipped a large parity tranche and the 0.3.3 release, while `devel` is still burning down the remaining surface area without leaving a review queue jam behind it.
+
+## Issues
+- The issue tracker spent this whole window converting parity gaps directly into fixes. Issues #190, #199, #201, #204, #206, #209, #217, #219, #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, #260, and #281 all opened and then closed within the same broader journal span as corresponding implementation work landed.
+- The sharpest recent example is issue #281 on report-export decoding, which opened on 2026-07-01 and closed the same day via PR #282.
+- Open product-facing gaps are now narrower than they were in May. The newer unresolved items are #247, #251, and #267, plus the broader roadmap tracker in #172.
+
+## CI Health
+- The current `main` signal is clean. The 2026-07-03 push that merged PR #287 passed `CI`, `Security`, and `OpenSSF Scorecard`.
+- The visible July parity burst on `devel` is clean too. Every surfaced PR run for that burst passed both `CI` and `Security`, despite the sheer number of fast back-to-back merges.
+- That matters because the repo is no longer just adding API surface. It is adding it quickly while still preserving a fully green validation story on both the shipped branch and the active parity lane.


### PR DESCRIPTION
## Summary
- add the 2026-07-04 journal entry
- summarize mainline, issue, queue, release, and CI activity since the 2026-05-14 baseline

Agent: Thoth