### PR TITLE
docs(journal): add 2026-04-29 journal entry

### DIFF
--- a/journal/2026-04-29.md
+++ b/journal/2026-04-29.md
@@ -1,0 +1,28 @@
+# 2026-04-29 — Mainline Quiet, Maintenance Queue Growing, Security Still Red
+
+## Release & Mainline Changes
+
+### No new commits landed on `main`
+- No commits landed on `main` after the 2026-04-23 journal entry
+- No pull requests merged and no issues opened or closed in this window
+- The repo's movement since then has been entirely in open maintenance branches and workflow activity
+
+## Maintenance Queue
+
+### Journal backlog continued to grow
+- New journal PRs #129, #130, #132, and #133 opened for the 2026-04-25 through 2026-04-28 entries
+- Those joined the still-open journal backlog instead of being merged down promptly
+
+### Dependency and CI repair lanes multiplied
+- Dependabot PRs #125 (`rustls-webpki`) and #126 (`rand`) opened on 2026-04-22 and remain open
+- A second `russh` lane, PR #128 (`0.60.1`), opened on 2026-04-24 while older PR #114 (`0.60.0`) stayed open
+- Cargo group PR #131 opened on 2026-04-27 and is still unresolved
+- Older repair/workflow branches PR #109 and PR #121 also remain open, so the queue is larger but not healthier
+
+## Issues
+- No issues were opened or closed after the last journal entry
+
+## CI Health
+- **Main branch**: the latest scheduled `Security` run failed on 2026-04-27
+- **OpenSSF Scorecard**: the 2026-04-26 scheduled run was skipped again
+- **Dependabot on `main`**: 2026-04-24 update runs completed successfully, but the 2026-04-27 GitHub Actions update run failed while companion cargo/actions update runs succeeded


### PR DESCRIPTION
## Summary

Adds the missing journal entry for 2026-04-29 from the existing `journal/2026-04-29` branch.

## Notes

This replaces the old closed/unmerged journal PR for the same date so the entry can be reviewed and merged normally.