### PR TITLE
Add credential store verify helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -29,7 +29,7 @@ use gvm_gmp::commands::agents::{
     delete_agent, get_agent, get_agent_installer_instruction, get_agent_support_bundle, get_agents,
     modify_agent, modify_agent_control_scan_config, sync_agents,
 };
-use gvm_gmp::commands::credentials::get_credential_stores;
+use gvm_gmp::commands::credentials::{get_credential_stores, verify_credential_store};
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
@@ -1158,6 +1158,12 @@ pub trait GmpNextCommands {
 
     /// List credential stores.
     async fn get_credential_stores(&mut self) -> Result<Response, GvmError>;
+
+    /// Verify a credential store connection.
+    async fn verify_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+    ) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -1622,6 +1628,15 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
 
     async fn get_credential_stores(&mut self) -> Result<Response, GvmError> {
         self.0.call(get_credential_stores()).await
+    }
+
+    async fn verify_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(verify_credential_store(credential_store_id))
+            .await
     }
 }
 

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -15,7 +15,8 @@ use gvm_connection::GvmConnection;
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
-    create_credential, get_credential_stores, get_credentials, CredentialOpts, GetCredentialsOpts,
+    create_credential, get_credential_stores, get_credentials, verify_credential_store,
+    CredentialOpts, GetCredentialsOpts,
 };
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
@@ -103,7 +104,7 @@ use gvm_gmp::responses::{
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
     GetVulnerabilitiesResponse, HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse,
     ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
-    VerifyScannerResponse,
+    VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -710,6 +711,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn get_credential_stores(&mut self) -> Result<GetCredentialStoresResponse, GvmError> {
         let response = self.send(get_credential_stores()).await?;
         GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `verify_credential_store` request and return a typed
+    /// [`VerifyCredentialStoreResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn verify_credential_store(
+        &mut self,
+        credential_store_id: &EntityId,
+    ) -> Result<VerifyCredentialStoreResponse, GvmError> {
+        let response = self
+            .send(verify_credential_store(credential_store_id))
+            .await?;
+        VerifyCredentialStoreResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── NVTs ──────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -41,6 +41,7 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_timezones"
         | "get_report_export"
         | "get_credential_stores"
+        | "verify_credential_store"
         | "create_oci_image_target"
         | "delete_oci_image_target"
         | "get_oci_image_targets"
@@ -214,6 +215,10 @@ mod tests {
         );
         assert_eq!(
             minimum_version_for_command("get_credential_stores"),
+            Some(GmpVersion(22, 8))
+        );
+        assert_eq!(
+            minimum_version_for_command("verify_credential_store"),
             Some(GmpVersion(22, 8))
         );
         assert!(!command_supported("get_agent_groups", GmpVersion(22, 7)));

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -519,6 +519,20 @@ async fn unsupported_next_command_rejected_before_send() {
         } if command == "get_timezones"
     ));
 
+    let credential_store_id = EntityId::new("credential-store-1").expect("valid id");
+    let error = client
+        .verify_credential_store(&credential_store_id)
+        .await
+        .expect_err("22.7 should reject typed credential store verification");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == "verify_credential_store"
+    ));
+
     server.shutdown().await;
 }
 
@@ -642,6 +656,40 @@ async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
         .await
         .expect("credential stores should parse");
     assert_eq!(stores.items[0].name, "Local credential store");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_verify_credential_store_uses_next_command_shape() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let credential_store_id = EntityId::new("credential-store-1").expect("valid id");
+    let response = client
+        .verify_credential_store(&credential_store_id)
+        .await
+        .expect("verify_credential_store should parse");
+    assert_eq!(response.status, 200);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "verify_credential_store");
+    assert_eq!(
+        std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 command"),
+        "<verify_credential_store credential_store_id=\"credential-store-1\"/>"
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -12,6 +12,7 @@ use gvm_client::{
 };
 use gvm_connection::UnixSocketConnection;
 use gvm_gmp::commands::agents::get_agents;
+use gvm_gmp::commands::credentials::verify_credential_store;
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
@@ -100,6 +101,47 @@ async fn next_client_exposes_next_trait_methods() {
         .await
         .expect("next-only command should succeed");
     assert_eq!(response.status_code(), Some(200));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_verify_credential_store_round_trip() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    server.clear_history();
+    let credential_store_id = EntityId::new("credential-store-1").expect("valid id");
+    let response = client
+        .verify_credential_store(&credential_store_id)
+        .await
+        .expect("verify_credential_store should succeed");
+    assert_eq!(response.status_code(), Some(200));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "verify_credential_store");
+    assert_eq!(
+        std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 request"),
+        "<verify_credential_store credential_store_id=\"credential-store-1\"/>"
+    );
 
     server.shutdown().await;
 }
