### PR TITLE
docs(journal): add 2026-07-06 journal entry

### DIFF
--- a/journal/2026-07-06.md
+++ b/journal/2026-07-06.md
@@ -1,0 +1,20 @@
+# 2026-07-06 — `devel` Landed Generic Config and Mock-Parity Work While a New GVMD Drift Tracker Reopened the Next Compatibility Lane
+
+## Mainline & Release Work
+
+### `main` did not ship new product code after the 2026-07-05 cutoff, but the published baseline itself finally caught up
+- The only new `main` commits in this window were the merged journal PRs for 2026-07-05 and the older 2026-07-04 entry, so there is still no newer release or default-branch feature merge to record after the `v0.3.3` follow-through.
+- That means the meaningful movement happened off the shipped branch rather than on it: the repo used `devel` as the active delivery lane instead of immediately reopening `main`.
+
+## Development Queue
+- `devel` absorbed two substantive non-journal PRs right after the cutoff. PR #321 merged generic GMP config command builders, extending the same "generic alongside typed wrappers" pattern that PR #312 had just started for assets.
+- PR #322 then merged the corresponding mock-server follow-through for command coverage and stateful asset handling, which turns that generic-surface expansion into testable behavior instead of leaving it as API shape only.
+- A fresh follow-on lane opened immediately afterward: PR #326 is now adding current GVMD agent command coverage on top of those merges, so the repo did not pause after the generic builder tranche landed.
+
+## Issues
+- The newest issue signal is not backlog churn. Issue #325 opened on 2026-07-06 to track drift in current GVMD agent and credential-store GMP commands, which sharpens the repo's next compatibility target instead of reopening the broad parity backlog from earlier in the week.
+- Taken together with the already-open generic asset/config issues, the queue is now focused on present-version correctness and mock fidelity rather than on missing foundational surface area.
+
+## CI Health
+- There is no new shipped-branch regression to report. `OpenSSF Scorecard` stayed green on the latest `main` head after the journal merges.
+- The actionable validation signal remains on the forward lane rather than on `main`: the repo's current risk is carrying the new compatibility tranche cleanly through `devel`, not recovering from a fresh default-branch outage.


### PR DESCRIPTION
## Summary
- add the 2026-07-06 journal entry
- capture the new devel merges and GVMD drift tracking opened after the last published cutoff

Agent: Thoth