### PR TITLE
Fix mock GMP command coverage and stateful asset handling

### DIFF
--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -206,6 +206,8 @@ impl SessionHandler {
             name if name.starts_with("create_") => self.handle_create(cmd, raw_xml, store),
             // Get commands
             name if name.starts_with("get_") => self.handle_get(cmd, store),
+            "modify_auth" => self.handle_modify_auth(cmd),
+            "modify_license" => self.handle_modify_license(cmd),
             // Modify commands
             name if name.starts_with("modify_") => self.handle_modify(cmd, raw_xml, store),
             // Delete commands
@@ -268,15 +270,34 @@ impl SessionHandler {
             return error_response(&cmd.name, 404, "Resource to clone not found");
         }
 
+        let asset_type = if resource_type == "asset" {
+            cmd.attr("asset_type")
+                .map(str::to_string)
+                .or_else(|| parse_element_text(raw_xml, "asset_type"))
+                .or_else(|| cmd.attr("type").map(str::to_string))
+                .or_else(|| parse_element_text(raw_xml, "type"))
+        } else {
+            None
+        };
+        let asset_value = if resource_type == "asset" {
+            parse_element_text(raw_xml, "value")
+        } else {
+            None
+        };
+
         let name = match resource_type {
             "note" | "override" => parse_element_text(raw_xml, "text")
                 .or_else(|| parse_element_text(raw_xml, "name"))
                 .unwrap_or_default(),
+            "asset" => parse_element_text(raw_xml, "name")
+                .or_else(|| asset_value.clone())
+                .or_else(|| asset_type.as_ref().map(|ty| format!("{ty} asset")))
+                .unwrap_or_else(|| "asset".to_string()),
             _ => parse_element_text(raw_xml, "name").unwrap_or_default(),
         };
         let requires_name = !matches!(
             resource_type,
-            "note" | "override" | "ticket" | "port_range" | "report"
+            "asset" | "note" | "override" | "ticket" | "port_range" | "report"
         );
         if name.is_empty() && requires_name {
             return error_response(&cmd.name, 400, "Missing required element: name");
@@ -352,15 +373,12 @@ impl SessionHandler {
         }
 
         if resource_type == "asset" {
-            let asset_type = cmd
-                .attr("asset_type")
-                .map(str::to_string)
-                .or_else(|| cmd.attr("type").map(str::to_string))
-                .or_else(|| parse_element_text(raw_xml, "type"))
-                .unwrap_or_default();
-            if !asset_type.is_empty() {
-                resource.set_attr("asset_type", &asset_type);
-                resource.set_attr("type", &asset_type);
+            if let Some(asset_type) = asset_type.as_ref().filter(|value| !value.is_empty()) {
+                resource.set_attr("asset_type", asset_type);
+                resource.set_attr("type", asset_type);
+            }
+            if let Some(value) = asset_value.as_ref().filter(|value| !value.is_empty()) {
+                resource.set_attr("value", value);
             }
         }
 
@@ -657,6 +675,20 @@ impl SessionHandler {
         } else {
             error_response(&cmd.name, 404, "Resource not found")
         }
+    }
+
+    fn handle_modify_auth(&self, cmd: &ParsedCommand) -> Vec<u8> {
+        match cmd.attr("enabled") {
+            Some("0" | "1") => {
+                format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
+            }
+            Some(_) => error_response(&cmd.name, 400, "Invalid enabled value"),
+            None => error_response(&cmd.name, 400, "Missing required attribute: enabled"),
+        }
+    }
+
+    fn handle_modify_license(&self, cmd: &ParsedCommand) -> Vec<u8> {
+        format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
     }
 
     fn handle_delete(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -8,6 +8,7 @@ use std::fmt::Write;
 use uuid::Uuid;
 
 use crate::util::xml_escape_attr;
+use crate::version::GmpVersion;
 
 const LARGE_REPORT_FORMAT_ID: Uuid = Uuid::from_u128(0xc402cc3e_b531_11e1_9163_406186ea4fc5);
 /// Well-known report-format UUID that returns a binary export payload in the mock server.
@@ -21,6 +22,211 @@ const SEVERITIES: [&str; 7] = ["2.1", "4.3", "5.0", "6.5", "7.5", "8.1", "9.8"];
 const DESCRIPTION_SENTENCE: &str =
     "Synthetic result payload generated for large-response integration testing. ";
 const REPORT_EXPORT_BINARY_BODY: &str = "SGVsbG8gUERG";
+
+/// Declared support level for a command recognized by the mock server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSupport {
+    /// Command has meaningful stateful behavior, either custom or generic CRUD.
+    Stateful,
+    /// Command returns deterministic built-in fixture-style data.
+    Fixture,
+    /// Command intentionally returns the generic echo success response.
+    EchoOnly,
+}
+
+/// Explicit command coverage metadata for commands recognized by the mock server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommandCoverage {
+    /// GMP command name.
+    pub name: &'static str,
+    /// Mock support level.
+    pub support: CommandSupport,
+    /// Minimum GMP version that exposes the command, if version-gated.
+    pub min_version: Option<GmpVersion>,
+}
+
+impl CommandCoverage {
+    const fn new(
+        name: &'static str,
+        support: CommandSupport,
+        min_version: Option<GmpVersion>,
+    ) -> Self {
+        Self {
+            name,
+            support,
+            min_version,
+        }
+    }
+}
+
+const fn stateful(name: &'static str) -> CommandCoverage {
+    CommandCoverage::new(name, CommandSupport::Stateful, None)
+}
+
+const fn fixture(name: &'static str) -> CommandCoverage {
+    CommandCoverage::new(name, CommandSupport::Fixture, None)
+}
+
+const fn echo_only(name: &'static str) -> CommandCoverage {
+    CommandCoverage::new(name, CommandSupport::EchoOnly, None)
+}
+
+const fn stateful_since(name: &'static str, version: GmpVersion) -> CommandCoverage {
+    CommandCoverage::new(name, CommandSupport::Stateful, Some(version))
+}
+
+const fn fixture_since(name: &'static str, version: GmpVersion) -> CommandCoverage {
+    CommandCoverage::new(name, CommandSupport::Fixture, Some(version))
+}
+
+/// Explicit support metadata for the mock server command surface.
+pub static COMMAND_COVERAGE: &[CommandCoverage] = &[
+    stateful("authenticate"),
+    stateful_since("create_agent_group", GmpVersion::V22_8),
+    stateful("create_alert"),
+    stateful("create_asset"),
+    stateful("create_config"),
+    stateful("create_credential"),
+    stateful("create_filter"),
+    stateful("create_group"),
+    stateful("create_note"),
+    stateful_since("create_oci_image_target", GmpVersion::V22_8),
+    stateful("create_override"),
+    stateful("create_permission"),
+    stateful("create_port_list"),
+    stateful("create_port_range"),
+    stateful("create_report"),
+    stateful_since("create_report_config", GmpVersion::V22_6),
+    stateful("create_report_format"),
+    stateful("create_role"),
+    stateful("create_scanner"),
+    stateful("create_schedule"),
+    stateful("create_tag"),
+    stateful("create_target"),
+    stateful("create_task"),
+    stateful("create_ticket"),
+    stateful("create_tls_certificate"),
+    stateful("create_user"),
+    stateful_since("create_web_application_target", GmpVersion::V22_8),
+    stateful_since("delete_agent_group", GmpVersion::V22_8),
+    stateful("delete_alert"),
+    stateful("delete_asset"),
+    stateful("delete_config"),
+    stateful("delete_credential"),
+    stateful("delete_filter"),
+    stateful("delete_group"),
+    stateful("delete_note"),
+    stateful_since("delete_oci_image_target", GmpVersion::V22_8),
+    stateful("delete_override"),
+    stateful("delete_permission"),
+    stateful("delete_port_list"),
+    stateful("delete_port_range"),
+    stateful("delete_report"),
+    stateful_since("delete_report_config", GmpVersion::V22_6),
+    stateful("delete_report_format"),
+    stateful("delete_role"),
+    stateful("delete_scanner"),
+    stateful("delete_schedule"),
+    stateful("delete_tag"),
+    stateful("delete_target"),
+    stateful("delete_task"),
+    stateful("delete_ticket"),
+    stateful("delete_tls_certificate"),
+    stateful("delete_user"),
+    stateful_since("delete_web_application_target", GmpVersion::V22_8),
+    echo_only("describe_auth"),
+    stateful("empty_trashcan"),
+    stateful_since("get_agent_groups", GmpVersion::V22_8),
+    fixture("get_aggregates"),
+    stateful("get_alerts"),
+    stateful("get_assets"),
+    stateful("get_configs"),
+    fixture_since("get_credential_stores", GmpVersion::V22_8),
+    stateful("get_credentials"),
+    stateful_since("get_features", GmpVersion::V22_6),
+    fixture("get_feeds"),
+    stateful("get_filters"),
+    stateful("get_groups"),
+    fixture("get_info"),
+    stateful_since("get_integration_configs", GmpVersion::V22_8),
+    stateful("get_license"),
+    stateful("get_notes"),
+    stateful("get_nvt_families"),
+    stateful("get_nvts"),
+    stateful_since("get_oci_image_targets", GmpVersion::V22_8),
+    stateful("get_overrides"),
+    stateful("get_permissions"),
+    stateful("get_port_lists"),
+    stateful("get_preferences"),
+    stateful_since("get_report_applications", GmpVersion::V22_8),
+    stateful_since("get_report_closed_cves", GmpVersion::V22_8),
+    stateful_since("get_report_configs", GmpVersion::V22_6),
+    stateful_since("get_report_cves", GmpVersion::V22_8),
+    stateful_since("get_report_errors", GmpVersion::V22_8),
+    stateful("get_report_formats"),
+    stateful_since("get_report_hosts", GmpVersion::V22_8),
+    stateful_since("get_report_operating_systems", GmpVersion::V22_8),
+    stateful_since("get_report_ports", GmpVersion::V22_8),
+    stateful_since("get_report_tls_certificates", GmpVersion::V22_8),
+    stateful_since("get_report_vulns", GmpVersion::V22_8),
+    stateful("get_reports"),
+    stateful("get_resource_names"),
+    stateful("get_results"),
+    stateful("get_roles"),
+    stateful("get_scanners"),
+    stateful("get_schedules"),
+    stateful("get_settings"),
+    fixture("get_system_reports"),
+    stateful("get_tags"),
+    stateful("get_targets"),
+    stateful("get_tasks"),
+    stateful("get_tickets"),
+    fixture_since("get_timezones", GmpVersion::V22_8),
+    stateful("get_tls_certificates"),
+    stateful("get_users"),
+    stateful("get_version"),
+    fixture("get_vulns"),
+    stateful_since("get_web_application_targets", GmpVersion::V22_8),
+    fixture("help"),
+    stateful_since("modify_agent_group", GmpVersion::V22_8),
+    stateful("modify_alert"),
+    stateful("modify_asset"),
+    stateful("modify_auth"),
+    stateful("modify_config"),
+    stateful("modify_credential"),
+    stateful("modify_filter"),
+    stateful("modify_group"),
+    stateful_since("modify_integration_config", GmpVersion::V22_8),
+    stateful("modify_license"),
+    stateful("modify_note"),
+    stateful_since("modify_oci_image_target", GmpVersion::V22_8),
+    stateful("modify_override"),
+    stateful("modify_permission"),
+    stateful("modify_port_list"),
+    stateful_since("modify_report_config", GmpVersion::V22_6),
+    stateful("modify_report_format"),
+    stateful("modify_role"),
+    stateful("modify_scanner"),
+    stateful("modify_schedule"),
+    stateful("modify_setting"),
+    stateful("modify_tag"),
+    stateful("modify_target"),
+    stateful("modify_task"),
+    stateful("modify_ticket"),
+    stateful("modify_tls_certificate"),
+    stateful("modify_user"),
+    stateful_since("modify_web_application_target", GmpVersion::V22_8),
+    echo_only("move_task"),
+    stateful("restore"),
+    stateful("resume_task"),
+    echo_only("run_wizard"),
+    stateful("start_task"),
+    stateful("stop_task"),
+    echo_only("sync_config"),
+    echo_only("test_alert"),
+    echo_only("verify_report_format"),
+    echo_only("verify_scanner"),
+];
 
 /// Configuration for synthetic large report generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +298,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "delete_target",
     "delete_task",
     "delete_ticket",
+    "delete_tls_certificate",
     "delete_user",
     "delete_web_application_target",
     "describe_auth",
@@ -101,12 +308,14 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "get_alerts",
     "get_assets",
     "get_configs",
+    "get_credential_stores",
     "get_credentials",
     "get_features",
     "get_feeds",
     "get_filters",
     "get_groups",
     "get_info",
+    "get_integration_configs",
     "get_license",
     "get_notes",
     "get_nvt_families",
@@ -116,8 +325,17 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "get_permissions",
     "get_port_lists",
     "get_preferences",
+    "get_report_applications",
+    "get_report_closed_cves",
     "get_report_configs",
+    "get_report_cves",
+    "get_report_errors",
     "get_report_formats",
+    "get_report_hosts",
+    "get_report_operating_systems",
+    "get_report_ports",
+    "get_report_tls_certificates",
+    "get_report_vulns",
     "get_reports",
     "get_resource_names",
     "get_results",
@@ -130,6 +348,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "get_targets",
     "get_tasks",
     "get_tickets",
+    "get_timezones",
     "get_tls_certificates",
     "get_users",
     "get_version",
@@ -144,6 +363,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "modify_credential",
     "modify_filter",
     "modify_group",
+    "modify_integration_config",
     "modify_license",
     "modify_note",
     "modify_oci_image_target",

--- a/crates/gvm-mock-server/tests/command_surface_parity.rs
+++ b/crates/gvm-mock-server/tests/command_surface_parity.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Parity tests for the mock server command recognition and coverage metadata.
+
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use gvm_mock_server::response_gen::{CommandSupport, COMMAND_COVERAGE, KNOWN_COMMANDS};
+use gvm_mock_server::version::{command_available, GmpVersion};
+
+fn collect_rust_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    for entry in fs::read_dir(dir).expect("read command source dir") {
+        let entry = entry.expect("read command source entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn extract_literal_args(source: &str, marker: &str, commands: &mut BTreeSet<String>) {
+    let mut remaining = source;
+    while let Some(index) = remaining.find(marker) {
+        let after_marker = &remaining[index + marker.len()..];
+        let Some(end) = after_marker.find('"') else {
+            break;
+        };
+        commands.insert(after_marker[..end].to_string());
+        remaining = &after_marker[end + 1..];
+    }
+}
+
+fn gvm_gmp_command_names() -> BTreeSet<String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let commands_dir = manifest_dir.join("../gvm-gmp/src/commands");
+    let mut files = Vec::new();
+    collect_rust_files(&commands_dir, &mut files);
+
+    let mut commands = BTreeSet::new();
+    for file in files {
+        let source = fs::read_to_string(&file).expect("read command source file");
+        extract_literal_args(&source, "XmlCommand::new(\"", &mut commands);
+        extract_literal_args(&source, "get_report_detail_command(\"", &mut commands);
+    }
+    commands
+}
+
+#[test]
+fn known_commands_are_sorted_for_binary_search() {
+    assert!(
+        KNOWN_COMMANDS
+            .windows(2)
+            .all(|window| window[0] < window[1]),
+        "KNOWN_COMMANDS must stay sorted because is_known_command uses binary_search"
+    );
+}
+
+#[test]
+fn coverage_metadata_matches_known_commands() {
+    let known: BTreeSet<_> = KNOWN_COMMANDS.iter().copied().collect();
+    let coverage: BTreeSet<_> = COMMAND_COVERAGE.iter().map(|entry| entry.name).collect();
+
+    let missing_coverage: Vec<_> = known.difference(&coverage).copied().collect();
+    let unknown_coverage: Vec<_> = coverage.difference(&known).copied().collect();
+
+    assert!(
+        missing_coverage.is_empty(),
+        "known commands missing coverage metadata: {missing_coverage:?}"
+    );
+    assert!(
+        unknown_coverage.is_empty(),
+        "coverage metadata has commands not in KNOWN_COMMANDS: {unknown_coverage:?}"
+    );
+}
+
+#[test]
+fn gvm_gmp_emitted_commands_are_known_and_classified() {
+    let emitted = gvm_gmp_command_names();
+    let known: BTreeSet<_> = KNOWN_COMMANDS.iter().copied().collect();
+    let coverage: BTreeSet<_> = COMMAND_COVERAGE.iter().map(|entry| entry.name).collect();
+
+    let unknown: Vec<_> = emitted
+        .iter()
+        .filter(|command| !known.contains(command.as_str()))
+        .cloned()
+        .collect();
+    let unclassified: Vec<_> = emitted
+        .iter()
+        .filter(|command| !coverage.contains(command.as_str()))
+        .cloned()
+        .collect();
+
+    assert!(
+        unknown.is_empty(),
+        "gvm-gmp emits commands unknown to the mock server: {unknown:?}"
+    );
+    assert!(
+        unclassified.is_empty(),
+        "gvm-gmp emits commands without mock coverage metadata: {unclassified:?}"
+    );
+}
+
+#[test]
+fn version_gated_commands_declare_minimum_version() {
+    let missing_min_version: Vec<_> = COMMAND_COVERAGE
+        .iter()
+        .filter(|entry| !command_available(entry.name, GmpVersion::V22_7))
+        .filter(|entry| entry.min_version.is_none())
+        .map(|entry| entry.name)
+        .collect();
+    assert!(
+        missing_min_version.is_empty(),
+        "version-gated commands missing min_version metadata: {missing_min_version:?}"
+    );
+
+    for entry in COMMAND_COVERAGE
+        .iter()
+        .filter(|entry| entry.min_version.is_some())
+    {
+        let min_version = entry.min_version.expect("checked above");
+        assert!(
+            command_available(entry.name, min_version),
+            "{} is not available at its declared minimum GMP version {}",
+            entry.name,
+            min_version
+        );
+    }
+}
+
+#[test]
+fn echo_only_commands_are_intentionally_listed() {
+    let echo_only: BTreeSet<_> = COMMAND_COVERAGE
+        .iter()
+        .filter(|entry| entry.support == CommandSupport::EchoOnly)
+        .map(|entry| entry.name)
+        .collect();
+
+    for expected in [
+        "describe_auth",
+        "move_task",
+        "run_wizard",
+        "sync_config",
+        "test_alert",
+        "verify_report_format",
+        "verify_scanner",
+    ] {
+        assert!(
+            echo_only.contains(expected),
+            "{expected} should be explicitly documented as echo-only"
+        );
+    }
+
+    for semantic in [
+        "create_asset",
+        "get_assets",
+        "modify_auth",
+        "modify_license",
+        "get_timezones",
+        "get_credential_stores",
+    ] {
+        let coverage = COMMAND_COVERAGE
+            .iter()
+            .find(|entry| entry.name == semantic)
+            .expect("semantic command should be classified");
+        assert_ne!(
+            coverage.support,
+            CommandSupport::EchoOnly,
+            "{semantic} should not be classified as generic echo behavior"
+        );
+    }
+}

--- a/crates/gvm-mock-server/tests/command_surface_parity.rs
+++ b/crates/gvm-mock-server/tests/command_surface_parity.rs
@@ -108,9 +108,21 @@ fn gvm_gmp_emitted_commands_are_known_and_classified() {
 
 #[test]
 fn version_gated_commands_declare_minimum_version() {
+    let versions = [
+        GmpVersion::V22_4,
+        GmpVersion::V22_5,
+        GmpVersion::V22_6,
+        GmpVersion::V22_7,
+        GmpVersion::V22_8,
+    ];
+
     let missing_min_version: Vec<_> = COMMAND_COVERAGE
         .iter()
-        .filter(|entry| !command_available(entry.name, GmpVersion::V22_7))
+        .filter(|entry| {
+            versions
+                .iter()
+                .any(|version| !command_available(entry.name, *version))
+        })
         .filter(|entry| entry.min_version.is_none())
         .map(|entry| entry.name)
         .collect();
@@ -124,11 +136,16 @@ fn version_gated_commands_declare_minimum_version() {
         .filter(|entry| entry.min_version.is_some())
     {
         let min_version = entry.min_version.expect("checked above");
+        let first_available = versions
+            .iter()
+            .copied()
+            .find(|version| command_available(entry.name, *version));
         assert!(
-            command_available(entry.name, min_version),
-            "{} is not available at its declared minimum GMP version {}",
+            first_available == Some(min_version),
+            "{} declares minimum GMP version {}, but first becomes available at {:?}",
             entry.name,
-            min_version
+            min_version,
+            first_available
         );
     }
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -11,8 +11,11 @@
     missing_docs
 )]
 
+use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
+use gvm_gmp::commands::system::{modify_auth, modify_license};
+use gvm_gmp::types::EntityId;
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
-use gvm_protocol::Response;
+use gvm_protocol::{Request, Response};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
@@ -23,6 +26,10 @@ async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
     let n = stream.read(&mut buf).await.expect("read failed");
     buf.truncate(n);
     Response::new(buf)
+}
+
+async fn send_request(stream: &mut UnixStream, request: impl Request) -> Response {
+    send_recv(stream, &request.to_bytes()).await
 }
 
 async fn stateful_server() -> Option<MockGmpServer> {
@@ -56,6 +63,58 @@ async fn auth_admin(stream: &mut UnixStream) {
 
 fn extract_id(resp: &Response) -> String {
     resp.id().expect("response should contain id")
+}
+
+#[tokio::test]
+async fn stateful_host_asset_uses_gmp_builder_shape() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let create = send_request(
+        &mut stream,
+        create_host(HostOpts {
+            value: Some("1.1.1.1".into()),
+            ..Default::default()
+        }),
+    )
+    .await;
+    assert_eq!(create.status_code(), Some(201));
+    let host_id = extract_id(&create);
+    let host_entity_id = EntityId::new(host_id.clone()).expect("valid host id");
+
+    let hosts = send_request(&mut stream, get_hosts(Default::default())).await;
+    let hosts_text = hosts.as_str().expect("utf8");
+    assert!(hosts_text.contains(&host_id));
+    assert!(hosts_text.contains("<asset_type>host</asset_type>"));
+    assert!(hosts_text.contains("<value>1.1.1.1</value>"));
+
+    let host = send_request(&mut stream, get_host(&host_entity_id)).await;
+    let host_text = host.as_str().expect("utf8");
+    assert!(host_text.contains(&host_id));
+    assert!(host_text.contains("<asset_type>host</asset_type>"));
+    assert!(host_text.contains("<value>1.1.1.1</value>"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_auth_and_license_modifiers_use_gmp_builder_shape() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let auth = send_request(&mut stream, modify_auth(true)).await;
+    assert_eq!(auth.status_code(), Some(200));
+
+    let license = send_request(&mut stream, modify_license("abc")).await;
+    assert_eq!(license.status_code(), Some(200));
+
+    server.shutdown().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What Problem This Solves

The mock GMP server had drifted from the command surface emitted by `gvm-gmp`, and a few valid stateful commands from the typed builders failed because they were routed through generic handlers with the wrong assumptions.

Fixes #316
Fixes #317
Fixes #318

## Why This Change Was Made

- Accept `create_host` / `create_asset` XML that uses `<asset_type>` and `<value>` without `<name>`.
- Preserve asset type and value in stateful responses.
- Handle `modify_auth` and `modify_license` explicitly instead of requiring bogus `auth_id` / `license_id` attributes.
- Add explicit command coverage metadata for stateful, fixture, echo-only, and version-gated mock support.
- Add a parity test that scans `gvm-gmp` command builders and fails when emitted commands are not known and classified by the mock.

## User Impact

The mock server should now behave consistently across echo and stateful modes for the current `gvm-gmp` command surface, and future GMP command additions should require an intentional mock coverage decision.

## Evidence

- `cargo test -p gvm-mock-server --test command_surface_parity`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps`
- `cargo test -p gvm-mock-server --features unix-socket-tests`
- `cargo clippy -p gvm-mock-server --features unix-socket-tests -- -D warnings`