### PR TITLE
Add credential store credential create helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -1831,17 +1831,33 @@ fn request_contains_credential_store_type(request_bytes: &[u8]) -> bool {
     let Ok(request) = std::str::from_utf8(request_bytes) else {
         return false;
     };
-    [
-        "<type>cs_cc</type>",
-        "<type>cs_snmp</type>",
-        "<type>cs_up</type>",
-        "<type>cs_usk</type>",
-        "<type>cs_smime</type>",
-        "<type>cs_pgp</type>",
-        "<type>cs_pw</type>",
-    ]
-    .iter()
-    .any(|credential_type| request.contains(credential_type))
+    request_element_text(request, "type").is_some_and(|value| value.starts_with("cs_"))
+}
+
+fn request_element_text<'a>(request: &'a str, element_name: &str) -> Option<&'a str> {
+    let opening = format!("<{element_name}");
+    let closing = format!("</{element_name}>");
+    let mut search_from = 0;
+
+    while let Some(relative_start) = request[search_from..].find(&opening) {
+        let element_start = search_from + relative_start;
+        let after_name = element_start + opening.len();
+        let delimiter = request.as_bytes().get(after_name).copied()?;
+        if delimiter != b'>' && !delimiter.is_ascii_whitespace() {
+            search_from = after_name;
+            continue;
+        }
+
+        let opening_end = after_name + request[after_name..].find('>')?;
+        if request[..opening_end].trim_end().ends_with('/') {
+            return Some("");
+        }
+        let content_start = opening_end + 1;
+        let content_end = content_start + request[content_start..].find(&closing)?;
+        return Some(request[content_start..content_end].trim());
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -2040,6 +2056,9 @@ mod tests {
                 format!("<create_credential><type>{credential_type}</type></create_credential>");
             assert!(request_contains_credential_store_type(request.as_bytes()));
         }
+        assert!(request_contains_credential_store_type(
+            b"<create_credential><type>\n  cs_future \t</type></create_credential>"
+        ));
     }
 
     #[test]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -2053,18 +2053,14 @@ mod tests {
             .ensure_command_supported(b"<create_credential><type>cs_up</type></create_credential>")
             .expect_err("credential-store create is gated before 22.8");
 