@@ -239,6 +281,21 @@ async fn versioned_client_rejects_oci_image_targets_before_next() {
             version: GmpVersion(22, 7),
             required: "22.8",
         } if command == "get_oci_image_targets"
+    ));
+
+    let credential_store_id = EntityId::new("credential-store-1").expect("valid id");
+    let error = client
+        .call(verify_credential_store(&credential_store_id))
+        .await
+        .expect_err("22.7 should reject next-only credential store verify command");
+
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "verify_credential_store"
     ));
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -114,6 +114,13 @@ pub fn get_credential_stores() -> impl Request {
     XmlCommand::new("get_credential_stores")
 }
 
+/// Build a `verify_credential_store` request.
+#[must_use]
+pub fn verify_credential_store(credential_store_id: &EntityId) -> impl Request {
+    XmlCommand::new("verify_credential_store")
+        .attribute("credential_store_id", credential_store_id.as_str())
+}
+
 /// Build a `modify_credential_store` request.
 #[must_use]
 pub fn modify_credential_store(
@@ -211,6 +218,10 @@ mod tests {
         assert!(rendered.contains("credential_id=\"c1\""));
         assert!(rendered.contains("details=\"1\""));
         assert_eq!(xml(get_credential_stores()), "<get_credential_stores/>");
+        assert_eq!(
+            xml(verify_credential_store(&id("cs1"))),
+            "<verify_credential_store credential_store_id=\"cs1\"/>"
+        );
         assert_eq!(
             xml(modify_credential_store(
                 &id("cs1"),

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -136,6 +136,8 @@ impl CreateCredentialResponse {
     }
 }
 
+pub type VerifyCredentialStoreResponse = ActionResponse;
+
 pub type ModifyCredentialResponse = ActionResponse;
 pub type DeleteCredentialResponse = ActionResponse;
 

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -52,6 +52,7 @@ pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, Pars
 pub use credential::{
     CreateCredentialResponse, Credential, CredentialStore, DeleteCredentialResponse,
     GetCredentialStoresResponse, GetCredentialsResponse, ModifyCredentialResponse,
+    VerifyCredentialStoreResponse,
 };
 pub use features::{Feature, GetFeaturesResponse};
 pub use feed::{Feed, GetFeedsResponse};

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -216,6 +216,7 @@ impl SessionHandler {
             "modify_license" => self.handle_modify_license(cmd),
             // Modify commands
             name if name.starts_with("modify_") => self.handle_modify(cmd, raw_xml, store),
+            "verify_credential_store" => handle_verify_credential_store(cmd),
             "delete_agent" => handle_agent_set_action(cmd),
             // Delete commands
             name if name.starts_with("delete_") => self.handle_delete(cmd, store),
@@ -1136,6 +1137,17 @@ fn handle_modify_agent_control_scan_config(cmd: &ParsedCommand) -> Vec<u8> {
 }
 
 fn handle_modify_credential_store(cmd: &ParsedCommand) -> Vec<u8> {
+    if cmd.attr("credential_store_id").is_none() {
+        return error_response(
+            &cmd.name,
+            400,
+            "Missing required attribute: credential_store_id",
+        );
+    }
+    format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
+}
+
+fn handle_verify_credential_store(cmd: &ParsedCommand) -> Vec<u8> {
     if cmd.attr("credential_store_id").is_none() {
         return error_response(
             &cmd.name,

--- a/crates/gvm-mock-server/src/response_gen.rs
+++ b/crates/gvm-mock-server/src/response_gen.rs
@@ -233,6 +233,7 @@ pub static COMMAND_COVERAGE: &[CommandCoverage] = &[
     echo_only("sync_config"),
     echo_only("test_alert"),
     echo_only("verify_report_format"),
+    stateful_since("verify_credential_store", GmpVersion::V22_8),
     echo_only("verify_scanner"),
 ];
 
@@ -407,6 +408,7 @@ pub static KNOWN_COMMANDS: &[&str] = &[
     "sync_agents",
     "sync_config",
     "test_alert",
+    "verify_credential_store",
     "verify_report_format",
     "verify_scanner",
 ];

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -73,6 +73,7 @@ const GMP_22_8_COMMANDS: &[&str] = &[
     "get_timezones",
     "get_credential_stores",
     "modify_credential_store",
+    "verify_credential_store",
     "create_oci_image_target",
     "delete_oci_image_target",
     "get_oci_image_targets",
@@ -190,6 +191,14 @@ mod tests {
         assert!(command_available("get_report_vulns", GmpVersion::V22_8));
         assert!(command_available(
             "get_credential_stores",
+            GmpVersion::V22_8
+        ));
+        assert!(!command_available(
+            "verify_credential_store",
+            GmpVersion::V22_7
+        ));
+        assert!(command_available(
+            "verify_credential_store",
             GmpVersion::V22_8
         ));
         assert!(!command_available("get_agent_groups", GmpVersion::V22_7));

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -17,7 +17,9 @@ use gvm_gmp::commands::agents::{
     modify_agent, modify_agent_control_scan_config, sync_agents, AgentInstallerLanguage,
     GetAgentsOpts, ModifyAgentControlScanConfigOpts, ModifyAgentOpts,
 };
-use gvm_gmp::commands::credentials::{modify_credential_store, ModifyCredentialStoreOpts};
+use gvm_gmp::commands::credentials::{
+    modify_credential_store, verify_credential_store, ModifyCredentialStoreOpts,
+};
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
 use gvm_gmp::commands::system::{modify_auth, modify_license};
 use gvm_gmp::types::EntityId;
@@ -208,6 +210,31 @@ async fn stateful_credential_store_modify_uses_gvmd_builder_shape() {
     )
     .await;
     assert_eq!(modify.status_code(), Some(200));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_credential_store_verify_uses_gvmd_builder_shape() {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let verify = send_request(
+        &mut stream,
+        verify_credential_store(&id("credential-store-1")),
+    )
+    .await;
+    assert_eq!(verify.status_code(), Some(200));
+
+    let missing_id = send_recv(&mut stream, b"<verify_credential_store/>").await;
+    assert_eq!(missing_id.status_code(), Some(400));
+    assert!(missing_id
+        .status_text()
+        .expect("status text")
+        .contains("credential_store_id"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -12,6 +12,7 @@
 
 use gvm_gmp::commands::agent_groups::{create_agent_group, get_agent_groups, CreateAgentGroupOpts};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::credentials::verify_credential_store;
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
@@ -238,6 +239,17 @@ async fn version_22_7_rejects_next_commands() {
 
     let response = send_recv(
         &mut stream,
+        verify_credential_store(&id("credential-store-1")),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response
+        .status_text()
+        .unwrap()
+        .contains("verify_credential_store"));
+
+    let response = send_recv(
+        &mut stream,
         create_oci_image_target(
             "Rejected OCI Target",
             &["registry.example/app:1".to_string()],
@@ -361,9 +373,15 @@ async fn version_22_8_accepts_next_commands() {
     assert!(web_target_xml.contains("<urls>https://example.com</urls>"));
     assert!(web_target_xml.contains("<credential_id>credential-web-gate</credential_id>"));
 
+    assert_credential_store_verify_works_on_next(&mut stream).await;
     assert_oci_image_targets_work_on_next(&mut stream).await;
 
     server.shutdown().await;
+}
+
+async fn assert_credential_store_verify_works_on_next(stream: &mut UnixStream) {
+    let response = send_recv(stream, verify_credential_store(&id("credential-store-1"))).await;
+    assert_eq!(response.status_code(), Some(200));
 }
 
 async fn assert_oci_image_targets_work_on_next(stream: &mut UnixStream) {


### PR DESCRIPTION
## Summary
- add a GMP builder for `verify_credential_store` with the `credential_store_id` attribute
- expose the command through the GMP Next client trait and typed client helper
- gate the command at GMP 22.8 in the client and mock server
- add stateful mock-server validation for the required `credential_store_id` attribute
- cover raw and typed client paths through unix-socket mock-server tests

## API note
This extends the existing public `GmpNextCommands` trait with a new GMP Next command method, following the current command-exposure pattern on `devel`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp credential_commands_build_xml`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_verify_credential_store_round_trip`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_verify_credential_store_uses_next_command_shape`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps stateful_credential_store_verify_uses_gvmd_builder_shape`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test version_gating`
- `cargo test -p gvm-client command_support_respects_version_gates`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo test -p gvm-gmp --quiet`
- `cargo test -p gvm-client --all-features --quiet`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features --quiet`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .`
- `git diff --check`

Known baseline notes: the MSRV workspace test emits the existing missing-doc warnings in feature-gated integration test crates; `cargo deny check` emits the existing unmatched allowlist/license/advisory warnings; `cargo audit` reports the existing allowed yanked `crypto-bigint 0.7.4` warning. Fuzzing was not run because this change is limited to command-builder, client-surface, version-gating, and mock command handling, and does not touch parser, transport framing, streaming, or fuzz-facing input consumers.
