### PR TITLE
Add credential store helper options

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -29,7 +29,10 @@ use gvm_gmp::commands::agents::{
     delete_agent, get_agent, get_agent_installer_instruction, get_agent_support_bundle, get_agents,
     modify_agent, modify_agent_control_scan_config, sync_agents,
 };
-use gvm_gmp::commands::credentials::{get_credential_stores, verify_credential_store};
+use gvm_gmp::commands::credentials::{
+    get_credential_store, get_credential_stores, get_credential_stores_with_opts,
+    verify_credential_store,
+};
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
@@ -68,6 +71,7 @@ pub use gvm_gmp::commands::agents::{
     AgentRetryConfig, AgentScriptExecutorConfig, GetAgentsOpts, ModifyAgentControlScanConfigOpts,
     ModifyAgentOpts,
 };
+pub use gvm_gmp::commands::credentials::GetCredentialStoresOpts;
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
@@ -1210,6 +1214,19 @@ pub trait GmpNextCommands {
         &mut self,
         credential_store_id: &EntityId,
     ) -> Result<Response, GvmError>;
+
+    /// List credential stores with optional filters.
+    async fn get_credential_stores_with_opts(
+        &mut self,
+        opts: GetCredentialStoresOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get a single credential store.
+    async fn get_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -1733,6 +1750,23 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
     ) -> Result<Response, GvmError> {
         self.0
             .call(verify_credential_store(credential_store_id))
+            .await
+    }
+
+    async fn get_credential_stores_with_opts(
+        &mut self,
+        opts: GetCredentialStoresOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.call(get_credential_stores_with_opts(opts)).await
+    }
+
+    async fn get_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(get_credential_store(credential_store_id, details))
             .await
     }
 }

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -15,8 +15,9 @@ use gvm_connection::GvmConnection;
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
-    create_credential, get_credential_stores, get_credentials, verify_credential_store,
-    CredentialOpts, GetCredentialsOpts,
+    create_credential, get_credential_store, get_credential_stores,
+    get_credential_stores_with_opts, get_credentials, verify_credential_store, CredentialOpts,
+    GetCredentialStoresOpts, GetCredentialsOpts,
 };
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
@@ -947,6 +948,35 @@ impl<C: GvmConnection + Send> GmpClient<C> {
             .send(verify_credential_store(credential_store_id))
             .await?;
         VerifyCredentialStoreResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a filtered `get_credential_stores` request and return a typed
+    /// [`GetCredentialStoresResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_credential_stores_with_opts(
+        &mut self,
+        opts: GetCredentialStoresOpts,
+    ) -> Result<GetCredentialStoresResponse, GvmError> {
+        let response = self.send(get_credential_stores_with_opts(opts)).await?;
+        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a single-store `get_credential_stores` request and return a typed
+    /// [`GetCredentialStoresResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<GetCredentialStoresResponse, GvmError> {
+        let response = self
+            .send(get_credential_store(credential_store_id, details))
+            .await?;
+        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── NVTs ──────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -5,8 +5,8 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GmpClient, GmpNextCommands,
-    GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
+    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GetCredentialStoresOpts, GmpClient,
+    GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
     ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
@@ -652,11 +652,49 @@ async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
         .iter()
         .any(|timezone| timezone.name == "UTC"));
 
+    server.clear_history();
+
     let stores = client
         .get_credential_stores()
         .await
         .expect("credential stores should parse");
     assert_eq!(stores.items[0].name, "Local credential store");
