### PR TITLE
journal: 2026-07-13 russh blocker update

### DIFF
--- a/journal/2026-07-13.md
+++ b/journal/2026-07-13.md
@@ -1,0 +1,14 @@
+# 2026-07-13 — The `russh` Upgrade Reopened as a Fresh Mainline Blocker
+
+## Dependency Queue
+- No new `main` commit, release, or tag shipped after the published 2026-07-12 journal entry, but the default-branch dependency queue still changed materially overnight.
+- Dependabot closed PR [#323](https://github.com/clawosiris/rust-gvm/pull/323) for `russh` `0.62.1` and immediately replaced it with PR [#356](https://github.com/clawosiris/rust-gvm/pull/356) for `russh` `0.62.2`, while also opening PR [#355](https://github.com/clawosiris/rust-gvm/pull/355) for `uuid` `1.23.5` and PR [#357](https://github.com/clawosiris/rust-gvm/pull/357) for the GitHub Actions dependency refresh.
+- That matters because the repo is no longer only carrying an aging incompatible SSH bump in the queue. There is now a fresh non-journal `main` PR retrying the upgrade against the latest `russh` line, which moves the unresolved compatibility question back into the active attention lane.
+
+## Validation
+- PR `#356` is not routine queue churn. Its CI now fails across `Clippy`, `Documentation`, `Coverage`, `MSRV Check`, and `Test (all features)` because `gvm-mock-server` still implements `channel_open_direct_streamlocal` with four parameters, while `russh` `0.62.x` requires the new `ChannelOpenHandle` argument in the `russh::server::Handler` trait.
+- The same PR also fails the security aggregation step: `cargo vet` now reports 19 unvetted dependencies introduced through the newer `russh` chain, and the workspace unsafe gate errors specifically on `gvm-mock-server`.
+- By contrast, the companion `uuid` patch PR `#355` and GitHub Actions refresh PR `#357` both opened with green checks, so the newly actionable blocker is the reopened `russh` lane rather than the broader dependency queue.
+
+## Attention
+- Near-term attention should stay on either adapting `gvm-mock-server` to the new `russh` channel-open signature and certifying the expanded dependency set, or explicitly parking the `russh` `0.62.x` lane again if that work is still out of scope.


### PR DESCRIPTION
## Summary
- Add the 2026-07-13 rust-gvm journal entry for the reopened russh blocker.
- Capture the closed #323 / opened #356 dependency state change and the new failing checks.

Agent: Thoth