### PR TITLE
Add credential store credential modify helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -31,7 +31,7 @@ use gvm_gmp::commands::agents::{
 };
 use gvm_gmp::commands::credentials::{
     create_credential_store_credential, get_credential_store, get_credential_stores,
-    get_credential_stores_with_opts, verify_credential_store,
+    get_credential_stores_with_opts, modify_credential_store_credential, verify_credential_store,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -71,7 +71,9 @@ pub use gvm_gmp::commands::agents::{
     AgentRetryConfig, AgentScriptExecutorConfig, GetAgentsOpts, ModifyAgentControlScanConfigOpts,
     ModifyAgentOpts,
 };
-pub use gvm_gmp::commands::credentials::{CredentialStoreCredentialOpts, GetCredentialStoresOpts};
+pub use gvm_gmp::commands::credentials::{
+    CredentialStoreCredentialOpts, GetCredentialStoresOpts, ModifyCredentialStoreCredentialOpts,
+};
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };
@@ -218,8 +220,9 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if request transmission or response parsing fails.
     pub async fn send<R: Request>(&mut self, request: R) -> Result<Response, GvmError> {
+        let semantic_command_name = request.semantic_command_name();
         let request_bytes = request.to_bytes();
-        self.ensure_command_supported(&request_bytes)?;
+        self.ensure_command_supported(&request_bytes, semantic_command_name)?;
         Self::send_on_bytes(
             &mut self.connection,
             request_bytes,
@@ -285,12 +288,17 @@ impl<C: GvmConnection> GmpClient<C> {
         Ok(Response::new(bytes))
     }
 
-    fn ensure_command_supported(&self, request_bytes: &[u8]) -> Result<(), GvmError> {
+    fn ensure_command_supported(
+        &self,
+        request_bytes: &[u8],
+        semantic_command_name: Option<&'static str>,
+    ) -> Result<(), GvmError> {
         let Some(command_name) = request_command_name(request_bytes) else {
             return Ok(());
         };
 
-        let semantic_command_name = next_only_semantic_command(command_name, request_bytes);
+        let semantic_command_name = semantic_command_name
+            .or_else(|| next_only_semantic_command(command_name, request_bytes));
         if semantic_command_name.is_some() && self.version >= GmpVersion(22, 8) {
             return Ok(());
         }
@@ -308,6 +316,22 @@ impl<C: GvmConnection> GmpClient<C> {
             command: command.to_string(),
             version: self.version,
             required,
+        })
+    }
+
+    pub(crate) fn ensure_semantic_command_supported(
+        &self,
+        command_name: &str,
+    ) -> Result<(), GvmError> {
+        if version::command_supported(command_name, self.version) {
+            return Ok(());
+        }
+
+        Err(GvmError::UnsupportedCommand {
+            command: command_name.to_string(),
+            version: self.version,
+            required: version::required_version_label(command_name)
+                .unwrap_or("a newer GMP version"),
         })
     }
 
@@ -1245,6 +1269,13 @@ pub trait GmpNextCommands {
         host_identifier: &str,
         opts: CredentialStoreCredentialOpts,
     ) -> Result<Response, GvmError>;
+
+    /// Modify a credential-store-backed credential.
+    async fn modify_credential_store_credential(
+        &mut self,
+        credential_id: &EntityId,
+        opts: ModifyCredentialStoreCredentialOpts,
+    ) -> Result<Response, GvmError>;
 }
 
 macro_rules! impl_gmp226_commands {
@@ -1806,6 +1837,16 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
             ))
             .await
     }
+
+    async fn modify_credential_store_credential(
+        &mut self,
+        credential_id: &EntityId,
+        opts: ModifyCredentialStoreCredentialOpts,
+    ) -> Result<Response, GvmError> {
+        self.0
+            .call(modify_credential_store_credential(credential_id, opts))
+            .await
+    }
 }
 
 fn request_command_name(request_bytes: &[u8]) -> Option<&str> {
@@ -1818,13 +1859,15 @@ fn request_command_name(request_bytes: &[u8]) -> Option<&str> {
 }
 
 fn next_only_semantic_command(command_name: &str, request_bytes: &[u8]) -> Option<&'static str> {
-    if command_name != "create_credential" {
-        return None;
+    match command_name {
+        "create_credential" if request_contains_credential_store_type(request_bytes) => {
+            Some("create_credential_store_credential")
+        }
+        "modify_credential" if request_contains_credential_store_modify_field(request_bytes) => {
+            Some("modify_credential_store_credential")
+        }
+        _ => None,
     }
-    if !request_contains_credential_store_type(request_bytes) {
-        return None;
-    }
-    Some("create_credential_store_credential")
 }
 
 fn request_contains_credential_store_type(request_bytes: &[u8]) -> bool {
@@ -1858,6 +1901,15 @@ fn request_element_text<'a>(request: &'a str, element_name: &str) -> Option<&'a 
     }
 
     None
