### PR TITLE
Add report import helper

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -63,7 +63,7 @@ pub use gvm_gmp::commands::oci_image_targets::{
     CreateOciImageTargetOpts, GetOciImageTargetsOpts, ModifyOciImageTargetOpts,
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
-pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts};
+pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -43,7 +43,7 @@ use gvm_gmp::commands::report_formats::{
 use gvm_gmp::commands::reports::{
     get_report_closed_cves, get_report_errors, get_report_export, get_report_export_with_opts,
     get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns, get_reports,
-    GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts,
+    import_report, GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts, ImportReportOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -83,7 +83,7 @@ use gvm_gmp::responses::{
     AuthenticateResponse, CreateAlertResponse, CreateCredentialResponse, CreateFilterResponse,
     CreateGroupResponse, CreateHostResponse, CreateNoteResponse, CreateOverrideResponse,
     CreatePermissionResponse, CreatePortListResponse, CreateReportConfigResponse,
-    CreateReportFormatResponse, CreateRoleResponse, CreateScanConfigResponse,
+    CreateReportFormatResponse, CreateReportResponse, CreateRoleResponse, CreateScanConfigResponse,
     CreateScannerResponse, CreateScheduleResponse, CreateTagResponse, CreateTargetResponse,
     CreateTaskResponse, CreateTicketResponse, CreateTlsCertificateResponse, CreateUserResponse,
     DeleteScanConfigResponse, DeleteScannerResponse, DescribeAuthResponse, EmptyTrashcanResponse,
@@ -1225,6 +1225,25 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         let request = import_report_format(report_format_xml)?;
         let response = self.send(request).await?;
         CreateReportFormatResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    // ── Reports ───────────────────────────────────────────────────────────────
+
+    /// Send a `create_report` request that imports report XML and return a typed
+    /// [`CreateReportResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if request construction fails, the request fails, or
+    /// response parsing fails.
+    pub async fn import_report(
+        &mut self,
+        report_xml: &str,
+        task_id: &EntityId,
+        opts: ImportReportOpts,
+    ) -> Result<CreateReportResponse, GvmError> {
+        let request = import_report(report_xml, task_id, opts)?;
+        let response = self.send(request).await?;
+        CreateReportResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Report Configs ────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -5,7 +5,8 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    GmpClient, GmpNextCommands, GmpVersioned, GvmError, WireTraceDirection, WireTraceEvent,
+    GmpClient, GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, WireTraceDirection,
+    WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
@@ -13,7 +14,9 @@ use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::feed::get_feed;
 use gvm_gmp::commands::nvts::{get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts};
 use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
-use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
+use gvm_gmp::commands::reports::{
+    get_report_hosts, get_report_vulnerabilities, get_reports, GetReportsOpts,
+};
 use gvm_gmp::commands::scan_configs::{
     create_policy, get_policies, get_scan_config_preference, get_scan_config_preferences,
     ConfigOpts, GetPolicyOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
@@ -1024,6 +1027,64 @@ async fn typed_report_format_import_and_clone_use_mock_server_create_command() {
     assert_eq!(
         commands[1],
         format!("<create_report_format>{report_format_xml}</create_report_format>")
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_report_import_uses_mock_server_stateful_create_command() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let task_id = EntityId::new("task-import").expect("valid id");
+    let report_xml = r#"<report id="imported-report"><name>Imported</name></report>"#;
+    let created = client
+        .import_report(
+            report_xml,
+            &task_id,
+            ImportReportOpts {
+                in_assets: Some(true),
+            },
+        )
+        .await
+        .expect("report import should succeed");
+    assert_eq!(created.status, 201);
+
+    let readback = client
+        .send(get_reports(GetReportsOpts {
+            details: Some(true),
+            ..Default::default()
+        }))
+        .await
+        .expect("get_reports should succeed");
+    let readback_xml = readback.as_str().expect("response XML should be UTF-8");
+    assert!(readback_xml.contains(&format!("id=\"{}\"", created.id)));
+    assert!(readback_xml.contains("<task_id>task-import</task_id>"));
+    assert!(readback_xml.contains("<in_assets>1</in_assets>"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].command_name(), "create_report");
+    assert_eq!(history[1].command_name(), "get_reports");
+    let import_command =
+        String::from_utf8(history[0].raw_xml().to_vec()).expect("history should be UTF-8");
+    assert_eq!(
+        import_command,
+        format!(
+            r#"<create_report><task id="task-import"/><in_assets>1</in_assets>{report_xml}</create_report>"#
+        )
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/report_formats.rs
+++ b/crates/gvm-gmp/src/commands/report_formats.rs
@@ -4,10 +4,11 @@
 //! Report format command builders.
 
 use gvm_protocol::{Request, XmlCommand};
-use quick_xml::events::Event;
-use quick_xml::Reader;
 
-use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::common::{
+    add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr,
+    validate_single_xml_document,
+};
 use crate::enums::ReportFormatType;
 use crate::responses::ParseError;
 use crate::types::EntityId;
@@ -57,7 +58,7 @@ pub fn clone_report_format(report_format_id: &EntityId) -> impl Request {
 /// Returns an error if `report_format_xml` is not a single well-formed XML
 /// document.
 pub fn import_report_format(report_format_xml: &str) -> Result<impl Request, ParseError> {
-    validate_single_xml_document(report_format_xml)?;
+    validate_single_xml_document(report_format_xml, "report_format_xml", None)?;
     let mut request = Vec::with_capacity(
         "<create_report_format></create_report_format>".len() + report_format_xml.len(),
     );
@@ -120,82 +121,6 @@ fn add_report_format_body(cmd: &mut XmlCommand, opts: &ReportFormatOpts) {
     }
 }
 
-fn validate_single_xml_document(xml: &str) -> Result<(), ParseError> {
-    let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
-    let mut depth = 0usize;
-    let mut saw_root = false;
-    let mut completed_root = false;
-
-    loop {
-        match reader.read_event()? {
-            Event::Start(_) => {
-                if completed_root {
-                    return Err(ParseError::InvalidValue {
-                        field: "report_format_xml".to_string(),
-                        value: "multiple root elements".to_string(),
-                    });
-                }
-                saw_root = true;
-                depth += 1;
-            }
-            Event::Empty(_) => {
-                if completed_root {
-                    return Err(ParseError::InvalidValue {
-                        field: "report_format_xml".to_string(),
-                        value: "multiple root elements".to_string(),
-                    });
-                }
-                saw_root = true;
-                completed_root = true;
-            }
-            Event::End(_) => {
-                if depth == 0 {
-                    return Err(ParseError::InvalidValue {
-                        field: "report_format_xml".to_string(),
-                        value: "unmatched end tag".to_string(),
-                    });
-                }
-                depth -= 1;
-                if depth == 0 {
-                    completed_root = true;
-                }
-            }
-            Event::Text(event) => {
-                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
-                    return Err(ParseError::InvalidValue {
-                        field: "report_format_xml".to_string(),
-                        value: if completed_root {
-                            "text after root element"
-                        } else {
-                            "text before root element"
-                        }
-                        .to_string(),
-                    });
-                }
-            }
-            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
-                return Err(ParseError::InvalidValue {
-                    field: "report_format_xml".to_string(),
-                    value: "content outside root element".to_string(),
-                });
-            }
-            Event::Eof => {
-                if saw_root && depth == 0 {
-                    return Ok(());
-                }
-                return Err(ParseError::MissingElement("root".to_string()));
-            }
-            Event::Decl(_)
-            | Event::PI(_)
-            | Event::DocType(_)
-            | Event::Comment(_)
-            | Event::CData(_)
-            | Event::GeneralRef(_) => {}
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,6 +161,10 @@ mod tests {
         .is_err());
         assert!(import_report_format(
             r#"<get_report_formats_response status="200" status_text="OK"/>suffix"#
+        )
+        .is_err());
+        assert!(import_report_format(
+            r#"<?xml version="1.0"?><get_report_formats_response status="200" status_text="OK"/>"#
         )
         .is_err());
         assert!(import_report_format("").is_err());

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -6,7 +6,11 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::commands::usage_type::UsageType;
-use crate::common::{add_filter_attrs, add_optional_id_element, bool_str, set_optional_bool_attr};
+use crate::common::{
+    add_filter_attrs, add_optional_id_element, bool_str, set_optional_bool_attr,
+    validate_single_xml_document,
+};
+use crate::responses::ParseError;
 use crate::types::EntityId;
 
 /// Optional fields for `create_report` requests.
@@ -18,6 +22,13 @@ pub struct CreateReportOpts {
     pub filter_id: Option<EntityId>,
     /// Whether pagination should be ignored.
     pub ignore_pagination: Option<bool>,
+}
+
+/// Optional fields for `import_report` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ImportReportOpts {
+    /// Whether to import assets embedded in the report XML.
+    pub in_assets: Option<bool>,
 }
 
 /// Options for `get_reports` requests.
@@ -89,6 +100,39 @@ pub fn create_report(task_id: &EntityId, opts: CreateReportOpts) -> impl Request
         cmd.set_attribute("ignore_pagination", bool_str(ignore_pagination));
     }
     cmd
+}
+
+/// Build a `create_report` request that imports existing report XML.
+///
+/// # Errors
+/// Returns an error if `report_xml` is not a single well-formed XML document.
+pub fn import_report(
+    report_xml: &str,
+    task_id: &EntityId,
+    opts: ImportReportOpts,
+) -> Result<impl Request, ParseError> {
+    validate_single_xml_document(report_xml, "report_xml", Some("report"))?;
+    let in_assets_len = opts
+        .in_assets
+        .map(|_| "<in_assets>0</in_assets>".len())
+        .unwrap_or_default();
+    let mut request = Vec::with_capacity(
+        "<create_report><task id=\"\"/></create_report>".len()
+            + task_id.as_str().len()
+            + in_assets_len
+            + report_xml.len(),
+    );
+    request.extend_from_slice(b"<create_report><task id=\"");
+    request.extend_from_slice(task_id.as_str().as_bytes());
+    request.extend_from_slice(b"\"/>");
+    if let Some(in_assets) = opts.in_assets {
+        request.extend_from_slice(b"<in_assets>");
+        request.extend_from_slice(bool_str(in_assets).as_bytes());
+        request.extend_from_slice(b"</in_assets>");
+    }
+    request.extend_from_slice(report_xml.as_bytes());
+    request.extend_from_slice(b"</create_report>");
+    Ok(request)
 }
 
 /// Build a `get_reports` request.

--- a/crates/gvm-gmp/src/common.rs
+++ b/crates/gvm-gmp/src/common.rs
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: 2026 Greenbone AG
 
 use gvm_protocol::XmlCommand;
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
+use crate::responses::ParseError;
 use crate::types::EntityId;
 
 pub(crate) fn bool_str(value: bool) -> &'static str {
@@ -63,6 +66,112 @@ pub(crate) fn add_string_list(cmd: &mut XmlCommand, parent: &str, child: &str, v
     for value in values {
         root.add_child_with_text(child, value);
     }
+}
+
+pub(crate) fn validate_single_xml_document(
+    xml: &str,
+    field: &str,
+    expected_root: Option<&str>,
+) -> Result<(), ParseError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut depth = 0usize;
+    let mut saw_root = false;
+    let mut completed_root = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(event) => {
+                if completed_root {
+                    return Err(ParseError::InvalidValue {
+                        field: field.to_string(),
+                        value: "multiple root elements".to_string(),
+                    });
+                }
+                if depth == 0 {
+                    validate_root_name(event.name().as_ref(), field, expected_root)?;
+                }
+                saw_root = true;
+                depth += 1;
+            }
+            Event::Empty(event) => {
+                if completed_root {
+                    return Err(ParseError::InvalidValue {
+                        field: field.to_string(),
+                        value: "multiple root elements".to_string(),
+                    });
+                }
+                if depth == 0 {
+                    validate_root_name(event.name().as_ref(), field, expected_root)?;
+                }
+                saw_root = true;
+                completed_root = true;
+            }
+            Event::End(_) => {
+                if depth == 0 {
+                    return Err(ParseError::InvalidValue {
+                        field: field.to_string(),
+                        value: "unmatched end tag".to_string(),
+                    });
+                }
+                depth -= 1;
+                if depth == 0 {
+                    completed_root = true;
+                }
+            }
+            Event::Text(event) => {
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
+                    return Err(ParseError::InvalidValue {
+                        field: field.to_string(),
+                        value: if completed_root {
+                            "text after root element"
+                        } else {
+                            "text before root element"
+                        }
+                        .to_string(),
+                    });
+                }
+            }
+            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
+                return Err(ParseError::InvalidValue {
+                    field: field.to_string(),
+                    value: "content outside root element".to_string(),
+                });
+            }
+            Event::Eof => {
+                if saw_root && depth == 0 {
+                    return Ok(());
+                }
+                return Err(ParseError::MissingElement("root".to_string()));
+            }
+            Event::Decl(_) | Event::DocType(_) => {
+                return Err(ParseError::InvalidValue {
+                    field: field.to_string(),
+                    value: "XML declarations and doctypes are not valid embedded command XML"
+                        .to_string(),
+                });
+            }
+            Event::PI(_) | Event::Comment(_) | Event::CData(_) | Event::GeneralRef(_) => {}
+        }
+    }
+}
+
+fn validate_root_name(
+    actual: &[u8],
+    field: &str,
+    expected_root: Option<&str>,
+) -> Result<(), ParseError> {
+    let Some(expected_root) = expected_root else {
+        return Ok(());
+    };
+    let actual = std::str::from_utf8(actual)?;
+    if actual == expected_root {
+        return Ok(());
+    }
+    Err(ParseError::InvalidValue {
+        field: field.to_string(),
+        value: format!("expected <{expected_root}> root element, got <{actual}>"),
+    })
 }
 
 #[cfg(test)]

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -78,10 +78,10 @@ pub use permission::{
 };
 pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
 pub use report::{
-    DeleteReportResponse, GetReportClosedCvesResponse, GetReportErrorsResponse,
-    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse, Report,
-    ReportClosedCve, ReportError, ReportExport, ReportTlsCertificate, ReportVulnerability,
-    ResultCount, Severity,
+    CreateReportResponse, DeleteReportResponse, GetReportClosedCvesResponse,
+    GetReportErrorsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
+    GetReportsResponse, Report, ReportClosedCve, ReportError, ReportExport, ReportTlsCertificate,
+    ReportVulnerability, ResultCount, Severity,
 };
 pub use report_config::{
     CreateReportConfigResponse, DeleteReportConfigResponse, GetReportConfigsResponse,

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -9,8 +9,9 @@ use quick_xml::events::Event;
 use quick_xml::Writer;
 
 use crate::responses::common::{
-    count_info, optional_u32, parse_document, parse_entity_meta, parse_named_entity,
-    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError,
+    count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
+    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
+    ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -64,6 +65,15 @@ pub struct GetReportsResponse {
     pub status_text: String,
     pub items: Vec<Report>,
     pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateReportResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -249,6 +259,23 @@ impl GetReportsResponse {
             status_text,
             items,
             counts: count_info(&root, "report_count")?,
+        })
+    }
+}
+
+impl CreateReportResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
         })
     }
 }
