### PR TITLE
Add scan config import helper

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -51,9 +51,10 @@ use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
     clone_scan_config, create_scan_config, delete_scan_config, get_policies, get_policy,
-    get_scan_config, get_scan_configs, import_policy, modify_policy_set_comment,
-    modify_policy_set_name, modify_scan_config, modify_scan_config_set_comment,
-    modify_scan_config_set_name, sync_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
+    get_scan_config, get_scan_configs, import_policy, import_scan_config,
+    modify_policy_set_comment, modify_policy_set_name, modify_scan_config,
+    modify_scan_config_set_comment, modify_scan_config_set_name, sync_config, ConfigOpts,
+    GetPolicyOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
     clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
@@ -186,6 +187,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: ConfigOpts,
     ) -> Result<CreateScanConfigResponse, GvmError> {
         let response = self.send(create_scan_config(name, base_id, opts)).await?;
+        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_config` request that imports scan-config XML and return a
+    /// typed [`CreateScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the import XML is invalid, the request fails, or
+    /// response parsing fails.
+    pub async fn import_scan_config(
+        &mut self,
+        scan_config_xml: &str,
+    ) -> Result<CreateScanConfigResponse, GvmError> {
+        let request = import_scan_config(scan_config_xml)?;
+        let response = self.send(request).await?;
         CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -51,10 +51,9 @@ use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
     clone_scan_config, create_scan_config, delete_scan_config, get_policies, get_policy,
-    get_scan_config, get_scan_configs, import_policy, import_scan_config,
-    modify_policy_set_comment, modify_policy_set_name, modify_scan_config,
-    modify_scan_config_set_comment, modify_scan_config_set_name, sync_config, ConfigOpts,
-    GetPolicyOpts, GetScanConfigsOpts,
+    get_scan_config, get_scan_configs, import_policy, modify_policy_set_comment,
+    modify_policy_set_name, modify_scan_config, modify_scan_config_set_comment,
+    modify_scan_config_set_name, sync_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
     clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
@@ -200,7 +199,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         scan_config_xml: &str,
     ) -> Result<CreateScanConfigResponse, GvmError> {
-        let request = import_scan_config(scan_config_xml)?;
+        let request = gvm_gmp::commands::scan_configs::import_scan_config(scan_config_xml)?;
         let response = self.send(request).await?;
         CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1225,6 +1225,62 @@ async fn typed_policy_import_uses_stateful_mock_server_create_command() {
 }
 
 #[tokio::test]
+async fn typed_scan_config_import_uses_stateful_mock_server_create_command() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let scan_config_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<owner><name>admin</name></owner>",
+        "<name>Imported scan config</name>",
+        "<comment>Imported comment</comment>",
+        "<usage_type>scan</usage_type>",
+        "</config>",
+        "</get_configs_response>"
+    );
+    let imported = client
+        .import_scan_config(scan_config_xml)
+        .await
+        .expect("scan config import should succeed");
+    assert_eq!(imported.status, 201);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "create_config");
+    assert_eq!(
+        String::from_utf8(history[0].raw_xml().to_vec()).expect("xml is utf-8"),
+        format!("<create_config>{scan_config_xml}</create_config>")
+    );
+
+    let fetched = client
+        .get_scan_config(&imported.id)
+        .await
+        .expect("imported scan config should be fetchable");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.id, imported.id);
+    assert_eq!(fetched.items[0].meta.name, "Imported scan config");
+    assert_eq!(
+        fetched.items[0].meta.comment.as_deref(),
+        Some("Imported comment")
+    );
+    assert_eq!(fetched.items[0].usage_type.as_deref(), Some("scan"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_report_format_import_and_clone_use_mock_server_create_command() {
     let Some(server) = echo_server(MockVersion::V22_5).await else {
         return;

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -88,6 +88,21 @@ pub fn create_scan_config(
     })
 }
 
+/// Build a `create_config` request that imports scan-config XML.
+///
+/// # Errors
+/// Returns an error if `scan_config_xml` is not a single well-formed XML
+/// document rooted at `get_configs_response`.
+pub fn import_scan_config(scan_config_xml: &str) -> Result<impl Request, ParseError> {
+    validate_scan_config_import_xml(scan_config_xml)?;
+    let mut request =
+        Vec::with_capacity("<create_config></create_config>".len() + scan_config_xml.len());
+    request.extend_from_slice(b"<create_config>");
+    request.extend_from_slice(scan_config_xml.as_bytes());
+    request.extend_from_slice(b"</create_config>");
+    Ok(request)
+}
+
 /// Build a `get_scan_configs` request.
 #[must_use]
 pub fn get_scan_configs(opts: GetScanConfigsOpts) -> impl Request {
@@ -473,6 +488,88 @@ fn validate_policy_import_root(root: &[u8]) -> Result<(), ParseError> {
 fn invalid_policy_xml<T>(value: &str) -> Result<T, ParseError> {
     Err(ParseError::InvalidValue {
         field: "policy_xml".to_string(),
+        value: value.to_string(),
+    })
+}
+
+fn validate_scan_config_import_xml(xml: &str) -> Result<(), ParseError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    reader.config_mut().check_comments = true;
+    let mut depth = 0usize;
+    let mut saw_root = false;
+    let mut completed_root = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(event) => {
+                if completed_root {
+                    return invalid_scan_config_xml("multiple root elements");
+                }
+                if !saw_root {
+                    validate_scan_config_import_root(event.name().as_ref())?;
+                    saw_root = true;
+                }
+                depth += 1;
+            }
+            Event::Empty(event) => {
+                if completed_root {
+                    return invalid_scan_config_xml("multiple root elements");
+                }
+                if !saw_root {
+                    validate_scan_config_import_root(event.name().as_ref())?;
+                    saw_root = true;
+                }
+                completed_root = true;
+            }
+            Event::End(_) => {
+                if depth == 0 {
+                    return invalid_scan_config_xml("unmatched end tag");
+                }
+                depth -= 1;
+                if depth == 0 {
+                    completed_root = true;
+                }
+            }
+            Event::Text(event) => {
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
+                    return invalid_scan_config_xml(if completed_root {
+                        "text after root element"
+                    } else {
+                        "text before root element"
+                    });
+                }
+            }
+            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
+                return invalid_scan_config_xml("content outside root element");
+            }
+            Event::Decl(_) => return invalid_scan_config_xml("XML declaration is not allowed"),
+            Event::DocType(_) => return invalid_scan_config_xml("DOCTYPE is not allowed"),
+            Event::Eof => {
+                if saw_root && depth == 0 {
+                    return Ok(());
+                }
+                return Err(ParseError::MissingElement(
+                    "get_configs_response".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn validate_scan_config_import_root(root: &[u8]) -> Result<(), ParseError> {
+    let root = std::str::from_utf8(root)?;
+    if root == "get_configs_response" {
+        Ok(())
+    } else {
+        invalid_scan_config_xml("root element must be get_configs_response")
+    }
+}
+
+fn invalid_scan_config_xml<T>(value: &str) -> Result<T, ParseError> {
+    Err(ParseError::InvalidValue {
+        field: "scan_config_xml".to_string(),
         value: value.to_string(),
     })
 }

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -513,20 +513,20 @@ fn validate_scan_config_import_xml(xml: &str) -> Result<(), ParseError> {
                 depth += 1;
             }
             Event::Empty(event) => {
-                if completed_root {
-                    return invalid_scan_config_xml("multiple root elements");
-                }
-                if !saw_root {
-                    validate_scan_config_import_root(event.name().as_ref())?;
+                if depth == 0 {
+                    if completed_root {
+                        return invalid_scan_config_xml("multiple root elements");
+                    }
+                    completed_root = true;
                     saw_root = true;
+                    validate_scan_config_import_root(event.name().as_ref())?;
                 }
-                completed_root = true;
             }
             Event::End(_) => {
-                if depth == 0 {
-                    return invalid_scan_config_xml("unmatched end tag");
-                }
-                depth -= 1;
+                depth = depth.checked_sub(1).ok_or(ParseError::InvalidValue {
+                    field: "scan_config_xml".to_string(),
+                    value: "unmatched end tag".to_string(),
+                })?;
                 if depth == 0 {
                     completed_root = true;
                 }

--- a/crates/gvm-gmp/tests/test_scan_configs.rs
+++ b/crates/gvm-gmp/tests/test_scan_configs.rs
@@ -32,6 +32,44 @@ fn test_create_scan_config_with_copy_and_options() {
 }
 
 #[test]
+fn test_import_scan_config_builds_create_config_xml() {
+    let scan_config_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<name>Foobar</name>",
+        "<comment>Foobar config</comment>",
+        "</config>",
+        "</get_configs_response>"
+    );
+
+    assert_eq!(
+        xml(import_scan_config(scan_config_xml).expect("import request builds")),
+        format!("<create_config>{scan_config_xml}</create_config>")
+    );
+}
+
+#[test]
+fn test_import_scan_config_rejects_invalid_xml() {
+    for invalid_xml in [
+        "",
+        "abcdef",
+        "<get_configs_response>",
+        "<get_configs_response/><get_configs_response/>",
+        "<get_report_configs_response/>",
+        "before<get_configs_response/>",
+        "<get_configs_response/>after",
+        r#"<get_configs_response><!-- invalid -- comment --></get_configs_response>"#,
+        r#"<?xml version="1.0"?><get_configs_response/>"#,
+        r#"<!DOCTYPE get_configs_response><get_configs_response/>"#,
+    ] {
+        assert!(
+            import_scan_config(invalid_xml).is_err(),
+            "expected invalid import XML to fail: {invalid_xml}"
+        );
+    }
+}
+
+#[test]
 fn test_import_policy_builds_create_config_xml() {
     let policy_xml = concat!(
         r#"<get_configs_response status="200" status_text="OK">"#,

--- a/crates/gvm-gmp/tests/test_scan_configs.rs
+++ b/crates/gvm-gmp/tests/test_scan_configs.rs
@@ -49,13 +49,39 @@ fn test_import_scan_config_builds_create_config_xml() {
 }
 
 #[test]
+fn test_import_scan_config_accepts_self_closing_and_comment_payloads() {
+    assert_eq!(
+        xml(import_scan_config("<get_configs_response/>").expect("self-closing import builds")),
+        "<create_config><get_configs_response/></create_config>"
+    );
+
+    let scan_config_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        "<!-- exported config follows -->",
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<scanner/>",
+        "<name>Foobar</name>",
+        "</config>",
+        "</get_configs_response>"
+    );
+    assert_eq!(
+        xml(import_scan_config(scan_config_xml).expect("comment import builds")),
+        format!("<create_config>{scan_config_xml}</create_config>")
+    );
+}
+
+#[test]
 fn test_import_scan_config_rejects_invalid_xml() {
     for invalid_xml in [
         "",
         "abcdef",
         "<get_configs_response>",
+        "<get_configs_response/><get_configs_response></get_configs_response>",
         "<get_configs_response/><get_configs_response/>",
+        "<get_configs_response/></unexpected>",
+        "<get_configs_response><config/></unexpected>",
         "<get_report_configs_response/>",
+        "<![CDATA[before]]><get_configs_response/>",
         "before<get_configs_response/>",
         "<get_configs_response/>after",
         r#"<get_configs_response><!-- invalid -- comment --></get_configs_response>"#,


### PR DESCRIPTION
## Summary
- add `import_scan_config` as a `create_config` import helper for raw `<get_configs_response>` XML
- expose a typed `GmpClient::import_scan_config` helper returning `CreateScanConfigResponse`
- tighten import XML validation for single-root `get_configs_response` payloads and reject XML declarations, doctypes, malformed comments, wrong roots, and extra content
- teach the stateful mock server to read imported config fields from the embedded `<config>` element so owner metadata does not replace the config name
- add real Unix-socket mock-server integration coverage for exact wire XML and stateful readback

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --test test_scan_configs --quiet`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_scan_config_import_uses_stateful_mock_server_create_command --quiet`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix matrix_configs_create_get_list --quiet`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo test --workspace --quiet`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-import-scan-config-final.lcov`
- `git diff --check`

Known baseline warnings observed: existing missing-doc warnings in feature-gated integration test crates during workspace tests; cargo-deny unmatched allow/license/advisory warnings; cargo-audit allowed yanked `crypto-bigint 0.7.4` warning. `cargo vet` produced the known `supply-chain/imports.lock` quote-normalization churn, which was inspected and restored.

Fuzzing was not run because this slice adds command construction, typed client exposure, import XML shape validation, and mock-server stateful import fidelity; it does not change transport framing, streaming XML completeness, large-response parsing, or fuzz-facing parser logic.
