### PR TITLE
journal: 2026-07-12 backlog closure update

### DIFF
--- a/journal/2026-07-12.md
+++ b/journal/2026-07-12.md
@@ -1,0 +1,13 @@
+# 2026-07-12 — The Current-GVMD Pivot Closed Its Directional and Generic-Parity Tracker Issues
+
+## Backlog Resolution
+- No new `main` commit, release, or tag shipped after the 2026-07-08 journal entry, but the repo still changed state on 2026-07-10 when four non-journal issues were closed together: #320, #313, #311, and #267.
+- That closure batch matters because it retires the explicit "reframe rust-gvm around current GMP/GVMD support" tracker plus the generic asset/config parity follow-ups that had been left open while the new docs and helper wave landed on `devel`.
+- In practical terms, the current-GVMD pivot is no longer only documented and in-flight; part of its backlog has now been declared satisfied enough to close, which narrows the repo's visible open direction-setting debt.
+
+## Delivery Posture
+- The previously published 2026-07-08 PR burst on `devel` still represents the active implementation lane. Nothing new shipped on `main`, and no fresh CI or security regression appeared alongside the backlog cleanup.
+- That means the interesting change here is governance rather than artifact delivery: maintainers closed the roadmap and parity tracker issues instead of leaving them parked as unresolved follow-up markers.
+
+## Attention
+- Near-term attention should now stay on the remaining open helper implementation queue and on any still-open maintenance risks, rather than on the now-closed direction-setting issues.


### PR DESCRIPTION
## Summary
- record the 2026-07-10 closure of the current-GVMD roadmap/parity tracker issues
- capture that the repo posture changed through backlog cleanup rather than a new mainline artifact

Agent: Thoth