### PR TITLE
Add generic GMP asset command builders alongside typed wrappers

### DIFF
--- a/crates/gvm-gmp/src/commands/assets.rs
+++ b/crates/gvm-gmp/src/commands/assets.rs
@@ -102,8 +102,8 @@ pub fn get_assets(opts: GetAssetsOpts) -> impl Request {
     if let Some(asset_type) = opts.asset_type.as_ref() {
         cmd.set_attribute("asset_type", asset_type.as_gmp_str());
     }
-    if let Some(asset_type) = opts.type_.as_ref() {
-        cmd.set_attribute("type", asset_type.as_gmp_str());
+    if let Some(type_) = opts.type_.as_ref() {
+        cmd.set_attribute("type", type_.as_gmp_str());
     }
     add_filter_attrs(
         &mut cmd,

--- a/crates/gvm-gmp/src/commands/assets.rs
+++ b/crates/gvm-gmp/src/commands/assets.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Generic GMP asset command builders.
+
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::common::{add_filter_attrs, bool_str, set_optional_bool_attr};
+use crate::types::EntityId;
+
+/// Typed GMP asset type values.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AssetType {
+    /// Host assets.
+    Host,
+    /// Operating-system assets.
+    OperatingSystem,
+    /// Forward-compatible custom asset type.
+    Custom(String),
+}
+
+impl AssetType {
+    /// Build a custom/unknown asset type value.
+    #[must_use]
+    pub fn custom(value: impl Into<String>) -> Self {
+        Self::Custom(value.into())
+    }
+
+    /// Returns the GMP wire-format string for this value.
+    #[must_use]
+    pub fn as_gmp_str(&self) -> &str {
+        match self {
+            Self::Host => "host",
+            Self::OperatingSystem => "os",
+            Self::Custom(value) => value.as_str(),
+        }
+    }
+}
+
+/// Optional fields for `create_asset` requests.
+#[derive(Debug, Clone)]
+pub struct CreateAssetOpts {
+    /// Asset type to create.
+    pub asset_type: AssetType,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional free-form value payload.
+    pub value: Option<String>,
+}
+
+/// Options for `get_assets` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetAssetsOpts {
+    /// Optional asset identifier.
+    pub asset_id: Option<EntityId>,
+    /// Optional `asset_type` attribute.
+    pub asset_type: Option<AssetType>,
+    /// Optional `type` attribute.
+    pub type_: Option<AssetType>,
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether to query trashcan resources.
+    pub trash: Option<bool>,
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+}
+
+/// Optional fields for `modify_asset` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyAssetOpts {
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional free-form value payload.
+    pub value: Option<String>,
+}
+
+/// Optional fields for `delete_asset` requests.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteAssetOpts {
+    /// Whether to permanently delete the asset.
+    pub ultimate: Option<bool>,
+}
+
+/// Build a generic `create_asset` request.
+#[must_use]
+pub fn create_asset(opts: CreateAssetOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("create_asset");
+    cmd.add_element_with_text("asset_type", opts.asset_type.as_gmp_str());
+    add_asset_body(&mut cmd, &opts.comment, &opts.value);
+    cmd
+}
+
+/// Build a generic `get_assets` request.
+#[must_use]
+pub fn get_assets(opts: GetAssetsOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_assets");
+    if let Some(asset_id) = opts.asset_id.as_ref() {
+        cmd.set_attribute("asset_id", asset_id.as_str());
+    }
+    if let Some(asset_type) = opts.asset_type.as_ref() {
+        cmd.set_attribute("asset_type", asset_type.as_gmp_str());
+    }
+    if let Some(asset_type) = opts.type_.as_ref() {
+        cmd.set_attribute("type", asset_type.as_gmp_str());
+    }
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "trash", opts.trash);
+    set_optional_bool_attr(&mut cmd, "details", opts.details);
+    cmd
+}
+
+/// Build a generic `modify_asset` request.
+#[must_use]
+pub fn modify_asset(asset_id: &EntityId, opts: ModifyAssetOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("modify_asset").attribute("asset_id", asset_id.as_str());
+    add_asset_body(&mut cmd, &opts.comment, &opts.value);
+    cmd
+}
+
+/// Build a generic `delete_asset` request.
+#[must_use]
+pub fn delete_asset(asset_id: &EntityId, opts: DeleteAssetOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("delete_asset").attribute("asset_id", asset_id.as_str());
+    if let Some(ultimate) = opts.ultimate {
+        cmd.set_attribute("ultimate", bool_str(ultimate));
+    }
+    cmd
+}
+
+fn add_asset_body(cmd: &mut XmlCommand, comment: &Option<String>, value: &Option<String>) {
+    if let Some(comment) = comment {
+        cmd.add_element_with_text("comment", comment);
+    }
+    if let Some(value) = value {
+        cmd.add_element_with_text("value", value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::xml;
+
+    fn id(value: &str) -> EntityId {
+        EntityId::new(value).expect("valid id")
+    }
+
+    #[test]
+    fn asset_type_maps_to_wire_values() {
+        assert_eq!(AssetType::Host.as_gmp_str(), "host");
+        assert_eq!(AssetType::OperatingSystem.as_gmp_str(), "os");
+        assert_eq!(AssetType::custom("firmware").as_gmp_str(), "firmware");
+    }
+
+    #[test]
+    fn create_asset_builds_xml() {
+        assert_eq!(
+            xml(create_asset(CreateAssetOpts {
+                asset_type: AssetType::Host,
+                comment: Some("c".into()),
+                value: Some("1.1.1.1".into()),
+            })),
+            "<create_asset><asset_type>host</asset_type><comment>c</comment><value>1.1.1.1</value></create_asset>"
+        );
+    }
+
+    #[test]
+    fn get_assets_builds_xml() {
+        assert_eq!(
+            xml(get_assets(GetAssetsOpts {
+                asset_id: Some(id("a1")),
+                asset_type: Some(AssetType::Host),
+                type_: Some(AssetType::custom("firmware")),
+                filter_string: Some("name=foo".into()),
+                filter_id: Some(id("f1")),
+                trash: Some(true),
+                details: Some(false),
+            })),
+            "<get_assets asset_id=\"a1\" asset_type=\"host\" details=\"0\" filt_id=\"f1\" filter=\"name=foo\" trash=\"1\" type=\"firmware\"/>"
+        );
+    }
+
+    #[test]
+    fn modify_delete_asset_build_xml() {
+        assert_eq!(
+            xml(modify_asset(
+                &id("a1"),
+                ModifyAssetOpts {
+                    comment: Some("updated".into()),
+                    value: Some("v".into()),
+                },
+            )),
+            "<modify_asset asset_id=\"a1\"><comment>updated</comment><value>v</value></modify_asset>"
+        );
+        assert_eq!(
+            xml(delete_asset(
+                &id("a1"),
+                DeleteAssetOpts {
+                    ultimate: Some(true),
+                },
+            )),
+            "<delete_asset asset_id=\"a1\" ultimate=\"1\"/>"
+        );
+        assert_eq!(
+            xml(delete_asset(&id("a1"), DeleteAssetOpts::default())),
+            "<delete_asset asset_id=\"a1\"/>"
+        );
+    }
+}

--- a/crates/gvm-gmp/src/commands/assets.rs
+++ b/crates/gvm-gmp/src/commands/assets.rs
@@ -5,7 +5,7 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
-use crate::common::{add_filter_attrs, bool_str, set_optional_bool_attr};
+use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
 use crate::types::EntityId;
 
 /// Typed GMP asset type values.
@@ -134,12 +134,8 @@ pub fn delete_asset(asset_id: &EntityId, opts: DeleteAssetOpts) -> impl Request 
 }
 
 fn add_asset_body(cmd: &mut XmlCommand, comment: &Option<String>, value: &Option<String>) {
-    if let Some(comment) = comment {
-        cmd.add_element_with_text("comment", comment);
-    }
-    if let Some(value) = value {
-        cmd.add_element_with_text("value", value);
-    }
+    add_text_element(cmd, "comment", comment.as_deref());
+    add_text_element(cmd, "value", value.as_deref());
 }
 
 #[cfg(test)]
@@ -171,6 +167,18 @@ mod tests {
     }
 
     #[test]
+    fn create_asset_skips_empty_optional_text() {
+        assert_eq!(
+            xml(create_asset(CreateAssetOpts {
+                asset_type: AssetType::Host,
+                comment: Some(String::new()),
+                value: Some(String::new()),
+            })),
+            "<create_asset><asset_type>host</asset_type></create_asset>"
+        );
+    }
+
+    #[test]
     fn get_assets_builds_xml() {
         assert_eq!(
             xml(get_assets(GetAssetsOpts {
@@ -197,6 +205,16 @@ mod tests {
                 },
             )),
             "<modify_asset asset_id=\"a1\"><comment>updated</comment><value>v</value></modify_asset>"
+        );
+        assert_eq!(
+            xml(modify_asset(
+                &id("a1"),
+                ModifyAssetOpts {
+                    comment: Some(String::new()),
+                    value: Some(String::new()),
+                },
+            )),
+            "<modify_asset asset_id=\"a1\"/>"
         );
         assert_eq!(
             xml(delete_asset(

--- a/crates/gvm-gmp/src/commands/hosts.rs
+++ b/crates/gvm-gmp/src/commands/hosts.rs
@@ -38,8 +38,8 @@ pub struct GetHostsOpts {
 pub fn create_host(opts: HostOpts) -> impl Request {
     create_asset(CreateAssetOpts {
         asset_type: AssetType::Host,
-        comment: normalize_optional_text(opts.comment),
-        value: normalize_optional_text(opts.value),
+        comment: opts.comment,
+        value: opts.value,
     })
 }
 
@@ -75,8 +75,8 @@ pub fn modify_host(host_id: &EntityId, opts: HostOpts) -> impl Request {
     modify_asset(
         host_id,
         ModifyAssetOpts {
-            comment: normalize_optional_text(opts.comment),
-            value: normalize_optional_text(opts.value),
+            comment: opts.comment,
+            value: opts.value,
         },
     )
 }
@@ -90,10 +90,6 @@ pub fn delete_host(host_id: &EntityId, ultimate: bool) -> impl Request {
             ultimate: Some(ultimate),
         },
     )
-}
-
-fn normalize_optional_text(value: Option<String>) -> Option<String> {
-    value.filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/gvm-gmp/src/commands/hosts.rs
+++ b/crates/gvm-gmp/src/commands/hosts.rs
@@ -3,9 +3,12 @@
 
 //! Host command builders.
 
-use gvm_protocol::{Request, XmlCommand};
+use gvm_protocol::Request;
 
-use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::commands::assets::{
+    create_asset, delete_asset, get_assets, modify_asset, AssetType, CreateAssetOpts,
+    DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
+};
 use crate::types::EntityId;
 
 /// Optional fields for host create and modify requests.
@@ -33,57 +36,64 @@ pub struct GetHostsOpts {
 /// Build a `create_host` request.
 #[must_use]
 pub fn create_host(opts: HostOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("create_asset");
-    cmd.add_element_with_text("asset_type", "host");
-    add_host_body(&mut cmd, &opts);
-    cmd
+    create_asset(CreateAssetOpts {
+        asset_type: AssetType::Host,
+        comment: normalize_optional_text(opts.comment),
+        value: normalize_optional_text(opts.value),
+    })
 }
 
 /// Build a `get_hosts` request.
 #[must_use]
 pub fn get_hosts(opts: GetHostsOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("get_assets")
-        .attribute("asset_type", "host")
-        .attribute("type", "host");
-    add_filter_attrs(
-        &mut cmd,
-        opts.filter_string.as_deref(),
-        opts.filter_id.as_ref(),
-    );
-    set_optional_bool_attr(&mut cmd, "trash", opts.trash);
-    set_optional_bool_attr(&mut cmd, "details", opts.details);
-    cmd
+    get_assets(GetAssetsOpts {
+        asset_type: Some(AssetType::Host),
+        type_: Some(AssetType::Host),
+        filter_string: opts.filter_string,
+        filter_id: opts.filter_id,
+        trash: opts.trash,
+        details: opts.details,
+        ..Default::default()
+    })
 }
 
 /// Build a `get_host` request.
 #[must_use]
 pub fn get_host(host_id: &EntityId) -> impl Request {
-    XmlCommand::new("get_assets")
-        .attribute("asset_id", host_id.as_str())
-        .attribute("asset_type", "host")
-        .attribute("type", "host")
-        .attribute("details", "1")
+    get_assets(GetAssetsOpts {
+        asset_id: Some(host_id.clone()),
+        asset_type: Some(AssetType::Host),
+        type_: Some(AssetType::Host),
+        details: Some(true),
+        ..Default::default()
+    })
 }
 
 /// Build a `modify_host` request.
 #[must_use]
 pub fn modify_host(host_id: &EntityId, opts: HostOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("modify_asset").attribute("asset_id", host_id.as_str());
-    add_host_body(&mut cmd, &opts);
-    cmd
+    modify_asset(
+        host_id,
+        ModifyAssetOpts {
+            comment: normalize_optional_text(opts.comment),
+            value: normalize_optional_text(opts.value),
+        },
+    )
 }
 
 /// Build a `delete_host` request.
 #[must_use]
 pub fn delete_host(host_id: &EntityId, ultimate: bool) -> impl Request {
-    XmlCommand::new("delete_asset")
-        .attribute("asset_id", host_id.as_str())
-        .attribute("ultimate", bool_str(ultimate))
+    delete_asset(
+        host_id,
+        DeleteAssetOpts {
+            ultimate: Some(ultimate),
+        },
+    )
 }
 
-fn add_host_body(cmd: &mut XmlCommand, opts: &HostOpts) {
-    add_text_element(cmd, "comment", opts.comment.as_deref());
-    add_text_element(cmd, "value", opts.value.as_deref());
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/gvm-gmp/src/commands/mod.rs
+++ b/crates/gvm-gmp/src/commands/mod.rs
@@ -9,6 +9,8 @@ pub mod agent_groups;
 pub mod aggregates;
 /// Alert command builders.
 pub mod alerts;
+/// Generic asset command builders.
+pub mod assets;
 /// Authentication command builders.
 pub mod authentication;
 /// Credential command builders.

--- a/crates/gvm-gmp/src/commands/operating_systems.rs
+++ b/crates/gvm-gmp/src/commands/operating_systems.rs
@@ -5,7 +5,9 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
-use crate::common::{add_filter_attrs, set_optional_bool_attr};
+use crate::commands::assets::{
+    delete_asset, get_assets, AssetType, DeleteAssetOpts, GetAssetsOpts,
+};
 use crate::types::EntityId;
 
 /// Options for `get_operating_systems` requests.
@@ -22,24 +24,24 @@ pub struct GetOperatingSystemsOpts {
 /// Build a `get_operating_systems` request.
 #[must_use]
 pub fn get_operating_systems(opts: GetOperatingSystemsOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("get_assets").attribute("type", "os");
-    add_filter_attrs(
-        &mut cmd,
-        opts.filter_string.as_deref(),
-        opts.filter_id.as_ref(),
-    );
-    set_optional_bool_attr(&mut cmd, "details", opts.details);
-    cmd
+    get_assets(GetAssetsOpts {
+        type_: Some(AssetType::OperatingSystem),
+        filter_string: opts.filter_string,
+        filter_id: opts.filter_id,
+        details: opts.details,
+        ..Default::default()
+    })
 }
 
 /// Build a `get_operating_system` request.
 #[must_use]
 pub fn get_operating_system(operating_system_id: &EntityId, details: Option<bool>) -> impl Request {
-    let mut cmd = XmlCommand::new("get_assets")
-        .attribute("asset_id", operating_system_id.as_str())
-        .attribute("type", "os");
-    set_optional_bool_attr(&mut cmd, "details", details);
-    cmd
+    get_assets(GetAssetsOpts {
+        asset_id: Some(operating_system_id.clone()),
+        type_: Some(AssetType::OperatingSystem),
+        details,
+        ..Default::default()
+    })
 }
 
 /// Build a `modify_operating_system` request.
@@ -57,7 +59,7 @@ pub fn modify_operating_system(
 /// Build a `delete_operating_system` request.
 #[must_use]
 pub fn delete_operating_system(operating_system_id: &EntityId) -> impl Request {
-    XmlCommand::new("delete_asset").attribute("asset_id", operating_system_id.as_str())
+    delete_asset(operating_system_id, DeleteAssetOpts::default())
 }
 
 #[cfg(test)]

--- a/crates/gvm-gmp/tests/test_assets.rs
+++ b/crates/gvm-gmp/tests/test_assets.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+mod common;
+
+use common::{id, xml};
+use gvm_gmp::commands::assets::*;
+use gvm_gmp::commands::hosts::{
+    create_host, delete_host, get_host, get_hosts, modify_host, HostOpts,
+};
+use gvm_gmp::commands::operating_systems::{
+    delete_operating_system, get_operating_system, get_operating_systems, modify_operating_system,
+    GetOperatingSystemsOpts,
+};
+
+#[test]
+fn test_create_asset_xml() {
+    assert_eq!(
+        xml(create_asset(CreateAssetOpts {
+            asset_type: AssetType::Host,
+            comment: Some("c".into()),
+            value: Some("1.1.1.1".into()),
+        })),
+        "<create_asset><asset_type>host</asset_type><comment>c</comment><value>1.1.1.1</value></create_asset>"
+    );
+}
+
+#[test]
+fn test_get_assets_with_custom_type_xml() {
+    assert_eq!(
+        xml(get_assets(GetAssetsOpts {
+            type_: Some(AssetType::custom("firmware")),
+            details: Some(true),
+            ..Default::default()
+        })),
+        "<get_assets details=\"1\" type=\"firmware\"/>"
+    );
+}
+
+#[test]
+fn test_modify_delete_asset_xml() {
+    assert_eq!(
+        xml(modify_asset(
+            &id("a1"),
+            ModifyAssetOpts {
+                comment: Some("updated".into()),
+                value: Some("v".into()),
+            },
+        )),
+        "<modify_asset asset_id=\"a1\"><comment>updated</comment><value>v</value></modify_asset>"
+    );
+    assert_eq!(
+        xml(delete_asset(
+            &id("a1"),
+            DeleteAssetOpts {
+                ultimate: Some(false),
+            },
+        )),
+        "<delete_asset asset_id=\"a1\" ultimate=\"0\"/>"
+    );
+}
+
+#[test]
+fn test_host_wrappers_match_generic_xml() {
+    let create_opts = HostOpts {
+        comment: Some("c".into()),
+        value: Some("1.1.1.1".into()),
+    };
+    assert_eq!(
+        xml(create_host(create_opts.clone())),
+        xml(create_asset(CreateAssetOpts {
+            asset_type: AssetType::Host,
+            comment: create_opts.comment.clone(),
+            value: create_opts.value.clone(),
+        }))
+    );
+
+    assert_eq!(
+        xml(get_host(&id("h1"))),
+        xml(get_assets(GetAssetsOpts {
+            asset_id: Some(id("h1")),
+            asset_type: Some(AssetType::Host),
+            type_: Some(AssetType::Host),
+            details: Some(true),
+            ..Default::default()
+        }))
+    );
+
+    assert_eq!(
+        xml(modify_host(&id("h1"), create_opts.clone())),
+        xml(modify_asset(
+            &id("h1"),
+            ModifyAssetOpts {
+                comment: create_opts.comment,
+                value: create_opts.value,
+            },
+        ))
+    );
+    assert_eq!(
+        xml(delete_host(&id("h1"), true)),
+        xml(delete_asset(
+            &id("h1"),
+            DeleteAssetOpts {
+                ultimate: Some(true),
+            },
+        ))
+    );
+}
+
+#[test]
+fn test_operating_system_wrapper_xml_regression() {
+    assert_eq!(
+        xml(get_operating_systems(GetOperatingSystemsOpts {
+            filter_string: Some("name=Debian".into()),
+            filter_id: Some(id("f1")),
+            details: Some(true),
+        })),
+        "<get_assets details=\"1\" filt_id=\"f1\" filter=\"name=Debian\" type=\"os\"/>"
+    );
+    assert_eq!(
+        xml(get_operating_system(&id("os1"), Some(false))),
+        "<get_assets asset_id=\"os1\" details=\"0\" type=\"os\"/>"
+    );
+    assert_eq!(
+        xml(modify_operating_system(&id("os1"), None)),
+        "<modify_asset asset_id=\"os1\"><comment></comment></modify_asset>"
+    );
+    assert_eq!(
+        xml(delete_operating_system(&id("os1"))),
+        "<delete_asset asset_id=\"os1\"/>"
+    );
+}
+
+#[test]
+fn test_get_hosts_wrapper_regression() {
+    assert_eq!(
+        xml(get_hosts(Default::default())),
+        "<get_assets asset_type=\"host\" type=\"host\"/>"
+    );
+}


### PR DESCRIPTION
## Summary
- add generic `create_asset`, `get_assets`, `modify_asset`, and `delete_asset` command builders in `gvm_gmp::commands::assets`
- keep existing typed host/operating-system helpers source-compatible, while reusing generic builders where XML behavior stays identical
- add generic asset XML serialization tests, wrapper-equivalence checks, and wrapper regression coverage

## Notes
- this change is intentionally limited to generic command builders and XML behavior
- generic response parsing is **not** added in this pass; existing typed host/operating-system response parsing remains unchanged

Closes #311