### PR TITLE
Add generic secinfo get_info helpers

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -19,6 +19,7 @@ use gvm_gmp::commands::scan_configs::{
     ConfigOpts, GetPolicyOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::ScannerOpts;
+use gvm_gmp::commands::secinfo::{get_info, get_info_list, GenericInfoType, GetInfoListOpts};
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
@@ -719,6 +720,69 @@ async fn typed_vulnerability_helpers_parse_stateful_mock_response() {
     assert_eq!(vulnerability.items[0].id, "vuln-1");
     assert_eq!(vulnerability.items[0].name, "Outdated package");
     assert_eq!(vulnerability.counts.total, Some(1));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn generic_secinfo_helpers_use_stateful_mock_server_path() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    server.clear_history();
+
+    let nvt = client
+        .call(get_info_list(
+            GenericInfoType::Nvt,
+            GetInfoListOpts {
+                filter: Some("family=General".into()),
+                filter_id: Some("filter-1".into()),
+                name: Some("Mock NVT one".into()),
+                details: Some(false),
+            },
+        ))
+        .await
+        .expect("NVT secinfo list should succeed");
+    let text = nvt.as_str().expect("response should be UTF-8");
+    assert!(text.contains("<nvt id=\"1.3.6.1.4.1.25623.1\">"));
+    assert!(text.contains("Mock NVT one"));
+    assert!(text.contains("<nvt_count>1<filtered>1</filtered></nvt_count>"));
+    assert!(!text.contains("Mock NVT two"));
+
+    let oval = client
+        .call(get_info("oval:org.example:def:1", GenericInfoType::Ovaldef))
+        .await
+        .expect("OVALDEF secinfo lookup should succeed");
+    let text = oval.as_str().expect("response should be UTF-8");
+    assert!(text.contains("<ovaldef id=\"oval:org.example:def:1\">"));
+    assert!(text.contains("Mock OVAL definition one"));
+    assert!(text.contains("<ovaldef_count>1<filtered>1</filtered></ovaldef_count>"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    let commands = history
+        .iter()
+        .map(|command| {
+            String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands,
+        [
+            "<get_info details=\"0\" filt_id=\"filter-1\" filter=\"family=General\" name=\"Mock NVT one\" type=\"NVT\"/>",
+            "<get_info details=\"1\" info_id=\"oval:org.example:def:1\" type=\"OVALDEF\"/>",
+        ]
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/secinfo.rs
+++ b/crates/gvm-gmp/src/commands/secinfo.rs
@@ -10,12 +10,12 @@ use crate::common::set_optional_bool_attr;
 /// Typed `SecInfo` resource kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InfoType {
+    /// CERT-Bund advisories.
+    CertBundAdvisory,
     /// CPE entries.
     Cpe,
     /// CVE entries.
     Cve,
-    /// CERT-Bund advisories.
-    CertBundAdvisory,
     /// DFN-CERT advisories.
     DfnCertAdvisory,
     /// Operating-system entries.
@@ -29,12 +29,64 @@ impl InfoType {
     #[must_use]
     pub const fn as_gmp_str(self) -> &'static str {
         match self {
+            Self::CertBundAdvisory => "CERT_BUND_ADV",
             Self::Cpe => "CPE",
             Self::Cve => "CVE",
-            Self::CertBundAdvisory => "CERT_BUND_ADV",
             Self::DfnCertAdvisory => "DFN_CERT_ADV",
             Self::OperatingSystem => "os",
             Self::Vulnerability => "vuln",
+        }
+    }
+}
+
+/// Security information kinds accepted by generic `get_info` requests.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GenericInfoType {
+    /// CERT-Bund advisories.
+    CertBundAdvisory,
+    /// CPE entries.
+    Cpe,
+    /// CVE entries.
+    Cve,
+    /// DFN-CERT advisories.
+    DfnCertAdvisory,
+    /// NVT entries.
+    Nvt,
+    /// OVAL definition entries.
+    Ovaldef,
+    /// Operating-system entries.
+    OperatingSystem,
+    /// Vulnerability entries.
+    Vulnerability,
+}
+
+impl GenericInfoType {
+    /// Returns the GMP wire-format string for this value.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::CertBundAdvisory => "CERT_BUND_ADV",
+            Self::Cpe => "CPE",
+            Self::Cve => "CVE",
+            Self::DfnCertAdvisory => "DFN_CERT_ADV",
+            Self::Nvt => "NVT",
+            Self::Ovaldef => "OVALDEF",
+            Self::OperatingSystem => "os",
+            Self::Vulnerability => "vuln",
+        }
+    }
+}
+
+impl From<InfoType> for GenericInfoType {
+    fn from(info_type: InfoType) -> Self {
+        match info_type {
+            InfoType::CertBundAdvisory => Self::CertBundAdvisory,
+            InfoType::Cpe => Self::Cpe,
+            InfoType::Cve => Self::Cve,
+            InfoType::DfnCertAdvisory => Self::DfnCertAdvisory,
+            InfoType::OperatingSystem => Self::OperatingSystem,
+            InfoType::Vulnerability => Self::Vulnerability,
         }
     }
 }
@@ -50,20 +102,49 @@ pub struct GetSecInfoOpts {
     pub details: Option<bool>,
 }
 
-fn get_info(info_type: &str, opts: &GetSecInfoOpts) -> XmlCommand {
+/// Options for generic `get_info` list requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetInfoListOpts {
+    /// Optional inline filter expression.
+    pub filter: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<String>,
+    /// Optional name or identifier of the requested information.
+    pub name: Option<String>,
+    /// Whether to request detailed output.
+    pub details: Option<bool>,
+}
+
+impl From<GetSecInfoOpts> for GetInfoListOpts {
+    fn from(opts: GetSecInfoOpts) -> Self {
+        Self {
+            filter: opts.filter,
+            filter_id: opts.filter_id,
+            name: None,
+            details: opts.details,
+        }
+    }
+}
+
+fn build_get_info_list(info_type: GenericInfoType, opts: &GetInfoListOpts) -> XmlCommand {
     let mut cmd = XmlCommand::new("get_info");
-    cmd.set_attribute("type", info_type);
+    cmd.set_attribute("type", info_type.as_gmp_str());
     if let Some(filter) = opts.filter.as_deref() {
         cmd.set_attribute("filter", filter);
     }
     if let Some(filter_id) = opts.filter_id.as_deref() {
         cmd.set_attribute("filt_id", filter_id);
     }
+    if let Some(name) = opts.name.as_deref() {
+        cmd.set_attribute("name", name);
+    }
     set_optional_bool_attr(&mut cmd, "details", opts.details);
     cmd
 }
 
-fn get_info_by_id(info_type: InfoType, info_id: &str) -> XmlCommand {
+/// Build a `get_info` request for one security information entry.
+#[must_use]
+pub fn get_info(info_id: &str, info_type: GenericInfoType) -> XmlCommand {
     let mut cmd = XmlCommand::new("get_info");
     cmd.set_attribute("info_id", info_id);
     cmd.set_attribute("type", info_type.as_gmp_str());
@@ -71,71 +152,78 @@ fn get_info_by_id(info_type: InfoType, info_id: &str) -> XmlCommand {
     cmd
 }
 
+/// Build a `get_info` request for security information entries.
+#[must_use]
+pub fn get_info_list(info_type: GenericInfoType, opts: GetInfoListOpts) -> XmlCommand {
+    build_get_info_list(info_type, &opts)
+}
+
 /// Build a `get_info` request for CPE entries.
 #[must_use]
 pub fn get_cpes(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::Cpe.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::Cpe.into(), &opts.into())
 }
 
 /// Build a `get_info` request for a single CPE entry.
 #[must_use]
 pub fn get_cpe(cpe_id: &str) -> XmlCommand {
-    get_info_by_id(InfoType::Cpe, cpe_id)
+    get_info(cpe_id, InfoType::Cpe.into())
 }
 
 /// Build a `get_info` request for CVE entries.
 #[must_use]
 pub fn get_cves(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::Cve.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::Cve.into(), &opts.into())
 }
 
 /// Build a `get_info` request for a single CVE entry.
 #[must_use]
 pub fn get_cve(cve_id: &str) -> XmlCommand {
-    get_info_by_id(InfoType::Cve, cve_id)
+    get_info(cve_id, InfoType::Cve.into())
 }
 
 /// Build a `get_info` request for CERT-Bund advisories.
 #[must_use]
 pub fn get_cert_bund_advisories(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::CertBundAdvisory.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::CertBundAdvisory.into(), &opts.into())
 }
 
 /// Build a `get_info` request for a single CERT-Bund advisory.
 #[must_use]
 pub fn get_cert_bund_advisory(cert_id: &str) -> XmlCommand {
-    get_info_by_id(InfoType::CertBundAdvisory, cert_id)
+    get_info(cert_id, InfoType::CertBundAdvisory.into())
 }
 
 /// Build a `get_info` request for DFN-CERT advisories.
 #[must_use]
 pub fn get_dfn_cert_advisories(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::DfnCertAdvisory.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::DfnCertAdvisory.into(), &opts.into())
 }
 
 /// Build a `get_info` request for a single DFN-CERT advisory.
 #[must_use]
 pub fn get_dfn_cert_advisory(cert_id: &str) -> XmlCommand {
-    get_info_by_id(InfoType::DfnCertAdvisory, cert_id)
+    get_info(cert_id, InfoType::DfnCertAdvisory.into())
 }
 
 /// Build a `get_info` request for operating-system entries.
 #[must_use]
 pub fn get_operating_systems(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::OperatingSystem.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::OperatingSystem.into(), &opts.into())
 }
 
 /// Build a `get_info` request for vulnerability entries.
 #[must_use]
 pub fn get_vulnerabilities(opts: GetSecInfoOpts) -> XmlCommand {
-    get_info(InfoType::Vulnerability.as_gmp_str(), &opts)
+    build_get_info_list(InfoType::Vulnerability.into(), &opts.into())
 }
 
 #[cfg(test)]
 mod tests {
     use crate::commands::secinfo::{
         get_cert_bund_advisories, get_cert_bund_advisory, get_cpe, get_cpes, get_cve, get_cves,
-        get_dfn_cert_advisories, get_dfn_cert_advisory, get_operating_systems, get_vulnerabilities,
+        get_dfn_cert_advisories, get_dfn_cert_advisory, get_info, get_info_list,
+        get_operating_systems, get_vulnerabilities, GenericInfoType, GetInfoListOpts,
         GetSecInfoOpts, InfoType,
     };
     use crate::common::xml;
@@ -148,6 +236,24 @@ mod tests {
         assert_eq!(InfoType::DfnCertAdvisory.as_gmp_str(), "DFN_CERT_ADV");
         assert_eq!(InfoType::OperatingSystem.as_gmp_str(), "os");
         assert_eq!(InfoType::Vulnerability.as_gmp_str(), "vuln");
+    }
+
+    #[test]
+    fn generic_info_type_variants_map_to_wire_values() {
+        assert_eq!(GenericInfoType::Cpe.as_gmp_str(), "CPE");
+        assert_eq!(GenericInfoType::Cve.as_gmp_str(), "CVE");
+        assert_eq!(
+            GenericInfoType::CertBundAdvisory.as_gmp_str(),
+            "CERT_BUND_ADV"
+        );
+        assert_eq!(
+            GenericInfoType::DfnCertAdvisory.as_gmp_str(),
+            "DFN_CERT_ADV"
+        );
+        assert_eq!(GenericInfoType::Nvt.as_gmp_str(), "NVT");
+        assert_eq!(GenericInfoType::Ovaldef.as_gmp_str(), "OVALDEF");
+        assert_eq!(GenericInfoType::OperatingSystem.as_gmp_str(), "os");
+        assert_eq!(GenericInfoType::Vulnerability.as_gmp_str(), "vuln");
     }
 
     #[test]
@@ -196,6 +302,49 @@ mod tests {
         assert_eq!(
             xml(get_dfn_cert_advisory("DFN-2026-001")),
             "<get_info details=\"1\" info_id=\"DFN-2026-001\" type=\"DFN_CERT_ADV\"/>"
+        );
+    }
+
+    #[test]
+    fn generic_secinfo_compatibility_commands_build_xml() {
+        assert_eq!(
+            xml(get_info("1.3.6.1.4.1.25623.1", GenericInfoType::Nvt)),
+            "<get_info details=\"1\" info_id=\"1.3.6.1.4.1.25623.1\" type=\"NVT\"/>"
+        );
+        assert_eq!(
+            xml(get_info("oval:org.example:def:1", GenericInfoType::Ovaldef)),
+            "<get_info details=\"1\" info_id=\"oval:org.example:def:1\" type=\"OVALDEF\"/>"
+        );
+        assert_eq!(
+            xml(get_info_list(
+                GenericInfoType::Nvt,
+                GetInfoListOpts {
+                    filter: Some("family=General".into()),
+                    filter_id: Some("filter-1".into()),
+                    name: None,
+                    details: Some(false),
+                },
+            )),
+            "<get_info details=\"0\" filt_id=\"filter-1\" filter=\"family=General\" type=\"NVT\"/>"
+        );
+        assert_eq!(
+            xml(get_info_list(
+                GenericInfoType::Nvt,
+                GetInfoListOpts {
+                    filter: Some("family=General".into()),
+                    filter_id: Some("filter-1".into()),
+                    name: Some("Mock NVT one".into()),
+                    details: Some(false),
+                },
+            )),
+            "<get_info details=\"0\" filt_id=\"filter-1\" filter=\"family=General\" name=\"Mock NVT one\" type=\"NVT\"/>"
+        );
+        assert_eq!(
+            xml(get_info_list(
+                GenericInfoType::Ovaldef,
+                GetInfoListOpts::default()
+            )),
+            "<get_info type=\"OVALDEF\"/>"
         );
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -126,6 +126,7 @@ impl SessionHandler {
     fn normal_response(&self, cmd: &ParsedCommand, xml: &[u8]) -> Vec<u8> {
         match self.mode {
             ServerMode::Echo => echo_response(&cmd.name, self.version.as_str()),
+            ServerMode::Fixture if cmd.name == "get_info" => render_secinfo_response(cmd),
             ServerMode::Fixture => self.handle_fixture(&cmd.name),
             ServerMode::Stateful => self.handle_stateful(cmd, xml),
             ServerMode::Scenario => self.handle_scenario(cmd),
@@ -1195,6 +1196,20 @@ fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
                 ("DFN-2026-002", "DFN-CERT advisory two"),
             ],
         ),
+        "NVT" | "nvt" => (
+            "nvt",
+            vec![
+                ("1.3.6.1.4.1.25623.1", "Mock NVT one"),
+                ("1.3.6.1.4.1.25623.2", "Mock NVT two"),
+            ],
+        ),
+        "OVALDEF" | "ovaldef" => (
+            "ovaldef",
+            vec![
+                ("oval:org.example:def:1", "Mock OVAL definition one"),
+                ("oval:org.example:def:2", "Mock OVAL definition two"),
+            ],
+        ),
         "os" => (
             "os",
             vec![("os-1", "Debian GNU/Linux"), ("os-2", "Ubuntu Linux")],
@@ -1210,9 +1225,11 @@ fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {
     };
 
     let info_id = cmd.attr("info_id");
+    let name = cmd.attr("name");
     let entries: Vec<_> = entries
         .into_iter()
         .filter(|(id, _)| info_id.is_none_or(|wanted| wanted == *id))
+        .filter(|(id, entry_name)| name.is_none_or(|wanted| wanted == *id || wanted == *entry_name))
         .collect();
     let count = entries.len();
     let items: String = entries

--- a/crates/gvm-mock-server/tests/fixture_coverage.rs
+++ b/crates/gvm-mock-server/tests/fixture_coverage.rs
@@ -116,6 +116,33 @@ async fn fixture_get_filters() {
 }
 
 #[tokio::test]
+async fn fixture_get_info_respects_secinfo_type_and_filters() {
+    let Some((server, mut s)) = server().await else {
+        return;
+    };
+
+    let r = send_recv(&mut s, br#"<get_info name="Mock NVT one" type="NVT"/>"#).await;
+    assert!(r.is_success());
+    let body = r.as_str().expect("fixture response should be utf8");
+    assert!(body.contains("<nvt id=\"1.3.6.1.4.1.25623.1\">"));
+    assert!(body.contains("<nvt_count>1<filtered>1</filtered></nvt_count>"));
+    assert!(!body.contains("Mock NVT two"));
+
+    let r = send_recv(
+        &mut s,
+        br#"<get_info info_id="oval:org.example:def:1" type="OVALDEF"/>"#,
+    )
+    .await;
+    assert!(r.is_success());
+    let body = r.as_str().expect("fixture response should be utf8");
+    assert!(body.contains("<ovaldef id=\"oval:org.example:def:1\">"));
+    assert!(body.contains("<ovaldef_count>1<filtered>1</filtered></ovaldef_count>"));
+    assert!(!body.contains("Mock OVAL definition two"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn fixture_get_reports() {
     let Some((server, mut s)) = server().await else {
         return;

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -516,6 +516,41 @@ async fn stateful_secinfo_accepts_uppercase_type_and_info_id() {
 }
 
 #[tokio::test]
+async fn stateful_secinfo_renders_nvt_and_ovaldef_entries() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let nvt = send_recv(
+        &mut stream,
+        br#"<get_info details="0" name="Mock NVT one" type="NVT"/>"#,
+    )
+    .await;
+    assert_eq!(nvt.status_code(), Some(200));
+    let text = nvt.as_str().expect("utf8");
+    assert!(text.contains("<nvt id=\"1.3.6.1.4.1.25623.1\">"));
+    assert!(text.contains("Mock NVT one"));
+    assert!(text.contains("<nvt_count>1<filtered>1</filtered></nvt_count>"));
+    assert!(!text.contains("Mock NVT two"));
+
+    let oval = send_recv(
+        &mut stream,
+        br#"<get_info details="1" info_id="oval:org.example:def:1" type="OVALDEF"/>"#,
+    )
+    .await;
+    assert_eq!(oval.status_code(), Some(200));
+    let text = oval.as_str().expect("utf8");
+    assert!(text.contains("<ovaldef id=\"oval:org.example:def:1\">"));
+    assert!(text.contains("Mock OVAL definition one"));
+    assert!(text.contains("<ovaldef_count>1<filtered>1</filtered></ovaldef_count>"));
+    assert!(!text.contains("Mock OVAL definition two"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn stateful_audit_reports_filter_by_usage_type() {
     let Some(server) = stateful_server().await else {
         return;


### PR DESCRIPTION
## Summary
- add generic secinfo `get_info` and `get_info_list` builders with Python-compatible `info_id`, `type`, `details`, `filter`, `filt_id`, and `name` wire attributes
- keep the existing specialized `GetSecInfoOpts`/`InfoType` surface source-compatible, with a new non-exhaustive `GenericInfoType` for NVT/OVALDEF-capable generic requests
- teach `gvm-mock-server` fixture and stateful modes to render/filter NVT and OVALDEF `get_info` responses explicitly
- add a real `gvm-client` Unix socket mock-server path test that asserts the raw XML emitted by the new helpers

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --lib commands::secinfo --quiet`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test fixture_coverage fixture_get_info_respects_secinfo_type_and_filters --quiet`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_command_surface_gaps stateful_secinfo_renders_nvt_and_ovaldef_entries --quiet`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration generic_secinfo_helpers_use_stateful_mock_server_path --quiet`
- `cargo test --workspace --quiet`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-get-info-compat.lcov`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off`
- `git diff --check`

## Notes
- `cargo test --workspace --quiet` and the MSRV test run still emit the existing missing-doc warnings for feature-gated integration test crates.
- `cargo deny check` still emits baseline unmatched allow/advisory warnings while passing; `cargo audit` still reports the allowed yanked `crypto-bigint 0.7.4` warning.
- `cargo vet` rewrote quote escaping in `supply-chain/imports.lock`; that generated churn was restored and is not part of this PR.
- Fuzzing was not run because this slice changes command builders and mock response shaping, not parser framing, streaming, or large-response handling.
- This PR validates generic NVT/OVALDEF behavior as raw XML over the client transport path; adding typed response models for those payloads remains separate work.
