### PR TITLE
Add get_vulnerability command alias

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -65,7 +65,8 @@ use gvm_gmp::commands::secinfo::{
     get_dfn_cert_advisories, get_dfn_cert_advisory, GetSecInfoOpts,
 };
 use gvm_gmp::commands::system::{
-    describe_auth, get_settings, get_timezones, get_vuln, get_vulns, FilteredGetOpts,
+    describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
+    get_vulns, FilteredGetOpts,
 };
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
@@ -814,7 +815,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         vulnerability_id: &str,
     ) -> Result<GetVulnerabilitiesResponse, GvmError> {
-        let response = self.send(get_vuln(vulnerability_id)).await?;
+        let response = self.send(get_vulnerability_cmd(vulnerability_id)).await?;
         GetVulnerabilitiesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -704,6 +704,8 @@ async fn typed_vulnerability_helpers_parse_stateful_mock_response() {
         .await
         .expect("authenticate should succeed");
 
+    server.clear_history();
+
     let vulnerabilities = client
         .get_vulnerabilities(Default::default())
         .await
@@ -719,6 +721,19 @@ async fn typed_vulnerability_helpers_parse_stateful_mock_response() {
     assert_eq!(vulnerability.items[0].id, "vuln-1");
     assert_eq!(vulnerability.items[0].name, "Outdated package");
     assert_eq!(vulnerability.counts.total, Some(1));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    let commands = history
+        .iter()
+        .map(|command| {
+            String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands,
+        ["<get_vulns/>", "<get_vulns vuln_id=\"vuln-1\"/>",]
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -222,6 +222,12 @@ pub fn get_vuln(vuln_id: &str) -> impl Request {
     XmlCommand::new("get_vulns").attribute("vuln_id", vuln_id)
 }
 
+/// Build a `get_vulns` request using python-gvm's descriptive helper name.
+#[must_use]
+pub fn get_vulnerability(vulnerability_id: &str) -> impl Request {
+    get_vuln(vulnerability_id)
+}
+
 /// Build a `get_license` request.
 #[must_use]
 pub fn get_license() -> impl Request {
@@ -329,6 +335,10 @@ mod tests {
             "<get_vulns filt_id=\"filter-1\" filter=\"severity&gt;5\"/>"
         );
         assert_eq!(xml(get_vuln("vuln-1")), "<get_vulns vuln_id=\"vuln-1\"/>");
+        assert_eq!(
+            xml(get_vulnerability("vuln-1")),
+            "<get_vulns vuln_id=\"vuln-1\"/>"
+        );
         assert_eq!(xml(modify_auth(true)), "<modify_auth enabled=\"1\"/>");
         assert_eq!(
             xml(modify_license("abc")),


### PR DESCRIPTION
## Summary
- add `get_vulnerability` as a descriptive command-builder alias for `get_vuln`, matching the python-gvm helper name while preserving the existing `get_vuln` API
- route the typed `GmpClient::get_vulnerability` helper through the new alias without changing the emitted `get_vulns` XML
- extend the stateful mock-server client integration test to assert the exact list and singular vulnerability request XML over the Unix socket path

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --lib commands::system::tests::system_filtered_mutation_commands_build_xml --quiet`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_vulnerability_helpers_parse_stateful_mock_response --quiet`
- `cargo test --workspace --quiet`
- `cargo test --workspace --all-features --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --quiet`
- `cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-get-vulnerability-alias.lcov`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- `python3 -B -m unittest tests.test_sbom_postprocess -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --error --metrics=off`
- `git diff --check`

## Notes
- `cargo test --workspace --quiet` and the MSRV test run still emit the existing missing-doc warnings for feature-gated integration test crates.
- `cargo deny check` still emits baseline unmatched allow/advisory warnings while passing; `cargo audit` still reports the allowed yanked `crypto-bigint 0.7.4` warning.
- `cargo vet` rewrote quote escaping in `supply-chain/imports.lock`; that generated churn was restored and is not part of this PR.
- Fuzzing was not run because this slice adds a thin command-builder alias and typed-client routing only; it does not touch parser framing, streaming, large-response handling, or fuzz-facing parser logic.