@@ -646,6 +673,18 @@ mod tests {
 
         assert!(parsed.items.is_empty());
         assert_eq!(parsed.counts.filtered, Some(0));
+    }
+
+    #[test]
+    fn parses_create_report_response() {
+        let response = Response::from(
+            r#"<create_report_response status="201" status_text="OK, resource created" id="report-1"/>"#,
+        );
+
+        let parsed = CreateReportResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.status, 201);
+        assert_eq!(parsed.id.as_str(), "report-1");
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_reports.rs
+++ b/crates/gvm-gmp/tests/test_reports.rs
@@ -32,6 +32,69 @@ fn test_create_report_with_optionals() {
 }
 
 #[test]
+fn test_import_report_basic() {
+    let report_xml = r#"<report id="r1"><name>Imported</name></report>"#;
+
+    assert_eq!(
+        xml(import_report(report_xml, &id("t1"), Default::default()).expect("valid report XML")),
+        r#"<create_report><task id="t1"/><report id="r1"><name>Imported</name></report></create_report>"#
+    );
+}
+
+#[test]
+fn test_import_report_with_in_assets() {
+    let report_xml = r#"<report id="r1"><name>Imported</name></report>"#;
+
+    assert_eq!(
+        xml(import_report(
+            report_xml,
+            &id("t1"),
+            ImportReportOpts {
+                in_assets: Some(false),
+            },
+        )
+        .expect("valid report XML")),
+        r#"<create_report><task id="t1"/><in_assets>0</in_assets><report id="r1"><name>Imported</name></report></create_report>"#
+    );
+    assert_eq!(
+        xml(import_report(
+            report_xml,
+            &id("t1"),
+            ImportReportOpts {
+                in_assets: Some(true),
+            },
+        )
+        .expect("valid report XML")),
+        r#"<create_report><task id="t1"/><in_assets>1</in_assets><report id="r1"><name>Imported</name></report></create_report>"#
+    );
+}
+
+#[test]
+fn test_import_report_rejects_invalid_report_xml() {
+    assert!(import_report("report", &id("t1"), Default::default()).is_err());
+    assert!(import_report("", &id("t1"), Default::default()).is_err());
+    assert!(import_report("<foo/>", &id("t1"), Default::default()).is_err());
+    assert!(import_report(
+        r#"<?xml version="1.0"?><report id="r1"/>"#,
+        &id("t1"),
+        Default::default()
+    )
+    .is_err());
+    assert!(import_report(
+        r#"<!DOCTYPE report><report id="r1"/>"#,
+        &id("t1"),
+        Default::default()
+    )
+    .is_err());
+    assert!(import_report(
+        r#"<report id="r1"/></create_report><delete_task/>"#,
+        &id("t1"),
+        Default::default()
+    )
+    .is_err());
+}
+
+#[test]
 fn test_report_get_and_delete() {
     assert_eq!(
         xml(get_report(&id("r1"))),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -370,6 +370,9 @@ impl SessionHandler {
                     }
                 }
             }
