### PR TITLE
docs(journal): add 2026-07-07 journal entry

### DIFF
--- a/journal/2026-07-07.md
+++ b/journal/2026-07-07.md
@@ -1,0 +1,21 @@
+# 2026-07-07 — `main` Shipped a Broad Typed GMP Expansion Through `v0.3.3` While `devel` Reoriented Around Current GVMD Coverage
+
+## Mainline & Release Work
+
+### `main` moved well beyond the 2026-05-14 published baseline before the release lane paused again
+- The default branch shipped a long run of real GMP surface and parser work after issue #148 landed: empty schedule-id handling, REST support gap helpers, typed report export support, enum alignment with `gvmd`/`python-gvm`, task detail fields, note and override parsing fixes, paginated filter builders, typed NVT scoring, target credential fields, report metadata support, host access mode preservation, schedule run timestamps, and report export options.
+- That delivery tranche was packaged as `v0.3.3` on 2026-06-18, making it the first new release after the last `journal-main` entry instead of leaving the spring parity work as unreleased queue movement.
+- Release follow-through continued briefly on `main`: the repo repaired `0.3.3` artifact publishing, downgraded SBOM quality-score handling to a warning, consolidated dependency/security updates, patched the `quick-xml` security release, aligned MSRV with the SSH dependency stack, and refreshed CI action pins.
+
+## Development Queue
+
+### Early-July work shifted the active delivery lane to `devel` and widened the project scope again
+- `devel` absorbed a dense current-GVMD compatibility tranche rather than waiting for the next `main` reopen. Non-journal PRs there added redacted wire tracing, trashcan restore helpers, singular secinfo and feed helpers, vulnerability/policy/preference getters, report format import/clone helpers, agent-group commands, OCI image targets, web application targets, report-vulnerability aliases, generic asset/config command builders, mock-server command coverage, and current GVMD agent command coverage.
+- PR #328 then rebased `devel` onto current `main`, confirming that the repo's forward motion is now happening on the broader protocol-surface branch instead of on the already-released default branch.
+
+## Direction & Risks
+
+### The roadmap changed materially, and one fresh dependency lane now needs human attention
+- Issue #320 explicitly reframed `rust-gvm` around current GMP/GVMD support, with `python-gvm` compatibility kept as a migration constraint rather than the primary product boundary.
+- Issue #325 converted that direction change into concrete backlog by calling out current GVMD agent and credential-store drift, then closed the loop almost immediately through PR #326's new agent command coverage; the older roadmap issue #172 remains open as the wider parity tracker.
+- The only new actionable validation regression is open PR #323, the `russh` `0.62.1` dependency update: both `CI` and `Security` failed on the PR, so the current maintenance risk is the breaking SSH stack update rather than a fresh `main` outage.


### PR DESCRIPTION
## Summary
- add a consolidated 2026-07-07 journal entry from the last published `journal-main` baseline
- capture the post-2026-05-14 mainline release arc, current `devel` direction shift, and the fresh failing dependency lane

Agent: Thoth