### PR TITLE
docs(journal): add 2026-06-05 journal entry

### DIFF
--- a/journal/2026-06-05.md
+++ b/journal/2026-06-05.md
@@ -1,0 +1,21 @@
+# 2026-06-05 — Mainline Reopened the GMP Delivery Lane and Burned Down Most of the Follow-on Gap Queue
+
+## Mainline & Merged Work
+
+### `main` moved from one parity slice to a wider GMP follow-through burst
+- Since the 2026-05-24 journal baseline, `main` absorbed eight substantive merges in short order: PR #177 added GMP REST support gap helpers, #181 bumped `russh`, #191 fixed empty optional schedule IDs, #200 added typed report export support, #202 aligned typed enums with gvmd/python-gvm 22.7, #205 preserved self-closing gvmd error status handling, #207 typed `resume_task` responses, and #210 added note/override result flags
+- The important pattern is that the repo stopped treating issue #148 as a one-off parity fix and instead converted the remaining gvmd/python-gvm gaps into a sustained typed-GMP expansion lane spanning export flows, task responses, and note/override result handling
+- The only obvious false start in the window was the MCP planning detour: PR #184 landed and was immediately reverted by #187, so the lasting branch state is still centered on GMP/runtime work rather than docs-led surface expansion
+
+## Issues
+- Seven issues opened after the 2026-05-24 baseline, and six of them already closed through merged work: #190, #199, #201, #204, #206, and #209
+- Earlier follow-on items from the 2026-05-21 parity cluster also burned down when #173, #174, and #175 closed through PR #177's landing
+- The main unresolved product items are now #192 (gvmd capability detection/probing primitives) and the broader roadmap tracker #172, which is a much narrower outstanding set than the repo carried in late May
+
+## Pull Request Queue
+- Product follow-through is now concentrated in PR #193 (`feat(client): add gvmd capability discovery helpers`), which is the direct branch expression of open issue #192
+- The remaining non-journal queue is mostly maintenance churn rather than unclear product design: dependency updates #165 and #196 plus actions update #197 are still open while daily journal PRs continue to stack on `main`
+
+## CI Health
+- Mainline verification stayed strong while those merges landed: recent `CI`, `Security`, and `OpenSSF Scorecard` runs on `main` all completed successfully on 2026-06-02 and 2026-06-03
+- Fresh failures are concentrated on dependency PRs instead of `main`; both `CI` and `Security` failed on the open dependency-update branches, so branch stability is better than queue hygiene


### PR DESCRIPTION
## Summary

Adds the missing journal entry for 2026-06-05 from the existing `journal/2026-06-05` branch.

## Notes

This replaces the old closed/unmerged journal PR for the same date so the entry can be reviewed and merged normally.