### PR TITLE
Add generic GMP config command builders

### DIFF
--- a/crates/gvm-gmp/src/commands/configs.rs
+++ b/crates/gvm-gmp/src/commands/configs.rs
@@ -124,9 +124,9 @@ impl Default for GetConfigOpts {
 /// Options for `modify_config` requests.
 #[derive(Debug, Clone, Default)]
 pub struct ModifyConfigOpts {
-    /// Optional config name.
+    /// Optional config name. `Some("")` emits an empty element to clear it.
     pub name: Option<String>,
-    /// Optional comment text included in the request.
+    /// Optional comment text included in the request. `Some("")` emits an empty element to clear it.
     pub comment: Option<String>,
     /// Optional config usage type.
     pub usage_type: Option<ConfigUsageType>,
@@ -200,8 +200,8 @@ pub fn get_config(config_id: &EntityId, opts: GetConfigOpts) -> impl Request {
 #[must_use]
 pub fn modify_config(config_id: &EntityId, opts: ModifyConfigOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_config").attribute("config_id", config_id.as_str());
-    add_text_element(&mut cmd, "name", opts.name.as_deref());
-    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_modify_text_element(&mut cmd, "name", opts.name.as_deref());
+    add_modify_text_element(&mut cmd, "comment", opts.comment.as_deref());
     add_usage_type_element(&mut cmd, opts.usage_type.as_ref());
     cmd
 }
@@ -217,6 +217,12 @@ pub fn delete_config(config_id: &EntityId, opts: DeleteConfigOpts) -> impl Reque
 fn add_usage_type_element(cmd: &mut XmlCommand, usage_type: Option<&ConfigUsageType>) {
     if let Some(usage_type) = usage_type {
         add_text_element(cmd, "usage_type", Some(usage_type.as_gmp_str()));
+    }
+}
+
+fn add_modify_text_element(cmd: &mut XmlCommand, name: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        cmd.add_element_with_text(name, value);
     }
 }
 
@@ -320,6 +326,17 @@ mod tests {
                 },
             )),
             "<modify_config config_id=\"c1\"><name>renamed</name><comment>updated</comment><usage_type>policy</usage_type></modify_config>"
