### PR TITLE
docs(journal): add 2026-04-26 journal entry

### DIFF
--- a/journal/2026-04-26.md
+++ b/journal/2026-04-26.md
@@ -1,0 +1,27 @@
+# 2026-04-26 — Journal Backlog Landed, Dependabot Mostly Green, One Russh Lane Still Broken
+
+## Mainline & Merge Activity
+
+### Backlogged journal history finally merged into main
+- Journal PRs #122, #123, #124, and #127 all merged on 2026-04-23, so `main` absorbed the queued 2026-04-20 through 2026-04-23 maintenance history in one batch
+- No new source commits landed on `main` after those merges, so the repo’s visible movement since the last entry has been queue cleanup rather than feature delivery
+
+### Release workflow repair branch recovered
+- PR #109 (`fix(ci): restore release.yml with SBOM, Docker, binaries`) flipped from failing to green on 2026-04-23 after fresh CI and Security reruns
+- That makes the release-repair lane look actionable again even though it is still open
+
+## Maintenance Queue
+
+### Fresh dependency PRs split into one bad lane and three clean ones
+- PR #128 (`russh` 0.60.1) opened on 2026-04-24 and failed both CI and Security immediately, duplicating the older stalled `russh` upgrade problem in PR #114
+- PR #121 (GitHub Actions group), PR #125 (`rustls-webpki`), and PR #126 (`rand`) all now show green CI and Security after initial churn on 2026-04-24
+- Journal PR #129 for 2026-04-25 is now the only fresh docs-only backlog item
+
+## Issues
+- No new issues were opened or closed after the last journal entry
+
+## CI Health
+- **Main branch**: no new code landed after the 2026-04-23 journal-merge batch; latest notable mainline automation was a successful Dependabot update cycle on 2026-04-24
+- **Release repair branch**: PR #109 is now green in both CI and Security after earlier failures
+- **Dependabot**: PRs #121, #125, and #126 are green; PR #128 remains the lone red dependency lane
+- **OpenSSF Scorecard**: scheduled run on 2026-04-26 was skipped again rather than producing a pass/fail signal


### PR DESCRIPTION
## Summary

Adds the missing journal entry for 2026-04-26 from the existing `journal/2026-04-26` branch.

## Notes

This replaces the old closed/unmerged journal PR for the same date so the entry can be reviewed and merged normally.