+}
+
+fn request_contains_credential_store_modify_field(request_bytes: &[u8]) -> bool {
+    let Ok(request) = std::str::from_utf8(request_bytes) else {
+        return false;
+    };
+    ["<credential_store_id>", "<vault_id>", "<host_identifier>"]
+        .iter()
+        .any(|field| request.contains(field))
 }
 
 #[cfg(test)]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -299,18 +299,15 @@ impl<C: GvmConnection> GmpClient<C> {
 
         let semantic_command_name = semantic_command_name
             .or_else(|| next_only_semantic_command(command_name, request_bytes));
-        if semantic_command_name.is_some() && self.version >= GmpVersion(22, 8) {
-            return Ok(());
-        }
-        if semantic_command_name.is_none() && version::command_supported(command_name, self.version)
+        let unsupported_semantic =
+            semantic_command_name.filter(|name| !version::command_supported(name, self.version));
+        if unsupported_semantic.is_none() && version::command_supported(command_name, self.version)
         {
             return Ok(());
         }
 
-        let command = semantic_command_name.unwrap_or(command_name);
-        let required = version::required_version_label(command)
-            .or_else(|| semantic_command_name.map(|_| "22.8"))
-            .unwrap_or("a newer GMP version");
+        let command = unsupported_semantic.unwrap_or(command_name);
+        let required = version::required_version_label(command).unwrap_or("a newer GMP version");
 
         Err(GvmError::UnsupportedCommand {
             command: command.to_string(),
@@ -1907,9 +1904,25 @@ fn request_contains_credential_store_modify_field(request_bytes: &[u8]) -> bool 
     let Ok(request) = std::str::from_utf8(request_bytes) else {
         return false;
     };
-    ["<credential_store_id>", "<vault_id>", "<host_identifier>"]
+    ["credential_store_id", "vault_id", "host_identifier"]
         .iter()
-        .any(|field| request.contains(field))
+        .any(|field| request_contains_element(request, field))
+}
+
+fn request_contains_element(request: &str, element_name: &str) -> bool {
+    let opening = format!("<{element_name}");
+    let mut search_from = 0;
+    while let Some(relative_start) = request[search_from..].find(&opening) {
+        let after_name = search_from + relative_start + opening.len();
+        let Some(delimiter) = request.as_bytes().get(after_name).copied() else {
+            return false;
+        };
+        if matches!(delimiter, b'>' | b'/') || delimiter.is_ascii_whitespace() {
+            return true;
+        }
+        search_from = after_name;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -2143,6 +2156,12 @@ mod tests {
             None
         );
         assert!(!request_contains_credential_store_modify_field(b"\xff"));
+        assert!(request_contains_credential_store_modify_field(
+            b"<modify_credential><vault_id/></modify_credential>"
+        ));
+        assert!(request_contains_credential_store_modify_field(
+            b"<modify_credential><host_identifier ></host_identifier></modify_credential>"
+        ));
     }
 
     #[test]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -2114,6 +2114,38 @@ mod tests {
     }
 
     #[test]
+    fn credential_store_modify_semantic_detection_matches_next_shape() {
+        for field in ["credential_store_id", "vault_id", "host_identifier"] {
+            let request = format!(
+                "<modify_credential credential_id=\"credential-1\"><{field}>value</{field}></modify_credential>"
+            );
+            assert_eq!(
+                next_only_semantic_command("modify_credential", request.as_bytes()),
+                Some("modify_credential_store_credential")
+            );
+            assert!(request_contains_credential_store_modify_field(
+                request.as_bytes()
+            ));
+        }
+
+        assert_eq!(
+            next_only_semantic_command(
+                "modify_credential",
+                b"<modify_credential credential_id=\"credential-1\"><comment>keep</comment></modify_credential>",
+            ),
+            None
+        );
+        assert_eq!(
+            next_only_semantic_command(
+                "create_credential",
+                b"<create_credential><vault_id>vault-1</vault_id></create_credential>",
+            ),
+            None
+        );
+        assert!(!request_contains_credential_store_modify_field(b"\xff"));
+    }
+
+    #[test]
     fn credential_store_create_semantic_gate_uses_next_version() {
         let client = GmpClient {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
@@ -2121,7 +2153,10 @@ mod tests {
             wire_trace: None,
         };
         let error = client
-            .ensure_command_supported(b"<create_credential><type>cs_up</type></create_credential>")
+            .ensure_command_supported(
+                b"<create_credential><type>cs_up</type></create_credential>",
+                None,
+            )
             .expect_err("credential-store create is gated before 22.8");
 
         assert!(matches!(
@@ -2139,11 +2174,72 @@ mod tests {
             wire_trace: None,
         };
         client
-            .ensure_command_supported(b"<create_credential><type>cs_up</type></create_credential>")
+            .ensure_command_supported(
+                b"<create_credential><type>cs_up</type></create_credential>",
+                None,
+            )
             .expect("credential-store create is available in 22.8");
         client
-            .ensure_command_supported(b"<get_version/>")
+            .ensure_command_supported(b"<get_version/>", None)
             .expect("normal supported command still passes");
+    }
+
+    #[test]
+    fn credential_store_modify_semantic_gate_uses_next_version() {
+        let client = GmpClient {
+            connection: ScriptedConnection::new(std::iter::empty::<&str>()),
+            version: GmpVersion(22, 7),
+            wire_trace: None,
+        };
+        let error = client
+            .ensure_command_supported(
+                b"<modify_credential credential_id=\"credential-1\"><vault_id>vault-1</vault_id></modify_credential>",
+                None,
+            )
+            .expect_err("credential-store modify is gated before 22.8");
+
+        match error {
+            GvmError::UnsupportedCommand {
+                command,
+                version,
+                required,
+            } => {
+                assert_eq!(command, "modify_credential_store_credential");
+                assert_eq!(version, GmpVersion(22, 7));
+                assert_eq!(required, "22.8");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        let error = client
+            .ensure_command_supported(
+                b"<modify_credential credential_id=\"credential-1\"/>",
+                Some("modify_credential_store_credential"),
+            )
+            .expect_err("semantic request metadata is gated before 22.8");
+        assert!(matches!(
+            error,
+            GvmError::UnsupportedCommand { command, .. }
+                if command == "modify_credential_store_credential"
+        ));
+        assert!(client
+            .ensure_semantic_command_supported("modify_credential_store_credential")
+            .is_err());
+
+        let client = GmpClient {
+            connection: ScriptedConnection::new(std::iter::empty::<&str>()),
+            version: GmpVersion(22, 8),
+            wire_trace: None,
+        };
+        client
+            .ensure_command_supported(
+                b"<modify_credential credential_id=\"credential-1\"><vault_id>vault-1</vault_id></modify_credential>",
+                None,
+            )
+            .expect("credential-store modify is available in 22.8");
+        client
+            .ensure_semantic_command_supported("modify_credential_store_credential")
+            .expect("semantic helper is available in 22.8");
     }
 
     #[tokio::test]
@@ -2170,6 +2266,32 @@ mod tests {
             .expect("request succeeds");
 
         assert_eq!(response.status_code(), Some(201));
+    }
+
+    #[tokio::test]
+    async fn next_trait_modify_credential_store_credential_sends_request() {
+        let mut connection = ScriptedConnection::new([
+            r#"<modify_credential_response status="200" status_text="OK"/>"#,
+        ]);
+        connection.connect().await.expect("connection opens");
+        let mut client = GmpNext(GmpClient {
+            connection,
+            version: GmpVersion(22, 8),
+            wire_trace: None,
+        });
+
+        let response = client
+            .modify_credential_store_credential(
+                &EntityId::new("credential-1").expect("valid id"),
+                ModifyCredentialStoreCredentialOpts {
+                    vault_id: Some("vault-1".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("request succeeds");
+
+        assert_eq!(response.status_code(), Some(200));
     }
 
     #[test]

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -2198,18 +2198,14 @@ mod tests {
             )
             .expect_err("credential-store modify is gated before 22.8");
 
-        match error {
+        assert!(matches!(
+            error,
             GvmError::UnsupportedCommand {
-                command,
-                version,
-                required,
-            } => {
-                assert_eq!(command, "modify_credential_store_credential");
-                assert_eq!(version, GmpVersion(22, 7));
-                assert_eq!(required, "22.8");
-            }
-            other => panic!("unexpected error: {other:?}"),
-        }
+                ref command,
+                version: GmpVersion(22, 7),
+                required: "22.8",
+            } if command == "modify_credential_store_credential"
+        ));
 
         let error = client
             .ensure_command_supported(

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -21,8 +21,9 @@ use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
     create_credential, create_credential_store_credential, get_credential_store,
     get_credential_stores, get_credential_stores_with_opts, get_credentials,
-    verify_credential_store, CredentialOpts, CredentialStoreCredentialOpts,
-    GetCredentialStoresOpts, GetCredentialsOpts,
+    modify_credential_store_credential, verify_credential_store, CredentialOpts,
+    CredentialStoreCredentialOpts, GetCredentialStoresOpts, GetCredentialsOpts,
+    ModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
@@ -122,7 +123,7 @@ use gvm_gmp::responses::{
     GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
     GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
     GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
-    GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse,
+    GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse, ModifyCredentialResponse,
     ModifyOciImageTargetResponse, ModifyScanConfigResponse, ModifyScannerResponse,
     ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
     StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
@@ -1222,6 +1223,23 @@ impl<C: GvmConnection + Send> GmpClient<C> {
             ))
             .await?;
         CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a credential-store-backed `modify_credential` request and return a
+    /// typed [`ModifyCredentialResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_credential_store_credential(
+        &mut self,
+        credential_id: &EntityId,
+        opts: ModifyCredentialStoreCredentialOpts,
+    ) -> Result<ModifyCredentialResponse, GvmError> {
+        self.ensure_semantic_command_supported("modify_credential_store_credential")?;
+        let response = self
+            .send(modify_credential_store_credential(credential_id, opts))
+            .await?;
+        ModifyCredentialResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Filters ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -42,6 +42,7 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_report_export"
         | "get_credential_stores"
         | "verify_credential_store"
+        | "modify_credential_store_credential"
         | "create_oci_image_target"
         | "delete_oci_image_target"
         | "get_oci_image_targets"

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -42,6 +42,7 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
         | "get_report_export"
         | "get_credential_stores"
         | "verify_credential_store"
+        | "create_credential_store_credential"
         | "modify_credential_store_credential"
         | "create_oci_image_target"
         | "delete_oci_image_target"
@@ -222,6 +223,14 @@ mod tests {
             minimum_version_for_command("verify_credential_store"),
             Some(GmpVersion(22, 8))
         );
+        assert!(!command_supported(
+            "create_credential_store_credential",
+            GmpVersion(22, 7)
+        ));
+        assert!(command_supported(
+            "create_credential_store_credential",
+            GmpVersion(22, 8)
+        ));
         assert!(!command_supported("get_agent_groups", GmpVersion(22, 7)));
         assert!(command_supported("get_agent_groups", GmpVersion(22, 8)));
         assert_eq!(

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -7,8 +7,8 @@
 use gvm_client::{
     CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts,
     CredentialStoreCredentialType, GetCredentialStoresOpts, GmpClient, GmpNextCommands,
-    GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
-    ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
+    GmpVersioned, GvmError, ImportReportOpts, ModifyCredentialStoreCredentialOpts,
+    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
@@ -16,7 +16,10 @@ use gvm_gmp::commands::assets::{
     AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
 };
 use gvm_gmp::commands::authentication::authenticate;
-use gvm_gmp::commands::credentials::create_credential_store_credential;
+use gvm_gmp::commands::credentials::{
+    create_credential_store_credential, get_credential, modify_credential_store_credential,
+    ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
+};
 use gvm_gmp::commands::feed::get_feed;
 use gvm_gmp::commands::nvts::{
     get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,
@@ -749,7 +752,48 @@ async fn credential_store_commands_are_rejected_before_v22_8() {
         } if command == "create_credential_store_credential"
     ));
 
+    assert_credential_store_credential_modify_rejected_before_next(&mut client).await;
+
     server.shutdown().await;
+}
+
+async fn assert_credential_store_credential_modify_rejected_before_next(
+    client: &mut GmpClient<UnixSocketConnection>,
+) {
+    let credential_id = EntityId::new("credential-1").expect("valid id");
+    for opts in [
+        GmpModifyCredentialStoreCredentialOpts::default(),
+        GmpModifyCredentialStoreCredentialOpts {
+            vault_id: Some("vault-1".into()),
+            ..Default::default()
+        },
+    ] {
+        let error = client
+            .call(modify_credential_store_credential(&credential_id, opts))
+            .await
+            .expect_err("22.7 should reject raw credential store credential modify");
+        assert_unsupported_next_command(error, "modify_credential_store_credential");
+    }
+
+    let error = client
+        .modify_credential_store_credential(
+            &credential_id,
+            ModifyCredentialStoreCredentialOpts::default(),
+        )
+        .await
+        .expect_err("22.7 should reject typed credential store credential modify");
+    assert_unsupported_next_command(error, "modify_credential_store_credential");
+}
+
+fn assert_unsupported_next_command(error: GvmError, expected_command: &str) {
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8"
+        } if command == expected_command
+    ));
 }
 
 #[tokio::test]
@@ -991,6 +1035,70 @@ async fn typed_create_credential_store_credential_uses_next_shape() {
         raw_xml,
         "<create_credential><name>Typed Store Credential</name><type>cs_pw</type><comment>typed store credential</comment><credential_store_id>credential-store-typed</credential_store_id><vault_id>vault-typed</vault_id><host_identifier>host-typed</host_identifier></create_credential>"
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_modify_credential_store_credential_uses_next_shape() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    let credential = client
+        .create_credential("Stored Credential", Default::default())
+        .await
+        .expect("create credential should succeed");
+
+    server.clear_history();
+
+    let response = client
+        .modify_credential_store_credential(
+            &credential.id,
+            ModifyCredentialStoreCredentialOpts {
+                name: Some("Updated Store Credential".into()),
+                comment: Some("from credential store".into()),
+                credential_store_id: Some(EntityId::new("credential-store-1").expect("valid id")),
+                vault_id: Some("vault-1".into()),
+                host_identifier: Some("host-1".into()),
+            },
+        )
+        .await
+        .expect("typed modify should succeed");
+    assert_eq!(response.status, 200);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("modify command recorded");
+    assert_eq!(command.command_name(), "modify_credential");
+    let raw_xml = String::from_utf8(command.raw_xml().to_vec()).expect("valid utf8");
+    assert_eq!(
+        raw_xml,
+        format!(
+            "<modify_credential credential_id=\"{}\"><name>Updated Store Credential</name><comment>from credential store</comment><credential_store_id>credential-store-1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></modify_credential>",
+            credential.id.as_str()
+        )
+    );
+
+    let get = client
+        .call(get_credential(&credential.id))
+        .await
+        .expect("get modified credential should succeed");
+    let xml = get.as_str().expect("utf8 response");
+    assert!(xml.contains("Updated Store Credential"));
+    assert!(xml.contains("<comment>from credential store</comment>"));
+    assert!(xml.contains("<credential_store_id>credential-store-1</credential_store_id>"));
+    assert!(xml.contains("<vault_id>vault-1</vault_id>"));
+    assert!(xml.contains("<host_identifier>host-1</host_identifier>"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -11,11 +11,11 @@ use gvm_client::{
     CreateWebApplicationTaskOpts, CredentialStoreCredentialOpts, CredentialStoreCredentialType,
     GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
     GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
-    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
+    ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
-use gvm_gmp::commands::credentials::verify_credential_store;
+use gvm_gmp::commands::credentials::{create_credential, verify_credential_store, CredentialOpts};
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
@@ -368,6 +368,70 @@ async fn next_client_create_credential_store_credential_round_trip() {
     assert_eq!(
         raw_xml,
         "<create_credential><name>Client Store Credential</name><type>cs_up</type><comment>stored credential</comment><credential_store_id>credential-store-1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></create_credential>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn next_client_modify_credential_store_credential_round_trip() {
+    let Some(server) = stateful_server(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpVersioned::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let create_response = client
+        .call(create_credential(
+            "Next Store Credential",
+            CredentialOpts::default(),
+        ))
+        .await
+        .expect("create credential should succeed");
+    let credential_id = id(&create_response.id().expect("created id"));
+
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+
+    server.clear_history();
+
+    let response = client
+        .modify_credential_store_credential(
+            &credential_id,
+            ModifyCredentialStoreCredentialOpts {
+                name: Some("Next Updated Store Credential".into()),
+                credential_store_id: Some(id("credential-store-next")),
+                vault_id: Some("vault-next".into()),
+                host_identifier: Some("host-next".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_credential_store_credential should succeed");
+    assert_eq!(response.status_code(), Some(200));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let command = history.last().expect("modify command recorded");
+    assert_eq!(command.command_name(), "modify_credential");
+    let raw_xml = String::from_utf8(command.raw_xml().to_vec()).expect("valid utf8");
+    assert_eq!(
+        raw_xml,
+        format!(
+            "<modify_credential credential_id=\"{}\"><name>Next Updated Store Credential</name><credential_store_id>credential-store-next</credential_store_id><vault_id>vault-next</vault_id><host_identifier>host-next</host_identifier></modify_credential>",
+            credential_id.as_str()
+        )
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -94,6 +94,36 @@ pub struct ModifyCredentialStoreOpts {
     pub preferences: Vec<CredentialStorePreference>,
 }
 
+/// Optional fields for `modify_credential_store_credential` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyCredentialStoreCredentialOpts {
+    /// Optional credential name.
+    pub name: Option<String>,
+    /// Optional comment text.
+    pub comment: Option<String>,
+    /// Optional credential store identifier.
+    pub credential_store_id: Option<EntityId>,
+    /// Optional vault identifier.
+    pub vault_id: Option<String>,
+    /// Optional host identifier.
+    pub host_identifier: Option<String>,
+}
+
+struct SemanticCommand {
+    command: XmlCommand,
+    semantic_command_name: &'static str,
+}
+
+impl Request for SemanticCommand {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.command.to_bytes()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some(self.semantic_command_name)
+    }
+}
+
 /// Build a clone request for an existing credential.
 #[must_use]
 pub fn clone_credential(credential_id: &EntityId) -> impl Request {
@@ -224,6 +254,27 @@ pub fn modify_credential(credential_id: &EntityId, opts: CredentialOpts) -> impl
     cmd
 }
 
+/// Build a `modify_credential` request for a credential-store-backed credential.
+#[must_use]
+pub fn modify_credential_store_credential(
+    credential_id: &EntityId,
+    opts: ModifyCredentialStoreCredentialOpts,
+) -> impl Request {
+    let mut cmd =
+        XmlCommand::new("modify_credential").attribute("credential_id", credential_id.as_str());
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(credential_store_id) = opts.credential_store_id {
+        cmd.add_element_with_text("credential_store_id", credential_store_id.as_str());
+    }
+    add_text_element(&mut cmd, "vault_id", opts.vault_id.as_deref());
+    add_text_element(&mut cmd, "host_identifier", opts.host_identifier.as_deref());
+    SemanticCommand {
+        command: cmd,
+        semantic_command_name: "modify_credential_store_credential",
+    }
+}
+
 /// Build a `delete_credential` request.
 #[must_use]
 pub fn delete_credential(credential_id: &EntityId, ultimate: bool) -> impl Request {
@@ -351,6 +402,26 @@ mod tests {
             },
         ));
         assert_eq!(rendered, "<modify_credential credential_id=\"c1\"><comment>updated</comment></modify_credential>");
+        assert_eq!(
+            xml(modify_credential_store_credential(
+                &id("c1"),
+                ModifyCredentialStoreCredentialOpts::default(),
+            )),
+            "<modify_credential credential_id=\"c1\"/>"
+        );
+        assert_eq!(
+            xml(modify_credential_store_credential(
+                &id("c1"),
+                ModifyCredentialStoreCredentialOpts {
+                    name: Some("store credential".into()),
+                    comment: Some("from store".into()),
+                    credential_store_id: Some(id("cs1")),
+                    vault_id: Some("vault-1".into()),
+                    host_identifier: Some("host-1".into()),
+                },
+            )),
+            "<modify_credential credential_id=\"c1\"><name>store credential</name><comment>from store</comment><credential_store_id>cs1</credential_store_id><vault_id>vault-1</vault_id><host_identifier>host-1</host_identifier></modify_credential>"
+        );
         assert_eq!(
             xml(delete_credential(&id("c1"), true)),
             "<delete_credential credential_id=\"c1\" ultimate=\"1\"/>"

--- a/crates/gvm-gmp/tests/test_credentials.rs
+++ b/crates/gvm-gmp/tests/test_credentials.rs
@@ -97,3 +97,27 @@ fn test_credential_get_modify_delete() {
         "<delete_credential credential_id=\"c1\" ultimate=\"1\"/>"
     );
 }
+
+#[test]
+fn test_modify_credential_store_credential() {
+    assert_eq!(
+        xml(modify_credential_store_credential(
+            &id("c1"),
+            ModifyCredentialStoreCredentialOpts::default(),
+        )),
+        "<modify_credential credential_id=\"c1\"/>"
+    );
+    assert_eq!(
+        xml(modify_credential_store_credential(
+            &id("c1"),
+            ModifyCredentialStoreCredentialOpts {
+                name: Some("foo_name".into()),
+                comment: Some("foo_comment".into()),
+                credential_store_id: Some(id("foo_csid")),
+                vault_id: Some("foo_vid".into()),
+                host_identifier: Some("foo_hid".into()),
+            },
+        )),
+        "<modify_credential credential_id=\"c1\"><name>foo_name</name><comment>foo_comment</comment><credential_store_id>foo_csid</credential_store_id><vault_id>foo_vid</vault_id><host_identifier>foo_hid</host_identifier></modify_credential>"
+    );
+}

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -206,7 +206,7 @@ impl SessionHandler {
             );
         }
         if cmd.name == "modify_credential"
-            && has_credential_store_credential_modify_field(&cmd)
+            && has_credential_store_credential_modify_field(cmd)
             && self.version != GmpVersion::V22_8
         {
             return error_response(

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -205,6 +205,16 @@ impl SessionHandler {
                 ),
             );
         }
+        if cmd.name == "modify_credential"
+            && has_credential_store_credential_modify_field(raw_xml)
+            && self.version != GmpVersion::V22_8
+        {
+            return error_response(
+                &cmd.name,
+                400,
+                "Credential-store-backed credentials require GMP 22.8",
+            );
+        }
 
         // Route to specific handlers
         match cmd.name.as_str() {
@@ -954,6 +964,9 @@ impl SessionHandler {
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
         let new_value = parse_element_text(raw_xml, "value");
+        let new_credential_store_id = parse_element_text(raw_xml, "credential_store_id");
+        let new_vault_id = parse_element_text(raw_xml, "vault_id");
+        let new_host_identifier = parse_element_text(raw_xml, "host_identifier");
         let (
             new_service_url,
             new_service_cacert,
@@ -1038,6 +1051,17 @@ impl SessionHandler {
             }
             if let Some(ref value) = new_value {
                 r.set_attr("value", value);
+            }
+            if resource_type == "credential" {
+                if let Some(ref credential_store_id) = new_credential_store_id {
+                    r.set_attr("credential_store_id", credential_store_id);
+                }
+                if let Some(ref vault_id) = new_vault_id {
+                    r.set_attr("vault_id", vault_id);
+                }
+                if let Some(ref host_identifier) = new_host_identifier {
+                    r.set_attr("host_identifier", host_identifier);
+                }
             }
             if let Some(ref service_url) = new_service_url {
                 r.set_attr("service_url", service_url);
@@ -1501,6 +1525,12 @@ fn is_credential_store_credential_type(credential_type: &str) -> bool {
         credential_type,
         "cs_cc" | "cs_snmp" | "cs_up" | "cs_usk" | "cs_smime" | "cs_pgp" | "cs_pw"
     )
+}
+
+fn has_credential_store_credential_modify_field(raw_xml: &[u8]) -> bool {
+    parse_element_text(raw_xml, "credential_store_id").is_some()
+        || parse_element_text(raw_xml, "vault_id").is_some()
+        || parse_element_text(raw_xml, "host_identifier").is_some()
 }
 
 fn has_agent_ids(cmd: &ParsedCommand) -> bool {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -206,7 +206,7 @@ impl SessionHandler {
             );
         }
         if cmd.name == "modify_credential"
-            && has_credential_store_credential_modify_field(raw_xml)
+            && has_credential_store_credential_modify_field(&cmd)
             && self.version != GmpVersion::V22_8
         {
             return error_response(
@@ -1527,10 +1527,13 @@ fn is_credential_store_credential_type(credential_type: &str) -> bool {
     )
 }
 
-fn has_credential_store_credential_modify_field(raw_xml: &[u8]) -> bool {
-    parse_element_text(raw_xml, "credential_store_id").is_some()
-        || parse_element_text(raw_xml, "vault_id").is_some()
-        || parse_element_text(raw_xml, "host_identifier").is_some()
+fn has_credential_store_credential_modify_field(cmd: &ParsedCommand) -> bool {
+    cmd.children.iter().any(|child| {
+        matches!(
+            child.name.as_str(),
+            "credential_store_id" | "vault_id" | "host_identifier"
+        )
+    })
 }
 
 fn has_agent_ids(cmd: &ParsedCommand) -> bool {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -18,8 +18,9 @@ use gvm_gmp::commands::agents::{
     GetAgentsOpts, ModifyAgentControlScanConfigOpts, ModifyAgentOpts,
 };
 use gvm_gmp::commands::credentials::{
-    create_credential_store_credential, modify_credential_store, verify_credential_store,
-    CredentialStoreCredentialOpts, ModifyCredentialStoreOpts,
+    create_credential, create_credential_store_credential, get_credential, modify_credential_store,
+    modify_credential_store_credential, verify_credential_store, CredentialOpts,
+    CredentialStoreCredentialOpts, ModifyCredentialStoreCredentialOpts, ModifyCredentialStoreOpts,
 };
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
 use gvm_gmp::commands::system::{modify_auth, modify_license};
@@ -302,6 +303,50 @@ async fn stateful_credential_store_create_credential_uses_gvmd_builder_shape() {
         .status_text()
         .unwrap()
         .contains("host_identifier"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_credential_store_modify_credential_uses_gvmd_builder_shape() {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let create = send_request(
+        &mut stream,
+        create_credential("Store Credential", CredentialOpts::default()),
+    )
+    .await;
+    assert_eq!(create.status_code(), Some(201));
+    let credential_id = EntityId::new(extract_id(&create)).expect("created credential id");
+
+    let modify = send_request(
+        &mut stream,
+        modify_credential_store_credential(
+            &credential_id,
+            ModifyCredentialStoreCredentialOpts {
+                name: Some("Updated Store Credential".into()),
+                comment: Some("from credential store".into()),
+                credential_store_id: Some(id("credential-store-1")),
+                vault_id: Some("vault-1".into()),
+                host_identifier: Some("host-1".into()),
+            },
+        ),
+    )
+    .await;
+    assert_eq!(modify.status_code(), Some(200));
+
+    let get = send_request(&mut stream, get_credential(&credential_id)).await;
+    assert_eq!(get.status_code(), Some(200));
+    let get_xml = get.as_str().expect("utf8");
+    assert!(get_xml.contains("Updated Store Credential"));
+    assert!(get_xml.contains("<comment>from credential store</comment>"));
+    assert!(get_xml.contains("<credential_store_id>credential-store-1</credential_store_id>"));
+    assert!(get_xml.contains("<vault_id>vault-1</vault_id>"));
+    assert!(get_xml.contains("<host_identifier>host-1</host_identifier>"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -428,7 +428,6 @@ async fn version_22_8_accepts_next_commands() {
     assert_credential_store_verify_works_on_next(&mut stream).await;
     assert_credential_store_credentials_work_on_next(&mut stream).await;
     assert_web_application_targets_and_tasks_work_on_next(&mut stream).await;
-    assert_credential_store_credentials_work_on_next(&mut stream).await;
     assert_oci_image_targets_work_on_next(&mut stream).await;
 
     server.shutdown().await;

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -326,6 +326,14 @@ async fn version_22_7_rejects_next_commands() {
     assert_eq!(response.status_code(), Some(400));
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
+    let response = send_recv(
+        &mut stream,
+        &b"<modify_credential credential_id=\"credential-1\"><vault_id/></modify_credential>"[..],
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("GMP 22.8"));
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -13,7 +13,8 @@
 use gvm_gmp::commands::agent_groups::{create_agent_group, get_agent_groups, CreateAgentGroupOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
-    create_credential_store_credential, verify_credential_store, CredentialStoreCredentialOpts,
+    create_credential_store_credential, modify_credential_store_credential,
+    verify_credential_store, CredentialStoreCredentialOpts, ModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::integration_configs::{
@@ -297,6 +298,20 @@ async fn version_22_7_rejects_next_commands() {
     assert_eq!(response.status_code(), Some(400));
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
+    let response = send_recv(
+        &mut stream,
+        modify_credential_store_credential(
+            &id("credential-1"),
+            ModifyCredentialStoreCredentialOpts {
+                vault_id: Some("vault-1".into()),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("GMP 22.8"));
+
     server.shutdown().await;
 }
 
@@ -387,6 +402,7 @@ async fn version_22_8_accepts_next_commands() {
     assert_credential_store_verify_works_on_next(&mut stream).await;
     assert_credential_store_credentials_work_on_next(&mut stream).await;
     assert_web_application_targets_and_tasks_work_on_next(&mut stream).await;
+    assert_credential_store_credentials_work_on_next(&mut stream).await;
     assert_oci_image_targets_work_on_next(&mut stream).await;
 
     server.shutdown().await;
@@ -435,7 +451,7 @@ async fn assert_credential_store_verify_works_on_next(stream: &mut UnixStream) {
 }
 
 async fn assert_credential_store_credentials_work_on_next(stream: &mut UnixStream) {
-    let response = send_recv(
+    let create = send_recv(
         stream,
         create_credential_store_credential(
             "Version Gated Store Credential",
@@ -446,7 +462,23 @@ async fn assert_credential_store_credentials_work_on_next(stream: &mut UnixStrea
         ),
     )
     .await;
-    assert_eq!(response.status_code(), Some(201));
+    assert_eq!(create.status_code(), Some(201));
+    let credential_id = id(&create.id().expect("created id"));
+
+    let response = send_recv(
+        stream,
+        modify_credential_store_credential(
+            &credential_id,
+            ModifyCredentialStoreCredentialOpts {
+                credential_store_id: Some(id("credential-store-gate")),
+                vault_id: Some("vault-gate".into()),
+                host_identifier: Some("host-gate".into()),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
 }
 
 async fn assert_oci_image_targets_work_on_next(stream: &mut UnixStream) {

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -312,6 +312,20 @@ async fn version_22_7_rejects_next_commands() {
     assert_eq!(response.status_code(), Some(400));
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
+    let response = send_recv(
+        &mut stream,
+        modify_credential_store_credential(
+            &id("credential-1"),
+            ModifyCredentialStoreCredentialOpts {
+                host_identifier: Some("host-1".into()),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+    assert!(response.status_text().unwrap().contains("GMP 22.8"));
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -284,8 +284,14 @@ async fn version_22_7_rejects_next_commands() {
         .unwrap()
         .contains("Web application target tasks"));
 
+    assert_credential_store_credentials_rejected_before_next(&mut stream).await;
+
+    server.shutdown().await;
+}
+
+async fn assert_credential_store_credentials_rejected_before_next(stream: &mut UnixStream) {
     let response = send_recv(
-        &mut stream,
+        stream,
         create_credential_store_credential(
             "Rejected Store Credential",
             CredentialStoreCredentialType::UsernamePassword,
@@ -299,7 +305,7 @@ async fn version_22_7_rejects_next_commands() {
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
     let response = send_recv(
-        &mut stream,
+        stream,
         modify_credential_store_credential(
             &id("credential-1"),
             ModifyCredentialStoreCredentialOpts {
@@ -313,7 +319,7 @@ async fn version_22_7_rejects_next_commands() {
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
     let response = send_recv(
-        &mut stream,
+        stream,
         modify_credential_store_credential(
             &id("credential-1"),
             ModifyCredentialStoreCredentialOpts {
@@ -327,14 +333,12 @@ async fn version_22_7_rejects_next_commands() {
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
 
     let response = send_recv(
-        &mut stream,
+        stream,
         &b"<modify_credential credential_id=\"credential-1\"><vault_id/></modify_credential>"[..],
     )
     .await;
     assert_eq!(response.status_code(), Some(400));
     assert!(response.status_text().unwrap().contains("GMP 22.8"));
-
-    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/gvm-protocol/src/request.rs
+++ b/crates/gvm-protocol/src/request.rs
@@ -7,6 +7,12 @@
 pub trait Request: Send {
     /// Serialize this request to GMP XML bytes.
     fn to_bytes(&self) -> Vec<u8>;
+
+    /// Return a semantic command name when a helper shares a wire command name
+    /// with older GMP behavior.
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 /// Blanket implementation: anything that is a `Request` can be converted to bytes.


### PR DESCRIPTION
## Summary
- add `modify_credential_store_credential` with python-gvm's `<modify_credential credential_id=...>` wire shape
- add `ModifyCredentialStoreCredentialOpts` for optional `name`, `comment`, `credential_store_id`, `vault_id`, and `host_identifier`
- add optional semantic command metadata to `Request` so helpers that share an older wire command can still be version-gated by `gvm-client`
- expose raw GMP Next and typed client helpers returning `ModifyCredentialResponse`
- persist credential-store modify fields in the stateful mock server and reject fielded credential-store modify payloads before GMP 22.8
- add Unix-socket mock-server client-path tests for raw Next and typed helpers, exact command-history XML, 22.7 rejection, and stateful readback

Note: the raw XML for an empty or name/comment-only helper payload is indistinguishable from ordinary `modify_credential` once serialized. Calls made through the Rust builder carry semantic request metadata and are rejected before GMP 22.8; manually supplied raw XML remains plain GMP bytes.

This branch is based on `upstream/devel`; PR #345 touches nearby credential/client/mock plumbing, so whichever PR merges second may need a small mechanical restack.

## Validation
- `cargo test -p gvm-gmp test_modify_credential_store_credential --test test_credentials`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps stateful_credential_store_modify_credential_uses_gvmd_builder_shape`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test version_gating`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration unsupported_next_command_rejected_before_send`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_modify_credential_store_credential_uses_next_shape`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client next_client_modify_credential_store_credential_round_trip`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo test -p gvm-client --features unix-socket-tests --test versioned_client`
- `cargo test -p gvm-gmp --quiet`
- `cargo test -p gvm-client --all-features --quiet`
- `cargo test -p gvm-mock-server --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --quiet`
- `RUSTDOCFLAGS=\"-Dwarnings\" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet` (passes with existing missing-doc warnings from feature-gated integration-test crates)
- `PATH=\"$PWD/.venv/bin:$PATH\" make test-integration`
- `cargo deny check` (passes with existing unmatched allowlist/advisory warnings)
- `cargo audit` (passes with existing allowed yanked `crypto-bigint 0.7.4` warning)
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `semgrep --config p/rust --config p/security-audit --config p/secrets --sarif --output semgrep.sarif .` (0 findings; SARIF artifact removed)
- `git diff --check`

Fuzzing was not run because this slice adds command builders, request metadata, client wiring, mock version/field validation, and command-history integration coverage; it does not change parsers, transport framing, streaming, or fuzz-facing input consumers.