+        );
+        assert_eq!(
+            xml(modify_config(
+                &id("c1"),
+                ModifyConfigOpts {
+                    name: Some(String::new()),
+                    comment: Some(String::new()),
+                    ..Default::default()
+                },
+            )),
+            "<modify_config config_id=\"c1\"><name></name><comment></comment></modify_config>"
         );
         assert_eq!(
             xml(delete_config(

--- a/crates/gvm-gmp/src/commands/configs.rs
+++ b/crates/gvm-gmp/src/commands/configs.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Generic GMP config command builders.
+
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::common::{add_filter_attrs, add_text_element, set_optional_bool_attr};
+use crate::types::EntityId;
+
+/// Typed GMP config usage-type values.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ConfigUsageType {
+    /// Standard scan configs.
+    Scan,
+    /// Policy configs.
+    Policy,
+    /// Forward-compatible custom usage type.
+    Custom(String),
+}
+
+impl ConfigUsageType {
+    /// Build a custom/unknown config usage-type value.
+    #[must_use]
+    pub fn custom(value: impl Into<String>) -> Self {
+        Self::Custom(value.into())
+    }
+
+    /// Returns the GMP wire-format string for this value.
+    #[must_use]
+    pub fn as_gmp_str(&self) -> &str {
+        match self {
+            Self::Scan => "scan",
+            Self::Policy => "policy",
+            Self::Custom(value) => value.as_str(),
+        }
+    }
+}
+
+/// Options for `clone_config` requests.
+#[derive(Debug, Clone, Default)]
+pub struct CloneConfigOpts {
+    /// Optional cloned config name.
+    pub name: Option<String>,
+}
+
+/// Options for `create_config` requests.
+#[derive(Debug, Clone)]
+pub struct CreateConfigOpts {
+    /// Config name.
+    pub name: String,
+    /// Optional base config identifier to copy.
+    pub base_id: Option<EntityId>,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional config usage type.
+    pub usage_type: Option<ConfigUsageType>,
+}
+
+/// Options for `get_configs` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetConfigsOpts {
+    /// Optional config identifier.
+    pub config_id: Option<EntityId>,
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether to query trashcan resources.
+    pub trash: Option<bool>,
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+    /// Whether to include families.
+    pub families: Option<bool>,
+    /// Whether to include preferences.
+    pub preferences: Option<bool>,
+    /// Whether to include tasks/audits using this config.
+    pub tasks: Option<bool>,
+    /// Optional config usage type.
+    pub usage_type: Option<ConfigUsageType>,
+}
+
+/// Options for singular `get_config` requests.
+#[derive(Debug, Clone)]
+pub struct GetConfigOpts {
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+    /// Whether to include families.
+    pub families: Option<bool>,
+    /// Whether to include preferences.
+    pub preferences: Option<bool>,
+    /// Whether to include tasks/audits using this config.
+    pub tasks: Option<bool>,
+    /// Optional config usage type.
+    pub usage_type: Option<ConfigUsageType>,
+}
+
+impl Default for GetConfigOpts {
+    fn default() -> Self {
+        Self {
+            details: Some(true),
+            families: None,
+            preferences: None,
+            tasks: None,
+            usage_type: None,
+        }
+    }
+}
+
+/// Options for `modify_config` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyConfigOpts {
+    /// Optional config name.
+    pub name: Option<String>,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional config usage type.
+    pub usage_type: Option<ConfigUsageType>,
+}
+
+/// Options for `delete_config` requests.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteConfigOpts {
+    /// Whether to permanently delete the config.
+    pub ultimate: Option<bool>,
+}
+
+/// Build a generic clone request for an existing config.
+#[must_use]
+pub fn clone_config(config_id: &EntityId, opts: CloneConfigOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("create_config");
+    cmd.add_element_with_text("copy", config_id.as_str());
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
+    cmd
+}
+
+/// Build a generic `create_config` request.
+#[must_use]
+pub fn create_config(opts: CreateConfigOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("create_config");
+    cmd.add_element_with_text("name", &opts.name);
+    if let Some(base_id) = opts.base_id.as_ref() {
+        cmd.add_element_with_text("copy", base_id.as_str());
+    }
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_usage_type_element(&mut cmd, opts.usage_type.as_ref());
+    cmd
+}
+
+/// Build a generic `get_configs` request.
+#[must_use]
+pub fn get_configs(opts: GetConfigsOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_configs");
+    if let Some(config_id) = opts.config_id.as_ref() {
+        cmd.set_attribute("config_id", config_id.as_str());
+    }
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "trash", opts.trash);
+    set_optional_bool_attr(&mut cmd, "details", opts.details);
+    set_optional_bool_attr(&mut cmd, "families", opts.families);
+    set_optional_bool_attr(&mut cmd, "preferences", opts.preferences);
+    set_optional_bool_attr(&mut cmd, "tasks", opts.tasks);
+    if let Some(usage_type) = opts.usage_type.as_ref() {
+        cmd.set_attribute("usage_type", usage_type.as_gmp_str());
+    }
+    cmd
+}
+
+/// Build a generic singular `get_configs` request for one config.
+#[must_use]
+pub fn get_config(config_id: &EntityId, opts: GetConfigOpts) -> impl Request {
+    get_configs(GetConfigsOpts {
+        config_id: Some(config_id.clone()),
+        details: opts.details,
+        families: opts.families,
+        preferences: opts.preferences,
+        tasks: opts.tasks,
+        usage_type: opts.usage_type,
+        ..Default::default()
+    })
+}
+
+/// Build a generic `modify_config` request.
+#[must_use]
+pub fn modify_config(config_id: &EntityId, opts: ModifyConfigOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("modify_config").attribute("config_id", config_id.as_str());
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_usage_type_element(&mut cmd, opts.usage_type.as_ref());
+    cmd
+}
+
+/// Build a generic `delete_config` request.
+#[must_use]
+pub fn delete_config(config_id: &EntityId, opts: DeleteConfigOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("delete_config").attribute("config_id", config_id.as_str());
+    set_optional_bool_attr(&mut cmd, "ultimate", opts.ultimate);
+    cmd
+}
+
+fn add_usage_type_element(cmd: &mut XmlCommand, usage_type: Option<&ConfigUsageType>) {
+    if let Some(usage_type) = usage_type {
+        add_text_element(cmd, "usage_type", Some(usage_type.as_gmp_str()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::xml;
+
+    fn id(value: &str) -> EntityId {
+        EntityId::new(value).expect("valid id")
+    }
+
+    #[test]
+    fn config_usage_type_maps_to_wire_values() {
+        assert_eq!(ConfigUsageType::Scan.as_gmp_str(), "scan");
+        assert_eq!(ConfigUsageType::Policy.as_gmp_str(), "policy");
+        assert_eq!(ConfigUsageType::custom("audit").as_gmp_str(), "audit");
+    }
+
+    #[test]
+    fn clone_create_config_build_xml() {
+        assert_eq!(
+            xml(clone_config(
+                &id("c1"),
+                CloneConfigOpts {
+                    name: Some("copy".into()),
+                },
+            )),
+            "<create_config><copy>c1</copy><name>copy</name></create_config>"
+        );
+        assert_eq!(
+            xml(create_config(CreateConfigOpts {
+                name: "cfg".into(),
+                base_id: Some(id("base1")),
+                comment: Some("c".into()),
+                usage_type: Some(ConfigUsageType::Scan),
+            })),
+            "<create_config><name>cfg</name><copy>base1</copy><comment>c</comment><usage_type>scan</usage_type></create_config>"
+        );
+    }
+
+    #[test]
+    fn get_config_variants_build_xml() {
+        assert_eq!(
+            xml(get_configs(GetConfigsOpts {
+                filter_string: Some("name=foo".into()),
+                filter_id: Some(id("f1")),
+                trash: Some(false),
+                details: Some(true),
+                families: Some(true),
+                preferences: Some(false),
+                tasks: Some(true),
+                usage_type: Some(ConfigUsageType::custom("policy")),
+                ..Default::default()
+            })),
+            "<get_configs details=\"1\" families=\"1\" filt_id=\"f1\" filter=\"name=foo\" preferences=\"0\" tasks=\"1\" trash=\"0\" usage_type=\"policy\"/>"
+        );
+        assert_eq!(
+            xml(get_config(
+                &id("c1"),
+                GetConfigOpts {
+                    usage_type: Some(ConfigUsageType::Policy),
+                    tasks: Some(true),
+                    ..Default::default()
+                },
+            )),
+            "<get_configs config_id=\"c1\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>"
+        );
+    }
+
+    #[test]
+    fn modify_delete_config_build_xml() {
+        assert_eq!(
+            xml(modify_config(
+                &id("c1"),
+                ModifyConfigOpts {
+                    name: Some("renamed".into()),
+                    comment: Some("updated".into()),
+                    usage_type: Some(ConfigUsageType::Policy),
+                },
+            )),
+            "<modify_config config_id=\"c1\"><name>renamed</name><comment>updated</comment><usage_type>policy</usage_type></modify_config>"
+        );
+        assert_eq!(
+            xml(delete_config(
+                &id("c1"),
+                DeleteConfigOpts {
+                    ultimate: Some(true),
+                },
+            )),
+            "<delete_config config_id=\"c1\" ultimate=\"1\"/>"
+        );
+        assert_eq!(
+            xml(delete_config(&id("c1"), DeleteConfigOpts::default())),
+            "<delete_config config_id=\"c1\"/>"
+        );
+    }
+}

--- a/crates/gvm-gmp/src/commands/configs.rs
+++ b/crates/gvm-gmp/src/commands/configs.rs
@@ -164,9 +164,7 @@ pub fn get_configs(opts: GetConfigsOpts) -> impl Request {
     set_optional_bool_attr(&mut cmd, "families", opts.families);
     set_optional_bool_attr(&mut cmd, "preferences", opts.preferences);
     set_optional_bool_attr(&mut cmd, "tasks", opts.tasks);
-    if let Some(usage_type) = opts.usage_type.as_ref() {
-        cmd.set_attribute("usage_type", usage_type.as_gmp_str());
-    }
+    set_usage_type_attr(&mut cmd, opts.usage_type.as_ref());
     cmd
 }
 
@@ -205,6 +203,15 @@ pub fn delete_config(config_id: &EntityId, opts: DeleteConfigOpts) -> impl Reque
 fn add_usage_type_element(cmd: &mut XmlCommand, usage_type: Option<&ConfigUsageType>) {
     if let Some(usage_type) = usage_type {
         add_text_element(cmd, "usage_type", Some(usage_type.as_gmp_str()));
+    }
+}
+
+fn set_usage_type_attr(cmd: &mut XmlCommand, usage_type: Option<&ConfigUsageType>) {
+    if let Some(value) = usage_type
+        .map(ConfigUsageType::as_gmp_str)
+        .filter(|value| !value.is_empty())
+    {
+        cmd.set_attribute("usage_type", value);
     }
 }
 
@@ -272,6 +279,13 @@ mod tests {
                 },
             )),
             "<get_configs config_id=\"c1\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>"
+        );
+        assert_eq!(
+            xml(get_configs(GetConfigsOpts {
+                usage_type: Some(ConfigUsageType::custom("")),
+                ..Default::default()
+            })),
+            "<get_configs/>"
         );
     }
 

