### PR TITLE
Add agent group task helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -48,6 +48,7 @@ use gvm_gmp::commands::reports::{
     get_report_vulns,
 };
 use gvm_gmp::commands::system::get_timezones;
+use gvm_gmp::commands::tasks::create_agent_group_task;
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
@@ -73,6 +74,7 @@ pub use gvm_gmp::commands::oci_image_targets::{
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
+pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
@@ -955,6 +957,15 @@ pub trait GmpNextCommands {
         opts: CreateAgentGroupOpts,
     ) -> Result<Response, GvmError>;
 
+    /// Create a task that scans an agent group.
+    async fn create_agent_group_task(
+        &mut self,
+        name: &str,
+        agent_group_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateAgentGroupTaskOpts,
+    ) -> Result<Response, GvmError>;
+
     /// Clone an agent group.
     async fn clone_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError>;
 
@@ -1371,6 +1382,23 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
     ) -> Result<Response, GvmError> {
         self.0
             .create_agent_group(name, agent_ids, scheduler_cron_time, opts)
+            .await
+    }
+
+    async fn create_agent_group_task(
+        &mut self,
+        name: &str,
+        agent_group_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateAgentGroupTaskOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(create_agent_group_task(
+                name,
+                agent_group_id,
+                scanner_id,
+                opts,
+            ))
             .await
     }
 

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -4,13 +4,15 @@
 #![allow(clippy::print_stderr, missing_docs)]
 #![cfg(feature = "unix-socket-tests")]
 
+use gvm_client::GmpNext;
 use gvm_client::{
-    AgentInstallerLanguage, CreateAgentGroupOpts, CreateOciImageTargetOpts,
-    CreateWebApplicationTargetOpts, GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
-    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
-    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
+    AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
+    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GetAgentsOpts, Gmp226Commands,
+    GmpNextCommands, GmpVersioned, GvmError, ModifyAgentControlScanConfigOpts,
+    ModifyAgentGroupOpts, ModifyAgentOpts, ModifyOciImageTargetOpts,
+    ModifyWebApplicationTargetOpts,
 };