-        match error {
+        assert!(matches!(
+            error,
             GvmError::UnsupportedCommand {
-                command,
-                version,
-                required,
-            } => {
-                assert_eq!(command, "create_credential_store_credential");
-                assert_eq!(version, GmpVersion(22, 7));
-                assert_eq!(required, "22.8");
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
+                ref command,
+                version: GmpVersion(22, 7),
+                required: "22.8",
+            } if command == "create_credential_store_credential"
+        ));
 
         let client = GmpClient {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -30,8 +30,8 @@ use gvm_gmp::commands::agents::{
     modify_agent, modify_agent_control_scan_config, sync_agents,
 };
 use gvm_gmp::commands::credentials::{
-    get_credential_store, get_credential_stores, get_credential_stores_with_opts,
-    verify_credential_store,
+    create_credential_store_credential, get_credential_store, get_credential_stores,
+    get_credential_stores_with_opts, verify_credential_store,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -71,7 +71,7 @@ pub use gvm_gmp::commands::agents::{
     AgentRetryConfig, AgentScriptExecutorConfig, GetAgentsOpts, ModifyAgentControlScanConfigOpts,
     ModifyAgentOpts,
 };
-pub use gvm_gmp::commands::credentials::GetCredentialStoresOpts;
+pub use gvm_gmp::commands::credentials::{CredentialStoreCredentialOpts, GetCredentialStoresOpts};
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
@@ -86,6 +86,7 @@ pub use gvm_gmp::commands::tasks::CreateWebApplicationTaskOpts;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
+pub use gvm_gmp::enums::CredentialStoreCredentialType;
 pub use version::{
     command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
     required_version_label,
@@ -289,15 +290,22 @@ impl<C: GvmConnection> GmpClient<C> {
             return Ok(());
         };
 
-        if version::command_supported(command_name, self.version) {
+        let semantic_command_name = next_only_semantic_command(command_name, request_bytes);
+        if semantic_command_name.is_some() && self.version >= GmpVersion(22, 8) {
+            return Ok(());
+        }
+        if semantic_command_name.is_none() && version::command_supported(command_name, self.version)
+        {
             return Ok(());
         }
 
-        let required =
-            version::required_version_label(command_name).unwrap_or("a newer GMP version");
+        let command = semantic_command_name.unwrap_or(command_name);
+        let required = version::required_version_label(command)
+            .or_else(|| semantic_command_name.map(|_| "22.8"))
+            .unwrap_or("a newer GMP version");
 
         Err(GvmError::UnsupportedCommand {
-            command: command_name.to_string(),
+            command: command.to_string(),
             version: self.version,
             required,
         })
@@ -1227,6 +1235,16 @@ pub trait GmpNextCommands {
         credential_store_id: &EntityId,
         details: Option<bool>,
     ) -> Result<Response, GvmError>;
+
+    /// Create a credential-store-backed credential.
+    async fn create_credential_store_credential(
+        &mut self,
+        name: &str,
+        credential_type: CredentialStoreCredentialType,
+        vault_id: &str,
+        host_identifier: &str,
+        opts: CredentialStoreCredentialOpts,
+    ) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -1769,6 +1787,25 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
             .call(get_credential_store(credential_store_id, details))
             .await
     }
+
+    async fn create_credential_store_credential(
+        &mut self,
+        name: &str,
+        credential_type: CredentialStoreCredentialType,
+        vault_id: &str,
+        host_identifier: &str,
+        opts: CredentialStoreCredentialOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(create_credential_store_credential(
+                name,
+                credential_type,
+                vault_id,
+                host_identifier,
+                opts,
+            ))
+            .await
+    }
 }
 
 fn request_command_name(request_bytes: &[u8]) -> Option<&str> {
@@ -1778,6 +1815,33 @@ fn request_command_name(request_bytes: &[u8]) -> Option<&str> {
         .find(|ch: char| ch == '>' || ch == '/' || ch.is_whitespace())
         .unwrap_or(request.len());
     Some(&request[..end])
+}
+
+fn next_only_semantic_command(command_name: &str, request_bytes: &[u8]) -> Option<&'static str> {
+    if command_name != "create_credential" {
+        return None;
+    }
+    if !request_contains_credential_store_type(request_bytes) {
+        return None;
+    }
+    Some("create_credential_store_credential")
+}
+
+fn request_contains_credential_store_type(request_bytes: &[u8]) -> bool {
+    let Ok(request) = std::str::from_utf8(request_bytes) else {
+        return false;
+    };
+    [
+        "<type>cs_cc</type>",
+        "<type>cs_snmp</type>",
+        "<type>cs_up</type>",
+        "<type>cs_usk</type>",
+        "<type>cs_smime</type>",
+        "<type>cs_pgp</type>",
+        "<type>cs_pw</type>",
+    ]
+    .iter()
+    .any(|credential_type| request.contains(credential_type))
 }
 
 #[cfg(test)]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -2009,6 +2009,103 @@ mod tests {
     }
 
     #[test]
+    fn credential_store_create_semantic_detection_matches_next_shape() {
+        assert_eq!(
+            next_only_semantic_command(
+                "create_credential",
+                b"<create_credential><type>cs_pw</type></create_credential>",
+            ),
+            Some("create_credential_store_credential")
+        );
+        assert_eq!(
+            next_only_semantic_command(
+                "create_credential",
+                b"<create_credential><type>up</type></create_credential>",
+            ),
+            None
+        );
+        assert_eq!(
+            next_only_semantic_command(
+                "modify_credential",
+                b"<modify_credential><type>cs_pw</type></modify_credential>",
+            ),
+            None
+        );
+        assert!(!request_contains_credential_store_type(b"\xff"));
+
+        for credential_type in [
+            "cs_cc", "cs_snmp", "cs_up", "cs_usk", "cs_smime", "cs_pgp", "cs_pw",
+        ] {
+            let request =
+                format!("<create_credential><type>{credential_type}</type></create_credential>");
+            assert!(request_contains_credential_store_type(request.as_bytes()));
+        }
+    }
+
+    #[test]
+    fn credential_store_create_semantic_gate_uses_next_version() {
+        let client = GmpClient {
+            connection: ScriptedConnection::new(std::iter::empty::<&str>()),
+            version: GmpVersion(22, 7),
+            wire_trace: None,
+        };
+        let error = client
+            .ensure_command_supported(b"<create_credential><type>cs_up</type></create_credential>")
+            .expect_err("credential-store create is gated before 22.8");
+
+        match error {
+            GvmError::UnsupportedCommand {
+                command,
+                version,
+                required,
+            } => {
+                assert_eq!(command, "create_credential_store_credential");
+                assert_eq!(version, GmpVersion(22, 7));
+                assert_eq!(required, "22.8");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        let client = GmpClient {
+            connection: ScriptedConnection::new(std::iter::empty::<&str>()),
+            version: GmpVersion(22, 8),
+            wire_trace: None,
+        };
+        client
+            .ensure_command_supported(b"<create_credential><type>cs_up</type></create_credential>")
+            .expect("credential-store create is available in 22.8");
+        client
+            .ensure_command_supported(b"<get_version/>")
+            .expect("normal supported command still passes");
+    }
+
+    #[tokio::test]
+    async fn next_trait_create_credential_store_credential_sends_request() {
+        let mut connection = ScriptedConnection::new([
+            r#"<create_credential_response id="credential-1" status="201" status_text="Created"/>"#,
+        ]);
+        connection.connect().await.expect("connection opens");
+        let mut client = GmpNext(GmpClient {
+            connection,
+            version: GmpVersion(22, 8),
+            wire_trace: None,
+        });
+
+        let response = client
+            .create_credential_store_credential(
+                "Credential",
+                CredentialStoreCredentialType::UsernamePassword,
+                "vault-1",
+                "host-1",
+                CredentialStoreCredentialOpts::default(),
+            )
+            .await
+            .expect("request succeeds");
+
+        assert_eq!(response.status_code(), Some(201));
+    }
+
+    #[test]
     fn redacts_known_credential_elements() {
         let bytes = br#"<root><password>pw</password><private>key</private><private_key>key2</private_key><passphrase>phrase</passphrase><secret>oidc-secret</secret><auth_password>auth</auth_password><privacy_password>privacy</privacy_password><password algorithm="x">again</password></root>"#;
 

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -15,8 +15,9 @@ use gvm_connection::GvmConnection;
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
-    create_credential, get_credential_store, get_credential_stores,
-    get_credential_stores_with_opts, get_credentials, verify_credential_store, CredentialOpts,
+    create_credential, create_credential_store_credential, get_credential_store,
+    get_credential_stores, get_credential_stores_with_opts, get_credentials,
+    verify_credential_store, CredentialOpts, CredentialStoreCredentialOpts,
     GetCredentialStoresOpts, GetCredentialsOpts,
 };
 use gvm_gmp::commands::feed::get_feeds;
@@ -122,6 +123,7 @@ use gvm_gmp::responses::{
     VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
+use gvm_gmp::CredentialStoreCredentialType;
 
 use crate::{GmpClient, GvmError};
 
@@ -1189,6 +1191,31 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: CredentialOpts,
     ) -> Result<CreateCredentialResponse, GvmError> {
         let response = self.send(create_credential(name, opts)).await?;
+        CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a credential-store-backed `create_credential` request and return a
+    /// typed [`CreateCredentialResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn create_credential_store_credential(
+        &mut self,
+        name: &str,
+        credential_type: CredentialStoreCredentialType,
+        vault_id: &str,
+        host_identifier: &str,
+        opts: CredentialStoreCredentialOpts,
+    ) -> Result<CreateCredentialResponse, GvmError> {
+        let response = self
+            .send(create_credential_store_credential(
+                name,
+                credential_type,
+                vault_id,
+                host_identifier,
+                opts,
+            ))
+            .await?;
         CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -522,6 +522,24 @@ async fn unsupported_next_command_rejected_before_send() {
         } if command == "get_timezones"
     ));
 
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn credential_store_commands_are_rejected_before_v22_8() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_7).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
     let credential_store_id = EntityId::new("credential-store-1").expect("valid id");
     let error = client
         .verify_credential_store(&credential_store_id)

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -5,13 +5,15 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GetCredentialStoresOpts, GmpClient,
-    GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
+    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts,
+    CredentialStoreCredentialType, GetCredentialStoresOpts, GmpClient, GmpNextCommands,
+    GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
     ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::credentials::create_credential_store_credential;
 use gvm_gmp::commands::feed::get_feed;
 use gvm_gmp::commands::nvts::{
     get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,
@@ -534,6 +536,44 @@ async fn unsupported_next_command_rejected_before_send() {
         } if command == "verify_credential_store"
     ));
 
+    let error = client
+        .call(create_credential_store_credential(
+            "Rejected Store Credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts::default(),
+        ))
+        .await
+        .expect_err("22.7 should reject raw credential store credential create");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == "create_credential_store_credential"
+    ));
+
+    let error = client
+        .create_credential_store_credential(
+            "Rejected Typed Store Credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts::default(),
+        )
+        .await
+        .expect_err("22.7 should reject typed credential store credential create");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == "create_credential_store_credential"
+    ));
+
     server.shutdown().await;
 }
 
