### PR TITLE
docs(journal): add 2026-07-05 journal entry

### DIFF
--- a/journal/2026-07-05.md
+++ b/journal/2026-07-05.md
@@ -1,0 +1,22 @@
+# 2026-07-05 — Mainline Finished the 0.3.3 Follow-Through While `devel` Kept Burning Down the Remaining GMP Surface
+
+## Mainline & Release Work
+
+### The local journal still stopped at 2026-05-14, but `main` did not stay quiet after that baseline
+- The first follow-on merge was PR #160 on 2026-05-18, which landed the integration-config and report-helper GMP parity work that the previous local entry had been setting up.
+- From late May through mid-June, `main` kept absorbing high-signal typed GMP work instead of isolated maintenance: REST support gap helpers in PR #177, typed report export support in PR #200, response-shape and enum repairs in PRs #202, #205, #221, #227, #239, #240, and #252, plus wider command and metadata coverage in PRs #207, #210, #218, #220, #224, #228, #230, #232, #235, #236, #244, #249, #258, and #261.
+- That lane turned into release work instead of stalling. `main` restored branch protection in PR #265, cut the automatic `0.3.3` release, and then spent early July on practical follow-through: PR #282 fixed report-export decoding, PR #283 consolidated dependency and security updates, PR #286 pulled in the `quick-xml` security release, and PR #287 aligned the MSRV with the newer SSH dependency stack.
+
+## Development Queue
+- The queue is no longer empty. PR #312 opened on 2026-07-05 to add generic GMP asset command builders alongside the typed wrappers, and PR #310 is still carrying the unmerged 2026-07-04 journal entry.
+- That is a much smaller visible queue than the amount of implementation work suggests because a large July 3-5 burst merged directly through `devel` rather than piling up review backlog. The still-open issues and fast PR traffic show the remaining parity work moved from broad missing surfaces into narrower asset/config coverage, mock-server fidelity, and `devel` branch automation.
+
+## Issues
+- The issue tracker converted a long list of parity gaps directly into fixes during this window. Issues #190, #199, #201, #204, #206, #209, #217, #219, #223, #225, #226, #229, #231, #233, #234, #237, #238, #242, #248, #250, #256, #257, #260, and #281 all opened and then closed as the corresponding implementation landed.
+- The newest open issue cluster on 2026-07-05 is narrower and more specific: #311 and #313 target generic asset/config command exposure, #314 tracks `devel` PR validation, and #316 through #318 focus on mock-server statefulness, parity guards, and command-coverage classification.
+- That leaves the repo in a better place than the local journal suggested. The broad GMP parity backlog has been substantially reduced, and the remaining work is now mostly refinement and completeness work instead of foundational missing support.
+
+## CI Health
+- The shipped branch is currently clean. The 2026-07-03 `main` push that merged PR #287 passed `CI`, `Security`, and `OpenSSF Scorecard`, and the 2026-07-05 scheduled `OpenSSF Scorecard` run stayed green.
+- The active forward lane is mostly clean too. The visible `devel` and PR runs in this window passed `CI` and `Security`, including the new `fix/devel-pr-ci` validation on 2026-07-05.
+- The only fresh noise in the broader run history is maintenance churn rather than product instability: one `Security` run and one `Dependabot Updates` run failed in the middle of an otherwise green run set before the later dependency fixes landed.


### PR DESCRIPTION
## Summary
- add the 2026-07-05 journal entry
- capture activity since the last locally present journal entry

## Testing
- not run (journal-only update)