+            if let Some(in_assets) = cmd.child_text("in_assets") {
+                resource.set_attr("in_assets", in_assets);
+            }
         }
 
         // Target-specific

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -563,3 +563,40 @@ async fn stateful_audit_reports_filter_by_usage_type() {
 
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn stateful_import_report_persists_task_and_in_assets() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let create = send_recv(
+        &mut stream,
+        br#"<create_report><task id="task-import"/><report id="imported-report"><name>Imported</name><in_assets>0</in_assets></report><in_assets>1</in_assets></create_report>"#,
+    )
+    .await;
+    let create_text = create.as_str().expect("response XML should be UTF-8");
+    assert!(create_text.contains(r#"status="201""#), "{create_text}");
+
+    let report_id = extract_id(&create);
+    let listed = send_recv(&mut stream, br#"<get_reports details="1"/>"#).await;
+    let listed_text = listed.as_str().expect("response XML should be UTF-8");
+
+    assert!(
+        listed_text.contains("<task_id>task-import</task_id>"),
+        "{listed_text}"
+    );
+    assert!(
+        listed_text.contains(&format!(r#"id="{report_id}""#)),
+        "{listed_text}"
+    );
+    assert!(
+        listed_text.contains("<in_assets>1</in_assets>"),
+        "{listed_text}"
+    );
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- add a GMP `import_report` builder for `create_report` payloads with task id and optional `in_assets`
- validate embedded report XML before splicing, including `<report>` root enforcement and declaration/doctype rejection
- add typed client response parsing and stateful mock-server coverage for imported report metadata

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --quiet`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `cargo deny check` (passes with existing unmatched allowlist/advisory warnings)
- `cargo audit` (passes with existing allowed yanked `crypto-bigint 0.7.4` warning)
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-import-report-final.lcov`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off`
