### PR TITLE
Add OCI image target task helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -49,7 +49,7 @@ use gvm_gmp::commands::reports::{
 };
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
-use gvm_gmp::commands::tasks::create_oci_image_target_task;
+use gvm_gmp::commands::tasks::create_oci_image_target_task as build_oci_image_target_task;
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
@@ -1482,7 +1482,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         opts: CreateOciImageTargetTaskOpts,
     ) -> Result<Response, GvmError> {
         self.0
-            .call(create_oci_image_target_task(
+            .call(build_oci_image_target_task(
                 name,
                 oci_image_target_id,
                 scanner_id,

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -49,6 +49,7 @@ use gvm_gmp::commands::reports::{
 };
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
+use gvm_gmp::commands::tasks::create_oci_image_target_task;
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
@@ -75,6 +76,7 @@ pub use gvm_gmp::commands::oci_image_targets::{
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
+pub use gvm_gmp::commands::tasks::CreateOciImageTargetTaskOpts;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
@@ -998,6 +1000,28 @@ pub trait GmpNextCommands {
         opts: CreateOciImageTargetOpts,
     ) -> Result<Response, GvmError>;
 
+    /// Create a task that scans an OCI image target.
+    async fn create_oci_image_target_task(
+        &mut self,
+        name: &str,
+        oci_image_target_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateOciImageTargetTaskOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Create a task that scans an OCI image target using python-gvm's
+    /// historical container-image helper name.
+    async fn create_container_image_task(
+        &mut self,
+        name: &str,
+        oci_image_target_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateOciImageTargetTaskOpts,
+    ) -> Result<Response, GvmError> {
+        self.create_oci_image_target_task(name, oci_image_target_id, scanner_id, opts)
+            .await
+    }
+
     /// Clone an OCI image target.
     async fn clone_oci_image_target(
         &mut self,
@@ -1447,6 +1471,23 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
     ) -> Result<Response, GvmError> {
         self.0
             .create_oci_image_target(name, image_references, opts)
+            .await
+    }
+
+    async fn create_oci_image_target_task(
+        &mut self,
+        name: &str,
+        oci_image_target_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateOciImageTargetTaskOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(create_oci_image_target_task(
+                name,
+                oci_image_target_id,
+                scanner_id,
+                opts,
+            ))
             .await
     }
 

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -7,10 +7,10 @@
 use gvm_client::GmpNext;
 use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
-    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GetAgentsOpts, Gmp226Commands,
-    GmpNextCommands, GmpVersioned, GvmError, ModifyAgentControlScanConfigOpts,
-    ModifyAgentGroupOpts, ModifyAgentOpts, ModifyOciImageTargetOpts,
-    ModifyWebApplicationTargetOpts,
+    CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
+    GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned, GvmError,
+    ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
+    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
@@ -80,6 +80,44 @@ async fn assert_create_agent_group_task_round_trip<C>(
         format!(
             "<create_task><name>Client Agent Group Task</name><usage_type>scan</usage_type><agent_group id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
             agent_group_id.as_str()
+        )
+    );
+}
+
+async fn assert_create_oci_image_target_task_round_trip<C>(
+    client: &mut GmpNext<C>,
+    server: &MockGmpServer,
+    oci_image_target_id: &EntityId,
+) where
+    C: GvmConnection + Send,
+{
+    server.clear_history();
+
+    let scanner_id = id("scanner-1");
+    let task_response = client
+        .create_container_image_task(
+            "Client OCI Target Task",
+            oci_image_target_id,
+            &scanner_id,
+            CreateOciImageTargetTaskOpts {
+                comment: Some("task through client".into()),
+                alterable: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_container_image_task should succeed");
+    assert_eq!(task_response.status_code(), Some(201));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("create_task command recorded");
+    assert_eq!(command.command_name(), "create_task");
+    assert_eq!(
+        String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8"),
+        format!(
+            "<create_task><name>Client OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
+            oci_image_target_id.as_str()
         )
     );
 }
@@ -518,6 +556,8 @@ async fn next_client_oci_image_targets_round_trip() {
         .expect("create_oci_image_target should succeed");
     assert_eq!(create_response.status_code(), Some(201));
     let target_id = EntityId::new(create_response.id().expect("created id")).expect("valid id");
+
+    assert_create_oci_image_target_task_round_trip(&mut client, &server, &target_id).await;
 
     let get_response = client
         .get_oci_image_target(&target_id, Some(true))

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -26,7 +26,7 @@ pub struct CreateTaskOpts {
     pub alert_ids: Vec<EntityId>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional schedule period count.
+    /// Optional schedule period count, serialized only when [`Self::schedule_id`] is set.
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
@@ -45,7 +45,7 @@ pub struct CreateAgentGroupTaskOpts {
     pub schedule_id: Option<EntityId>,
     /// Alert identifiers associated with the request.
     pub alert_ids: Vec<EntityId>,
-    /// Optional schedule period count.
+    /// Optional schedule period count, serialized only when [`Self::schedule_id`] is set.
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
@@ -64,7 +64,7 @@ pub struct CreateOciImageTargetTaskOpts {
     pub schedule_id: Option<EntityId>,
     /// Alert identifiers associated with the request.
     pub alert_ids: Vec<EntityId>,
-    /// Optional schedule period count.
+    /// Optional schedule period count, serialized only when [`Self::schedule_id`] is set.
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -53,6 +53,25 @@ pub struct CreateAgentGroupTaskOpts {
     pub preferences: Vec<(String, String)>,
 }
 
+/// Optional fields for `create_oci_image_target_task` requests.
+#[derive(Debug, Clone, Default)]
+pub struct CreateOciImageTargetTaskOpts {
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Whether the task should be alterable.
+    pub alterable: Option<bool>,
+    /// Optional schedule identifier.
+    pub schedule_id: Option<EntityId>,
+    /// Alert identifiers associated with the request.
+    pub alert_ids: Vec<EntityId>,
+    /// Optional schedule period count.
+    pub schedule_periods: Option<u32>,
+    /// Observer names associated with the task.
+    pub observers: Vec<String>,
+    /// Preference key/value pairs to include.
+    pub preferences: Vec<(String, String)>,
+}
+
 /// Options for `get_tasks` requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetTasksOpts {
@@ -152,6 +171,51 @@ pub fn create_agent_group_task(
     add_string_list(&mut cmd, "observers", "observer", &opts.observers);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
+}
+
+/// Build a `create_task` request for an OCI image target scan task.
+#[must_use]
+pub fn create_oci_image_target_task(
+    name: &str,
+    oci_image_target_id: &EntityId,
+    scanner_id: &EntityId,
+    opts: CreateOciImageTargetTaskOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("create_task");
+    cmd.add_element_with_text("name", name);
+    cmd.add_element_with_text("usage_type", UsageType::Scan.as_gmp_str());
+    add_id_element(&mut cmd, "oci_image_target", oci_image_target_id);
+    add_id_element(&mut cmd, "scanner", scanner_id);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(alterable) = opts.alterable {
+        cmd.add_element_with_text("alterable", bool_str(alterable));
+    }
+    for alert_id in &opts.alert_ids {
+        add_id_element(&mut cmd, "alert", alert_id);
+    }
+    if let Some(schedule_id) = opts.schedule_id.as_ref() {
+        add_id_element(&mut cmd, "schedule", schedule_id);
+        if let Some(schedule_periods) = opts.schedule_periods {
+            cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
+        }
+    }
+    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_preferences(&mut cmd, &opts.preferences);
+    cmd
+}
+
+/// Build a `create_task` request for an OCI image target scan task.
+///
+/// This compatibility alias uses python-gvm's historic "container image"
+/// helper name for the same GMP Next OCI image target task shape.
+#[must_use]
+pub fn create_container_image_task(
+    name: &str,
+    oci_image_target_id: &EntityId,
+    scanner_id: &EntityId,
+    opts: CreateOciImageTargetTaskOpts,
+) -> impl Request {
+    create_oci_image_target_task(name, oci_image_target_id, scanner_id, opts)
 }
 
 /// Build a `create_task` request.

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -91,6 +91,65 @@ fn test_create_agent_group_task_ignores_schedule_periods_without_schedule() {
 }
 
 #[test]
+fn test_create_oci_image_target_task() {
+    assert_eq!(
+        xml(create_oci_image_target_task(
+            "foo",
+            &id("oci1"),
+            &id("s1"),
+            Default::default()
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/></create_task>"
+    );
+    assert_eq!(
+        xml(create_container_image_task(
+            "foo",
+            &id("oci1"),
+            &id("s1"),
+            Default::default()
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
+fn test_create_oci_image_target_task_with_optionals() {
+    assert_eq!(
+        xml(create_oci_image_target_task(
+            "foo",
+            &id("oci1"),
+            &id("s1"),
+            CreateOciImageTargetTaskOpts {
+                comment: Some("bar".into()),
+                alterable: Some(true),
+                schedule_id: Some(id("sched1")),
+                alert_ids: vec![id("a1"), id("a2")],
+                schedule_periods: Some(5),
+                observers: vec!["alice".into(), "bob".into()],
+                preferences: vec![("k".into(), "v".into())],
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+    );
+}
+
+#[test]
+fn test_create_oci_image_target_task_ignores_schedule_periods_without_schedule() {
+    assert_eq!(
+        xml(create_oci_image_target_task(
+            "foo",
+            &id("oci1"),
+            &id("s1"),
+            CreateOciImageTargetTaskOpts {
+                schedule_periods: Some(5),
+                ..Default::default()
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
 fn test_task_mutation_and_actions() {
     assert_eq!(
         xml(clone_task(&id("a1"))),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -378,6 +378,9 @@ impl SessionHandler {
             if let Some(agent_group_id) = cmd.child_attr("agent_group", "id") {
                 resource.set_attr("agent_group_id", agent_group_id);
             }
+            if let Some(oci_image_target_id) = cmd.child_attr("oci_image_target", "id") {
+                resource.set_attr("oci_image_target_id", oci_image_target_id);
+            }
             if let Some(config_id) = cmd.child_attr("config", "id") {
                 resource.set_attr("config_id", config_id);
             }

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -166,6 +166,36 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn stateful_create_oci_image_target_task_preserves_target_id() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let create_resp = send_recv(
+        &mut stream,
+        br#"<create_task><name>OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id="oci1"/><scanner id="s1"/></create_task>"#,
+    )
+    .await;
+    assert_eq!(create_resp.status_code(), Some(201));
+    let task_id = create_resp.id().expect("should have id");
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+
+    let text = get_resp.as_str().expect("valid utf8");
+    assert!(text.contains("OCI Target Task"));
+    assert!(text.contains("<oci_image_target_id>oci1</oci_image_target_id>"));
+    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+
+    server.shutdown().await;
+}
+
 // CRUD-T002: Get created task by ID
 #[tokio::test]
 async fn stateful_create_then_get_task() {


### PR DESCRIPTION
## Summary
- add create_oci_image_target_task plus a create_container_image_task compatibility alias for the GMP Next OCI image target task shape
- expose the helper through GmpNextCommands, including the python-gvm-compatible create_container_image_task default alias
- preserve oci_image_target_id in stateful mock-server task storage and cover it with readback testing

## Notes
- the wire command is create_task, so the version-safe convenience is exposed on GmpNextCommands; raw GmpClient::call can still send any builder by design
- schedule_periods follows python-gvm next behavior and is emitted only when schedule_id is present
- observer serialization keeps the existing Rust task-builder shape (<observers><observer>...</observer></observers>), rather than changing the broader task surface in this PR

## Validation
- cargo test -p gvm-gmp --test test_tasks
- cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_oci_image_targets_round_trip
- cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_mode stateful_create_oci_image_target_task_preserves_target_id
- cargo test -p gvm-client --features unix-socket-tests --test versioned_client
- cargo test -p gvm-gmp --quiet
- cargo test -p gvm-client --all-features --quiet
- cargo test -p gvm-mock-server --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --all-features --quiet
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace --quiet
- PATH="/home/rpelfrey/github projects/rust-gvm/code-repo/.venv/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.codex/tmp/arg0/codex-arg06fORSF:/home/rpelfrey/.local/bin:/home/rpelfrey/.cargo/bin:/home/rpelfrey/.nvm/versions/node/v24.14.1/bin:/home/rpelfrey/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.local/bin:/home/rpelfrey/.vscode/extensions/openai.chatgpt-26.623.101652-linux-x64/bin/linux-x86_64:/home/rpelfrey/.local/bin" make test-integration
- cargo deny check (passes with existing unmatched allow/advisory warnings)
- cargo audit (passes with allowed yanked crypto-bigint 0.7.4 warning)
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- python3 -B -m unittest tests.test_sbom_postprocess -q
- semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif . (0 findings; SARIF removed)