-use gvm_connection::UnixSocketConnection;
+use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::{EntityId, GmpVersion};
@@ -41,6 +43,44 @@ async fn stateful_server(version: MockVersion) -> Option<MockGmpServer> {
 
 fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
     UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
+}
+
+async fn assert_create_agent_group_task_round_trip<C>(
+    client: &mut GmpNext<C>,
+    server: &MockGmpServer,
+    agent_group_id: &EntityId,
+) where
+    C: GvmConnection + Send,
+{
+    server.clear_history();
+
+    let scanner_id = EntityId::new("scanner-1").expect("valid id");
+    let task_response = client
+        .create_agent_group_task(
+            "Client Agent Group Task",
+            agent_group_id,
+            &scanner_id,
+            CreateAgentGroupTaskOpts {
+                comment: Some("task through client".into()),
+                alterable: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_agent_group_task should succeed");
+    assert_eq!(task_response.status_code(), Some(201));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("create_task command recorded");
+    assert_eq!(command.command_name(), "create_task");
+    assert_eq!(
+        String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8"),
+        format!(
+            "<create_task><name>Client Agent Group Task</name><usage_type>scan</usage_type><agent_group id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
+            agent_group_id.as_str()
+        )
+    );
 }
 
 #[tokio::test]
@@ -144,6 +184,8 @@ async fn next_client_agent_groups_round_trip() {
     assert_eq!(create_response.status_code(), Some(201));
     let agent_group_id = EntityId::new(create_response.id().expect("created id"))
         .expect("server id should be valid");
+
+    assert_create_agent_group_task_round_trip(&mut client, &server, &agent_group_id).await;
 
     let clone_response = client
         .clone_agent_group(&agent_group_id)

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -34,6 +34,25 @@ pub struct CreateTaskOpts {
     pub preferences: Vec<(String, String)>,
 }
 
+/// Optional fields for `create_agent_group_task` requests.
+#[derive(Debug, Clone, Default)]
+pub struct CreateAgentGroupTaskOpts {
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Whether the task should be alterable.
+    pub alterable: Option<bool>,
+    /// Optional schedule identifier.
+    pub schedule_id: Option<EntityId>,
+    /// Alert identifiers associated with the request.
+    pub alert_ids: Vec<EntityId>,
+    /// Optional schedule period count.
+    pub schedule_periods: Option<u32>,
+    /// Observer names associated with the task.
+    pub observers: Vec<String>,
+    /// Preference key/value pairs to include.
+    pub preferences: Vec<(String, String)>,
+}
+
 /// Options for `get_tasks` requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetTasksOpts {
@@ -102,6 +121,37 @@ pub fn create_import_task(name: &str, comment: Option<&str>) -> impl Request {
 #[must_use]
 pub fn create_container_task(name: &str, comment: Option<&str>) -> impl Request {
     create_import_task(name, comment)
+}
+
+/// Build a `create_task` request for an agent-group scan task.
+#[must_use]
+pub fn create_agent_group_task(
+    name: &str,
+    agent_group_id: &EntityId,
+    scanner_id: &EntityId,
+    opts: CreateAgentGroupTaskOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("create_task");
+    cmd.add_element_with_text("name", name);
+    cmd.add_element_with_text("usage_type", UsageType::Scan.as_gmp_str());
+    add_id_element(&mut cmd, "agent_group", agent_group_id);
+    add_id_element(&mut cmd, "scanner", scanner_id);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(alterable) = opts.alterable {
+        cmd.add_element_with_text("alterable", bool_str(alterable));
+    }
+    for alert_id in &opts.alert_ids {
+        add_id_element(&mut cmd, "alert", alert_id);
+    }
+    if let Some(schedule_id) = opts.schedule_id.as_ref() {
+        add_id_element(&mut cmd, "schedule", schedule_id);
+        if let Some(schedule_periods) = opts.schedule_periods {
+            cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
+        }
+    }
+    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_preferences(&mut cmd, &opts.preferences);
+    cmd
 }
 
 /// Build a `create_task` request.

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -41,6 +41,56 @@ fn test_create_task_with_optionals() {
 }
 
 #[test]
+fn test_create_agent_group_task() {
+    assert_eq!(
+        xml(create_agent_group_task(
+            "foo",
+            &id("ag1"),
+            &id("s1"),
+            Default::default()
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><agent_group id=\"ag1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
+fn test_create_agent_group_task_with_optionals() {
+    assert_eq!(
+        xml(create_agent_group_task(
+            "foo",
+            &id("ag1"),
+            &id("s1"),
+            CreateAgentGroupTaskOpts {
+                comment: Some("bar".into()),
+                alterable: Some(true),
+                schedule_id: Some(id("sched1")),
+                alert_ids: vec![id("a1"), id("a2")],
+                schedule_periods: Some(5),
+                observers: vec!["alice".into(), "bob".into()],
+                preferences: vec![("k".into(), "v".into())],
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><agent_group id=\"ag1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+    );
+}
+
+#[test]
+fn test_create_agent_group_task_ignores_schedule_periods_without_schedule() {
+    assert_eq!(
+        xml(create_agent_group_task(
+            "foo",
+            &id("ag1"),
+            &id("s1"),
+            CreateAgentGroupTaskOpts {
+                schedule_periods: Some(5),
+                ..Default::default()
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><agent_group id=\"ag1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
 fn test_task_mutation_and_actions() {
     assert_eq!(
         xml(clone_task(&id("a1"))),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -374,6 +374,9 @@ impl SessionHandler {
             if let Some(target_id) = cmd.child_attr("target", "id") {
                 resource.set_attr("target_id", target_id);
             }
+            if let Some(agent_group_id) = cmd.child_attr("agent_group", "id") {
+                resource.set_attr("agent_group_id", agent_group_id);
+            }
             if let Some(config_id) = cmd.child_attr("config", "id") {
                 resource.set_attr("config_id", config_id);
             }

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -136,6 +136,36 @@ async fn stateful_create_task() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn stateful_create_agent_group_task_preserves_agent_group_id() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let create_resp = send_recv(
+        &mut stream,
+        br#"<create_task><name>Agent Group Task</name><usage_type>scan</usage_type><agent_group id="ag1"/><scanner id="s1"/></create_task>"#,
+    )
+    .await;
+    assert_eq!(create_resp.status_code(), Some(201));
+    let task_id = create_resp.id().expect("should have id");
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+
+    let text = get_resp.as_str().expect("valid utf8");
+    assert!(text.contains("Agent Group Task"));
+    assert!(text.contains("<agent_group_id>ag1</agent_group_id>"));
+    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+
+    server.shutdown().await;
+}
+
 // CRUD-T002: Get created task by ID
 #[tokio::test]
 async fn stateful_create_then_get_task() {


### PR DESCRIPTION
## Summary
- add a gvm-gmp create_agent_group_task builder with option coverage for comment, alterable, schedule, alerts, observers, and preferences
- expose the helper through the GMP Next client surface with a mock-server round trip
- preserve agent_group_id in stateful mock-server task storage and cover it with a readback test

## Notes
- the wire command is still create_task, so the version-safe convenience is exposed on GmpNextCommands; raw GmpClient::call can still send any builder by design
- schedule_periods follows python-gvm next behavior and is emitted only when schedule_id is present
- observer serialization keeps the existing Rust task-builder shape (<observers><observer>...</observer></observers>), rather than changing the broader task surface in this PR

## Validation
- cargo test -p gvm-gmp --test test_tasks
- cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_agent_groups_round_trip
- cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_mode stateful_create_agent_group_task_preserves_agent_group_id
- cargo test -p gvm-mock-server --all-features
- cargo test -p gvm-gmp --quiet
- cargo test -p gvm-client --all-features --quiet
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --all-features --quiet
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace --quiet
- PATH="/home/rpelfrey/github projects/rust-gvm/code-repo/.venv/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.codex/tmp/arg0/codex-arg06fORSF:/home/rpelfrey/.local/bin:/home/rpelfrey/.cargo/bin:/home/rpelfrey/.nvm/versions/node/v24.14.1/bin:/home/rpelfrey/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.vscode/extensions/openai.chatgpt-26.623.101652-linux-x64/bin/linux-x86_64:/home/rpelfrey/.local/bin" make test-integration
- cargo deny check (passes with existing unmatched allow/advisory warnings)
- cargo audit (passes with allowed yanked crypto-bigint 0.7.4 warning)
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- python3 -B -m unittest tests.test_sbom_postprocess -q
- semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif . (0 findings; SARIF removed)