--- a/crates/gvm-gmp/src/commands/configs.rs
+++ b/crates/gvm-gmp/src/commands/configs.rs
@@ -5,6 +5,7 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
+use crate::commands::usage_type::UsageType;
 use crate::common::{add_filter_attrs, add_text_element, set_optional_bool_attr};
 use crate::types::EntityId;
 
@@ -13,6 +14,8 @@ use crate::types::EntityId;
 pub enum ConfigUsageType {
     /// Standard scan configs.
     Scan,
+    /// Audit configs.
+    Audit,
     /// Policy configs.
     Policy,
     /// Forward-compatible custom usage type.
@@ -30,9 +33,20 @@ impl ConfigUsageType {
     #[must_use]
     pub fn as_gmp_str(&self) -> &str {
         match self {
-            Self::Scan => "scan",
-            Self::Policy => "policy",
+            Self::Scan => UsageType::Scan.as_gmp_str(),
+            Self::Audit => UsageType::Audit.as_gmp_str(),
+            Self::Policy => UsageType::Policy.as_gmp_str(),
             Self::Custom(value) => value.as_str(),
+        }
+    }
+}
+
+impl From<UsageType> for ConfigUsageType {
+    fn from(value: UsageType) -> Self {
+        match value {
+            UsageType::Scan => Self::Scan,
+            UsageType::Audit => Self::Audit,
+            UsageType::Policy => Self::Policy,
         }
     }
 }
@@ -227,8 +241,13 @@ mod tests {
     #[test]
     fn config_usage_type_maps_to_wire_values() {
         assert_eq!(ConfigUsageType::Scan.as_gmp_str(), "scan");
+        assert_eq!(ConfigUsageType::Audit.as_gmp_str(), "audit");
         assert_eq!(ConfigUsageType::Policy.as_gmp_str(), "policy");
-        assert_eq!(ConfigUsageType::custom("audit").as_gmp_str(), "audit");
+        assert_eq!(ConfigUsageType::custom("custom").as_gmp_str(), "custom");
+        assert_eq!(
+            ConfigUsageType::from(UsageType::Audit).as_gmp_str(),
+            "audit"
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/src/commands/mod.rs
+++ b/crates/gvm-gmp/src/commands/mod.rs
@@ -13,6 +13,8 @@ pub mod alerts;
 pub mod assets;
 /// Authentication command builders.
 pub mod authentication;
+/// Generic config command builders.
+pub mod configs;
 /// Credential command builders.
 pub mod credentials;
 /// Feature command builders.

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -6,8 +6,12 @@
 use base64::Engine as _;
 use gvm_protocol::{xml_command::XmlElement, Request, XmlCommand};
 
-use crate::commands::usage_type::UsageType;
-use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::commands::configs::{
+    clone_config, create_config, delete_config, get_config, get_configs, modify_config,
+    CloneConfigOpts, ConfigUsageType, CreateConfigOpts, DeleteConfigOpts, GetConfigOpts,
+    GetConfigsOpts, ModifyConfigOpts,
+};
+use crate::common::bool_str;
 use crate::types::EntityId;
 
 /// Optional fields for scan-configuration create and modify requests.
@@ -62,7 +66,7 @@ pub struct GetPolicyOpts {
 /// Build a clone request for an existing scan config.
 #[must_use]
 pub fn clone_scan_config(config_id: &EntityId) -> impl Request {
-    XmlCommand::new("create_config").child_with_text("copy", config_id.as_str())
+    clone_config(config_id, CloneConfigOpts::default())
 }
 
 /// Build a `create_scan_config` request.
@@ -72,56 +76,30 @@ pub fn create_scan_config(
     base_id: Option<&EntityId>,
     opts: ConfigOpts,
 ) -> impl Request {
-    create_config_with_usage(name, base_id, opts, None)
-}
-
-fn create_config_with_usage(
-    name: &str,
-    base_id: Option<&EntityId>,
-    opts: ConfigOpts,
-    usage_type: Option<UsageType>,
-) -> XmlCommand {
-    let mut cmd = XmlCommand::new("create_config");
-    cmd.add_element_with_text("name", name);
-    if let Some(base_id) = base_id {
-        cmd.add_element("copy").set_text(base_id.as_str());
-    }
-    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    if let Some(usage_type) = usage_type {
-        cmd.add_element_with_text("usage_type", usage_type.as_gmp_str());
-    } else {
-        add_text_element(&mut cmd, "usage_type", opts.usage_type.as_deref());
-    }
-    cmd
+    create_config(CreateConfigOpts {
+        name: name.into(),
+        base_id: base_id.cloned(),
+        comment: opts.comment,
+        usage_type: opts.usage_type.map(ConfigUsageType::custom),
+    })
 }
 
 /// Build a `get_scan_configs` request.
 #[must_use]
 pub fn get_scan_configs(opts: GetScanConfigsOpts) -> impl Request {
-    get_configs_with_usage(opts, None)
-}
-
-fn get_configs_with_usage(opts: GetScanConfigsOpts, usage_type: Option<UsageType>) -> XmlCommand {
-    let mut cmd = XmlCommand::new("get_configs");
-    add_filter_attrs(
-        &mut cmd,
-        opts.filter_string.as_deref(),
-        opts.filter_id.as_ref(),
-    );
-    set_optional_bool_attr(&mut cmd, "trash", opts.trash);
-    set_optional_bool_attr(&mut cmd, "details", opts.details);
-    if let Some(usage_type) = usage_type {
-        cmd.set_attribute("usage_type", usage_type.as_gmp_str());
-    }
-    cmd
+    get_configs(GetConfigsOpts {
+        filter_string: opts.filter_string,
+        filter_id: opts.filter_id,
+        trash: opts.trash,
+        details: opts.details,
+        ..Default::default()
+    })
 }
 
 /// Build a `get_scan_config` request.
 #[must_use]
 pub fn get_scan_config(config_id: &EntityId) -> impl Request {
-    XmlCommand::new("get_configs")
-        .attribute("config_id", config_id.as_str())
-        .attribute("details", "1")
+    get_config(config_id, GetConfigOpts::default())
 }
 
 /// Build a `get_preferences` request for scan-config preferences.
@@ -165,7 +143,14 @@ fn get_preferences_with(
 /// Build a `modify_scan_config` request.
 #[must_use]
 pub fn modify_scan_config(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
-    modify_config_with_usage(config_id, opts, None)
+    modify_config(
+        config_id,
+        ModifyConfigOpts {
+            comment: opts.comment,
+            usage_type: opts.usage_type.map(ConfigUsageType::custom),
+            ..Default::default()
+        },
+    )
 }
 
 /// Build a `modify_config` request that sets a scan-config NVT preference.
@@ -225,22 +210,6 @@ pub fn modify_scan_config_set_name(config_id: &EntityId, name: &str) -> impl Req
 #[must_use]
 pub fn modify_scan_config_set_comment(config_id: &EntityId, comment: Option<&str>) -> impl Request {
     modify_config_set_comment(config_id, comment)
-}
-
-fn modify_config_with_usage(
-    config_id: &EntityId,
-    opts: ConfigOpts,
-    usage_type: Option<UsageType>,
-) -> XmlCommand {
-    let mut cmd = XmlCommand::new("modify_config").attribute("config_id", config_id.as_str());
-    add_text_element(&mut cmd, "name", Some(""));
-    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    if let Some(usage_type) = usage_type {
-        cmd.add_element_with_text("usage_type", usage_type.as_gmp_str());
-    } else {
-        add_text_element(&mut cmd, "usage_type", opts.usage_type.as_deref());
-    }
-    cmd
 }
 
 fn modify_config_set_nvt_preference(
@@ -322,9 +291,12 @@ fn modify_config_set_comment(config_id: &EntityId, comment: Option<&str>) -> Xml
 /// Build a `delete_scan_config` request.
 #[must_use]
 pub fn delete_scan_config(config_id: &EntityId, ultimate: bool) -> impl Request {
-    XmlCommand::new("delete_config")
-        .attribute("config_id", config_id.as_str())
-        .attribute("ultimate", bool_str(ultimate))
+    delete_config(
+        config_id,
+        DeleteConfigOpts {
+            ultimate: Some(ultimate),
+        },
+    )
 }
 
 /// Build a `sync_config` request.
@@ -342,30 +314,51 @@ pub fn clone_policy(config_id: &EntityId) -> impl Request {
 /// Build a `create_config` request for a policy.
 #[must_use]
 pub fn create_policy(name: &str, opts: ConfigOpts) -> impl Request {
-    create_config_with_usage(name, None, opts, Some(UsageType::Policy))
+    create_config(CreateConfigOpts {
+        name: name.into(),
+        base_id: None,
+        comment: opts.comment,
+        usage_type: Some(ConfigUsageType::Policy),
+    })
 }
 
 /// Build a `get_configs` request scoped to policies.
 #[must_use]
 pub fn get_policies(opts: GetScanConfigsOpts) -> impl Request {
-    get_configs_with_usage(opts, Some(UsageType::Policy))
+    get_configs(GetConfigsOpts {
+        filter_string: opts.filter_string,
+        filter_id: opts.filter_id,
+        trash: opts.trash,
+        details: opts.details,
+        usage_type: Some(ConfigUsageType::Policy),
+        ..Default::default()
+    })
 }
 
 /// Build a `get_configs` request for a single policy.
 #[must_use]
 pub fn get_policy(policy_id: &EntityId, opts: GetPolicyOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("get_configs")
-        .attribute("config_id", policy_id.as_str())
-        .attribute("usage_type", UsageType::Policy.as_gmp_str())
-        .attribute("details", "1");
-    set_optional_bool_attr(&mut cmd, "tasks", opts.audits);
-    cmd
+    get_config(
+        policy_id,
+        GetConfigOpts {
+            usage_type: Some(ConfigUsageType::Policy),
+            tasks: opts.audits,
+            ..Default::default()
+        },
+    )
 }
 
 /// Build a `modify_config` request scoped to policies.
 #[must_use]
 pub fn modify_policy(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
-    modify_config_with_usage(config_id, opts, Some(UsageType::Policy))
+    modify_config(
+        config_id,
+        ModifyConfigOpts {
+            comment: opts.comment,
+            usage_type: Some(ConfigUsageType::Policy),
+            ..Default::default()
+        },
+    )
 }
 
 /// Build a `modify_config` request that sets a policy NVT preference.

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -11,6 +11,7 @@ use crate::commands::configs::{
     CloneConfigOpts, ConfigUsageType, CreateConfigOpts, DeleteConfigOpts, GetConfigOpts,
     GetConfigsOpts, ModifyConfigOpts,
 };
+use crate::commands::usage_type::UsageType;
 use crate::common::bool_str;
 use crate::types::EntityId;
 
@@ -318,7 +319,7 @@ pub fn create_policy(name: &str, opts: ConfigOpts) -> impl Request {
         name: name.into(),
         base_id: None,
         comment: opts.comment,
-        usage_type: Some(ConfigUsageType::Policy),
+        usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
     })
 }
 
@@ -330,7 +331,7 @@ pub fn get_policies(opts: GetScanConfigsOpts) -> impl Request {
         filter_id: opts.filter_id,
         trash: opts.trash,
         details: opts.details,
-        usage_type: Some(ConfigUsageType::Policy),
+        usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
         ..Default::default()
     })
 }
@@ -341,7 +342,7 @@ pub fn get_policy(policy_id: &EntityId, opts: GetPolicyOpts) -> impl Request {
     get_config(
         policy_id,
         GetConfigOpts {
-            usage_type: Some(ConfigUsageType::Policy),
+            usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
             tasks: opts.audits,
             ..Default::default()
         },
@@ -355,7 +356,7 @@ pub fn modify_policy(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
         config_id,
         ModifyConfigOpts {
             comment: opts.comment,
-            usage_type: Some(ConfigUsageType::Policy),
+            usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
             ..Default::default()
         },
     )

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -147,7 +147,7 @@ pub fn modify_scan_config(config_id: &EntityId, opts: ConfigOpts) -> impl Reques
     modify_config(
         config_id,
         ModifyConfigOpts {
-            comment: opts.comment,
+            comment: normalize_optional_text(opts.comment),
             usage_type: opts.usage_type.map(ConfigUsageType::custom),
             ..Default::default()
         },
@@ -355,11 +355,15 @@ pub fn modify_policy(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
     modify_config(
         config_id,
         ModifyConfigOpts {
-            comment: opts.comment,
+            comment: normalize_optional_text(opts.comment),
             usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
             ..Default::default()
         },
     )
+}
+
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
 }
 
 /// Build a `modify_config` request that sets a policy NVT preference.

--- a/crates/gvm-gmp/tests/test_configs.rs
+++ b/crates/gvm-gmp/tests/test_configs.rs
@@ -73,6 +73,13 @@ fn test_generic_configs_get_xml() {
         )),
         "<get_configs config_id=\"c1\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>"
     );
+    assert_eq!(
+        xml(get_configs(GetConfigsOpts {
+            usage_type: Some(ConfigUsageType::custom("")),
+            ..Default::default()
+        })),
+        "<get_configs/>"
+    );
 }
 
 #[test]

--- a/crates/gvm-gmp/tests/test_configs.rs
+++ b/crates/gvm-gmp/tests/test_configs.rs
@@ -102,6 +102,17 @@ fn test_generic_configs_modify_delete_xml() {
         "<modify_config config_id=\"c1\"><name>renamed</name><comment>updated</comment><usage_type>policy</usage_type></modify_config>"
     );
     assert_eq!(
+        xml(modify_config(
+            &id("c1"),
+            ModifyConfigOpts {
+                name: Some(String::new()),
+                comment: Some(String::new()),
+                ..Default::default()
+            },
+        )),
+        "<modify_config config_id=\"c1\"><name></name><comment></comment></modify_config>"
+    );
+    assert_eq!(
         xml(delete_config(
             &id("c1"),
             DeleteConfigOpts {
@@ -166,6 +177,16 @@ fn test_scan_configs_wrappers_match_generic_xml() {
                 ..Default::default()
             },
         ))
+    );
+    assert_eq!(
+        xml(modify_scan_config(
+            &id("c1"),
+            ConfigOpts {
+                comment: Some(String::new()),
+                ..Default::default()
+            },
+        )),
+        "<modify_config config_id=\"c1\"/>"
     );
     assert_eq!(
         xml(delete_scan_config(&id("c1"), true)),
@@ -233,6 +254,16 @@ fn test_policies_wrappers_match_generic_xml() {
                 ..Default::default()
             },
         ))
+    );
+    assert_eq!(
+        xml(modify_policy(
+            &id("p1"),
+            ConfigOpts {
+                comment: Some(String::new()),
+                ..Default::default()
+            },
+        )),
+        "<modify_config config_id=\"p1\"><usage_type>policy</usage_type></modify_config>"
     );
     assert_eq!(
         xml(delete_policy(&id("p1"))),

--- a/crates/gvm-gmp/tests/test_configs.rs
+++ b/crates/gvm-gmp/tests/test_configs.rs
@@ -12,12 +12,18 @@ use gvm_gmp::commands::scan_configs::{
     delete_scan_config, get_policies, get_policy, get_scan_config, get_scan_configs, modify_policy,
     modify_scan_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
 };
+use gvm_gmp::commands::usage_type::UsageType;
 
 #[test]
 fn test_generic_configs_usage_type_xml() {
     assert_eq!(ConfigUsageType::Scan.as_gmp_str(), "scan");
+    assert_eq!(ConfigUsageType::Audit.as_gmp_str(), "audit");
     assert_eq!(ConfigUsageType::Policy.as_gmp_str(), "policy");
-    assert_eq!(ConfigUsageType::custom("audit").as_gmp_str(), "audit");
+    assert_eq!(ConfigUsageType::custom("custom").as_gmp_str(), "custom");
+    assert_eq!(
+        ConfigUsageType::from(UsageType::Audit).as_gmp_str(),
+        "audit"
+    );
 }
 
 #[test]
@@ -66,7 +72,7 @@ fn test_generic_configs_get_xml() {
         xml(get_config(
             &id("c1"),
             GetConfigOpts {
-                usage_type: Some(ConfigUsageType::Policy),
+                usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
                 tasks: Some(true),
                 ..Default::default()
             },
@@ -196,7 +202,7 @@ fn test_policies_wrappers_match_generic_xml() {
     assert_eq!(
         xml(get_policies(GetScanConfigsOpts::default())),
         xml(get_configs(GetConfigsOpts {
-            usage_type: Some(ConfigUsageType::Policy),
+            usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
             ..Default::default()
         }))
     );
@@ -205,7 +211,7 @@ fn test_policies_wrappers_match_generic_xml() {
         xml(get_config(
             &id("p1"),
             GetConfigOpts {
-                usage_type: Some(ConfigUsageType::Policy),
+                usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
                 tasks: Some(true),
                 ..Default::default()
             },
@@ -223,7 +229,7 @@ fn test_policies_wrappers_match_generic_xml() {
             &id("p1"),
             ModifyConfigOpts {
                 comment: Some("updated".into()),
-                usage_type: Some(ConfigUsageType::Policy),
+                usage_type: Some(ConfigUsageType::from(UsageType::Policy)),
                 ..Default::default()
             },
         ))

--- a/crates/gvm-gmp/tests/test_configs.rs
+++ b/crates/gvm-gmp/tests/test_configs.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+mod common;
+
+use common::{id, xml};
+use gvm_gmp::commands::configs::*;
+use gvm_gmp::commands::scan_configs::{
+    clone_policy, clone_scan_config, create_policy, create_scan_config, delete_policy,
+    delete_scan_config, get_policies, get_policy, get_scan_config, get_scan_configs, modify_policy,
+    modify_scan_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
+};
+
+#[test]
+fn test_generic_configs_usage_type_xml() {
+    assert_eq!(ConfigUsageType::Scan.as_gmp_str(), "scan");
+    assert_eq!(ConfigUsageType::Policy.as_gmp_str(), "policy");
+    assert_eq!(ConfigUsageType::custom("audit").as_gmp_str(), "audit");
+}
+
+#[test]
+fn test_generic_configs_clone_create_xml() {
+    assert_eq!(
+        xml(clone_config(&id("c1"), CloneConfigOpts::default())),
+        "<create_config><copy>c1</copy></create_config>"
+    );
+    assert_eq!(
+        xml(clone_config(
+            &id("c1"),
+            CloneConfigOpts {
+                name: Some("copy".into()),
+            },
+        )),
+        "<create_config><copy>c1</copy><name>copy</name></create_config>"
+    );
+    assert_eq!(
+        xml(create_config(CreateConfigOpts {
+            name: "cfg".into(),
+            base_id: Some(id("base1")),
+            comment: Some("c".into()),
+            usage_type: Some(ConfigUsageType::Scan),
+        })),
+        "<create_config><name>cfg</name><copy>base1</copy><comment>c</comment><usage_type>scan</usage_type></create_config>"
+    );
+}
+
+#[test]
+fn test_generic_configs_get_xml() {
+    assert_eq!(
+        xml(get_configs(GetConfigsOpts {
+            filter_string: Some("name=foo".into()),
+            filter_id: Some(id("f1")),
+            trash: Some(false),
+            details: Some(true),
+            families: Some(true),
+            preferences: Some(false),
+            tasks: Some(true),
+            usage_type: Some(ConfigUsageType::custom("policy")),
+            ..Default::default()
+        })),
+        "<get_configs details=\"1\" families=\"1\" filt_id=\"f1\" filter=\"name=foo\" preferences=\"0\" tasks=\"1\" trash=\"0\" usage_type=\"policy\"/>"
+    );
+    assert_eq!(
+        xml(get_config(
+            &id("c1"),
+            GetConfigOpts {
+                usage_type: Some(ConfigUsageType::Policy),
+                tasks: Some(true),
+                ..Default::default()
+            },
+        )),
+        "<get_configs config_id=\"c1\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>"
+    );
+}
+
+#[test]
+fn test_generic_configs_modify_delete_xml() {
+    assert_eq!(
+        xml(modify_config(
+            &id("c1"),
+            ModifyConfigOpts {
+                name: Some("renamed".into()),
+                comment: Some("updated".into()),
+                usage_type: Some(ConfigUsageType::Policy),
+            },
+        )),
+        "<modify_config config_id=\"c1\"><name>renamed</name><comment>updated</comment><usage_type>policy</usage_type></modify_config>"
+    );
+    assert_eq!(
+        xml(delete_config(
+            &id("c1"),
+            DeleteConfigOpts {
+                ultimate: Some(true),
+            },
+        )),
+        "<delete_config config_id=\"c1\" ultimate=\"1\"/>"
+    );
+}
+
+#[test]
+fn test_scan_configs_wrappers_match_generic_xml() {
+    assert_eq!(
+        xml(clone_scan_config(&id("c1"))),
+        xml(clone_config(&id("c1"), CloneConfigOpts::default()))
+    );
+    assert_eq!(
+        xml(create_scan_config(
+            "cfg",
+            Some(&id("base1")),
+            ConfigOpts {
+                comment: Some("c".into()),
+                usage_type: Some("scan".into()),
+            },
+        )),
+        xml(create_config(CreateConfigOpts {
+            name: "cfg".into(),
+            base_id: Some(id("base1")),
+            comment: Some("c".into()),
+            usage_type: Some(ConfigUsageType::Scan),
+        }))
+    );
+    assert_eq!(
+        xml(get_scan_configs(GetScanConfigsOpts {
+            filter_string: Some("name=foo".into()),
+            details: Some(true),
+            ..Default::default()
+        })),
+        xml(get_configs(GetConfigsOpts {
+            filter_string: Some("name=foo".into()),
+            details: Some(true),
+            ..Default::default()
+        }))
+    );
+    assert_eq!(
+        xml(get_scan_config(&id("c1"))),
+        xml(get_config(&id("c1"), GetConfigOpts::default()))
+    );
+    assert_eq!(
+        xml(modify_scan_config(
+            &id("c1"),
+            ConfigOpts {
+                comment: Some("updated".into()),
+                usage_type: Some("scan".into()),
+            },
+        )),
+        xml(modify_config(
+            &id("c1"),
+            ModifyConfigOpts {
+                comment: Some("updated".into()),
+                usage_type: Some(ConfigUsageType::Scan),
+                ..Default::default()
+            },
+        ))
+    );
+    assert_eq!(
+        xml(delete_scan_config(&id("c1"), true)),
+        xml(delete_config(
+            &id("c1"),
+            DeleteConfigOpts {
+                ultimate: Some(true),
+            },
+        ))
+    );
+}
+
+#[test]
+fn test_policies_wrappers_match_generic_xml() {
+    assert_eq!(
+        xml(clone_policy(&id("p1"))),
+        xml(clone_config(&id("p1"), CloneConfigOpts::default()))
+    );
+    assert_eq!(
+        xml(create_policy(
+            "policy",
+            ConfigOpts {
+                comment: Some("audit baseline".into()),
+                ..Default::default()
+            },
+        )),
+        xml(create_config(CreateConfigOpts {
+            name: "policy".into(),
+            base_id: None,
+            comment: Some("audit baseline".into()),
+            usage_type: Some(ConfigUsageType::Policy),
+        }))
+    );
+    assert_eq!(
+        xml(get_policies(GetScanConfigsOpts::default())),
+        xml(get_configs(GetConfigsOpts {
+            usage_type: Some(ConfigUsageType::Policy),
+            ..Default::default()
+        }))
+    );
+    assert_eq!(
+        xml(get_policy(&id("p1"), GetPolicyOpts { audits: Some(true) })),
+        xml(get_config(
+            &id("p1"),
+            GetConfigOpts {
+                usage_type: Some(ConfigUsageType::Policy),
+                tasks: Some(true),
+                ..Default::default()
+            },
+        ))
+    );
+    assert_eq!(
+        xml(modify_policy(
+            &id("p1"),
+            ConfigOpts {
+                comment: Some("updated".into()),
+                ..Default::default()
+            },
+        )),
+        xml(modify_config(
+            &id("p1"),
+            ModifyConfigOpts {
+                comment: Some("updated".into()),
+                usage_type: Some(ConfigUsageType::Policy),
+                ..Default::default()
+            },
+        ))
+    );
+    assert_eq!(
+        xml(delete_policy(&id("p1"))),
+        xml(delete_config(
+            &id("p1"),
+            DeleteConfigOpts {
+                ultimate: Some(false),
+            },
+        ))
+    );
+}


### PR DESCRIPTION
## Summary

- add public generic GMP-shaped config command builders in `gvm_gmp::commands::configs`
- model config usage types with known `scan`/`policy` variants plus a forward-compatible custom path
- rewire existing scan-config and policy wrappers through the generic builders where XML behavior stays compatible
- add generic config XML tests and wrapper-equivalence coverage

## Notes

- existing scan-config and policy helper APIs remain source-compatible
- specialized preference, NVT selection, family selection, name, and comment helpers remain available
- generic config response parsing is intentionally not added in this pass

## Validation

- `cargo fmt --check`
- `cargo check -p gvm-gmp`
- `cargo test -p gvm-gmp configs`
- `cargo test -p gvm-gmp scan_configs`
- `cargo test -p gvm-gmp policies`

Closes #313
