### PR TITLE
Add web application task helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -50,6 +50,7 @@ use gvm_gmp::commands::reports::{
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
 use gvm_gmp::commands::tasks::create_oci_image_target_task as build_oci_image_target_task;
+use gvm_gmp::commands::tasks::create_web_application_task;
 use gvm_gmp::commands::version::get_version;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
@@ -77,6 +78,7 @@ pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateOciImageTargetTaskOpts;
+pub use gvm_gmp::commands::tasks::CreateWebApplicationTaskOpts;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
@@ -1096,6 +1098,15 @@ pub trait GmpNextCommands {
         ultimate: bool,
     ) -> Result<Response, GvmError>;
 
+    /// Create a scan task for a web application target.
+    async fn create_web_application_task(
+        &mut self,
+        name: &str,
+        web_application_target_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateWebApplicationTaskOpts,
+    ) -> Result<Response, GvmError>;
+
     /// Get a single integration configuration.
     async fn get_integration_config(
         &mut self,
@@ -1587,6 +1598,23 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
     ) -> Result<Response, GvmError> {
         self.0
             .delete_web_application_target(web_application_target_id, ultimate)
+            .await
+    }
+
+    async fn create_web_application_task(
+        &mut self,
+        name: &str,
+        web_application_target_id: &EntityId,
+        scanner_id: &EntityId,
+        opts: CreateWebApplicationTaskOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(create_web_application_task(
+                name,
+                web_application_target_id,
+                scanner_id,
+                opts,
+            ))
             .await
     }
 

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -8,8 +8,8 @@ use gvm_client::GmpNext;
 use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
     CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
-    GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned, GvmError,
-    ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
+    CreateWebApplicationTaskOpts, GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
+    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
     ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::{GvmConnection, UnixSocketConnection};
@@ -118,6 +118,38 @@ async fn assert_create_oci_image_target_task_round_trip<C>(
         format!(
             "<create_task><name>Client OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
             oci_image_target_id.as_str()
+        )
+    );
+}
+
+async fn assert_create_web_application_task_round_trip(
+    client: &mut GmpNext<UnixSocketConnection>,
+    server: &MockGmpServer,
+    target_id: &EntityId,
+) {
+    server.clear_history();
+    let scanner_id = EntityId::new("scanner-web-1").expect("valid id");
+    let task_response = client
+        .create_web_application_task(
+            "Client Web Task",
+            target_id,
+            &scanner_id,
+            CreateWebApplicationTaskOpts {
+                comment: Some("created from versioned client".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_web_application_task should succeed");
+    assert_eq!(task_response.status_code(), Some(201));
+    let history = server.command_history();
+    let command = history.last().expect("create task command recorded");
+    assert_eq!(command.command_name(), "create_task");
+    let raw_xml = String::from_utf8(command.raw_xml().to_vec()).expect("history should be utf8");
+    assert_eq!(
+        raw_xml,
+        format!(
+            "<create_task><name>Client Web Task</name><usage_type>scan</usage_type><web_application_target id=\"{target_id}\"/><scanner id=\"scanner-web-1\"/><comment>created from versioned client</comment></create_task>"
         )
     );
 }
@@ -677,6 +709,8 @@ async fn next_client_web_application_targets_round_trip() {
     assert!(get_xml.contains("<urls>https://example.com,https://example.com/app</urls>"));
     assert!(get_xml.contains("<exclude_urls>https://example.com/logout</exclude_urls>"));
     assert!(get_xml.contains("<credential_id>credential-web-1</credential_id>"));
+
+    assert_create_web_application_task_round_trip(&mut client, &server, &target_id).await;
 
     let clone_response = client
         .clone_web_application_target(&target_id)

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -83,7 +83,7 @@ pub struct CreateWebApplicationTaskOpts {
     pub alert_ids: Vec<EntityId>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional schedule period count.
+    /// Optional schedule period count, serialized only when [`Self::schedule_id`] is set.
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -72,6 +72,25 @@ pub struct CreateOciImageTargetTaskOpts {
     pub preferences: Vec<(String, String)>,
 }
 
+/// Optional fields for web application target `create_task` requests.
+#[derive(Debug, Clone, Default)]
+pub struct CreateWebApplicationTaskOpts {
+    /// Whether the task should be alterable.
+    pub alterable: Option<bool>,
+    /// Optional schedule identifier.
+    pub schedule_id: Option<EntityId>,
+    /// Alert identifiers associated with the request.
+    pub alert_ids: Vec<EntityId>,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional schedule period count.
+    pub schedule_periods: Option<u32>,
+    /// Observer names associated with the task.
+    pub observers: Vec<String>,
+    /// Preference key/value pairs to include.
+    pub preferences: Vec<(String, String)>,
+}
+
 /// Options for `get_tasks` requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetTasksOpts {
@@ -264,6 +283,41 @@ fn create_task_with_usage(
     }
     for alert_id in &opts.alert_ids {
         add_id_element(&mut cmd, "alert", alert_id);
+    }
+    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_preferences(&mut cmd, &opts.preferences);
+    cmd
+}
+
+/// Build a `create_task` request for a web application target.
+#[must_use]
+pub fn create_web_application_task(
+    name: &str,
+    web_application_target_id: &EntityId,
+    scanner_id: &EntityId,
+    opts: CreateWebApplicationTaskOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("create_task");
+    cmd.add_element_with_text("name", name);
+    cmd.add_element_with_text("usage_type", UsageType::Scan.as_gmp_str());
+    add_id_element(
+        &mut cmd,
+        "web_application_target",
+        web_application_target_id,
+    );
+    add_id_element(&mut cmd, "scanner", scanner_id);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(alterable) = opts.alterable {
+        cmd.add_element_with_text("alterable", bool_str(alterable));
+    }
+    for alert_id in &opts.alert_ids {
+        add_id_element(&mut cmd, "alert", alert_id);
+    }
+    if let Some(schedule_id) = opts.schedule_id.as_ref() {
+        add_id_element(&mut cmd, "schedule", schedule_id);
+        if let Some(schedule_periods) = opts.schedule_periods {
+            cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
+        }
     }
     add_string_list(&mut cmd, "observers", "observer", &opts.observers);
     add_preferences(&mut cmd, &opts.preferences);
@@ -492,6 +546,44 @@ mod tests {
         assert!(rendered.contains("<alert id=\"a1\"/>"));
         assert!(rendered.contains("<observer>alice</observer>"));
         assert!(rendered.contains("<scanner_name>k</scanner_name><value>v</value>"));
+    }
+
+    #[test]
+    fn create_web_application_task_builds_full_xml() {
+        let rendered = xml(create_web_application_task(
+            "web task",
+            &id("wt1"),
+            &id("s1"),
+            CreateWebApplicationTaskOpts {
+                alterable: Some(true),
+                schedule_id: Some(id("sched1")),
+                alert_ids: vec![id("a1"), id("a2")],
+                comment: Some("scan web app".into()),
+                schedule_periods: Some(5),
+                observers: vec!["alice".into(), "bob".into()],
+                preferences: vec![("k".into(), "v".into())],
+            },
+        ));
+        assert_eq!(
+            rendered,
+            "<create_task><name>web task</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>scan web app</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+        );
+    }
+
+    #[test]
+    fn create_web_application_task_omits_schedule_periods_without_schedule() {
+        assert_eq!(
+            xml(create_web_application_task(
+                "web task",
+                &id("wt1"),
+                &id("s1"),
+                CreateWebApplicationTaskOpts {
+                    schedule_periods: Some(5),
+                    ..Default::default()
+                },
+            )),
+            "<create_task><name>web task</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/></create_task>"
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -150,6 +150,56 @@ fn test_create_oci_image_target_task_ignores_schedule_periods_without_schedule()
 }
 
 #[test]
+fn test_create_web_application_task_basic() {
+    assert_eq!(
+        xml(create_web_application_task(
+            "foo",
+            &id("wt1"),
+            &id("s1"),
+            Default::default()
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
+fn test_create_web_application_task_with_optionals() {
+    assert_eq!(
+        xml(create_web_application_task(
+            "foo",
+            &id("wt1"),
+            &id("s1"),
+            CreateWebApplicationTaskOpts {
+                alterable: Some(true),
+                schedule_id: Some(id("sched1")),
+                alert_ids: vec![id("a1"), id("a2")],
+                comment: Some("bar".into()),
+                schedule_periods: Some(5),
+                observers: vec!["alice".into(), "bob".into()],
+                preferences: vec![("k".into(), "v".into())],
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+    );
+}
+
+#[test]
+fn test_create_web_application_task_omits_schedule_periods_without_schedule() {
+    assert_eq!(
+        xml(create_web_application_task(
+            "foo",
+            &id("wt1"),
+            &id("s1"),
+            CreateWebApplicationTaskOpts {
+                schedule_periods: Some(5),
+                ..Default::default()
+            }
+        )),
+        "<create_task><name>foo</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/></create_task>"
+    );
+}
+
+#[test]
 fn test_task_mutation_and_actions() {
     assert_eq!(
         xml(clone_task(&id("a1"))),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -372,6 +372,18 @@ impl SessionHandler {
 
         // Task-specific: extract references
         if resource_type == "task" {
+            if cmd.child_attr("web_application_target", "id").is_some()
+                && !matches!(self.version, GmpVersion::V22_8)
+            {
+                return error_response(
+                    &cmd.name,
+                    400,
+                    &format!(
+                        "Web application target tasks are not available in GMP {}",
+                        self.version
+                    ),
+                );
+            }
             if let Some(target_id) = cmd.child_attr("target", "id") {
                 resource.set_attr("target_id", target_id);
             }
@@ -380,6 +392,10 @@ impl SessionHandler {
             }
             if let Some(oci_image_target_id) = cmd.child_attr("oci_image_target", "id") {
                 resource.set_attr("oci_image_target_id", oci_image_target_id);
+            }
+            if let Some(web_application_target_id) = cmd.child_attr("web_application_target", "id")
+            {
+                resource.set_attr("web_application_target_id", web_application_target_id);
             }
             if let Some(config_id) = cmd.child_attr("config", "id") {
                 resource.set_attr("config_id", config_id);

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -372,9 +372,11 @@ impl SessionHandler {
 
         // Task-specific: extract references
         if resource_type == "task" {
-            if cmd.child_attr("web_application_target", "id").is_some()
-                && !matches!(self.version, GmpVersion::V22_8)
-            {
+            let has_web_application_target = cmd
+                .children
+                .iter()
+                .any(|child| child.name == "web_application_target");
+            if has_web_application_target && !matches!(self.version, GmpVersion::V22_8) {
                 return error_response(
                     &cmd.name,
                     400,
@@ -382,6 +384,17 @@ impl SessionHandler {
                         "Web application target tasks are not available in GMP {}",
                         self.version
                     ),
+                );
+            }
+            if has_web_application_target
+                && cmd
+                    .child_attr("web_application_target", "id")
+                    .is_none_or(str::is_empty)
+            {
+                return error_response(
+                    &cmd.name,
+                    400,
+                    "Missing required attribute: web_application_target id",
                 );
             }
             if let Some(target_id) = cmd.child_attr("target", "id") {

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -26,10 +26,14 @@ async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
 }
 
 async fn stateful_server() -> Option<MockGmpServer> {
+    stateful_server_with_version(GmpVersion::V22_5).await
+}
+
+async fn stateful_server_with_version(version: GmpVersion) -> Option<MockGmpServer> {
     build_server(
         MockGmpServer::builder()
             .mode(ServerMode::Stateful)
-            .version(GmpVersion::V22_5)
+            .version(version)
             .credentials("admin", "secret")
             .unix_socket_auto(),
     )
@@ -191,6 +195,35 @@ async fn stateful_create_oci_image_target_task_preserves_target_id() {
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("OCI Target Task"));
     assert!(text.contains("<oci_image_target_id>oci1</oci_image_target_id>"));
+    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_create_web_application_task_preserves_target_id() {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let create_resp = send_recv(
+        &mut stream,
+        br#"<create_task><name>Web Task</name><usage_type>scan</usage_type><web_application_target id="wt1"/><scanner id="s1"/></create_task>"#,
+    )
+    .await;
+    assert_eq!(create_resp.status_code(), Some(201));
+    let task_id = create_resp.id().expect("should have id");
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+
+    let text = get_resp.as_str().expect("valid utf8");
+    assert!(text.contains("<web_application_target_id>wt1</web_application_target_id>"));
     assert!(text.contains("<scanner_id>s1</scanner_id>"));
 
     server.shutdown().await;

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -207,6 +207,17 @@ async fn stateful_create_web_application_task_preserves_target_id() {
     };
     let mut stream = connect_and_auth(&server).await;
 
+    let missing_id = send_recv(
+        &mut stream,
+        br#"<create_task><name>Invalid Web Task</name><web_application_target/><scanner id="s1"/></create_task>"#,
+    )
+    .await;
+    assert_eq!(missing_id.status_code(), Some(400));
+    assert!(missing_id
+        .status_text()
+        .expect("status text")
+        .contains("web_application_target id"));
+
     let create_resp = send_recv(
         &mut stream,
         br#"<create_task><name>Web Task</name><usage_type>scan</usage_type><web_application_target id="wt1"/><scanner id="s1"/></create_task>"#,

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -24,6 +24,7 @@ use gvm_gmp::commands::oci_image_targets::{
 use gvm_gmp::commands::report_configs::{create_report_config, get_report_configs};
 use gvm_gmp::commands::reports::{get_report_cves, get_report_hosts};
 use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
+use gvm_gmp::commands::tasks::{create_web_application_task, CreateWebApplicationTaskOpts};
 use gvm_gmp::commands::web_application_targets::{
     create_web_application_target, get_web_application_targets, CreateWebApplicationTargetOpts,
 };
@@ -263,6 +264,22 @@ async fn version_22_7_rejects_next_commands() {
         .unwrap()
         .contains("create_oci_image_target"));
 
+    let response = send_recv(
+        &mut stream,
+        create_web_application_task(
+            "Rejected Web Application Task",
+            &id("web-target-1"),
+            &id("scanner-1"),
+            CreateWebApplicationTaskOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response
+        .status_text()
+        .unwrap()
+        .contains("Web application target tasks"));
+
     server.shutdown().await;
 }
 
@@ -350,8 +367,16 @@ async fn version_22_8_accepts_next_commands() {
     .await;
     assert_eq!(report_helper.status_code(), Some(404));
 
+    assert_credential_store_verify_works_on_next(&mut stream).await;
+    assert_web_application_targets_and_tasks_work_on_next(&mut stream).await;
+    assert_oci_image_targets_work_on_next(&mut stream).await;
+
+    server.shutdown().await;
+}
+
+async fn assert_web_application_targets_and_tasks_work_on_next(stream: &mut UnixStream) {
     let web_target_response = send_recv(
-        &mut stream,
+        stream,
         create_web_application_target(
             "Version Gated Web Target",
             &["https://example.com".to_string()],
@@ -365,18 +390,25 @@ async fn version_22_8_accepts_next_commands() {
     .await;
     assert_eq!(web_target_response.status_code(), Some(201));
 
-    let web_target_list =
-        send_recv(&mut stream, get_web_application_targets(Default::default())).await;
+    let web_target_list = send_recv(stream, get_web_application_targets(Default::default())).await;
     assert_eq!(web_target_list.status_code(), Some(200));
     let web_target_xml = web_target_list.as_str().expect("utf8");
     assert!(web_target_xml.contains("Version Gated Web Target"));
     assert!(web_target_xml.contains("<urls>https://example.com</urls>"));
     assert!(web_target_xml.contains("<credential_id>credential-web-gate</credential_id>"));
 
-    assert_credential_store_verify_works_on_next(&mut stream).await;
-    assert_oci_image_targets_work_on_next(&mut stream).await;
-
-    server.shutdown().await;
+    let web_target_id = id(&web_target_response.id().expect("created web target id"));
+    let web_task_response = send_recv(
+        stream,
+        create_web_application_task(
+            "Version Gated Web Task",
+            &web_target_id,
+            &id("scanner-web-gate"),
+            CreateWebApplicationTaskOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(web_task_response.status_code(), Some(201));
 }
 
 async fn assert_credential_store_verify_works_on_next(stream: &mut UnixStream) {


### PR DESCRIPTION
## Summary
- add a GMP Next `create_web_application_task` builder for web application target scans
- expose it through `GmpNextCommands` and client re-exports
- preserve `web_application_target_id` in stateful mock-server task creates, with 22.8 version-fidelity coverage

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --test test_tasks`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_web_application_targets_round_trip`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_mode stateful_create_web_application_task_preserves_target_id`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test version_gating`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client`
- `cargo test -p gvm-gmp --quiet`
- `cargo test -p gvm-client --all-features --quiet`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features --quiet`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .`

Known baseline validation notes: `cargo deny check` reports existing unmatched allowlist/license/advisory warnings; `cargo audit` reports the allowed yanked `crypto-bigint 0.7.4` warning; the pinned-toolchain workspace test emits existing missing-doc warnings from feature-gated `gvm-client` integration test crates. Fuzzing was not run because this change adds command-builder/client/mock CRUD coverage without changing parsers, transport framing, streaming, or fuzz-facing input consumers.