### PR TITLE
Expose agent commands in gvm-client

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -25,6 +25,10 @@ use gvm_gmp::commands::agent_groups::{
     clone_agent_group, create_agent_group, delete_agent_group, get_agent_group, get_agent_groups,
     modify_agent_group,
 };
+use gvm_gmp::commands::agents::{
+    delete_agent, get_agent, get_agent_installer_instruction, get_agent_support_bundle, get_agents,
+    modify_agent, modify_agent_control_scan_config, sync_agents,
+};
 use gvm_gmp::commands::credentials::get_credential_stores;
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -55,6 +59,11 @@ use gvm_protocol::{Request, Response};
 pub use error::GvmError;
 pub use gvm_gmp::commands::agent_groups::{
     CreateAgentGroupOpts, GetAgentGroupsOpts, ModifyAgentGroupOpts,
+};
+pub use gvm_gmp::commands::agents::{
+    AgentConfigOpts, AgentControlConfig, AgentHeartbeatConfig, AgentInstallerLanguage,
+    AgentRetryConfig, AgentScriptExecutorConfig, GetAgentsOpts, ModifyAgentControlScanConfigOpts,
+    ModifyAgentOpts,
 };
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
@@ -322,6 +331,99 @@ impl<C: GvmConnection> GmpClient<C> {
     ) -> Result<Response, GvmError> {
         self.call(modify_integration_config(integration_config_id, opts))
             .await
+    }
+
+    /// List agents.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError> {
+        self.call(get_agents(opts)).await
+    }
+
+    /// Get a single agent.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError> {
+        self.call(get_agent(agent_id)).await
+    }
+
+    /// Modify one or more agents.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn modify_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+        opts: ModifyAgentOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(modify_agent(agent_ids, opts)).await
+    }
+
+    /// Delete one or more agents.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError> {
+        self.call(delete_agent(agent_ids)).await
+    }
+
+    /// Synchronize agents.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn sync_agents(&mut self) -> Result<Response, GvmError> {
+        self.call(sync_agents()).await
+    }
+
+    /// Modify the agent-control scan configuration defaults.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn modify_agent_control_scan_config(
+        &mut self,
+        agent_control_id: &EntityId,
+        opts: ModifyAgentControlScanConfigOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(modify_agent_control_scan_config(agent_control_id, opts))
+            .await
+    }
+
+    /// Get agent installer instructions.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agent_installer_instruction(
+        &mut self,
+        scanner_id: &EntityId,
+        language: AgentInstallerLanguage,
+        origin_url: &str,
+    ) -> Result<Response, GvmError> {
+        self.call(get_agent_installer_instruction(
+            scanner_id, language, origin_url,
+        ))
+        .await
+    }
+
+    /// Get an agent support bundle.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_agent_support_bundle(
+        &mut self,
+        agent_uuid: &EntityId,
+        days: Option<u32>,
+    ) -> Result<Response, GvmError> {
+        self.call(get_agent_support_bundle(agent_uuid, days)).await
     }
 
     /// Create an agent group.
