### PR TITLE
Add policy import helper

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -49,9 +49,9 @@ use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
     clone_scan_config, create_scan_config, delete_scan_config, get_policies, get_policy,
-    get_scan_config, get_scan_configs, modify_policy_set_comment, modify_policy_set_name,
-    modify_scan_config, modify_scan_config_set_comment, modify_scan_config_set_name, sync_config,
-    ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
+    get_scan_config, get_scan_configs, import_policy, modify_policy_set_comment,
+    modify_policy_set_name, modify_scan_config, modify_scan_config_set_comment,
+    modify_scan_config_set_name, sync_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
     clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
@@ -222,6 +222,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<GetScanConfigsResponse, GvmError> {
         let response = self.send(get_policy(policy_id, opts)).await?;
         GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_config` request that imports policy XML and return a
+    /// typed [`CreateScanConfigResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the import XML is invalid, request sending fails, or
+    /// response parsing fails.
+    pub async fn import_policy(
+        &mut self,
+        policy_xml: &str,
+    ) -> Result<CreateScanConfigResponse, GvmError> {
+        let request = import_policy(policy_xml)?;
+        let response = self.send(request).await?;
+        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a `modify_scan_config` request and return a typed [`ModifyScanConfigResponse`].

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -979,6 +979,79 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
 }
 
 #[tokio::test]
+async fn typed_policy_import_uses_stateful_mock_server_create_command() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    server.clear_history();
+
+    let policy_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<owner><name>admin</name></owner>",
+        "<name>Imported policy</name>",
+        "<comment>Imported policy comment</comment>",
+        "<usage_type>policy</usage_type>",
+        "</config>",
+        "</get_configs_response>"
+    );
+    let policy = client
+        .import_policy(policy_xml)
+        .await
+        .expect("policy import should succeed");
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "create_config");
+    assert_eq!(
+        String::from_utf8(history[0].raw_xml().to_vec()).expect("xml is utf-8"),
+        format!("<create_config>{policy_xml}</create_config>")
+    );
+
+    let fetched = client
+        .get_policy(&policy.id, GetPolicyOpts { audits: Some(true) })
+        .await
+        .expect("imported policy should be fetched");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.id, policy.id);
+    assert_eq!(fetched.items[0].meta.name, "Imported policy");
+    assert_eq!(
+        fetched.items[0].meta.comment.as_deref(),
+        Some("Imported policy comment")
+    );
+    assert_eq!(fetched.items[0].usage_type.as_deref(), Some("policy"));
+
+    let multi_policy_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<name>First policy</name>",
+        "<usage_type>policy</usage_type>",
+        "</config>",
+        r#"<config id="d5aa21e4-23e6-4064-ae49-c0d425738a99">"#,
+        "<name>Second policy</name>",
+        "<usage_type>policy</usage_type>",
+        "</config>",
+        "</get_configs_response>"
+    );
+    assert!(
+        client.import_policy(multi_policy_xml).await.is_err(),
+        "stateful mock should reject multi-config policy imports instead of truncating"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_report_format_import_and_clone_use_mock_server_create_command() {
     let Some(server) = echo_server(MockVersion::V22_5).await else {
         return;

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -5,6 +5,8 @@
 
 use base64::Engine as _;
 use gvm_protocol::{xml_command::XmlElement, Request, XmlCommand};
+use quick_xml::events::Event;
+use quick_xml::Reader;
 
 use crate::commands::configs::{
     clone_config, create_config, delete_config, get_config, get_configs, modify_config,
@@ -13,6 +15,7 @@ use crate::commands::configs::{
 };
 use crate::commands::usage_type::UsageType;
 use crate::common::bool_str;
+use crate::responses::ParseError;
 use crate::types::EntityId;
 
 /// Optional fields for scan-configuration create and modify requests.
@@ -323,6 +326,22 @@ pub fn create_policy(name: &str, opts: ConfigOpts) -> impl Request {
     })
 }
 
+/// Build a `create_config` request that imports policy XML.
+///
+/// # Errors
+/// Returns an error if `policy_xml` is not a single well-formed XML document
+/// rooted at `get_configs_response`.
+pub fn import_policy(policy_xml: &str) -> Result<impl Request, ParseError> {
+    validate_policy_import_xml(policy_xml)?;
+    let policy_xml = strip_leading_xml_declaration(policy_xml);
+    let mut request =
+        Vec::with_capacity("<create_config></create_config>".len() + policy_xml.len());
+    request.extend_from_slice(b"<create_config>");
+    request.extend_from_slice(policy_xml.as_bytes());
+    request.extend_from_slice(b"</create_config>");
+    Ok(request)
+}
+
 /// Build a `get_configs` request scoped to policies.
 #[must_use]
 pub fn get_policies(opts: GetScanConfigsOpts) -> impl Request {
@@ -364,6 +383,98 @@ pub fn modify_policy(config_id: &EntityId, opts: ConfigOpts) -> impl Request {
 
 fn normalize_optional_text(value: Option<String>) -> Option<String> {
     value.filter(|value| !value.is_empty())
+}
+
+fn validate_policy_import_xml(xml: &str) -> Result<(), ParseError> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    reader.config_mut().check_comments = true;
+    let mut depth = 0usize;
+    let mut saw_root = false;
+    let mut completed_root = false;
+
+    loop {
+        match reader.read_event()? {
+            Event::Start(event) => {
+                if completed_root {
+                    return invalid_policy_xml("multiple root elements");
+                }
+                if !saw_root {
+                    validate_policy_import_root(event.name().as_ref())?;
+                    saw_root = true;
+                }
+                depth += 1;
+            }
+            Event::Empty(event) => {
+                if depth == 0 {
+                    if completed_root {
+                        return invalid_policy_xml("multiple root elements");
+                    }
+                    completed_root = true;
+                    saw_root = true;
+                    validate_policy_import_root(event.name().as_ref())?;
+                }
+            }
+            Event::End(_) => {
+                depth = depth.checked_sub(1).ok_or(ParseError::InvalidValue {
+                    field: "policy_xml".to_string(),
+                    value: "unmatched end tag".to_string(),
+                })?;
+                if depth == 0 {
+                    completed_root = true;
+                }
+            }
+            Event::Text(event) => {
+                if depth == 0 && !std::str::from_utf8(event.as_ref())?.trim().is_empty() {
+                    return invalid_policy_xml(if completed_root {
+                        "text after root element"
+                    } else {
+                        "text before root element"
+                    });
+                }
+            }
+            Event::CData(_) | Event::GeneralRef(_) if depth == 0 => {
+                return invalid_policy_xml("content outside root element");
+            }
+            Event::Decl(_) => {
+                if saw_root || completed_root || depth != 0 {
+                    return invalid_policy_xml("XML declaration outside document prolog");
+                }
+            }
+            Event::DocType(_) => return invalid_policy_xml("DOCTYPE is not allowed"),
+            Event::Eof => {
+                if saw_root && depth == 0 {
+                    return Ok(());
+                }
+                return Err(ParseError::MissingElement(
+                    "get_configs_response".to_string(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn strip_leading_xml_declaration(xml: &str) -> &str {
+    xml.strip_prefix("<?xml")
+        .and_then(|rest| rest.find("?>").map(|end| &rest[end + 2..]))
+        .unwrap_or(xml)
+}
+
+fn validate_policy_import_root(root: &[u8]) -> Result<(), ParseError> {
+    let root = std::str::from_utf8(root)?;
+    if root == "get_configs_response" {
+        Ok(())
+    } else {
+        invalid_policy_xml("root element must be get_configs_response")
+    }
+}
+
+fn invalid_policy_xml<T>(value: &str) -> Result<T, ParseError> {
+    Err(ParseError::InvalidValue {
+        field: "policy_xml".to_string(),
+        value: value.to_string(),
+    })
 }
 
 /// Build a `modify_config` request that sets a policy NVT preference.

--- a/crates/gvm-gmp/tests/test_scan_configs.rs
+++ b/crates/gvm-gmp/tests/test_scan_configs.rs
@@ -32,6 +32,78 @@ fn test_create_scan_config_with_copy_and_options() {
 }
 
 #[test]
+fn test_import_policy_builds_create_config_xml() {
+    let policy_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<name>Foobar</name>",
+        "<comment>Foobar policy</comment>",
+        "<usage_type>policy</usage_type>",
+        "</config>",
+        "</get_configs_response>"
+    );
+
+    assert_eq!(
+        xml(import_policy(policy_xml).expect("policy import request builds")),
+        format!("<create_config>{policy_xml}</create_config>")
+    );
+}
+
+#[test]
+fn test_import_policy_accepts_self_closing_and_comment_payloads() {
+    assert_eq!(
+        xml(import_policy("<get_configs_response/>").expect("self-closing import builds")),
+        "<create_config><get_configs_response/></create_config>"
+    );
+    assert_eq!(
+        xml(
+            import_policy(r#"<?xml version="1.0"?><get_configs_response/>"#)
+                .expect("XML declaration import builds")
+        ),
+        "<create_config><get_configs_response/></create_config>"
+    );
+
+    let policy_xml = concat!(
+        r#"<get_configs_response status="200" status_text="OK">"#,
+        "<!-- exported policy follows -->",
+        r#"<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">"#,
+        "<scanner/>",
+        "<name>Foobar</name>",
+        "</config>",
+        "</get_configs_response>"
+    );
+    assert_eq!(
+        xml(import_policy(policy_xml).expect("comment import builds")),
+        format!("<create_config>{policy_xml}</create_config>")
+    );
+}
+
+#[test]
+fn test_import_policy_rejects_invalid_xml() {
+    for invalid_xml in [
+        "",
+        "abcdef",
+        "<get_configs_response>",
+        "<get_configs_response/><get_configs_response></get_configs_response>",
+        "<get_configs_response/><get_configs_response/>",
+        "<get_configs_response/></unexpected>",
+        "<get_configs_response><config/></unexpected>",
+        "<get_report_configs_response/>",
+        "<![CDATA[before]]><get_configs_response/>",
+        "before<get_configs_response/>",
+        "<get_configs_response/>after",
+        r#"<get_configs_response/><?xml version="1.0"?>"#,
+        r#"<get_configs_response><!-- invalid -- comment --></get_configs_response>"#,
+        r#"<!DOCTYPE get_configs_response><get_configs_response/>"#,
+    ] {
+        assert!(
+            import_policy(invalid_xml).is_err(),
+            "expected invalid import XML to fail: {invalid_xml}"
+        );
+    }
+}
+
+#[test]
 fn test_scan_config_get_delete_sync() {
     assert_eq!(
         xml(clone_scan_config(&id("c1"))),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::command_parser::{parse_command, parse_element_text, ParsedCommand};
+use crate::command_parser::{parse_command, parse_element_text, ParsedCommand, ParsedElement};
 use crate::fault::{FaultAction, FaultEngine};
 use crate::fixtures::FixtureStore;
 use crate::history::CommandHistory;
@@ -260,6 +260,12 @@ impl SessionHandler {
 
     fn handle_create(&self, cmd: &ParsedCommand, raw_xml: &[u8], store: &ResourceStore) -> Vec<u8> {
         let resource_type = cmd.name.strip_prefix("create_").unwrap_or("unknown");
+        let has_config_import_payload = resource_type == "config" && has_config_import_payload(cmd);
+        let imported_config = if resource_type == "config" {
+            imported_config_element(cmd)
+        } else {
+            None
+        };
 
         // Check for clone (copy element)
         if let Some(copy_id) = parse_element_text(raw_xml, "copy") {
@@ -300,6 +306,10 @@ impl SessionHandler {
                 .or_else(|| asset_value.clone())
                 .or_else(|| asset_type.as_ref().map(|ty| format!("{ty} asset")))
                 .unwrap_or_else(|| "asset".to_string()),
+            "config" if has_config_import_payload => imported_config
+                .and_then(|config| element_child_text(config, "name").map(ToOwned::to_owned))
+                .unwrap_or_default(),
+            "config" => parse_element_text(raw_xml, "name").unwrap_or_default(),
             _ => parse_element_text(raw_xml, "name").unwrap_or_default(),
         };
         let requires_name = !matches!(
@@ -313,7 +323,13 @@ impl SessionHandler {
         let mut resource = Resource::new(resource_type, &name);
 
         // Extract comment
-        if let Some(comment) = parse_element_text(raw_xml, "comment") {
+        let comment = if has_config_import_payload {
+            imported_config
+                .and_then(|config| element_child_text(config, "comment").map(ToOwned::to_owned))
+        } else {
+            parse_element_text(raw_xml, "comment")
+        };
+        if let Some(comment) = comment {
             resource.comment = comment;
         }
         if let Some(scheduler_cron_time) = parse_element_text(raw_xml, "scheduler_cron_time") {
@@ -340,7 +356,14 @@ impl SessionHandler {
         }
 
         if matches!(resource_type, "config" | "task") {
-            if let Some(usage_type) = parse_element_text(raw_xml, "usage_type") {
+            let usage_type = if has_config_import_payload {
+                imported_config.and_then(|config| {
+                    element_child_text(config, "usage_type").map(ToOwned::to_owned)
+                })
+            } else {
+                parse_element_text(raw_xml, "usage_type")
+            };
+            if let Some(usage_type) = usage_type {
                 resource.set_attr("usage_type", &usage_type);
             }
         }
@@ -1108,6 +1131,32 @@ fn has_agent_ids(cmd: &ParsedCommand) -> bool {
                 .iter()
                 .any(|agent| agent.name == "agent" && agent.attributes.contains_key("id"))
         })
+}
+
+fn has_config_import_payload(cmd: &ParsedCommand) -> bool {
+    cmd.children
+        .iter()
+        .any(|child| child.name == "get_configs_response")
+}
+
+fn imported_config_element(cmd: &ParsedCommand) -> Option<&ParsedElement> {
+    let mut configs = cmd
+        .children
+        .iter()
+        .find(|child| child.name == "get_configs_response")
+        .into_iter()
+        .flat_map(|response| response.children.iter())
+        .filter(|child| child.name == "config");
+    let config = configs.next()?;
+    configs.next().is_none().then_some(config)
+}
+
+fn element_child_text<'a>(element: &'a ParsedElement, name: &str) -> Option<&'a str> {
+    element
+        .children
+        .iter()
+        .find(|child| child.name == name)
+        .and_then(|child| child.text.as_deref())
 }
 
 fn usage_type_matches(resource: &Resource, requested_usage_type: Option<&str>) -> bool {


### PR DESCRIPTION
## Summary
- add `import_policy` as a policy-scoped `create_config` import helper for raw `<get_configs_response>` payloads
- expose typed `GmpClient::import_policy` returning `CreateScanConfigResponse`
- teach the stateful mock server to import direct embedded config metadata and reject multi-config policy imports instead of truncating

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --test test_scan_configs --quiet`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_policy_import_uses_stateful_mock_server_create_command --quiet`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix matrix_configs_create_get_list --quiet`
- `cargo test --workspace --quiet`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-import-policy-final.lcov`
- `git diff --check`

Known baseline warnings: `cargo deny` reports existing unmatched allow/license/advisory entries, `cargo audit` reports the allowed yanked `crypto-bigint 0.7.4`, and MSRV workspace tests emit existing missing-doc warnings in feature-gated integration test crates.