### PR TITLE
Add scan config NVT helper options

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -23,7 +23,9 @@ use gvm_gmp::commands::groups::{create_group, get_groups, GetGroupsOpts, GroupOp
 use gvm_gmp::commands::help::help;
 use gvm_gmp::commands::hosts::{create_host, get_hosts, GetHostsOpts, HostOpts};
 use gvm_gmp::commands::notes::{create_note, get_notes, GetNotesOpts, NoteOpts};
-use gvm_gmp::commands::nvts::{get_nvt_families, get_nvts, GetNvtsOpts};
+use gvm_gmp::commands::nvts::{
+    get_nvt_families, get_nvts, get_scan_config_nvt, get_scan_config_nvts, GetNvtsOpts,
+};
 use gvm_gmp::commands::overrides::{
     create_override, get_overrides, GetOverridesOpts, OverrideOpts,
 };
@@ -688,6 +690,30 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_nvts(&mut self, opts: GetNvtsOpts) -> Result<GetNvtsResponse, GvmError> {
         let response = self.send(get_nvts(opts)).await?;
+        GetNvtsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a scan-config scoped `get_nvts` request and return a typed [`GetNvtsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_scan_config_nvts(
+        &mut self,
+        opts: GetNvtsOpts,
+    ) -> Result<GetNvtsResponse, GvmError> {
+        let response = self.send(get_scan_config_nvts(opts)).await?;
+        GetNvtsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a scan-config compatibility `get_nvts` request for a single NVT.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_scan_config_nvt(
+        &mut self,
+        nvt_oid: &str,
+    ) -> Result<GetNvtsResponse, GvmError> {
+        let response = self.send(get_scan_config_nvt(nvt_oid)).await?;
         GetNvtsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -11,7 +11,9 @@ use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::feed::get_feed;
-use gvm_gmp::commands::nvts::{get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts};
+use gvm_gmp::commands::nvts::{
+    get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,
+};
 use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
 use gvm_gmp::commands::reports::{get_report_hosts, get_report_vulnerabilities};
 use gvm_gmp::commands::scan_configs::{
@@ -28,7 +30,7 @@ use gvm_gmp::responses::{CreateScanConfigResponse, GetScanConfigsResponse};
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::FeedType;
-use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
+use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, Resource, ServerMode};
 use std::sync::{Arc, Mutex};
 
 async fn stateful_server() -> Option<MockGmpServer> {
@@ -890,6 +892,95 @@ async fn preference_getters_send_expected_mock_server_commands() {
     assert_eq!(
         commands[3],
         "<get_preferences nvt_oid=\"1.3.6.1\" preference=\"timeout\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_scan_config_nvt_helpers_use_stateful_mock_server_filters() {
+    let wanted_oid = "1.3.6.1.4.1.25623.1.0.90001";
+    let other_oid = "1.3.6.1.4.1.25623.1.0.90002";
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(MockVersion::V22_5)
+        .unix_socket_auto()
+        .seed(move |store| {
+            let mut wanted = Resource::new("nvt", "Config-scoped NVT");
+            wanted.set_attr("oid", wanted_oid);
+            wanted.set_attr("config_id", "config-1");
+            wanted.set_attr("preferences_config_id", "prefs-1");
+            wanted.set_attr("family", "General");
+            store.seed(wanted);
+
+            let mut other = Resource::new("nvt", "Other NVT");
+            other.set_attr("oid", other_oid);
+            other.set_attr("config_id", "config-2");
+            other.set_attr("preferences_config_id", "prefs-2");
+            other.set_attr("family", "Other");
+            store.seed(other);
+        })
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let listed = client
+        .get_scan_config_nvts(GetNvtsOpts {
+            details: Some(true),
+            preferences: Some(true),
+            preference_count: Some(true),
+            timeout: Some(false),
+            config_id: Some(EntityId::new("config-1").expect("valid id")),
+            preferences_config_id: Some(EntityId::new("prefs-1").expect("valid id")),
+            family: Some("General".into()),
+            sort_order: Some("ascending".into()),
+            sort_field: Some("name".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("scan-config NVT list request should succeed");
+    assert_eq!(listed.items.len(), 1);
+    assert_eq!(listed.items[0].oid, wanted_oid);
+    assert_eq!(listed.items[0].name, "Config-scoped NVT");
+    assert_eq!(listed.items[0].family.as_deref(), Some("General"));
+
+    let single = client
+        .get_scan_config_nvt(wanted_oid)
+        .await
+        .expect("scan-config NVT request should succeed");
+    assert_eq!(single.items.len(), 1);
+    assert_eq!(single.items[0].oid, wanted_oid);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert!(history
+        .iter()
+        .all(|record| record.command_name() == "get_nvts"));
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands[0],
+        "<get_nvts config_id=\"config-1\" details=\"1\" family=\"General\" preference_count=\"1\" preferences=\"1\" preferences_config_id=\"prefs-1\" sort_field=\"name\" sort_order=\"ascending\" timeout=\"0\"/>"
+    );
+    assert_eq!(
+        commands[1],
+        "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1.4.1.25623.1.0.90001\" preference_count=\"1\" preferences=\"1\"/>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/nvts.rs
+++ b/crates/gvm-gmp/src/commands/nvts.rs
@@ -17,6 +17,22 @@ pub struct GetNvtsOpts {
     pub filter_id: Option<EntityId>,
     /// Whether to request detailed output.
     pub details: Option<bool>,
+    /// Whether to include NVT preferences.
+    pub preferences: Option<bool>,
+    /// Whether to include the preference count.
+    pub preference_count: Option<bool>,
+    /// Whether to include the special timeout preference.
+    pub timeout: Option<bool>,
+    /// Optional scan config identifier to restrict NVT listing.
+    pub config_id: Option<EntityId>,
+    /// Optional scan config identifier to use for preference values.
+    pub preferences_config_id: Option<EntityId>,
+    /// Optional NVT family to restrict listing.
+    pub family: Option<String>,
+    /// Optional sort order.
+    pub sort_order: Option<String>,
+    /// Optional sort field.
+    pub sort_field: Option<String>,
 }
 
 /// Options for NVT `get_preferences` requests.
@@ -36,7 +52,31 @@ pub fn get_nvts(opts: GetNvtsOpts) -> impl Request {
         opts.filter_id.as_ref(),
     );
     set_optional_bool_attr(&mut cmd, "details", opts.details);
+    set_optional_bool_attr(&mut cmd, "preferences", opts.preferences);
+    set_optional_bool_attr(&mut cmd, "preference_count", opts.preference_count);
+    set_optional_bool_attr(&mut cmd, "timeout", opts.timeout);
+    if let Some(config_id) = opts.config_id.as_ref() {
+        cmd.set_attribute("config_id", config_id.as_str());
+    }
+    if let Some(preferences_config_id) = opts.preferences_config_id.as_ref() {
+        cmd.set_attribute("preferences_config_id", preferences_config_id.as_str());
+    }
+    if let Some(family) = opts.family.as_deref() {
+        cmd.set_attribute("family", family);
+    }
+    if let Some(sort_order) = opts.sort_order.as_deref() {
+        cmd.set_attribute("sort_order", sort_order);
+    }
+    if let Some(sort_field) = opts.sort_field.as_deref() {
+        cmd.set_attribute("sort_field", sort_field);
+    }
     cmd
+}
+
+/// Build a `get_nvts` request for scan-config scoped NVT listing.
+#[must_use]
+pub fn get_scan_config_nvts(opts: GetNvtsOpts) -> impl Request {
+    get_nvts(opts)
 }
 
 /// Build a `get_nvts` request for a single NVT.
@@ -45,6 +85,16 @@ pub fn get_nvt(nvt_oid: &str) -> impl Request {
     XmlCommand::new("get_nvts")
         .attribute("nvt_oid", nvt_oid)
         .attribute("details", "1")
+}
+
+/// Build a scan-config compatibility `get_nvts` request for a single NVT.
+#[must_use]
+pub fn get_scan_config_nvt(nvt_oid: &str) -> impl Request {
+    XmlCommand::new("get_nvts")
+        .attribute("nvt_oid", nvt_oid)
+        .attribute("details", "1")
+        .attribute("preferences", "1")
+        .attribute("preference_count", "1")
 }
 
 /// Build a `get_preferences` request for NVT preferences.
@@ -97,6 +147,26 @@ mod tests {
         assert_eq!(
             xml(get_nvt("1.3.6.1")),
             "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1\"/>"
+        );
+        assert_eq!(
+            xml(get_scan_config_nvts(GetNvtsOpts {
+                filter_string: Some("family=General".into()),
+                filter_id: Some(id("f1")),
+                details: Some(true),
+                preferences: Some(true),
+                preference_count: Some(false),
+                timeout: Some(true),
+                config_id: Some(id("c1")),
+                preferences_config_id: Some(id("pc1")),
+                family: Some("General".into()),
+                sort_order: Some("ascending".into()),
+                sort_field: Some("name".into()),
+            })),
+            "<get_nvts config_id=\"c1\" details=\"1\" family=\"General\" filt_id=\"f1\" filter=\"family=General\" preference_count=\"0\" preferences=\"1\" preferences_config_id=\"pc1\" sort_field=\"name\" sort_order=\"ascending\" timeout=\"1\"/>"
+        );
+        assert_eq!(
+            xml(get_scan_config_nvt("1.3.6.1")),
+            "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1\" preference_count=\"1\" preferences=\"1\"/>"
         );
         assert_eq!(
             xml(get_nvt_preferences(GetNvtPreferencesOpts::default())),

--- a/crates/gvm-gmp/tests/test_nvts.rs
+++ b/crates/gvm-gmp/tests/test_nvts.rs
@@ -6,7 +6,9 @@
 mod common;
 
 use common::{id, xml};
-use gvm_gmp::commands::nvts::{get_nvt, get_nvt_families, get_nvts, GetNvtsOpts};
+use gvm_gmp::commands::nvts::{
+    get_nvt, get_nvt_families, get_nvts, get_scan_config_nvt, get_scan_config_nvts, GetNvtsOpts,
+};
 
 #[test]
 fn test_get_nvts_basic() {
@@ -20,8 +22,28 @@ fn test_get_nvts_with_options() {
             filter_string: Some("family=foo".into()),
             filter_id: Some(id("f1")),
             details: Some(true),
+            ..Default::default()
         })),
         "<get_nvts details=\"1\" filt_id=\"f1\" filter=\"family=foo\"/>"
+    );
+}
+
+#[test]
+fn test_get_scan_config_nvts_with_options() {
+    assert_eq!(
+        xml(get_scan_config_nvts(GetNvtsOpts {
+            details: Some(true),
+            preferences: Some(true),
+            preference_count: Some(false),
+            timeout: Some(true),
+            config_id: Some(id("config-1")),
+            preferences_config_id: Some(id("config-2")),
+            family: Some("General".into()),
+            sort_order: Some("ascending".into()),
+            sort_field: Some("name".into()),
+            ..Default::default()
+        })),
+        "<get_nvts config_id=\"config-1\" details=\"1\" family=\"General\" preference_count=\"0\" preferences=\"1\" preferences_config_id=\"config-2\" sort_field=\"name\" sort_order=\"ascending\" timeout=\"1\"/>"
     );
 }
 
@@ -30,6 +52,10 @@ fn test_get_nvt_and_families() {
     assert_eq!(
         xml(get_nvt("1.3.6.1")),
         "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1\"/>"
+    );
+    assert_eq!(
+        xml(get_scan_config_nvt("1.3.6.1")),
+        "<get_nvts details=\"1\" nvt_oid=\"1.3.6.1\" preference_count=\"1\" preferences=\"1\"/>"
     );
     assert_eq!(xml(get_nvt_families()), "<get_nvt_families/>");
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -507,6 +507,27 @@ impl SessionHandler {
             }
         }
 
+        if cmd.name == "get_nvts" {
+            if let Some(nvt_oid) = cmd.attr("nvt_oid") {
+                resources.retain(|resource| {
+                    resource.attr("oid") == Some(nvt_oid)
+                        || resource.attr("nvt_oid") == Some(nvt_oid)
+                        || resource.id.to_string() == nvt_oid
+                });
+            }
+            if let Some(config_id) = cmd.attr("config_id") {
+                resources.retain(|resource| resource.attr("config_id") == Some(config_id));
+            }
+            if let Some(preferences_config_id) = cmd.attr("preferences_config_id") {
+                resources.retain(|resource| {
+                    resource.attr("preferences_config_id") == Some(preferences_config_id)
+                });
+            }
+            if let Some(family) = cmd.attr("family") {
+                resources.retain(|resource| resource.attr("family") == Some(family));
+            }
+        }
+
         if let Some(usage_type) = requested_usage_type {
             resources.retain(|resource| resource.attr("usage_type") == Some(usage_type));
         }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock};
 
 use uuid::Uuid;
 
-use crate::util::{now_iso, xml_escape};
+use crate::util::{now_iso, xml_escape, xml_escape_attr};
 
 /// Task status in the lifecycle state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,14 +103,23 @@ impl Resource {
         } else {
             "name"
         };
+        let oid_attr = if self.resource_type == "nvt" {
+            self.attr("oid")
+                .or_else(|| self.attr("nvt_oid"))
+                .map(|oid| format!(" oid=\"{}\"", xml_escape_attr(oid)))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
         let mut xml = format!(
-            "<{type} id=\"{id}\">\
+            "<{type} id=\"{id}\"{oid_attr}>\
              <{name_tag}>{name}</{name_tag}>\
              <comment>{comment}</comment>\
              <creation_time>{ct}</creation_time>\
              <modification_time>{mt}</modification_time>",
             type = self.resource_type,
             id = self.id,
+            oid_attr = oid_attr,
             name_tag = name_tag,
             name = xml_escape(&self.name),
             comment = xml_escape(&self.comment),
@@ -119,6 +128,14 @@ impl Resource {
         );
         // Add type-specific attributes
         for (k, v) in &self.attrs {
+            if self.resource_type == "nvt"
+                && matches!(
+                    k.as_str(),
+                    "oid" | "nvt_oid" | "config_id" | "preferences_config_id"
+                )
+            {
+                continue;
+            }
             xml.push_str(&format!("<{k}>{}</{k}>", xml_escape(v)));
         }
         xml.push_str(&format!("</{}>", self.resource_type));

--- a/crates/gvm-mock-server/tests/store_extended.rs
+++ b/crates/gvm-mock-server/tests/store_extended.rs
@@ -63,6 +63,23 @@ fn crud_scanners() {
 }
 
 #[test]
+fn nvt_xml_uses_oid_attribute_without_request_scope_children() {
+    let mut nvt = Resource::new("nvt", "Config NVT");
+    nvt.set_attr("oid", "1.3.6.1.4.1.25623.1.0.90001");
+    nvt.set_attr("config_id", "config-1");
+    nvt.set_attr("preferences_config_id", "prefs-1");
+    nvt.set_attr("family", "General");
+
+    let xml = nvt.to_xml();
+
+    assert!(xml.contains(" oid=\"1.3.6.1.4.1.25623.1.0.90001\""));
+    assert!(xml.contains("<family>General</family>"));
+    assert!(!xml.contains("<oid>"));
+    assert!(!xml.contains("<config_id>"));
+    assert!(!xml.contains("<preferences_config_id>"));
+}
+
+#[test]
 fn crud_alerts() {
     let store = ResourceStore::new();
     let id1 = store.create(Resource::new("alert", "Alert 1"));


### PR DESCRIPTION
## Summary
- expand get_nvts options for scan-config scoped NVT listing attributes
- add get_scan_config_nvts/get_scan_config_nvt command builders and typed client helpers
- teach the stateful mock server to filter NVT resources by NVT/config scope and render NVT OIDs as protocol-shaped attributes

## Validation
- cargo fmt --all -- --check
- cargo test -p gvm-gmp --test test_nvts --quiet
- cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_scan_config_nvt_helpers_use_stateful_mock_server_filters --quiet
- cargo test -p gvm-mock-server --test store_extended nvt_xml_uses_oid_attribute_without_request_scope_children --quiet
- cargo test --workspace --quiet
- cargo test --workspace --all-features --quiet
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace --quiet
- cargo deny check
- cargo audit
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- python3 -B -m unittest tests.test_sbom_postprocess -q
- make test-integration
- semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off
- cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-config-nvt-helpers.lcov
- git diff --check

Notes: cargo deny reported only the existing unmatched allow/license/advisory warnings; cargo audit reported the existing allowed yanked crypto-bigint 0.7.4 warning. The CI-style cargo-geiger report command generated per-crate reports with dependency parser warnings; the blocking workspace unsafe gate reported no unsafe usage in workspace crates.