@@ -728,6 +768,53 @@ async fn typed_verify_credential_store_uses_next_command_shape() {
     assert_eq!(
         std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 command"),
         "<verify_credential_store credential_store_id=\"credential-store-1\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_create_credential_store_credential_uses_next_shape() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    server.clear_history();
+
+    let response = client
+        .create_credential_store_credential(
+            "Typed Store Credential",
+            CredentialStoreCredentialType::PasswordOnly,
+            "vault-typed",
+            "host-typed",
+            CredentialStoreCredentialOpts {
+                comment: Some("typed store credential".into()),
+                credential_store_id: Some(
+                    EntityId::new("credential-store-typed").expect("valid id"),
+                ),
+            },
+        )
+        .await
+        .expect("typed create should succeed");
+    assert_eq!(response.status, 201);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("create command recorded");
+    assert_eq!(command.command_name(), "create_credential");
+    let raw_xml = String::from_utf8(command.raw_xml().to_vec()).expect("valid utf8");
+    assert_eq!(
+        raw_xml,
+        "<create_credential><name>Typed Store Credential</name><type>cs_pw</type><comment>typed store credential</comment><credential_store_id>credential-store-typed</credential_store_id><vault_id>vault-typed</vault_id><host_identifier>host-typed</host_identifier></create_credential>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -8,10 +8,10 @@ use gvm_client::GmpNext;
 use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
     CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
-    CreateWebApplicationTaskOpts, GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands,
-    GmpNextCommands, GmpVersioned, GvmError, ModifyAgentControlScanConfigOpts,
-    ModifyAgentGroupOpts, ModifyAgentOpts, ModifyOciImageTargetOpts,
-    ModifyWebApplicationTargetOpts,
+    CreateWebApplicationTaskOpts, CredentialStoreCredentialOpts, CredentialStoreCredentialType,
+    GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
+    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
+    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
@@ -316,6 +316,58 @@ async fn next_client_credential_store_helpers_send_expected_commands() {
     assert_eq!(
         std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 request"),
         "<get_credential_stores details=\"0\" filt_id=\"filter-1\" filter=\"name=Local\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_create_credential_store_credential_round_trip() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    server.clear_history();
+    let create_response = client
+        .create_credential_store_credential(
+            "Client Store Credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts {
+                comment: Some("stored credential".into()),
+                credential_store_id: Some(id("credential-store-1")),
+            },
+        )
+        .await
+        .expect("create_credential_store_credential should succeed");
+    assert_eq!(create_response.status_code(), Some(201));
+    assert!(create_response.id().is_some());
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("create command recorded");
+    assert_eq!(command.command_name(), "create_credential");
+    let raw_xml = String::from_utf8(command.raw_xml().to_vec()).expect("valid utf8");
+    assert_eq!(
+        raw_xml,
+        "<create_credential><name>Client Store Credential</name><type>cs_up</type><comment>stored credential</comment><credential_store_id>credential-store-1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></create_credential>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -6,7 +6,10 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
-use crate::enums::{CredentialFormat, CredentialType, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm};
+use crate::enums::{
+    CredentialFormat, CredentialStoreCredentialType, CredentialType, SnmpAuthAlgorithm,
+    SnmpPrivacyAlgorithm,
+};
 use crate::types::EntityId;
 
 /// Optional fields for credential create and modify requests.
@@ -30,6 +33,15 @@ pub struct CredentialOpts {
     pub privacy_algorithm: Option<SnmpPrivacyAlgorithm>,
     /// Optional credential or report format value.
     pub format: Option<CredentialFormat>,
+}
+
+/// Optional fields for credential-store-backed credential creation.
+#[derive(Debug, Clone, Default)]
+pub struct CredentialStoreCredentialOpts {
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional credential store identifier.
+    pub credential_store_id: Option<EntityId>,
 }
 
 /// Options for `get_credentials` requests.
@@ -94,6 +106,27 @@ pub fn create_credential(name: &str, opts: CredentialOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_credential");
     cmd.add_element_with_text("name", name);
     add_credential_body(&mut cmd, &opts);
+    cmd
+}
+
+/// Build a `create_credential` request for a credential-store-backed credential.
+#[must_use]
+pub fn create_credential_store_credential(
+    name: &str,
+    credential_type: CredentialStoreCredentialType,
+    vault_id: &str,
+    host_identifier: &str,
+    opts: CredentialStoreCredentialOpts,
+) -> impl Request {
+    let mut cmd = XmlCommand::new("create_credential");
+    cmd.add_element_with_text("name", name);
+    cmd.add_element_with_text("type", credential_type.as_gmp_str());
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(credential_store_id) = opts.credential_store_id {
+        cmd.add_element_with_text("credential_store_id", credential_store_id.as_str());
+    }
+    cmd.add_element_with_text("vault_id", vault_id);
+    cmd.add_element_with_text("host_identifier", host_identifier);
     cmd
 }
 
@@ -242,6 +275,19 @@ mod tests {
         ));
         assert!(rendered.contains("<type>up</type>"));
         assert!(rendered.contains("<password>pass</password>"));
+        assert_eq!(
+            xml(create_credential_store_credential(
+                "stored",
+                CredentialStoreCredentialType::UsernamePassword,
+                "vault-1",
+                "host-1",
+                CredentialStoreCredentialOpts {
+                    comment: Some("from store".into()),
+                    credential_store_id: Some(id("cs1")),
+                },
+            )),
+            "<create_credential><name>stored</name><type>cs_up</type><comment>from store</comment><credential_store_id>cs1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></create_credential>"
+        );
         assert_eq!(
             xml(clone_credential(&id("c1"))),
             "<create_credential><copy>c1</copy></create_credential>"

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -420,15 +420,13 @@ fn validate_policy_import_xml(xml: &str) -> Result<(), ParseError> {
                 }
                 depth += 1;
             }
-            Event::Empty(event) => {
-                if depth == 0 {
-                    if completed_root {
-                        return invalid_policy_xml("multiple root elements");
-                    }
-                    completed_root = true;
-                    saw_root = true;
-                    validate_policy_import_root(event.name().as_ref())?;
+            Event::Empty(event) if depth == 0 => {
+                if completed_root {
+                    return invalid_policy_xml("multiple root elements");
                 }
+                completed_root = true;
+                saw_root = true;
+                validate_policy_import_root(event.name().as_ref())?;
             }
             Event::End(_) => {
                 depth = depth.checked_sub(1).ok_or(ParseError::InvalidValue {
@@ -439,22 +437,20 @@ fn validate_policy_import_xml(xml: &str) -> Result<(), ParseError> {
                     completed_root = true;
                 }
             }
-            Event::Text(event) => {
-                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
-                    return invalid_policy_xml(if completed_root {
-                        "text after root element"
-                    } else {
-                        "text before root element"
-                    });
-                }
+            Event::Text(event)
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() =>
+            {
+                return invalid_policy_xml(if completed_root {
+                    "text after root element"
+                } else {
+                    "text before root element"
+                });
             }
             Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
                 return invalid_policy_xml("content outside root element");
             }
-            Event::Decl(_) => {
-                if saw_root || completed_root || depth != 0 {
-                    return invalid_policy_xml("XML declaration outside document prolog");
-                }
+            Event::Decl(_) if saw_root || completed_root || depth != 0 => {
+                return invalid_policy_xml("XML declaration outside document prolog");
             }
             Event::DocType(_) => return invalid_policy_xml("DOCTYPE is not allowed"),
             Event::Eof => {
@@ -512,15 +508,13 @@ fn validate_scan_config_import_xml(xml: &str) -> Result<(), ParseError> {
                 }
                 depth += 1;
             }
-            Event::Empty(event) => {
-                if depth == 0 {
-                    if completed_root {
-                        return invalid_scan_config_xml("multiple root elements");
-                    }
-                    completed_root = true;
-                    saw_root = true;
-                    validate_scan_config_import_root(event.name().as_ref())?;
+            Event::Empty(event) if depth == 0 => {
+                if completed_root {
+                    return invalid_scan_config_xml("multiple root elements");
                 }
+                completed_root = true;
+                saw_root = true;
+                validate_scan_config_import_root(event.name().as_ref())?;
             }
             Event::End(_) => {
                 depth = depth.checked_sub(1).ok_or(ParseError::InvalidValue {
@@ -531,14 +525,14 @@ fn validate_scan_config_import_xml(xml: &str) -> Result<(), ParseError> {
                     completed_root = true;
                 }
             }
-            Event::Text(event) => {
-                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
-                    return invalid_scan_config_xml(if completed_root {
-                        "text after root element"
-                    } else {
-                        "text before root element"
-                    });
-                }
+            Event::Text(event)
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() =>
+            {
+                return invalid_scan_config_xml(if completed_root {
+                    "text after root element"
+                } else {
+                    "text before root element"
+                });
             }
             Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
                 return invalid_scan_config_xml("content outside root element");

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -374,6 +374,15 @@ gmp_enum!(CredentialType {
     UsernamePassword => "up",
     UsernameSshKey => "usk"
 });
+gmp_enum!(CredentialStoreCredentialType {
+    ClientCertificate => "cs_cc",
+    PasswordOnly => "cs_pw",
+    PgpEncryptionKey => "cs_pgp",
+    SmimeCertificate => "cs_smime",
+    Snmp => "cs_snmp",
+    UsernamePassword => "cs_up",
+    UsernameSshKey => "cs_usk"
+});
 gmp_enum!(EntityType {
     Alert => "alert",
     Asset => "asset",
@@ -827,6 +836,12 @@ mod tests {
         CredentialType,
         UsernamePassword,
         "up"
+    );
+    enum_round_trip_test!(
+        credential_store_credential_type_round_trip,
+        CredentialStoreCredentialType,
+        UsernamePassword,
+        "cs_up"
     );
     enum_round_trip_test!(entity_type_round_trip, EntityType, Task, "task");
     enum_round_trip_test!(resource_type_round_trip, ResourceType, Task, "TASK");

--- a/crates/gvm-gmp/tests/test_credentials.rs
+++ b/crates/gvm-gmp/tests/test_credentials.rs
@@ -7,7 +7,10 @@ mod common;
 
 use common::{id, xml};
 use gvm_gmp::commands::credentials::*;
-use gvm_gmp::{CredentialFormat, CredentialType, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm};
+use gvm_gmp::{
+    CredentialFormat, CredentialStoreCredentialType, CredentialType, SnmpAuthAlgorithm,
+    SnmpPrivacyAlgorithm,
+};
 
 #[test]
 fn test_create_credential_basic() {
@@ -36,6 +39,47 @@ fn test_create_credential_with_all_optionals() {
         )),
         "<create_credential><name>cred</name><comment>c</comment><type>up</type><login>u</login><password>p</password><private>k</private><certificate>cert</certificate><auth_algorithm>sha1</auth_algorithm><privacy_algorithm>aes</privacy_algorithm><format>pem</format></create_credential>"
     );
+}
+
+#[test]
+fn test_create_credential_store_credential() {
+    assert_eq!(
+        xml(create_credential_store_credential(
+            "stored",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts {
+                comment: Some("from store".into()),
+                credential_store_id: Some(id("cs1")),
+            },
+        )),
+        "<create_credential><name>stored</name><type>cs_up</type><comment>from store</comment><credential_store_id>cs1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></create_credential>"
+    );
+}
+
+#[test]
+fn test_create_credential_store_credential_types() {
+    for (credential_type, wire_type) in [
+        (CredentialStoreCredentialType::ClientCertificate, "cs_cc"),
+        (CredentialStoreCredentialType::Snmp, "cs_snmp"),
+        (CredentialStoreCredentialType::UsernamePassword, "cs_up"),
+        (CredentialStoreCredentialType::UsernameSshKey, "cs_usk"),
+        (CredentialStoreCredentialType::SmimeCertificate, "cs_smime"),
+        (CredentialStoreCredentialType::PgpEncryptionKey, "cs_pgp"),
+        (CredentialStoreCredentialType::PasswordOnly, "cs_pw"),
+    ] {
+        let rendered = xml(create_credential_store_credential(
+            "stored",
+            credential_type,
+            "vault-1",
+            "host-1",
+            Default::default(),
+        ));
+        assert!(rendered.contains(&format!("<type>{wire_type}</type>")));
+        assert!(rendered.contains("<vault_id>vault-1</vault_id>"));
+        assert!(rendered.contains("<host_identifier>host-1</host_identifier>"));
+    }
 }
 
 #[test]

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -334,11 +334,14 @@ impl SessionHandler {
                 "Credential-store-backed credentials require GMP 22.8",
             );
         }
-        if credential_store_type.is_some() && parse_element_text(raw_xml, "vault_id").is_none() {
+        if credential_store_type.is_some()
+            && parse_element_text(raw_xml, "vault_id").is_none_or(|value| value.trim().is_empty())
+        {
             return error_response(&cmd.name, 400, "Missing required element: vault_id");
         }
         if credential_store_type.is_some()
-            && parse_element_text(raw_xml, "host_identifier").is_none()
+            && parse_element_text(raw_xml, "host_identifier")
+                .is_none_or(|value| value.trim().is_empty())
         {
             return error_response(&cmd.name, 400, "Missing required element: host_identifier");
         }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -321,6 +321,27 @@ impl SessionHandler {
         if name.is_empty() && requires_name {
             return error_response(&cmd.name, 400, "Missing required element: name");
         }
+        let credential_store_type = if resource_type == "credential" {
+            parse_element_text(raw_xml, "type")
+                .filter(|credential_type| is_credential_store_credential_type(credential_type))
+        } else {
+            None
+        };
+        if credential_store_type.is_some() && self.version != GmpVersion::V22_8 {
+            return error_response(
+                &cmd.name,
+                400,
+                "Credential-store-backed credentials require GMP 22.8",
+            );
+        }
+        if credential_store_type.is_some() && parse_element_text(raw_xml, "vault_id").is_none() {
+            return error_response(&cmd.name, 400, "Missing required element: vault_id");
+        }
+        if credential_store_type.is_some()
+            && parse_element_text(raw_xml, "host_identifier").is_none()
+        {
+            return error_response(&cmd.name, 400, "Missing required element: host_identifier");
+        }
 
         let mut resource = Resource::new(resource_type, &name);
 
@@ -367,6 +388,20 @@ impl SessionHandler {
             };
             if let Some(usage_type) = usage_type {
                 resource.set_attr("usage_type", &usage_type);
+            }
+        }
+        if resource_type == "credential" {
+            if let Some(credential_type) = parse_element_text(raw_xml, "type") {
+                resource.set_attr("type", &credential_type);
+            }
+            if let Some(credential_store_id) = parse_element_text(raw_xml, "credential_store_id") {
+                resource.set_attr("credential_store_id", &credential_store_id);
+            }
+            if let Some(vault_id) = parse_element_text(raw_xml, "vault_id") {
+                resource.set_attr("vault_id", &vault_id);
+            }
+            if let Some(host_identifier) = parse_element_text(raw_xml, "host_identifier") {
+                resource.set_attr("host_identifier", &host_identifier);
             }
         }
 
@@ -1191,6 +1226,13 @@ fn handle_verify_credential_store(cmd: &ParsedCommand) -> Vec<u8> {
         );
     }
     format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
+}
+
+fn is_credential_store_credential_type(credential_type: &str) -> bool {
+    matches!(
+        credential_type,
+        "cs_cc" | "cs_snmp" | "cs_up" | "cs_usk" | "cs_smime" | "cs_pgp" | "cs_pw"
+    )
 }
 
 fn has_agent_ids(cmd: &ParsedCommand) -> bool {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -18,11 +18,13 @@ use gvm_gmp::commands::agents::{
     GetAgentsOpts, ModifyAgentControlScanConfigOpts, ModifyAgentOpts,
 };
 use gvm_gmp::commands::credentials::{
-    modify_credential_store, verify_credential_store, ModifyCredentialStoreOpts,
+    create_credential_store_credential, modify_credential_store, verify_credential_store,
+    CredentialStoreCredentialOpts, ModifyCredentialStoreOpts,
 };
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
 use gvm_gmp::commands::system::{modify_auth, modify_license};
 use gvm_gmp::types::EntityId;
+use gvm_gmp::CredentialStoreCredentialType;
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -235,6 +237,52 @@ async fn stateful_credential_store_verify_uses_gvmd_builder_shape() {
         .status_text()
         .expect("status text")
         .contains("credential_store_id"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_credential_store_create_credential_uses_gvmd_builder_shape() {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let create = send_request(
+        &mut stream,
+        create_credential_store_credential(
+            "Store Credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts {
+                comment: Some("from credential store".into()),
+                credential_store_id: Some(id("credential-store-1")),
+            },
+        ),
+    )
+    .await;
+    assert_eq!(create.status_code(), Some(201));
+
+    let missing_vault = send_recv(
+        &mut stream,
+        b"<create_credential><name>Missing Vault</name><type>cs_up</type><host_identifier>host-1</host_identifier></create_credential>",
+    )
+    .await;
+    assert_eq!(missing_vault.status_code(), Some(400));
+    assert!(missing_vault.status_text().unwrap().contains("vault_id"));
+
+    let missing_host = send_recv(
+        &mut stream,
+        b"<create_credential><name>Missing Host</name><type>cs_up</type><vault_id>vault-1</vault_id></create_credential>",
+    )
+    .await;
+    assert_eq!(missing_host.status_code(), Some(400));
+    assert!(missing_host
+        .status_text()
+        .unwrap()
+        .contains("host_identifier"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -273,6 +273,14 @@ async fn stateful_credential_store_create_credential_uses_gvmd_builder_shape() {
     assert_eq!(missing_vault.status_code(), Some(400));
     assert!(missing_vault.status_text().unwrap().contains("vault_id"));
 
+    let empty_vault = send_recv(
+        &mut stream,
+        b"<create_credential><name>Empty Vault</name><type>cs_up</type><vault_id/><host_identifier>host-1</host_identifier></create_credential>",
+    )
+    .await;
+    assert_eq!(empty_vault.status_code(), Some(400));
+    assert!(empty_vault.status_text().unwrap().contains("vault_id"));
+
     let missing_host = send_recv(
         &mut stream,
         b"<create_credential><name>Missing Host</name><type>cs_up</type><vault_id>vault-1</vault_id></create_credential>",
@@ -280,6 +288,17 @@ async fn stateful_credential_store_create_credential_uses_gvmd_builder_shape() {
     .await;
     assert_eq!(missing_host.status_code(), Some(400));
     assert!(missing_host
+        .status_text()
+        .unwrap()
+        .contains("host_identifier"));
+
+    let empty_host = send_recv(
+        &mut stream,
+        b"<create_credential><name>Empty Host</name><type>cs_up</type><vault_id>vault-1</vault_id><host_identifier>  </host_identifier></create_credential>",
+    )
+    .await;
+    assert_eq!(empty_host.status_code(), Some(400));
+    assert!(empty_host
         .status_text()
         .unwrap()
         .contains("host_identifier"));

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -12,7 +12,9 @@
 
 use gvm_gmp::commands::agent_groups::{create_agent_group, get_agent_groups, CreateAgentGroupOpts};
 use gvm_gmp::commands::authentication::authenticate;
-use gvm_gmp::commands::credentials::verify_credential_store;
+use gvm_gmp::commands::credentials::{
+    create_credential_store_credential, verify_credential_store, CredentialStoreCredentialOpts,
+};
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
@@ -28,6 +30,7 @@ use gvm_gmp::commands::tasks::{create_web_application_task, CreateWebApplication
 use gvm_gmp::commands::web_application_targets::{
     create_web_application_target, get_web_application_targets, CreateWebApplicationTargetOpts,
 };
+use gvm_gmp::CredentialStoreCredentialType;
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response, XmlCommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -280,6 +283,20 @@ async fn version_22_7_rejects_next_commands() {
         .unwrap()
         .contains("Web application target tasks"));
 
+    let response = send_recv(
+        &mut stream,
+        create_credential_store_credential(
+            "Rejected Store Credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("GMP 22.8"));
+
     server.shutdown().await;
 }
 
@@ -368,6 +385,7 @@ async fn version_22_8_accepts_next_commands() {
     assert_eq!(report_helper.status_code(), Some(404));
 
     assert_credential_store_verify_works_on_next(&mut stream).await;
+    assert_credential_store_credentials_work_on_next(&mut stream).await;
     assert_web_application_targets_and_tasks_work_on_next(&mut stream).await;
     assert_oci_image_targets_work_on_next(&mut stream).await;
 
@@ -414,6 +432,21 @@ async fn assert_web_application_targets_and_tasks_work_on_next(stream: &mut Unix
 async fn assert_credential_store_verify_works_on_next(stream: &mut UnixStream) {
     let response = send_recv(stream, verify_credential_store(&id("credential-store-1"))).await;
     assert_eq!(response.status_code(), Some(200));
+}
+
+async fn assert_credential_store_credentials_work_on_next(stream: &mut UnixStream) {
+    let response = send_recv(
+        stream,
+        create_credential_store_credential(
+            "Version Gated Store Credential",
+            CredentialStoreCredentialType::PasswordOnly,
+            "vault-1",
+            "host-1",
+            CredentialStoreCredentialOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
 }
 
 async fn assert_oci_image_targets_work_on_next(stream: &mut UnixStream) {


### PR DESCRIPTION
## Summary
- add `CredentialStoreCredentialType` for the GMP 22.8 `cs_*` credential-store credential kinds
- add a `create_credential_store_credential` request builder with required `vault_id`/`host_identifier` and optional `comment`/`credential_store_id`
- expose raw Next and typed client helpers, including payload-aware client-side version gating for `create_credential` requests carrying `cs_*` types
- teach the stateful mock server to reject credential-store-backed credentials before GMP 22.8 and to validate required `vault_id`/`host_identifier`
- add Unix-socket mock-server client-path tests for raw Next and typed helpers plus exact command-history XML assertions

The Rust API keeps `vault_id` and `host_identifier` required so invalid python-gvm calls that would raise at runtime are unconstructable here; `credential_store_id` stays optional in the opts struct.

## Validation
- `cargo test -p gvm-gmp test_create_credential_store_credential --test test_credentials`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps stateful_credential_store_create_credential_uses_gvmd_builder_shape`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test version_gating`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_create_credential_store_credential_round_trip`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_create_credential_store_credential_uses_next_shape`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client`
- `cargo test -p gvm-client --all-features --quiet`
- `cargo test -p gvm-gmp --quiet`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --quiet`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet` (passes with existing missing-doc warnings from feature-gated integration-test crates)
- `RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --workspace --all-features --no-deps`
- `PATH=\"$PWD/.venv/bin:$PATH\" make test-integration`
- `cargo deny check` (passes with existing unmatched allowlist/advisory warnings)
- `cargo audit` (passes with existing allowed yanked `crypto-bigint 0.7.4` warning)
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .` (0 findings; SARIF artifact removed)
- `git diff --check`

Fuzzing was not run because this slice adds command builders, client wiring, mock version/field validation, and command-history integration coverage; it does not change parsers, transport framing, streaming, or fuzz-facing input consumers.