@@ -803,6 +905,47 @@ pub trait Gmp226Commands {
 /// Commands available only in GMP 22.8 and later.
 #[async_trait::async_trait]
 pub trait GmpNextCommands {
+    /// List agents.
+    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError>;
+
+    /// Get a single agent.
+    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError>;
+
+    /// Modify one or more agents.
+    async fn modify_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+        opts: ModifyAgentOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Delete one or more agents.
+    async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError>;
+
+    /// Synchronize agents.
+    async fn sync_agents(&mut self) -> Result<Response, GvmError>;
+
+    /// Modify the agent-control scan configuration defaults.
+    async fn modify_agent_control_scan_config(
+        &mut self,
+        agent_control_id: &EntityId,
+        opts: ModifyAgentControlScanConfigOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get agent installer instructions.
+    async fn get_agent_installer_instruction(
+        &mut self,
+        scanner_id: &EntityId,
+        language: AgentInstallerLanguage,
+        origin_url: &str,
+    ) -> Result<Response, GvmError>;
+
+    /// Get an agent support bundle.
+    async fn get_agent_support_bundle(
+        &mut self,
+        agent_uuid: &EntityId,
+        days: Option<u32>,
+    ) -> Result<Response, GvmError>;
+
     /// Create an agent group.
     async fn create_agent_group(
         &mut self,
@@ -1166,6 +1309,59 @@ impl_gmp226_commands!(GmpNext);
 
 #[async_trait::async_trait]
 impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
+    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError> {
+        self.0.get_agents(opts).await
+    }
+
+    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError> {
+        self.0.get_agent(agent_id).await
+    }
+
+    async fn modify_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+        opts: ModifyAgentOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.modify_agent(agent_ids, opts).await
+    }
+
+    async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError> {
+        self.0.delete_agent(agent_ids).await
+    }
+
+    async fn sync_agents(&mut self) -> Result<Response, GvmError> {
+        self.0.sync_agents().await
+    }
+
+    async fn modify_agent_control_scan_config(
+        &mut self,
+        agent_control_id: &EntityId,
+        opts: ModifyAgentControlScanConfigOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .modify_agent_control_scan_config(agent_control_id, opts)
+            .await
+    }
+
+    async fn get_agent_installer_instruction(
+        &mut self,
+        scanner_id: &EntityId,
+        language: AgentInstallerLanguage,
+        origin_url: &str,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .get_agent_installer_instruction(scanner_id, language, origin_url)
+            .await
+    }
+
+    async fn get_agent_support_bundle(
+        &mut self,
+        agent_uuid: &EntityId,
+        days: Option<u32>,
+    ) -> Result<Response, GvmError> {
+        self.0.get_agent_support_bundle(agent_uuid, days).await
+    }
+
     async fn create_agent_group(
         &mut self,
         name: &str,

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -17,9 +17,16 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "modify_report_config"
         | "get_features" => Some(GmpVersion(22, 6)),
         "create_agent_group"
+        | "delete_agent"
         | "delete_agent_group"
+        | "get_agents"
         | "get_agent_groups"
+        | "get_agent_installer_instruction"
+        | "get_agent_support_bundle"
+        | "modify_agent"
+        | "modify_agent_control_scan_config"
         | "modify_agent_group"
+        | "sync_agents"
         | "get_integration_configs"
         | "modify_integration_config"
         | "get_report_hosts"
@@ -213,6 +220,32 @@ mod tests {
         assert!(command_supported("get_agent_groups", GmpVersion(22, 8)));
         assert_eq!(
             minimum_version_for_command("create_agent_group"),
+            Some(GmpVersion(22, 8))
+        );
+        assert!(!command_supported("get_agents", GmpVersion(22, 7)));
+        assert!(command_supported("get_agents", GmpVersion(22, 8)));
+        assert_eq!(
+            minimum_version_for_command("modify_agent"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("delete_agent"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("sync_agents"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("modify_agent_control_scan_config"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("get_agent_installer_instruction"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("get_agent_support_bundle"),
             Some(GmpVersion(22, 8))
         );
         assert!(!command_supported(

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -5,11 +5,13 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    CreateAgentGroupOpts, CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, Gmp226Commands,
-    GmpNextCommands, GmpVersioned, GvmError, ModifyAgentGroupOpts, ModifyOciImageTargetOpts,
-    ModifyWebApplicationTargetOpts,
+    AgentInstallerLanguage, CreateAgentGroupOpts, CreateOciImageTargetOpts,
+    CreateWebApplicationTargetOpts, GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
+    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
+    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::UnixSocketConnection;
+use gvm_gmp::commands::agents::get_agents;
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
@@ -238,6 +240,142 @@ async fn versioned_client_rejects_oci_image_targets_before_next() {
             required: "22.8",
         } if command == "get_oci_image_targets"
     ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn versioned_client_rejects_agent_commands_before_next() {
+    let Some(server) = stateful_server(MockVersion::V22_7).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let error = client
+        .call(get_agents(Default::default()))
+        .await
+        .expect_err("22.7 should reject next-only agent commands");
+
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "get_agents"
+    ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_agent_commands_round_trip() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    let agents = client
+        .get_agents(GetAgentsOpts {
+            filter_string: Some("scanner=agent-controller".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("get_agents should succeed");
+    assert_eq!(agents.status_code(), Some(200));
+
+    let missing_agent = client
+        .get_agent(&id("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+        .await
+        .expect_err("unseeded agent should not be found");
+    assert!(matches!(
+        missing_agent,
+        GvmError::Server { status: 404, .. }
+    ));
+
+    let agent_ids = [id("00000000-0000-0000-0000-000000000002")];
+    let modify = client
+        .modify_agent(
+            &agent_ids,
+            ModifyAgentOpts {
+                authorized: Some(true),
+                update_to_latest: Some(true),
+                comment: Some("managed from versioned client".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_agent should succeed");
+    assert_eq!(modify.status_code(), Some(200));
+
+    let sync = client
+        .sync_agents()
+        .await
+        .expect("sync_agents should succeed");
+    assert_eq!(sync.status_code(), Some(200));
+
+    let control_config = client
+        .modify_agent_control_scan_config(
+            &id("00000000-0000-0000-0000-000000000003"),
+            ModifyAgentControlScanConfigOpts {
+                update_to_latest: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_agent_control_scan_config should succeed");
+    assert_eq!(control_config.status_code(), Some(200));
+
+    let instruction = client
+        .get_agent_installer_instruction(
+            &id("00000000-0000-0000-0000-000000000004"),
+            AgentInstallerLanguage::En,
+            "https://gvmd.example",
+        )
+        .await
+        .expect("get_agent_installer_instruction should succeed");
+    let instruction_xml = instruction.as_str().expect("valid UTF-8 XML");
+    assert!(instruction_xml.contains("<language>en</language>"));
+    assert!(instruction_xml.contains("<instruction>"));
+
+    let bundle = client
+        .get_agent_support_bundle(&agent_ids[0], Some(7))
+        .await
+        .expect("get_agent_support_bundle should succeed");
+    let bundle_xml = bundle.as_str().expect("valid UTF-8 XML");
+    assert!(bundle_xml.contains("<content_type>application/octet-stream</content_type>"));
+    assert!(bundle_xml.contains("<content encoding=\"base64\">"));
+
+    let delete = client
+        .delete_agent(&agent_ids)
+        .await
+        .expect("delete_agent should succeed");
+    assert_eq!(delete.status_code(), Some(200));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Summary
- expose the existing GMP agent command builders through `GmpClient` and `GmpNextCommands`
- re-export agent option/config types from `gvm-client`
- gate agent commands at GMP 22.8 and add versioned-client mock-server coverage

## Validation
- cargo fmt --all -- --check
- cargo test --workspace --all-features --quiet
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace --quiet
- PATH="$PWD/.venv/bin:$PATH" make test-integration
- cargo deny check
- cargo audit
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- python3 -B -m unittest tests.test_sbom_postprocess -q
- semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .

## Notes
- `cargo deny check` still reports existing unmatched allowlist warnings while passing.
- `cargo audit` still reports the existing allowed yanked `crypto-bigint 0.7.4` warning while passing.
- The pinned-toolchain test run still emits existing missing-doc warnings from feature-gated integration test crates.
- Fuzzing was not run; this PR only wires existing command builders through the client/version layer and does not change parsers, framing, or input-consuming protocol logic.