### PR TITLE
docs(journal): add 2026-07-08 journal entry

### DIFF
--- a/journal/2026-07-08.md
+++ b/journal/2026-07-08.md
@@ -1,0 +1,22 @@
+# 2026-07-08 — `devel` Opened a New Current-GVMD Helper Wave While the Reframed Roadmap Landed in Docs
+
+## Direction & Documentation
+
+### The current-GVMD pivot moved from issue text into the repo's published guidance
+- PR #337 (`docs: reframe GMP support direction`) merged into `devel` after the last journal cutoff, turning issue #320's directional change into concrete repository guidance.
+- The merge added a new roadmap, a status note, and an agent-facing code map while updating the README to state that current GMP/GVMD support is now the primary target and `python-gvm` compatibility is a secondary migration constraint.
+- That matters because the repo is no longer only signaling a strategic change through backlog text; the new support boundary is now documented where contributors will actually encounter it.
+
+## Development Queue
+
+### A same-day burst of new non-journal PRs widened the active `devel` lane again
+- PRs #338 through #352 all opened after the previous journal entry, and together they push the current-GVMD tranche further into agent, task, import, credential-store, config, secinfo, and vulnerability helper coverage.
+- The new queue includes exposing agent commands in `gvm-client`, import task and agent-group task helpers, OCI image and web-application task helpers, credential-store get/verify/create/modify support, report/scan-config/policy import helpers, scan-config NVT options, generic secinfo `get_info` helpers, and a `get_vulnerability` alias.
+- None of that shipped on `main` yet, but the concentration of new open work is itself material: the forward delivery lane clearly stayed on `devel`, and the backlog is now moving deeper into the current-GVMD helper surface that yesterday's entry only described at a high level.
+
+## Validation & Risks
+
+### Fresh validation stayed green, and the known dependency failure did not change
+- Every new PR in the #338-#352 wave opened with successful `CI` and `Security` runs, so the broadened `devel` queue did not introduce a new visible validation regression.
+- There were no new default-branch commits or releases/tags after the 2026-07-07 journal cutoff, which keeps the journal focus on queue direction rather than on new shipped artifacts.
+- PR #323 remains the notable open maintenance risk from the prior entry, but it did not materially change during this window, so today's update is about healthy queue expansion rather than new breakage or recovery.


### PR DESCRIPTION
## Summary
- add the 2026-07-08 rust-gvm journal entry
- record the merged roadmap/docs reframe in PR #337
- capture the new PR #338-#352 devel helper wave and its green validation

## Validation
- journal entry reviewed locally
- git diff --check

Agent: Thoth
