### PR TITLE
docs(journal): add 2026-04-27 journal entry

### DIFF
--- a/journal/2026-04-27.md
+++ b/journal/2026-04-27.md
@@ -1,0 +1,49 @@
+# 2026-04-27 — Typed coverage complete, CI/security hardening, dependency backlog churn
+
+## Repository Activity
+
+### Mainline delivery since the last journal entry
+- `main` moved substantially after the 2026-03-18 entry, including typed GMP response work, security workflow hardening, fuzzing infrastructure, release workflow cleanup, and journal backfill merges.
+- Notable merged PRs included:
+  - **#41** — closed the remaining python-gvm command-surface gaps
+  - **#54–#56** — switched cross-repo E2E dispatch onto the standalone test repo path
+  - **#62–#75** — tracked and then expanded dependency/security controls (`cargo-audit`, `cargo-deny`, `cargo-vet`, `cargo-geiger`) plus typed response model phases
+  - **#77–#90** — added Semgrep, OpenSSF Scorecard, fuzz harnesses, and GitHub Actions hardening
+  - **#94–#105** — completed typed response coverage, added convenience client APIs, and cleaned up release workflows/documentation
+  - **#106–#127** — merged the April journal backlog through the 2026-04-23 entry
+
+### Open PR queue shifted again overnight
+- **#109** (`fix(ci): restore release.yml with SBOM, Docker, binaries`) is still open and appears to be the highest-value green maintenance lane.
+- Dependabot maintenance PRs **#121**, **#125**, and **#126** remain open and green.
+- Two overlapping `russh` remediation lanes are still open:
+  - **#114** — bump `russh` to 0.60.0
+  - **#128** — bump `russh` to 0.60.1
+- A fresh dependency bundle landed overnight as **#131** (`build(deps): bump the cargo group with 4 updates`), immediately widening the backlog with a broad CI failure set.
+- Journal maintenance PRs **#129** and **#130** are still open behind the current backlog.
+
+## Issues
+
+### Issues opened since the last journal entry
+- **#38** — architecture: multi-endpoint access control gateway
+- **#59** — main-branch `Cargo Audit` / `Cargo Deny` failures caused by `RUSTSEC-2026-0074` via `russh` / `libcrux`
+- **#71** — evaluate `cargo-crev` for distributed dependency reviews
+- **#72** — add OpenSSF Scorecard for project security posture
+- **#91** — security: OpenSSF Scorecard analysis of external GitHub Actions
+- **#92** — security: code review of external GitHub Actions
+
+### Issues closed since the last journal entry
+- **#22**, **#23**, **#24** — E2E harness and command-surface follow-up work landed
+- **#28–#32** — high/medium review and security findings closed via PR #36
+- **#49**, **#52**, **#60**, **#61**, **#69**, **#70**, **#76**, **#84**, **#85**, **#93**, **#102** — closed as E2E fixes, typed-response milestones, CI/security tasks, and mock-server hardening completed
+
+## CI Health
+- **Main branch automation**: mixed but functioning; recent 2026-04-27 Dependabot update runs produced two successes and one failure on `main`.
+- **Open PRs**:
+  - **#109**, **#121**, **#125**, **#126** are currently green.
+  - **#114** and **#128** still fail in the `russh` upgrade lane.
+  - **#131** is broadly red across CI and Security checks, including `Cargo Audit`, `Clippy`, `Cargo Vet`, docs, coverage, geiger, and MSRV.
+- **Scheduled security posture**: the latest OpenSSF Scorecard run on 2026-04-26 completed as skipped rather than failed.
+
+## Current State
+- The repo has moved far beyond the March baseline: typed response coverage is effectively complete, release/documentation cleanup landed, and the security toolchain is much richer.
+- The immediate operational concern is now backlog hygiene rather than missing architecture work: merge the clean lanes, deduplicate the `russh` fix path, and decide whether **#131** is worth repairing or should be split into narrower dependency updates.


### PR DESCRIPTION
## Summary

Adds the missing journal entry for 2026-04-27 from the existing `journal/2026-04-27` branch.

## Notes

This replaces the old closed/unmerged journal PR for the same date so the entry can be reviewed and merged normally.