+
+    let store_id = EntityId::new("local").expect("valid id");
+    let store = client
+        .get_credential_store(&store_id, Some(true))
+        .await
+        .expect("credential store should parse");
+    assert_eq!(store.items[0].name, "Local credential store");
+
+    let filtered_stores = client
+        .get_credential_stores_with_opts(GetCredentialStoresOpts {
+            filter_string: Some("name=Local".into()),
+            filter_id: Some(EntityId::new("filter-1").expect("valid id")),
+            details: Some(false),
+        })
+        .await
+        .expect("filtered credential stores should parse");
+    assert_eq!(filtered_stores.items[0].name, "Local credential store");
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 3);
+    assert!(history
+        .iter()
+        .all(|record| record.command_name() == "get_credential_stores"));
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(commands[0], "<get_credential_stores/>");
+    assert_eq!(
+        commands[1],
+        "<get_credential_stores details=\"1\"><credential_store_id>local</credential_store_id></get_credential_stores>"
+    );
+    assert_eq!(
+        commands[2],
+        "<get_credential_stores details=\"0\" filt_id=\"filter-1\" filter=\"name=Local\"/>"
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -8,9 +8,10 @@ use gvm_client::GmpNext;
 use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
     CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
-    CreateWebApplicationTaskOpts, GetAgentsOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
-    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
-    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
+    CreateWebApplicationTaskOpts, GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands,
+    GmpNextCommands, GmpVersioned, GvmError, ModifyAgentControlScanConfigOpts,
+    ModifyAgentGroupOpts, ModifyAgentOpts, ModifyOciImageTargetOpts,
+    ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
@@ -251,6 +252,70 @@ async fn next_client_verify_credential_store_round_trip() {
     assert_eq!(
         std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 request"),
         "<verify_credential_store credential_store_id=\"credential-store-1\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_credential_store_helpers_send_expected_commands() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    server.clear_history();
+    let credential_store_id = EntityId::new("local").expect("valid id");
+    let response = client
+        .get_credential_store(&credential_store_id, Some(true))
+        .await
+        .expect("get_credential_store should succeed");
+    assert_eq!(response.status_code(), Some(200));
+    assert!(response
+        .as_str()
+        .expect("valid UTF-8 XML")
+        .contains("Local credential store"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "get_credential_stores");
+    assert_eq!(
+        std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 request"),
+        "<get_credential_stores details=\"1\"><credential_store_id>local</credential_store_id></get_credential_stores>"
+    );
+
+    server.clear_history();
+    let response = client
+        .get_credential_stores_with_opts(GetCredentialStoresOpts {
+            filter_string: Some("name=Local".into()),
+            filter_id: Some(EntityId::new("filter-1").expect("valid id")),
+            details: Some(false),
+        })
+        .await
+        .expect("get_credential_stores_with_opts should succeed");
+    assert_eq!(response.status_code(), Some(200));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "get_credential_stores");
+    assert_eq!(
+        std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 request"),
+        "<get_credential_stores details=\"0\" filt_id=\"filter-1\" filter=\"name=Local\"/>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -45,6 +45,17 @@ pub struct GetCredentialsOpts {
     pub details: Option<bool>,
 }
 
+/// Options for `get_credential_stores` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetCredentialStoresOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+}
+
 /// A credential-store preference update.
 #[derive(Debug, Clone, Default)]
 pub struct CredentialStorePreference {
@@ -111,7 +122,29 @@ pub fn get_credential(credential_id: &EntityId) -> impl Request {
 /// Build a `get_credential_stores` request.
 #[must_use]
 pub fn get_credential_stores() -> impl Request {
-    XmlCommand::new("get_credential_stores")
+    get_credential_stores_with_opts(GetCredentialStoresOpts::default())
+}
+
+/// Build a `get_credential_stores` request with optional filters.
+#[must_use]
+pub fn get_credential_stores_with_opts(opts: GetCredentialStoresOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("get_credential_stores");
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    set_optional_bool_attr(&mut cmd, "details", opts.details);
+    cmd
+}
+
+/// Build a `get_credential_stores` request for a single credential store.
+#[must_use]
+pub fn get_credential_store(credential_store_id: &EntityId, details: Option<bool>) -> impl Request {
+    let mut cmd = XmlCommand::new("get_credential_stores");
+    cmd.add_element_with_text("credential_store_id", credential_store_id.as_str());
+    set_optional_bool_attr(&mut cmd, "details", details);
+    cmd
 }
 
 /// Build a `verify_credential_store` request.
@@ -221,6 +254,22 @@ mod tests {
         assert_eq!(
             xml(verify_credential_store(&id("cs1"))),
             "<verify_credential_store credential_store_id=\"cs1\"/>"
+        );
+        assert_eq!(
+            xml(get_credential_store(&id("cs1"), Some(true))),
+            "<get_credential_stores details=\"1\"><credential_store_id>cs1</credential_store_id></get_credential_stores>"
+        );
+        assert_eq!(
+            xml(get_credential_store(&id("cs1"), Some(false))),
+            "<get_credential_stores details=\"0\"><credential_store_id>cs1</credential_store_id></get_credential_stores>"
+        );
+        assert_eq!(
+            xml(get_credential_stores_with_opts(GetCredentialStoresOpts {
+                filter_string: Some("name=store".into()),
+                filter_id: Some(id("f1")),
+                details: Some(true),
+            })),
+            "<get_credential_stores details=\"1\" filt_id=\"f1\" filter=\"name=store\"/>"
         );
         assert_eq!(
             xml(modify_credential_store(

--- a/crates/gvm-mock-server/tests/fixture_coverage.rs
+++ b/crates/gvm-mock-server/tests/fixture_coverage.rs
@@ -185,6 +185,14 @@ async fn fixture_get_timezones_and_credential_stores() {
     assert!(r.is_success());
     assert!(r.as_str().expect("utf8").contains("Local credential store"));
 
+    let r = send_recv(
+        &mut s,
+        b"<get_credential_stores details=\"1\"><credential_store_id>local</credential_store_id></get_credential_stores>",
+    )
+    .await;
+    assert!(r.is_success());
+    assert!(r.as_str().expect("utf8").contains("Local credential store"));
+
     server.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary
- add `GetCredentialStoresOpts`, filtered `get_credential_stores_with_opts`, and singular `get_credential_store` builder support using python-gvm's child `<credential_store_id>` shape
- expose the credential-store helpers through `gvm-client` Next/raw and typed client APIs while preserving the existing no-arg `get_credential_stores` path
- add unix-socket mock-server/client history assertions for raw Next and typed client paths, plus fixture coverage for the singular child-id request

## Validation
- cargo fmt --all -- --check
- cargo test -p gvm-gmp credential_commands_build_xml
- cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_credential_store_helpers_send_expected_commands
- cargo test -p gvm-mock-server --features unix-socket-tests --test fixture_coverage fixture_get_timezones_and_credential_stores
- cargo test -p gvm-client --features unix-socket-tests --test versioned_client
- cargo test -p gvm-gmp --quiet
- cargo test -p gvm-client --all-features --quiet
- cargo test -p gvm-mock-server --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --all-features --quiet
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace --quiet
- PATH="$PWD/.venv/bin:$PATH" make test-integration
- cargo deny check
- cargo audit
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- python3 -B -m unittest tests.test_sbom_postprocess -q
- semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .

## Notes
- `GmpNextCommands` is extended with the new credential-store methods, matching the existing devel-target Next command exposure pattern.
- `cargo deny check` still reports existing unmatched allowlist/license/advisory warnings while passing.
- `cargo audit` still reports the existing allowed yanked `crypto-bigint 0.7.4` warning while passing.
- The pinned-toolchain test run still emits existing missing-doc warnings from feature-gated `gvm-client` integration test crates.
- `cargo vet` rewrote quote escaping in `supply-chain/imports.lock`; that mechanical churn was restored before commit.
- Fuzzing was not run; this PR adds command builders, client wrappers, and mock fixture/client coverage without changing parser, framing, or input-consuming protocol logic.
