### PR TITLE
Conform asset lifecycle with current gvmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,14 @@ The mock server is the most developed component. It's designed to be a drop-in t
 - **Pre-seeding** — populate the store before tests via builder API
 - **Template substitution** — `{{uuid}}`, `{{now}}`, `{{version}}` in fixture responses
 - **Resource filtering** — basic GMP filter string support (`name=foo status=Running`)
+- **gvmd-conformant direct-host assets** — canonical host/OS responses plus
+  stateful direct-host create/get/modify/delete; historical flat asset inputs
+  require an explicit compatibility profile. Report-import creation and
+  report-based bulk deletion are outside this stateful handler's scope.
 
 ### Validated Against
 
-The mock server is validated against [python-gvm](https://github.com/greenbone/python-gvm) in CI, exercising the full protocol flow: version negotiation, authentication, target/task CRUD, notes lifecycle, and cleanup. This protects migration and client interoperability while rust-gvm continues to model GMP/GVMD behavior directly.
+The mock server is validated against [python-gvm](https://github.com/greenbone/python-gvm) in CI, exercising version negotiation, authentication, target/task CRUD, the canonical host-asset lifecycle, notes, and cleanup. This protects migration and client interoperability while rust-gvm continues to model GMP/GVMD behavior directly.
 
 ## Connection Crate
 

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -13,6 +13,10 @@
 
 use gvm_connection::GvmConnection;
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
+use gvm_gmp::commands::assets::{
+    create_asset, delete_asset, get_assets, modify_asset, CreateAssetOpts, DeleteAssetOpts,
+    GetAssetsOpts, ModifyAssetOpts,
+};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::credentials::{
     create_credential, get_credential_stores, get_credentials, verify_credential_store,
@@ -95,16 +99,17 @@ use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_gmp::responses::{
-    AuthenticateResponse, CreateAlertResponse, CreateCredentialResponse, CreateFilterResponse,
-    CreateGroupResponse, CreateHostResponse, CreateNoteResponse, CreateOciImageTargetResponse,
-    CreateOverrideResponse, CreatePermissionResponse, CreatePortListResponse,
-    CreateReportConfigResponse, CreateReportFormatResponse, CreateReportResponse,
-    CreateRoleResponse, CreateScanConfigResponse, CreateScannerResponse, CreateScheduleResponse,
-    CreateTagResponse, CreateTargetResponse, CreateTaskResponse, CreateTicketResponse,
-    CreateTlsCertificateResponse, CreateUserResponse, CreateWebApplicationTargetResponse,
-    DeleteOciImageTargetResponse, DeleteScanConfigResponse, DeleteScannerResponse,
-    DeleteWebApplicationTargetResponse, DescribeAuthResponse, EmptyTrashcanResponse,
-    GetAlertsResponse, GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
+    AuthenticateResponse, CreateAlertResponse, CreateAssetResponse, CreateCredentialResponse,
+    CreateFilterResponse, CreateGroupResponse, CreateHostResponse, CreateNoteResponse,
+    CreateOciImageTargetResponse, CreateOverrideResponse, CreatePermissionResponse,
+    CreatePortListResponse, CreateReportConfigResponse, CreateReportFormatResponse,
+    CreateReportResponse, CreateRoleResponse, CreateScanConfigResponse, CreateScannerResponse,
+    CreateScheduleResponse, CreateTagResponse, CreateTargetResponse, CreateTaskResponse,
+    CreateTicketResponse, CreateTlsCertificateResponse, CreateUserResponse,
+    CreateWebApplicationTargetResponse, DeleteAssetResponse, DeleteOciImageTargetResponse,
+    DeleteScanConfigResponse, DeleteScannerResponse, DeleteWebApplicationTargetResponse,
+    DescribeAuthResponse, EmptyTrashcanResponse, GetAlertsResponse, GetAssetsResponse,
+    GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
     GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
     GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
     GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse, GetOverridesResponse,
@@ -115,10 +120,10 @@ use gvm_gmp::responses::{
     GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
     GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
     GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
-    GetWebApplicationTargetsResponse, HelpResponse, ModifyOciImageTargetResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ModifyWebApplicationTargetResponse,
-    ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
-    VerifyCredentialStoreResponse, VerifyScannerResponse,
+    GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse,
+    ModifyOciImageTargetResponse, ModifyScanConfigResponse, ModifyScannerResponse,
+    ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
+    StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 
@@ -1434,6 +1439,55 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn create_host(&mut self, opts: HostOpts) -> Result<CreateHostResponse, GvmError> {
         let response = self.send(create_host(opts)).await?;
         CreateHostResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    // ── Assets ──────────────────────────────────────────────────────────────────
+
+    /// Send a `get_assets` request and return a typed [`GetAssetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_assets(&mut self, opts: GetAssetsOpts) -> Result<GetAssetsResponse, GvmError> {
+        let response = self.send(get_assets(opts)).await?;
+        GetAssetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_asset` request and return a typed [`CreateAssetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn create_asset(
+        &mut self,
+        opts: CreateAssetOpts,
+    ) -> Result<CreateAssetResponse, GvmError> {
+        let response = self.send(create_asset(opts)).await?;
+        CreateAssetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_asset` request and return a typed [`ModifyAssetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_asset(
+        &mut self,
+        asset_id: &EntityId,
+        opts: ModifyAssetOpts,
+    ) -> Result<ModifyAssetResponse, GvmError> {
+        let response = self.send(modify_asset(asset_id, opts)).await?;
+        ModifyAssetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `delete_asset` request and return a typed [`DeleteAssetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn delete_asset(
+        &mut self,
+        asset_id: &EntityId,
+        opts: DeleteAssetOpts,
+    ) -> Result<DeleteAssetResponse, GvmError> {
+        let response = self.send(delete_asset(asset_id, opts)).await?;
+        DeleteAssetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── TLS Certificates ──────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -11,6 +11,9 @@ use gvm_client::{
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
+use gvm_gmp::commands::assets::{
+    AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
+};
 use gvm_gmp::commands::authentication::authenticate;
 use gvm_gmp::commands::feed::get_feed;
 use gvm_gmp::commands::nvts::{
@@ -31,7 +34,7 @@ use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
-use gvm_gmp::responses::{CreateScanConfigResponse, GetScanConfigsResponse};
+use gvm_gmp::responses::{Asset, CreateScanConfigResponse, GetScanConfigsResponse};
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::FeedType;
@@ -360,7 +363,7 @@ async fn operating_system_helpers_send_asset_commands() {
     let response = client
         .call(get_operating_systems(GetOperatingSystemsOpts {
             filter_string: Some("name=Debian".into()),
-            filter_id: Some(EntityId::new("filter-1").expect("valid id")),
+            filter_id: Some(EntityId::new("0").expect("valid id")),
             details: Some(true),
         }))
         .await
@@ -373,8 +376,162 @@ async fn operating_system_helpers_send_asset_commands() {
     assert_eq!(command.command_name(), "get_assets");
     assert_eq!(
         std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
-        "<get_assets details=\"1\" filt_id=\"filter-1\" filter=\"name=Debian\" type=\"os\"/>"
+        "<get_assets details=\"1\" filt_id=\"0\" filter=\"name=Debian\" type=\"os\"/>"
     );
+
+    server.shutdown().await;
+}
+
+async fn typed_host_asset_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
+    let mut create_opts = CreateAssetOpts::host("192.0.2.10");
+    create_opts.comment = Some("created through typed client".into());
+    let created = client
+        .create_asset(create_opts)
+        .await
+        .expect("create_asset should succeed");
+    let asset_id = created
+        .id
+        .expect("direct host creation should return an id");
+
+    let fetched = client
+        .get_assets(GetAssetsOpts {
+            asset_id: Some(asset_id.clone()),
+            type_: Some(AssetType::Host),
+            ..Default::default()
+        })
+        .await
+        .expect("get_assets should return the created host");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.counts.total, Some(1));
+    assert_eq!(fetched.counts.filtered, Some(1));
+    assert_eq!(fetched.counts.page, Some(1));
+    let Asset::Host(host) = &fetched.items[0] else {
+        panic!("created asset should be a host");
+    };
+    assert_eq!(host.meta.id, asset_id);
+    assert_eq!(host.meta.name, "192.0.2.10");
+    assert_eq!(
+        host.meta.comment.as_deref(),
+        Some("created through typed client")
+    );
+
+    client
+        .modify_asset(
+            &asset_id,
+            ModifyAssetOpts {
+                comment: Some("updated through typed client".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_asset should succeed");
+
+    let updated = client
+        .get_assets(GetAssetsOpts {
+            asset_id: Some(asset_id.clone()),
+            type_: Some(AssetType::Host),
+            ..Default::default()
+        })
+        .await
+        .expect("get_assets should return the updated host");
+    let Asset::Host(host) = &updated.items[0] else {
+        panic!("updated asset should be a host");
+    };
+    assert_eq!(
+        host.meta.comment.as_deref(),
+        Some("updated through typed client")
+    );
+
+    client
+        .modify_asset(&asset_id, ModifyAssetOpts::default())
+        .await
+        .expect("modify_asset without a comment should clear it");
+    let cleared = client
+        .get_assets(GetAssetsOpts {
+            asset_id: Some(asset_id.clone()),
+            type_: Some(AssetType::Host),
+            ..Default::default()
+        })
+        .await
+        .expect("get_assets should return the host with a cleared comment");
+    let Asset::Host(host) = &cleared.items[0] else {
+        panic!("cleared asset should be a host");
+    };
+    assert_eq!(host.meta.comment, None);
+
+    client
+        .delete_asset(&asset_id, DeleteAssetOpts::default())
+        .await
+        .expect("delete_asset should succeed");
+    let remaining = client
+        .get_assets(GetAssetsOpts {
+            type_: Some(AssetType::Host),
+            ..Default::default()
+        })
+        .await
+        .expect("get_assets should succeed after deletion");
+    assert!(remaining.items.is_empty());
+    assert_eq!(remaining.counts.total, Some(0));
+    assert_eq!(remaining.counts.filtered, Some(0));
+    assert_eq!(remaining.counts.page, Some(0));
+}
+
+async fn typed_operating_system_get(client: &mut GmpClient<UnixSocketConnection>) {
+    let operating_systems = client
+        .get_assets(GetAssetsOpts {
+            type_: Some(AssetType::OperatingSystem),
+            ..Default::default()
+        })
+        .await
+        .expect("get_assets should parse operating-system assets");
+    assert_eq!(operating_systems.items.len(), 1);
+    let Asset::OperatingSystem(operating_system) = &operating_systems.items[0] else {
+        panic!("seeded asset should be an operating system");
+    };
+    assert_eq!(operating_system.title, "Example Linux");
+    assert_eq!(operating_system.installs, 0);
+    assert_eq!(operating_system.all_installs, 0);
+    assert_eq!(operating_system.host_count, 0);
+    assert!(operating_system.hosts.is_empty());
+    assert_eq!(operating_system.latest_severity.as_deref(), Some("6.1"));
+}
+
+#[tokio::test]
+async fn typed_asset_helpers_cover_host_lifecycle_over_unix_transport() {
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(MockVersion::V22_5)
+        .unix_socket_auto()
+        .seed(|store| {
+            let mut operating_system = Resource::new("asset", "cpe:/o:example:linux");
+            operating_system.set_attr("type", "os");
+            operating_system.set_attr("title", "Example Linux");
+            operating_system.set_attr("installs", "0");
+            operating_system.set_attr("all_installs", "0");
+            operating_system.set_attr("latest_severity", "6.1");
+            operating_system.set_attr("highest_severity", "9.8");
+            operating_system.set_attr("average_severity", "7.95");
+            store.seed(operating_system);
+        })
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    typed_host_asset_lifecycle(&mut client).await;
+    typed_operating_system_get(&mut client).await;
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/assets.rs
+++ b/crates/gvm-gmp/src/commands/assets.rs
@@ -5,7 +5,7 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
-use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::common::{add_filter_attrs, set_optional_bool_attr};
 use crate::types::EntityId;
 
 /// Typed GMP asset type values.
@@ -16,6 +16,9 @@ pub enum AssetType {
     /// Operating-system assets.
     OperatingSystem,
     /// Forward-compatible custom asset type.
+    ///
+    /// Current gvmd accepts only `host` for direct creation and `host` or
+    /// `os` for retrieval, so custom values may be rejected by the server.
     Custom(String),
 }
 
@@ -40,12 +43,29 @@ impl AssetType {
 /// Optional fields for `create_asset` requests.
 #[derive(Debug, Clone)]
 pub struct CreateAssetOpts {
-    /// Asset type to create.
+    /// Asset type to create. Current gvmd accepts only [`AssetType::Host`]
+    /// for direct asset creation.
     pub asset_type: AssetType,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional free-form value payload.
+    /// Host name accepted by gvmd, which must be an IPv4 or IPv6 address.
+    ///
+    /// The field name is retained for source compatibility with the original
+    /// generic asset API. It is serialized as the nested GMP `asset/name`
+    /// element, not as a `value` element.
     pub value: Option<String>,
+}
+
+impl CreateAssetOpts {
+    /// Create options for a host asset with the given IP address.
+    #[must_use]
+    pub fn host(name: impl Into<String>) -> Self {
+        Self {
+            asset_type: AssetType::Host,
+            comment: None,
+            value: Some(name.into()),
+        }
+    }
 }
 
 /// Options for `get_assets` requests.
@@ -53,7 +73,10 @@ pub struct CreateAssetOpts {
 pub struct GetAssetsOpts {
     /// Optional asset identifier.
     pub asset_id: Option<EntityId>,
-    /// Optional `asset_type` attribute.
+    /// Compatibility alias for the canonical GMP `type` attribute.
+    ///
+    /// When both this field and [`Self::type_`] are set, `type_` takes
+    /// precedence. The non-standard `asset_type` attribute is never emitted.
     pub asset_type: Option<AssetType>,
     /// Optional `type` attribute.
     pub type_: Option<AssetType>,
@@ -72,14 +95,21 @@ pub struct GetAssetsOpts {
 pub struct ModifyAssetOpts {
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional free-form value payload.
+    /// Compatibility field retained from the original generic API.
+    ///
+    /// Current gvmd does not support modifying an asset value, so this field
+    /// is deliberately not serialized.
     pub value: Option<String>,
 }
 
 /// Optional fields for `delete_asset` requests.
 #[derive(Debug, Clone, Default)]
 pub struct DeleteAssetOpts {
-    /// Whether to permanently delete the asset.
+    /// Compatibility field retained from the original generic API.
+    ///
+    /// Current gvmd does not accept an `ultimate` attribute for assets and
+    /// always applies its asset-specific deletion semantics, so this field is
+    /// deliberately not serialized.
     pub ultimate: Option<bool>,
 }
 
@@ -87,8 +117,12 @@ pub struct DeleteAssetOpts {
 #[must_use]
 pub fn create_asset(opts: CreateAssetOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_asset");
-    cmd.add_element_with_text("asset_type", opts.asset_type.as_gmp_str());
-    add_asset_body(&mut cmd, &opts.comment, &opts.value);
+    let asset = cmd.add_element("asset");
+    asset.add_child_with_text("type", opts.asset_type.as_gmp_str());
+    asset.add_child_with_text("name", opts.value.as_deref().unwrap_or_default());
+    if let Some(comment) = opts.comment.as_deref().filter(|value| !value.is_empty()) {
+        asset.add_child_with_text("comment", comment);
+    }
     cmd
 }
 
@@ -99,10 +133,7 @@ pub fn get_assets(opts: GetAssetsOpts) -> impl Request {
     if let Some(asset_id) = opts.asset_id.as_ref() {
         cmd.set_attribute("asset_id", asset_id.as_str());
     }
-    if let Some(asset_type) = opts.asset_type.as_ref() {
-        cmd.set_attribute("asset_type", asset_type.as_gmp_str());
-    }
-    if let Some(type_) = opts.type_.as_ref() {
+    if let Some(type_) = opts.type_.as_ref().or(opts.asset_type.as_ref()) {
         cmd.set_attribute("type", type_.as_gmp_str());
     }
     add_filter_attrs(
@@ -119,23 +150,14 @@ pub fn get_assets(opts: GetAssetsOpts) -> impl Request {
 #[must_use]
 pub fn modify_asset(asset_id: &EntityId, opts: ModifyAssetOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_asset").attribute("asset_id", asset_id.as_str());
-    add_asset_body(&mut cmd, &opts.comment, &opts.value);
+    cmd.add_element_with_text("comment", opts.comment.as_deref().unwrap_or_default());
     cmd
 }
 
 /// Build a generic `delete_asset` request.
 #[must_use]
-pub fn delete_asset(asset_id: &EntityId, opts: DeleteAssetOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("delete_asset").attribute("asset_id", asset_id.as_str());
-    if let Some(ultimate) = opts.ultimate {
-        cmd.set_attribute("ultimate", bool_str(ultimate));
-    }
-    cmd
-}
-
-fn add_asset_body(cmd: &mut XmlCommand, comment: &Option<String>, value: &Option<String>) {
-    add_text_element(cmd, "comment", comment.as_deref());
-    add_text_element(cmd, "value", value.as_deref());
+pub fn delete_asset(asset_id: &EntityId, _opts: DeleteAssetOpts) -> impl Request {
+    XmlCommand::new("delete_asset").attribute("asset_id", asset_id.as_str())
 }
 
 #[cfg(test)]
@@ -162,7 +184,7 @@ mod tests {
                 comment: Some("c".into()),
                 value: Some("1.1.1.1".into()),
             })),
-            "<create_asset><asset_type>host</asset_type><comment>c</comment><value>1.1.1.1</value></create_asset>"
+            "<create_asset><asset><type>host</type><name>1.1.1.1</name><comment>c</comment></asset></create_asset>"
         );
     }
 
@@ -174,7 +196,7 @@ mod tests {
                 comment: Some(String::new()),
                 value: Some(String::new()),
             })),
-            "<create_asset><asset_type>host</asset_type></create_asset>"
+            "<create_asset><asset><type>host</type><name></name></asset></create_asset>"
         );
     }
 
@@ -190,7 +212,7 @@ mod tests {
                 trash: Some(true),
                 details: Some(false),
             })),
-            "<get_assets asset_id=\"a1\" asset_type=\"host\" details=\"0\" filt_id=\"f1\" filter=\"name=foo\" trash=\"1\" type=\"firmware\"/>"
+            "<get_assets asset_id=\"a1\" details=\"0\" filt_id=\"f1\" filter=\"name=foo\" trash=\"1\" type=\"firmware\"/>"
         );
     }
 
@@ -204,7 +226,7 @@ mod tests {
                     value: Some("v".into()),
                 },
             )),
-            "<modify_asset asset_id=\"a1\"><comment>updated</comment><value>v</value></modify_asset>"
+            "<modify_asset asset_id=\"a1\"><comment>updated</comment></modify_asset>"
         );
         assert_eq!(
             xml(modify_asset(
@@ -214,7 +236,7 @@ mod tests {
                     value: Some(String::new()),
                 },
             )),
-            "<modify_asset asset_id=\"a1\"/>"
+            "<modify_asset asset_id=\"a1\"><comment></comment></modify_asset>"
         );
         assert_eq!(
             xml(delete_asset(
@@ -223,7 +245,7 @@ mod tests {
                     ultimate: Some(true),
                 },
             )),
-            "<delete_asset asset_id=\"a1\" ultimate=\"1\"/>"
+            "<delete_asset asset_id=\"a1\"/>"
         );
         assert_eq!(
             xml(delete_asset(&id("a1"), DeleteAssetOpts::default())),

--- a/crates/gvm-gmp/src/commands/assets.rs
+++ b/crates/gvm-gmp/src/commands/assets.rs
@@ -46,7 +46,10 @@ pub struct CreateAssetOpts {
     /// Asset type to create. Current gvmd accepts only [`AssetType::Host`]
     /// for direct asset creation.
     pub asset_type: AssetType,
-    /// Optional comment text included in the request.
+    /// Comment text included in the request.
+    ///
+    /// Current gvmd requires this element for `modify_asset`, so `None` is
+    /// serialized as an empty comment and clears any existing value.
     pub comment: Option<String>,
     /// Host name accepted by gvmd, which must be an IPv4 or IPv6 address.
     ///

--- a/crates/gvm-gmp/src/commands/hosts.rs
+++ b/crates/gvm-gmp/src/commands/hosts.rs
@@ -16,8 +16,22 @@ use crate::types::EntityId;
 pub struct HostOpts {
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional free-form value payload.
+    /// Host IPv4 or IPv6 address used as the asset name when creating a host.
+    ///
+    /// This field is ignored by `modify_host`, because current gvmd only
+    /// supports modifying the host comment.
     pub value: Option<String>,
+}
+
+impl HostOpts {
+    /// Create options for the given host IP address.
+    #[must_use]
+    pub fn named(name: impl Into<String>) -> Self {
+        Self {
+            comment: None,
+            value: Some(name.into()),
+        }
+    }
 }
 
 /// Options for `get_hosts` requests.
@@ -47,7 +61,6 @@ pub fn create_host(opts: HostOpts) -> impl Request {
 #[must_use]
 pub fn get_hosts(opts: GetHostsOpts) -> impl Request {
     get_assets(GetAssetsOpts {
-        asset_type: Some(AssetType::Host),
         type_: Some(AssetType::Host),
         filter_string: opts.filter_string,
         filter_id: opts.filter_id,
@@ -62,7 +75,6 @@ pub fn get_hosts(opts: GetHostsOpts) -> impl Request {
 pub fn get_host(host_id: &EntityId) -> impl Request {
     get_assets(GetAssetsOpts {
         asset_id: Some(host_id.clone()),
-        asset_type: Some(AssetType::Host),
         type_: Some(AssetType::Host),
         details: Some(true),
         ..Default::default()
@@ -76,20 +88,15 @@ pub fn modify_host(host_id: &EntityId, opts: HostOpts) -> impl Request {
         host_id,
         ModifyAssetOpts {
             comment: opts.comment,
-            value: opts.value,
+            value: None,
         },
     )
 }
 
 /// Build a `delete_host` request.
 #[must_use]
-pub fn delete_host(host_id: &EntityId, ultimate: bool) -> impl Request {
-    delete_asset(
-        host_id,
-        DeleteAssetOpts {
-            ultimate: Some(ultimate),
-        },
-    )
+pub fn delete_host(host_id: &EntityId, _ultimate: bool) -> impl Request {
+    delete_asset(host_id, DeleteAssetOpts { ultimate: None })
 }
 
 #[cfg(test)]
@@ -107,11 +114,11 @@ mod tests {
             value: Some("1.1.1.1".into()),
             ..Default::default()
         }));
-        assert!(rendered.contains("<asset_type>host</asset_type>"));
-        assert!(rendered.contains("<value>1.1.1.1</value>"));
+        assert!(rendered.contains("<type>host</type>"));
+        assert!(rendered.contains("<name>1.1.1.1</name>"));
         assert_eq!(
             xml(get_host(&id("h1"))),
-            "<get_assets asset_id=\"h1\" asset_type=\"host\" details=\"1\" type=\"host\"/>"
+            "<get_assets asset_id=\"h1\" details=\"1\" type=\"host\"/>"
         );
     }
 
@@ -121,7 +128,6 @@ mod tests {
             details: Some(true),
             ..Default::default()
         }));
-        assert!(rendered.contains("asset_type=\"host\""));
         assert!(rendered.contains("type=\"host\""));
         let rendered = xml(modify_host(
             &id("h1"),
@@ -136,7 +142,7 @@ mod tests {
         );
         assert_eq!(
             xml(delete_host(&id("h1"), false)),
-            "<delete_asset asset_id=\"h1\" ultimate=\"0\"/>"
+            "<delete_asset asset_id=\"h1\"/>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/hosts.rs
+++ b/crates/gvm-gmp/src/commands/hosts.rs
@@ -94,6 +94,9 @@ pub fn modify_host(host_id: &EntityId, opts: HostOpts) -> impl Request {
 }
 
 /// Build a `delete_host` request.
+///
+/// The `ultimate` argument is retained for API compatibility but is ignored:
+/// current gvmd does not accept an `ultimate` attribute for asset deletion.
 #[must_use]
 pub fn delete_host(host_id: &EntityId, _ultimate: bool) -> impl Request {
     delete_asset(host_id, DeleteAssetOpts { ultimate: None })

--- a/crates/gvm-gmp/src/responses/asset.rs
+++ b/crates/gvm-gmp/src/responses/asset.rs
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Asset response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, parse_u32,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError, XmlNode,
+};
+use crate::responses::host::Host;
+use crate::EntityId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OperatingSystemHost {
+    pub id: EntityId,
+    pub name: String,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OperatingSystemAsset {
+    pub meta: EntityMeta,
+    pub title: String,
+    pub installs: u32,
+    pub all_installs: u32,
+    pub latest_severity: Option<String>,
+    pub highest_severity: Option<String>,
+    pub average_severity: Option<String>,
+    pub host_count: u32,
+    pub hosts: Vec<OperatingSystemHost>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Asset {
+    Host(Host),
+    OperatingSystem(OperatingSystemAsset),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAssetsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Asset>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateAssetResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: Option<EntityId>,
+}
+
+impl Asset {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let asset_type = node
+            .child_text("type")
+            .ok_or_else(|| ParseError::MissingElement("asset.type".to_string()))?;
+
+        match asset_type.as_str() {
+            "host" => {
+                if node.child("host").is_none() {
+                    return Err(ParseError::MissingElement("asset.host".to_string()));
+                }
+                Host::from_node(node).map(Self::Host)
+            }
+            "os" => OperatingSystemAsset::from_node(node).map(Self::OperatingSystem),
+            value => Err(ParseError::InvalidValue {
+                field: "asset.type".to_string(),
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+impl OperatingSystemAsset {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let os = node
+            .child("os")
+            .ok_or_else(|| ParseError::MissingElement("asset.os".to_string()))?;
+        let hosts = os
+            .child("hosts")
+            .ok_or_else(|| ParseError::MissingElement("asset.os.hosts".to_string()))?;
+
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            title: required_text(os, "title", "asset.os.title")?,
+            installs: required_u32(os, "installs", "asset.os.installs")?,
+            all_installs: required_u32(os, "all_installs", "asset.os.all_installs")?,
+            latest_severity: severity_value(os, "latest_severity"),
+            highest_severity: severity_value(os, "highest_severity"),
+            average_severity: severity_value(os, "average_severity"),
+            host_count: parse_u32(&hosts.text, "asset.os.hosts.count")?,
+            hosts: hosts
+                .children_named("asset")
+                .map(OperatingSystemHost::from_node)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl OperatingSystemHost {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: parse_entity_id(
+                node.attr("id").ok_or_else(|| {
+                    ParseError::MissingElement("asset.os.hosts.asset.id".to_string())
+                })?,
+                "asset.os.hosts.asset.id",
+            )?,
+            name: required_text(node, "name", "asset.os.hosts.asset.name")?,
+            severity: severity_value(node, "severity"),
+        })
+    }
+}
+
+impl GetAssetsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("asset")
+            .map(Asset::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "asset_count")?,
+        })
+    }
+}
+
+impl CreateAssetResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = root
+            .attr("id")
+            .map(|id| parse_entity_id(id, "id"))
+            .transpose()?;
+
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyAssetResponse = ActionResponse;
+pub type DeleteAssetResponse = ActionResponse;
+
+fn severity_value(node: &XmlNode, name: &str) -> Option<String> {
+    node.child(name)
+        .and_then(|severity| severity.optional_child_text("value"))
+}
+
+fn required_text(node: &XmlNode, name: &str, field: &str) -> Result<String, ParseError> {
+    node.child_text(name)
+        .ok_or_else(|| ParseError::MissingElement(field.to_string()))
+}
+
+fn required_u32(node: &XmlNode, name: &str, field: &str) -> Result<u32, ParseError> {
+    parse_u32(&required_text(node, name, field)?, field)
+}
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_current_runtime_host_asset() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset id="host-1">
+                    <owner><name>admin</name></owner>
+                    <name>192.0.2.10</name>
+                    <comment>edge host</comment>
+                    <creation_time>2026-07-14T10:00:00Z</creation_time>
+                    <modification_time>2026-07-14T11:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <permissions><permission><name>Everything</name></permission></permissions>
+                    <identifiers>
+                        <identifier id="identifier-ip">
+                            <name>ip</name><value>192.0.2.10</value>
+                            <creation_time>2026-07-14T10:00:00Z</creation_time>
+                            <modification_time>2026-07-14T10:00:00Z</modification_time>
+                            <source id="user-1">
+                                <type>User</type><data></data><deleted>0</deleted><name>admin</name>
+                            </source>
+                        </identifier>
+                        <identifier id="identifier-hostname">
+                            <name>hostname</name><value>edge.example.test</value>
+                            <creation_time>2026-07-14T10:00:00Z</creation_time>
+                            <modification_time>2026-07-14T10:00:00Z</modification_time>
+                            <source id="report-1">
+                                <type>Report Host Detail</type><data>hostname</data><deleted>0</deleted><name></name>
+                            </source>
+                        </identifier>
+                        <identifier id="identifier-os">
+                            <name>OS</name><value>cpe:/o:example:linux</value>
+                            <creation_time>2026-07-14T10:00:00Z</creation_time>
+                            <modification_time>2026-07-14T10:00:00Z</modification_time>
+                            <source id="report-1">
+                                <type>Report Host Detail</type><data>best_os_cpe</data><deleted>0</deleted><name></name>
+                            </source>
+                            <os id="os-1"><title>Example Linux</title></os>
+                        </identifier>
+                    </identifiers>
+                    <type>host</type>
+                    <host>
+                        <severity><value>8.4</value></severity>
+                        <detail>
+                            <name>best_os_cpe</name><value>cpe:/o:example:linux</value>
+                            <source id="report-1"><type>Report Host Detail</type></source>
+                        </detail>
+                        <routes><route><host distance="1" same_source="1"><ip>192.0.2.1</ip></host></route></routes>
+                    </host>
+                </asset>
+                <filters id=""><term>first=1 rows=10</term><keywords></keywords></filters>
+                <sort><field>name<order>ascending</order></field></sort>
+                <assets start="1" max="10"/>
+                <asset_count>1<filtered>1</filtered><page>1</page></asset_count>
+            </get_assets_response>"#,
+        );
+
+        let parsed = GetAssetsResponse::from_response(&response).expect("asset response parses");
+        let Asset::Host(host) = &parsed.items[0] else {
+            panic!("expected host asset");
+        };
+
+        assert_eq!(host.meta.id.as_str(), "host-1");
+        assert_eq!(host.ip.as_deref(), Some("192.0.2.10"));
+        assert_eq!(host.hostname.as_deref(), Some("edge.example.test"));
+        assert_eq!(host.severity.as_deref(), Some("8.4"));
+        assert_eq!(host.os.as_deref(), Some("Example Linux"));
+        assert_eq!(host.identifiers.len(), 3);
+        assert_eq!(host.details.len(), 1);
+        assert_eq!(
+            host.details[0]
+                .source
+                .as_ref()
+                .expect("runtime detail should include a source")
+                .source_type,
+            "Report Host Detail"
+        );
+        assert_eq!(parsed.counts.total, Some(1));
+    }
+
+    #[test]
+    fn parses_current_runtime_operating_system_asset() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset id="os-1">
+                    <owner><name>admin</name></owner>
+                    <name>cpe:/o:example:linux</name>
+                    <comment></comment>
+                    <creation_time>2026-07-14T10:00:00Z</creation_time>
+                    <modification_time>2026-07-14T11:00:00Z</modification_time>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                    <permissions><permission><name>get_assets</name></permission></permissions>
+                    <type>os</type>
+                    <os>
+                        <latest_severity><value>6.1</value></latest_severity>
+                        <highest_severity><value>9.8</value></highest_severity>
+                        <average_severity><value>7.95</value></average_severity>
+                        <title>Example Linux</title>
+                        <installs>2</installs>
+                        <all_installs>3</all_installs>
+                        <hosts>2
+                            <asset id="host-1"><name>192.0.2.10</name><severity><value>9.8</value></severity></asset>
+                            <asset id="host-2"><name>192.0.2.11</name><severity><value>6.1</value></severity></asset>
+                        </hosts>
+                    </os>
+                </asset>
+                <assets start="1" max="10"/>
+                <asset_count>1<filtered>1</filtered><page>1</page></asset_count>
+            </get_assets_response>"#,
+        );
+
+        let parsed = GetAssetsResponse::from_response(&response).expect("asset response parses");
+        let Asset::OperatingSystem(os) = &parsed.items[0] else {
+            panic!("expected operating-system asset");
+        };
+
+        assert_eq!(os.meta.id.as_str(), "os-1");
+        assert_eq!(os.title, "Example Linux");
+        assert_eq!(os.installs, 2);
+        assert_eq!(os.all_installs, 3);
+        assert_eq!(os.latest_severity.as_deref(), Some("6.1"));
+        assert_eq!(os.highest_severity.as_deref(), Some("9.8"));
+        assert_eq!(os.average_severity.as_deref(), Some("7.95"));
+        assert_eq!(os.host_count, 2);
+        assert_eq!(os.hosts.len(), 2);
+        assert_eq!(os.hosts[0].id.as_str(), "host-1");
+        assert_eq!(os.hosts[0].severity.as_deref(), Some("9.8"));
+    }
+
+    #[test]
+    fn parses_empty_asset_response() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset_count>0<filtered>0</filtered><page>0</page></asset_count>
+            </get_assets_response>"#,
+        );
+
+        let parsed = GetAssetsResponse::from_response(&response).expect("empty response parses");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn rejects_server_error() {
+        let response = Response::from(
+            r#"<get_assets_response status="404" status_text="Failed to find type 'printer'"/>"#,
+        );
+
+        let error = GetAssetsResponse::from_response(&response).expect_err("server error expected");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError { status: 404, message }
+                if message == "Failed to find type 'printer'"
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_empty_and_unknown_asset_types() {
+        for (asset_xml, expected_value) in [
+            ("<asset id=\"asset-1\"><name>missing</name></asset>", None),
+            (
+                "<asset id=\"asset-1\"><name>empty</name><type></type></asset>",
+                Some(""),
+            ),
+            (
+                "<asset id=\"asset-1\"><name>unknown</name><type>printer</type></asset>",
+                Some("printer"),
+            ),
+        ] {
+            let response = Response::from(
+                format!(
+                    "<get_assets_response status=\"200\" status_text=\"OK\">{asset_xml}</get_assets_response>"
+                )
+                .into_bytes(),
+            );
+            let error = GetAssetsResponse::from_response(&response).expect_err("type rejected");
+
+            match expected_value {
+                None => assert!(matches!(
+                    error,
+                    ParseError::MissingElement(field) if field == "asset.type"
+                )),
+                Some(expected) => assert!(matches!(
+                    error,
+                    ParseError::InvalidValue { field, value }
+                        if field == "asset.type" && value == expected
+                )),
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_type_payload_mismatch() {
+        let response = Response::from(
+            r#"<get_assets_response status="200" status_text="OK">
+                <asset id="host-1"><name>192.0.2.10</name><type>host</type><os/></asset>
+            </get_assets_response>"#,
+        );
+
+        let error = GetAssetsResponse::from_response(&response).expect_err("mismatch rejected");
+
+        assert!(matches!(
+            error,
+            ParseError::MissingElement(field) if field == "asset.host"
+        ));
+    }
+
+    #[test]
+    fn create_asset_id_is_optional_for_report_import() {
+        let direct = Response::from(
+            r#"<create_asset_response status="201" status_text="OK, resource created" id="host-1"/>"#,
+        );
+        let report_import = Response::from(
+            r#"<create_asset_response status="201" status_text="OK, resource created"/>"#,
+        );
+
+        assert_eq!(
+            CreateAssetResponse::from_response(&direct)
+                .expect("direct create parses")
+                .id
+                .expect("direct create should include an id")
+                .as_str(),
+            "host-1"
+        );
+        assert_eq!(
+            CreateAssetResponse::from_response(&report_import)
+                .expect("report import parses")
+                .id,
+            None
+        );
+    }
+}

--- a/crates/gvm-gmp/src/responses/asset.rs
+++ b/crates/gvm-gmp/src/responses/asset.rs
@@ -184,6 +184,20 @@ mod tests {
 
     use super::*;
 
+    fn as_host(asset: &Asset) -> Option<&Host> {
+        match asset {
+            Asset::Host(host) => Some(host),
+            Asset::OperatingSystem(_) => None,
+        }
+    }
+
+    fn as_operating_system(asset: &Asset) -> Option<&OperatingSystemAsset> {
+        match asset {
+            Asset::OperatingSystem(os) => Some(os),
+            Asset::Host(_) => None,
+        }
+    }
+
     #[test]
     fn parses_current_runtime_host_asset() {
         let response = Response::from(
@@ -242,10 +256,8 @@ mod tests {
         );
 
         let parsed = GetAssetsResponse::from_response(&response).expect("asset response parses");
-        let Asset::Host(host) = &parsed.items[0] else {
-            panic!("expected host asset");
-        };
-
+        let host = as_host(&parsed.items[0]).expect("expected host asset");
+        assert!(as_operating_system(&parsed.items[0]).is_none());
         assert_eq!(host.meta.id.as_str(), "host-1");
         assert_eq!(host.ip.as_deref(), Some("192.0.2.10"));
         assert_eq!(host.hostname.as_deref(), Some("edge.example.test"));
@@ -297,10 +309,8 @@ mod tests {
         );
 
         let parsed = GetAssetsResponse::from_response(&response).expect("asset response parses");
-        let Asset::OperatingSystem(os) = &parsed.items[0] else {
-            panic!("expected operating-system asset");
-        };
-
+        let os = as_operating_system(&parsed.items[0]).expect("expected operating-system asset");
+        assert!(as_host(&parsed.items[0]).is_none());
         assert_eq!(os.meta.id.as_str(), "os-1");
         assert_eq!(os.title, "Example Linux");
         assert_eq!(os.installs, 2);
@@ -312,6 +322,26 @@ mod tests {
         assert_eq!(os.hosts.len(), 2);
         assert_eq!(os.hosts[0].id.as_str(), "host-1");
         assert_eq!(os.hosts[0].severity.as_deref(), Some("9.8"));
+    }
+
+    #[test]
+    fn rejects_missing_and_invalid_operating_system_host_ids() {
+        for host in [
+            "<asset><name>192.0.2.10</name></asset>",
+            "<asset id=\"not a valid id\"><name>192.0.2.10</name></asset>",
+        ] {
+            let response = Response::from(
+                format!(
+                    "<get_assets_response status=\"200\" status_text=\"OK\">\
+                     <asset id=\"os-1\"><name>cpe:/o:example:linux</name><type>os</type><os>\
+                     <title>Example Linux</title><installs>1</installs><all_installs>1</all_installs>\
+                     <hosts>1{host}</hosts></os></asset></get_assets_response>"
+                )
+                .into_bytes(),
+            );
+
+            assert!(GetAssetsResponse::from_response(&response).is_err());
+        }
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/host.rs
+++ b/crates/gvm-gmp/src/responses/host.rs
@@ -6,9 +6,51 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
-    ActionResponse, CountInfo, EntityMeta, ParseError,
+    count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError, XmlNode,
 };
+use crate::EntityId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AssetSource {
+    pub id: Option<EntityId>,
+    pub source_type: String,
+    pub data: Option<String>,
+    pub deleted: Option<bool>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HostOperatingSystem {
+    pub id: Option<EntityId>,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HostIdentifier {
+    pub id: Option<EntityId>,
+    pub name: String,
+    pub value: String,
+    pub creation_time: Option<String>,
+    pub modification_time: Option<String>,
+    pub source: Option<AssetSource>,
+    pub operating_system: Option<HostOperatingSystem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HostDetail {
+    pub name: String,
+    pub value: String,
+    pub source: Option<AssetSource>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -19,6 +61,10 @@ pub struct Host {
     pub hostname: Option<String>,
     pub severity: Option<String>,
     pub os: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub identifiers: Vec<HostIdentifier>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub details: Vec<HostDetail>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,41 +87,135 @@ pub struct CreateHostResponse {
 }
 
 impl Host {
-    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
-        let ip = node
+    pub(crate) fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let identifiers = node
             .child("identifiers")
-            .and_then(|ids| {
-                ids.children_named("identifier")
-                    .find(|id| id.child_text("name").as_deref() == Some("ip"))
-                    .and_then(|id| id.optional_child_text("value"))
+            .map(|identifiers| {
+                identifiers
+                    .children_named("identifier")
+                    .map(HostIdentifier::from_node)
+                    .collect::<Result<Vec<_>, _>>()
             })
+            .transpose()?
+            .unwrap_or_default();
+        let host = node.child("host");
+        let details = host
+            .map(|host| {
+                host.children_named("detail")
+                    .map(HostDetail::from_node)
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let ip = identifiers
+            .iter()
+            .find(|identifier| identifier.name == "ip")
+            .map(|identifier| identifier.value.clone())
             .or_else(|| node.optional_child_text("ip"));
-
-        let hostname = node
-            .child("identifiers")
-            .and_then(|ids| {
-                ids.children_named("identifier")
-                    .find(|id| id.child_text("name").as_deref() == Some("hostname"))
-                    .and_then(|id| id.optional_child_text("value"))
-            })
+        let hostname = identifiers
+            .iter()
+            .find(|identifier| identifier.name == "hostname")
+            .map(|identifier| identifier.value.clone())
             .or_else(|| node.optional_child_text("hostname"));
-
-        let severity = node
-            .child("severity")
+        let severity = host
+            .and_then(|host| host.child("severity"))
             .and_then(|s| {
                 s.optional_child_text("value")
                     .or_else(|| (!s.text.is_empty()).then_some(s.text.clone()))
             })
-            .or_else(|| node.optional_child_text("severity"));
+            .or_else(|| {
+                node.child("severity").and_then(|severity| {
+                    severity
+                        .optional_child_text("value")
+                        .or_else(|| (!severity.text.is_empty()).then_some(severity.text.clone()))
+                })
+            });
+        let os = identifiers
+            .iter()
+            .find(|identifier| identifier.name == "OS")
+            .and_then(|identifier| identifier.operating_system.as_ref())
+            .map(|os| os.title.clone())
+            .or_else(|| node.optional_child_text("os"));
 
         Ok(Self {
             meta: parse_entity_meta(node)?,
             ip,
             hostname,
             severity,
-            os: node.optional_child_text("os"),
+            os,
+            identifiers,
+            details,
         })
     }
+}
+
+impl AssetSource {
+    fn from_node(node: &XmlNode, field: &str) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: optional_node_id(node, &format!("{field}.id"))?,
+            source_type: node
+                .required_child_text("type")
+                .map_err(|_| ParseError::MissingElement(format!("{field}.type")))?,
+            data: node.optional_child_text("data"),
+            deleted: node
+                .optional_child_text("deleted")
+                .map(|value| parse_bool(&value, &format!("{field}.deleted")))
+                .transpose()?,
+            name: node.optional_child_text("name"),
+        })
+    }
+}
+
+impl HostOperatingSystem {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: optional_node_id(node, "identifier.os.id")?,
+            title: node
+                .required_child_text("title")
+                .map_err(|_| ParseError::MissingElement("identifier.os.title".to_string()))?,
+        })
+    }
+}
+
+impl HostIdentifier {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            id: optional_node_id(node, "identifier.id")?,
+            name: node.required_child_text("name")?,
+            value: node.required_child_text("value")?,
+            creation_time: node.optional_child_text("creation_time"),
+            modification_time: node.optional_child_text("modification_time"),
+            source: node
+                .child("source")
+                .map(|source| AssetSource::from_node(source, "identifier.source"))
+                .transpose()?,
+            operating_system: node
+                .child("os")
+                .map(HostOperatingSystem::from_node)
+                .transpose()?,
+        })
+    }
+}
+
+impl HostDetail {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            name: node.required_child_text("name")?,
+            value: node.required_child_text("value")?,
+            source: node
+                .child("source")
+                .map(|source| AssetSource::from_node(source, "host.detail.source"))
+                .transpose()?,
+        })
+    }
+}
+
+fn optional_node_id(node: &XmlNode, field: &str) -> Result<Option<EntityId>, ParseError> {
+    node.attr("id")
+        .filter(|id| !id.is_empty())
+        .map(|id| parse_entity_id(id, field))
+        .transpose()
 }
 
 impl GetHostsResponse {

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod aggregates;
 pub mod alert;
+pub mod asset;
 pub mod auth;
 pub mod common;
 pub mod credential;
@@ -49,6 +50,10 @@ pub use aggregates::{AggregateGroup, AggregateStats, AggregateSubgroup, GetAggre
 pub use alert::{
     Alert, CreateAlertResponse, DeleteAlertResponse, GetAlertsResponse, ModifyAlertResponse,
 };
+pub use asset::{
+    Asset, CreateAssetResponse, DeleteAssetResponse, GetAssetsResponse, ModifyAssetResponse,
+    OperatingSystemAsset, OperatingSystemHost,
+};
 pub use auth::AuthenticateResponse;
 pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, ParseError};
 pub use credential::{
@@ -65,7 +70,8 @@ pub use group::{
     CreateGroupResponse, DeleteGroupResponse, GetGroupsResponse, Group, ModifyGroupResponse,
 };
 pub use host::{
-    CreateHostResponse, DeleteHostResponse, GetHostsResponse, Host, ModifyHostResponse,
+    AssetSource, CreateHostResponse, DeleteHostResponse, GetHostsResponse, Host, HostDetail,
+    HostIdentifier, HostOperatingSystem, ModifyHostResponse,
 };
 pub use note::{
     CreateNoteResponse, DeleteNoteResponse, GetNotesResponse, ModifyNoteResponse, Note,

--- a/crates/gvm-gmp/tests/test_assets.rs
+++ b/crates/gvm-gmp/tests/test_assets.rs
@@ -23,7 +23,7 @@ fn test_create_asset_xml() {
             comment: Some("c".into()),
             value: Some("1.1.1.1".into()),
         })),
-        "<create_asset><asset_type>host</asset_type><comment>c</comment><value>1.1.1.1</value></create_asset>"
+        "<create_asset><asset><type>host</type><name>1.1.1.1</name><comment>c</comment></asset></create_asset>"
     );
 }
 
@@ -40,6 +40,25 @@ fn test_get_assets_with_custom_type_xml() {
 }
 
 #[test]
+fn test_asset_type_alias_emits_only_canonical_type() {
+    assert_eq!(
+        xml(get_assets(GetAssetsOpts {
+            asset_type: Some(AssetType::Host),
+            ..Default::default()
+        })),
+        "<get_assets type=\"host\"/>"
+    );
+    assert_eq!(
+        xml(get_assets(GetAssetsOpts {
+            asset_type: Some(AssetType::Host),
+            type_: Some(AssetType::OperatingSystem),
+            ..Default::default()
+        })),
+        "<get_assets type=\"os\"/>"
+    );
+}
+
+#[test]
 fn test_modify_delete_asset_xml() {
     assert_eq!(
         xml(modify_asset(
@@ -49,7 +68,7 @@ fn test_modify_delete_asset_xml() {
                 value: Some("v".into()),
             },
         )),
-        "<modify_asset asset_id=\"a1\"><comment>updated</comment><value>v</value></modify_asset>"
+        "<modify_asset asset_id=\"a1\"><comment>updated</comment></modify_asset>"
     );
     assert_eq!(
         xml(delete_asset(
@@ -58,7 +77,7 @@ fn test_modify_delete_asset_xml() {
                 ultimate: Some(false),
             },
         )),
-        "<delete_asset asset_id=\"a1\" ultimate=\"0\"/>"
+        "<delete_asset asset_id=\"a1\"/>"
     );
 }
 
@@ -81,7 +100,6 @@ fn test_host_wrappers_match_generic_xml() {
         xml(get_host(&id("h1"))),
         xml(get_assets(GetAssetsOpts {
             asset_id: Some(id("h1")),
-            asset_type: Some(AssetType::Host),
             type_: Some(AssetType::Host),
             details: Some(true),
             ..Default::default()
@@ -94,18 +112,13 @@ fn test_host_wrappers_match_generic_xml() {
             &id("h1"),
             ModifyAssetOpts {
                 comment: create_opts.comment,
-                value: create_opts.value,
+                value: None,
             },
         ))
     );
     assert_eq!(
         xml(delete_host(&id("h1"), true)),
-        xml(delete_asset(
-            &id("h1"),
-            DeleteAssetOpts {
-                ultimate: Some(true),
-            },
-        ))
+        xml(delete_asset(&id("h1"), DeleteAssetOpts { ultimate: None },))
     );
 }
 
@@ -137,6 +150,6 @@ fn test_operating_system_wrapper_xml_regression() {
 fn test_get_hosts_wrapper_regression() {
     assert_eq!(
         xml(get_hosts(Default::default())),
-        "<get_assets asset_type=\"host\" type=\"host\"/>"
+        "<get_assets type=\"host\"/>"
     );
 }

--- a/crates/gvm-gmp/tests/test_hosts.rs
+++ b/crates/gvm-gmp/tests/test_hosts.rs
@@ -12,7 +12,7 @@ use gvm_gmp::commands::hosts::*;
 fn test_create_host_basic() {
     assert_eq!(
         xml(create_host(Default::default())),
-        "<create_asset><asset_type>host</asset_type></create_asset>"
+        "<create_asset><asset><type>host</type><name></name></asset></create_asset>"
     );
 }
 
@@ -20,7 +20,15 @@ fn test_create_host_basic() {
 fn test_create_host_with_value_and_comment() {
     assert_eq!(
         xml(create_host(HostOpts { comment: Some("c".into()), value: Some("1.1.1.1".into()) })),
-        "<create_asset><asset_type>host</asset_type><comment>c</comment><value>1.1.1.1</value></create_asset>"
+        "<create_asset><asset><type>host</type><name>1.1.1.1</name><comment>c</comment></asset></create_asset>"
+    );
+}
+
+#[test]
+fn test_create_host_named_constructor() {
+    assert_eq!(
+        xml(create_host(HostOpts::named("2001:db8::1"))),
+        "<create_asset><asset><type>host</type><name>2001:db8::1</name></asset></create_asset>"
     );
 }
 
@@ -28,10 +36,10 @@ fn test_create_host_with_value_and_comment() {
 fn test_host_get_modify_delete() {
     assert_eq!(
         xml(get_host(&id("h1"))),
-        "<get_assets asset_id=\"h1\" asset_type=\"host\" details=\"1\" type=\"host\"/>"
+        "<get_assets asset_id=\"h1\" details=\"1\" type=\"host\"/>"
     );
     assert_eq!(
         xml(delete_host(&id("h1"), false)),
-        "<delete_asset asset_id=\"h1\" ultimate=\"0\"/>"
+        "<delete_asset asset_id=\"h1\"/>"
     );
 }

--- a/crates/gvm-mock-server/src/builder.rs
+++ b/crates/gvm-mock-server/src/builder.rs
@@ -12,7 +12,7 @@ use crate::fixtures::FixtureStore;
 use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
 use crate::server::{MockGmpServer, ServerOptions, UnixSocketBinding};
-use crate::store::ResourceStore;
+use crate::store::{AssetInputProfile, ResourceStore};
 use crate::version::GmpVersion;
 use crate::ServerMode;
 
@@ -30,6 +30,7 @@ pub struct MockGmpServerBuilder {
     scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
     large_report: Option<LargeReportConfig>,
     max_request_bytes: Option<usize>,
+    asset_input_profile: AssetInputProfile,
 }
 
 enum Transport {
@@ -55,6 +56,7 @@ impl MockGmpServerBuilder {
             scenario_config: None,
             large_report: None,
             max_request_bytes: Some(DEFAULT_MAX_REQUEST_BYTES),
+            asset_input_profile: AssetInputProfile::GvmdStrict,
         }
     }
 
@@ -123,6 +125,17 @@ impl MockGmpServerBuilder {
         self
     }
 
+    /// Select the input profile for stateful asset commands.
+    ///
+    /// The default is [`AssetInputProfile::GvmdStrict`]. Select
+    /// [`AssetInputProfile::LegacyFlatCompatibility`] only for compatibility
+    /// with the mock server's historical flat asset command shapes.
+    #[must_use]
+    pub fn asset_input_profile(mut self, profile: AssetInputProfile) -> Self {
+        self.asset_input_profile = profile;
+        self
+    }
+
     /// Inject a fault for error testing.
     #[must_use]
     pub fn inject_fault(mut self, fault: Fault) -> Self {
@@ -187,6 +200,7 @@ impl MockGmpServerBuilder {
             scenario_config,
             large_report,
             max_request_bytes,
+            asset_input_profile,
         } = self;
 
         if max_request_bytes == Some(0) {
@@ -222,6 +236,7 @@ impl MockGmpServerBuilder {
                 Some((ref u, ref p)) => ResourceStore::with_credentials(u, p),
                 None => ResourceStore::new(),
             };
+            s.set_asset_input_profile(asset_input_profile);
             if let Some(seed_fn) = seed_fn {
                 seed_fn(&s);
             }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -19,7 +19,7 @@ use crate::response_gen::{
     generate_xml_report_export, LargeReportConfig, REPORT_EXPORT_XML_FORMAT_ID,
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
-use crate::store::{AssetInputProfile, Resource, ResourceStore, TaskStatus};
+use crate::store::{AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, TaskStatus};
 use crate::util::xml_escape;
 use crate::version::{command_available, GmpVersion};
 use crate::ServerMode;
@@ -516,25 +516,12 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
-        let Some(asset) = store
-            .get(&id)
-            .filter(|resource| resource.resource_type == "asset")
-        else {
-            return error_response(&cmd.name, 404, "Asset not found");
-        };
-        if asset.asset_type() == Some("os")
-            && asset
-                .attr("installs")
-                .and_then(|value| value.parse::<u32>().ok())
-                .is_some_and(|count| count > 0)
-        {
-            return error_response(&cmd.name, 400, "Asset is in use");
-        }
-
-        if store.delete_permanently_if_type(&id, "asset") {
-            b"<delete_asset_response status=\"200\" status_text=\"OK\"/>".to_vec()
-        } else {
-            error_response(&cmd.name, 404, "Asset not found")
+        match store.delete_asset_permanently(&id) {
+            DeleteAssetResult::Deleted => {
+                b"<delete_asset_response status=\"200\" status_text=\"OK\"/>".to_vec()
+            }
+            DeleteAssetResult::InUse => error_response(&cmd.name, 400, "Asset is in use"),
+            DeleteAssetResult::NotFound => error_response(&cmd.name, 404, "Asset not found"),
         }
     }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -3,6 +3,7 @@
 
 //! GMP session handler — processes commands and generates responses.
 
+use std::net::IpAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -18,7 +19,7 @@ use crate::response_gen::{
     generate_xml_report_export, LargeReportConfig, REPORT_EXPORT_XML_FORMAT_ID,
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
-use crate::store::{Resource, ResourceStore, TaskStatus};
+use crate::store::{AssetInputProfile, Resource, ResourceStore, TaskStatus};
 use crate::util::xml_escape;
 use crate::version::{command_available, GmpVersion};
 use crate::ServerMode;
@@ -48,6 +49,15 @@ pub enum HandleResult {
     },
     /// Close the connection immediately (fault injection).
     Disconnect,
+}
+
+fn asset_sort_value<'a>(resource: &'a Resource, field: &str) -> &'a str {
+    match field {
+        "name" => &resource.name,
+        "comment" => &resource.comment,
+        "type" => resource.asset_type().unwrap_or_default(),
+        _ => resource.attr(field).unwrap_or_default(),
+    }
 }
 
 impl SessionHandler {
@@ -205,6 +215,10 @@ impl SessionHandler {
             }
             "get_agent_installer_instruction" => render_agent_installer_instruction_response(cmd),
             "get_agent_support_bundle" => render_agent_support_bundle_response(cmd),
+            "create_asset" => self.handle_create_asset(cmd, store),
+            "get_assets" => self.handle_get_assets(cmd, store),
+            "modify_asset" => self.handle_modify_asset(cmd, store),
+            "delete_asset" => self.handle_delete_asset(cmd, store),
             // Create commands
             name if name.starts_with("create_") => self.handle_create(cmd, raw_xml, store),
             // Get commands
@@ -257,6 +271,270 @@ impl SessionHandler {
                 .to_vec()
         } else {
             error_response(&cmd.name, 400, "Authentication failed")
+        }
+    }
+
+    fn handle_create_asset(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let profile = store.asset_input_profile();
+        let canonical = cmd.children.iter().find(|child| child.name == "asset");
+
+        let parsed = canonical.and_then(|asset| {
+            let asset_type = element_child_text(asset, "type")?;
+            let name = element_child_text(asset, "name")?;
+            let comment = asset
+                .children
+                .iter()
+                .find(|child| child.name == "comment")
+                .map(|child| child.text.as_deref().unwrap_or_default())
+                .unwrap_or_default();
+            Some((
+                asset_type.to_string(),
+                name.to_string(),
+                comment.to_string(),
+                false,
+            ))
+        });
+
+        let parsed = parsed.or_else(|| {
+            (profile == AssetInputProfile::LegacyFlatCompatibility).then(|| {
+                let asset_type = cmd
+                    .attr("asset_type")
+                    .or_else(|| cmd.child_text("asset_type"))
+                    .or_else(|| cmd.attr("type"))
+                    .or_else(|| cmd.child_text("type"))?
+                    .to_string();
+                let name = cmd
+                    .child_text("name")
+                    .or_else(|| cmd.child_text("value"))?
+                    .to_string();
+                let comment = cmd.child_text("comment").unwrap_or_default().to_string();
+                Some((asset_type, name, comment, true))
+            })?
+        });
+
+        let Some((asset_type, name, comment, legacy_flat)) = parsed else {
+            return error_response(
+                &cmd.name,
+                400,
+                "Missing required nested asset/type/name elements",
+            );
+        };
+        if asset_type.is_empty() || name.is_empty() {
+            return error_response(&cmd.name, 400, "Asset type and name must not be empty");
+        }
+
+        let asset_type = asset_type.to_ascii_lowercase();
+        if asset_type != "host"
+            && !(legacy_flat
+                && profile == AssetInputProfile::LegacyFlatCompatibility
+                && asset_type == "os")
+        {
+            return error_response(
+                &cmd.name,
+                400,
+                "Direct asset creation supports only host assets",
+            );
+        }
+
+        if asset_type == "host" && !legacy_flat && name.parse::<IpAddr>().is_err() {
+            return error_response(
+                &cmd.name,
+                400,
+                "Host asset name must be a valid IPv4 or IPv6 address",
+            );
+        }
+
+        let mut resource = Resource::new("asset", &name);
+        resource.comment = comment;
+        resource.set_attr("type", &asset_type);
+        if legacy_flat {
+            resource.set_attr("asset_type", &asset_type);
+            resource.set_attr("value", &name);
+        }
+
+        let id = store.create(resource);
+        format!(
+            "<create_asset_response status=\"201\" status_text=\"OK, resource created\" id=\"{id}\"/>"
+        )
+        .into_bytes()
+    }
+
+    fn handle_get_assets(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let profile = store.asset_input_profile();
+        let asset_type = cmd.attr("type").or_else(|| {
+            (profile == AssetInputProfile::LegacyFlatCompatibility)
+                .then(|| cmd.attr("asset_type"))
+                .flatten()
+        });
+        let Some(asset_type) = asset_type else {
+            return error_response(&cmd.name, 400, "Missing required attribute: type");
+        };
+        let asset_type = asset_type.to_ascii_lowercase();
+        if !matches!(asset_type.as_str(), "host" | "os") {
+            return error_response(
+                &cmd.name,
+                404,
+                &format!("Failed to find type '{asset_type}'"),
+            );
+        }
+
+        if cmd
+            .attr("filt_id")
+            .is_some_and(|filter_id| filter_id != "0")
+        {
+            return error_response(&cmd.name, 404, "Saved filter not found");
+        }
+
+        let trash = matches!(cmd.attr("trash"), Some("1" | "true"));
+        let mut resources: Vec<Resource> = if trash {
+            store.list_trashed("asset")
+        } else {
+            store.list("asset")
+        }
+        .into_iter()
+        .filter(|resource| resource.asset_type() == Some(asset_type.as_str()))
+        .collect();
+        let total = resources.len();
+
+        if let Some(id) = cmd.attr("asset_id") {
+            let Ok(id) = Uuid::parse_str(id) else {
+                return error_response(&cmd.name, 400, "Invalid UUID");
+            };
+            let Some(resource) = resources.into_iter().find(|resource| resource.id == id) else {
+                return error_response(&cmd.name, 404, "Resource not found");
+            };
+            return format!(
+                "<get_assets_response status=\"200\" status_text=\"OK\">{}\
+                 <asset_count>{total}<filtered>1</filtered><page>1</page></asset_count>\
+                 </get_assets_response>",
+                resource.to_asset_xml(),
+            )
+            .into_bytes();
+        }
+
+        let mut first = 1usize;
+        let mut rows = None;
+        let mut sort_field = "name";
+        let mut reverse = false;
+        if let Some(filter) = cmd.attr("filter") {
+            for predicate in filter.split_whitespace() {
+                let Some((key, value)) = predicate.split_once('=') else {
+                    continue;
+                };
+                match key {
+                    "first" => {
+                        first = value
+                            .parse::<isize>()
+                            .ok()
+                            .map_or(1, |value| value.max(0) as usize);
+                    }
+                    "rows" => {
+                        rows = value
+                            .parse::<isize>()
+                            .ok()
+                            .and_then(|value| (value > 0).then_some(value as usize));
+                    }
+                    "sort" => sort_field = value,
+                    "sort-reverse" => {
+                        sort_field = value;
+                        reverse = true;
+                    }
+                    "permission" | "owner" | "min_qod" => {}
+                    "name" => resources.retain(|resource| resource.name == value),
+                    "comment" => resources.retain(|resource| resource.comment == value),
+                    "uuid" | "id" => {
+                        resources.retain(|resource| resource.id.to_string() == value);
+                    }
+                    "type" => {
+                        resources.retain(|resource| resource.asset_type() == Some(value));
+                    }
+                    _ => resources.retain(|resource| resource.attr(key) == Some(value)),
+                }
+            }
+        }
+        resources.sort_by(|left, right| {
+            let left = asset_sort_value(left, sort_field);
+            let right = asset_sort_value(right, sort_field);
+            if reverse {
+                right.cmp(left)
+            } else {
+                left.cmp(right)
+            }
+        });
+
+        let filtered = resources.len();
+        if !matches!(cmd.attr("ignore_pagination"), Some("1" | "true")) {
+            let start = first.saturating_sub(1).min(resources.len());
+            let end = rows.map_or(resources.len(), |rows| {
+                start.saturating_add(rows).min(resources.len())
+            });
+            resources = resources[start..end].to_vec();
+        }
+
+        let page = resources.len();
+        let items: String = resources.iter().map(Resource::to_asset_xml).collect();
+        format!(
+            "<get_assets_response status=\"200\" status_text=\"OK\">\
+             {items}\
+             <asset_count>{total}<filtered>{filtered}</filtered><page>{page}</page></asset_count>\
+             </get_assets_response>"
+        )
+        .into_bytes()
+    }
+
+    fn handle_modify_asset(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let Some(id) = cmd.attr("asset_id") else {
+            return error_response(&cmd.name, 400, "Missing required attribute: asset_id");
+        };
+        let Ok(id) = Uuid::parse_str(id) else {
+            return error_response(&cmd.name, 400, "Invalid UUID");
+        };
+        let comment = cmd
+            .children
+            .iter()
+            .find(|child| child.name == "comment")
+            .and_then(|comment| comment.text.as_deref())
+            .unwrap_or_default();
+
+        if store.modify_host_asset_comment(&id, comment) {
+            b"<modify_asset_response status=\"200\" status_text=\"OK\"/>".to_vec()
+        } else {
+            error_response(&cmd.name, 404, "Host asset not found")
+        }
+    }
+
+    fn handle_delete_asset(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let Some(id) = cmd.attr("asset_id") else {
+            let message = if cmd.attr("report_id").is_some() {
+                "Report-based bulk asset deletion is not implemented by the stateful mock"
+            } else {
+                "Missing required attribute: asset_id"
+            };
+            return error_response(&cmd.name, 400, message);
+        };
+        let Ok(id) = Uuid::parse_str(id) else {
+            return error_response(&cmd.name, 400, "Invalid UUID");
+        };
+
+        let Some(asset) = store
+            .get(&id)
+            .filter(|resource| resource.resource_type == "asset")
+        else {
+            return error_response(&cmd.name, 404, "Asset not found");
+        };
+        if asset.asset_type() == Some("os")
+            && asset
+                .attr("installs")
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_some_and(|count| count > 0)
+        {
+            return error_response(&cmd.name, 400, "Asset is in use");
+        }
+
+        if store.delete_permanently_if_type(&id, "asset") {
+            b"<delete_asset_response status=\"200\" status_text=\"OK\"/>".to_vec()
+        } else {
+            error_response(&cmd.name, 404, "Asset not found")
         }
     }
 

--- a/crates/gvm-mock-server/src/lib.rs
+++ b/crates/gvm-mock-server/src/lib.rs
@@ -63,7 +63,7 @@ pub use history::CommandRecord;
 pub use response_gen::LargeReportConfig;
 pub use scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 pub use server::MockGmpServer;
-pub use store::{Resource, ResourceStore};
+pub use store::{AssetInputProfile, Resource, ResourceStore};
 pub use version::GmpVersion;
 
 /// Server operating mode.

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -23,6 +23,16 @@ pub enum AssetInputProfile {
     LegacyFlatCompatibility,
 }
 
+/// Result of an atomic permanent asset deletion.
+pub(crate) enum DeleteAssetResult {
+    /// The asset was deleted.
+    Deleted,
+    /// The operating-system asset is still referenced.
+    InUse,
+    /// No live asset with the requested ID exists.
+    NotFound,
+}
+
 /// Task status in the lifecycle state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskStatus {
@@ -442,14 +452,25 @@ impl ResourceStore {
         }
     }
 
-    /// Permanently delete a non-trashed resource only when its type matches.
-    pub(crate) fn delete_permanently_if_type(&self, id: &Uuid, resource_type: &str) -> bool {
+    /// Permanently delete an asset while checking its lifecycle atomically.
+    pub(crate) fn delete_asset_permanently(&self, id: &Uuid) -> DeleteAssetResult {
         let mut inner = self.inner.write().expect("store lock poisoned");
-        let matches = inner
-            .resources
-            .get(id)
-            .is_some_and(|resource| resource.resource_type == resource_type && !resource.trashed);
-        matches && inner.resources.remove(id).is_some()
+        let Some(resource) = inner.resources.get(id) else {
+            return DeleteAssetResult::NotFound;
+        };
+        if resource.resource_type != "asset" || resource.trashed {
+            return DeleteAssetResult::NotFound;
+        }
+        if resource.asset_type() == Some("os")
+            && resource
+                .attr("installs")
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_some_and(|count| count > 0)
+        {
+            return DeleteAssetResult::InUse;
+        }
+        inner.resources.remove(id);
+        DeleteAssetResult::Deleted
     }
 
     /// Restore a trashed resource.
@@ -584,6 +605,63 @@ mod tests {
         });
         assert!(modified);
         assert_eq!(store.get(&id).unwrap().name, "New Name");
+    }
+
+    #[test]
+    fn asset_helpers_cover_unknown_rendering_and_missing_modification() {
+        let store = ResourceStore::new();
+        let missing = Uuid::new_v4();
+        assert!(!store.modify_host_asset_comment(&missing, "unused"));
+        assert!(matches!(
+            store.delete_asset_permanently(&missing),
+            DeleteAssetResult::NotFound
+        ));
+
+        let mut unknown = Resource::new("asset", "mystery");
+        unknown.set_attr("type", "firmware");
+        assert!(unknown
+            .to_asset_xml()
+            .contains("<type>firmware</type></asset>"));
+    }
+
+    #[test]
+    fn atomic_asset_delete_has_exactly_one_winner() {
+        let store = ResourceStore::new();
+        let mut host = Resource::new("asset", "192.0.2.10");
+        host.set_attr("type", "host");
+        let id = store.create(host);
+        let barrier = Arc::new(Barrier::new(3));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    store.delete_asset_permanently(&id)
+                })
+            })
+            .collect();
+        barrier.wait();
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("delete thread panicked"))
+            .collect();
+
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, DeleteAssetResult::Deleted))
+                .count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, DeleteAssetResult::NotFound))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -10,6 +10,19 @@ use uuid::Uuid;
 
 use crate::util::{now_iso, xml_escape, xml_escape_attr};
 
+/// Input profile for stateful asset commands.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AssetInputProfile {
+    /// Require the asset command shapes accepted by current gvmd.
+    #[default]
+    GvmdStrict,
+    /// Accept the historical flat mock inputs (`asset_type`, `<asset_type>`, and `<value>`).
+    ///
+    /// This profile exists only for consumers that explicitly need compatibility
+    /// with the mock's former, non-canonical asset command surface.
+    LegacyFlatCompatibility,
+}
+
 /// Task status in the lifecycle state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskStatus {
@@ -95,6 +108,97 @@ impl Resource {
         self.attrs.get(key).map(String::as_str)
     }
 
+    /// Return the canonical asset type, including legacy seeded resources.
+    pub(crate) fn asset_type(&self) -> Option<&str> {
+        self.attr("type").or_else(|| self.attr("asset_type"))
+    }
+
+    /// Generate the canonical gvmd asset representation used by `get_assets`.
+    pub(crate) fn to_asset_xml(&self) -> String {
+        let asset_type = self.asset_type().unwrap_or_default();
+        let writable = if asset_type == "os" { "0" } else { "1" };
+        let in_use = if asset_type == "os"
+            && self
+                .attr("installs")
+                .and_then(|value| value.parse::<u32>().ok())
+                .is_some_and(|count| count > 0)
+        {
+            "1"
+        } else {
+            "0"
+        };
+        let common = format!(
+            "<asset id=\"{id}\">\
+             <owner><name>admin</name></owner>\
+             <name>{name}</name>\
+             <comment>{comment}</comment>\
+             <creation_time>{ct}</creation_time>\
+             <modification_time>{mt}</modification_time>\
+             <writable>{writable}</writable>\
+             <in_use>{in_use}</in_use>\
+             <permissions><permission><name>Everything</name></permission></permissions>",
+            id = self.id,
+            name = xml_escape(&self.name),
+            comment = xml_escape(&self.comment),
+            ct = self.creation_time,
+            mt = self.modification_time,
+            writable = writable,
+            in_use = in_use,
+        );
+
+        match asset_type {
+            "host" => {
+                let severity = self.attr("severity").unwrap_or_default();
+                format!(
+                    "{common}\
+                     <identifiers><identifier id=\"{id}\">\
+                     <name>ip</name><value>{name}</value>\
+                     <creation_time>{ct}</creation_time>\
+                     <modification_time>{mt}</modification_time>\
+                     <source><type>User</type><data></data><deleted>0</deleted><name>admin</name></source>\
+                     </identifier></identifiers>\
+                     <type>host</type>\
+                     <host><severity><value>{severity}</value></severity></host>\
+                     </asset>",
+                    id = self.id,
+                    name = xml_escape(&self.name),
+                    ct = self.creation_time,
+                    mt = self.modification_time,
+                    severity = xml_escape(severity),
+                )
+            }
+            "os" => {
+                let title = self.attr("title").unwrap_or(&self.name);
+                let installs = self.attr("installs").unwrap_or("0");
+                let all_installs = self.attr("all_installs").unwrap_or(installs);
+                let latest = self.attr("latest_severity").unwrap_or_default();
+                let highest = self.attr("highest_severity").unwrap_or_default();
+                let average = self.attr("average_severity").unwrap_or_default();
+                format!(
+                    "{common}\
+                     <type>os</type>\
+                     <os>\
+                     <latest_severity><value>{latest}</value></latest_severity>\
+                     <highest_severity><value>{highest}</value></highest_severity>\
+                     <average_severity><value>{average}</value></average_severity>\
+                     <title>{title}</title>\
+                     <installs>{installs}</installs>\
+                     <all_installs>{all_installs}</all_installs>\
+                     <hosts>{installs}</hosts>\
+                     </os>\
+                     </asset>",
+                    latest = xml_escape(latest),
+                    highest = xml_escape(highest),
+                    average = xml_escape(average),
+                    title = xml_escape(title),
+                    installs = xml_escape(installs),
+                    all_installs = xml_escape(all_installs),
+                )
+            }
+            _ => format!("{common}<type>{}</type></asset>", xml_escape(asset_type)),
+        }
+    }
+
     /// Generate XML representation for get responses.
     pub fn to_xml(&self) -> String {
         // Notes and overrides use <text> instead of <name>
@@ -152,6 +256,8 @@ pub struct ResourceStore {
 #[derive(Debug)]
 struct StoreInner {
     resources: HashMap<Uuid, Resource>,
+    /// Stateful asset request parsing profile.
+    asset_input_profile: AssetInputProfile,
     /// Authenticated sessions.
     authenticated_sessions: std::collections::HashSet<u64>,
     /// Configured credentials.
@@ -207,6 +313,7 @@ impl ResourceStore {
         Self {
             inner: Arc::new(RwLock::new(StoreInner {
                 resources: default_resources(),
+                asset_input_profile: AssetInputProfile::GvmdStrict,
                 authenticated_sessions: std::collections::HashSet::new(),
                 username: username.to_string(),
                 password: password.to_string(),
@@ -229,6 +336,18 @@ impl ResourceStore {
     pub fn is_authenticated(&self, session_id: u64) -> bool {
         let inner = self.inner.read().expect("store lock poisoned");
         inner.authenticated_sessions.contains(&session_id)
+    }
+
+    /// Set the asset request parsing profile before the server starts.
+    pub(crate) fn set_asset_input_profile(&self, profile: AssetInputProfile) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.asset_input_profile = profile;
+    }
+
+    /// Return the configured asset request parsing profile.
+    pub(crate) fn asset_input_profile(&self) -> AssetInputProfile {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.asset_input_profile
     }
 
     /// Check whether the provided credentials match the configured SSH credentials.
@@ -293,6 +412,23 @@ impl ResourceStore {
         }
     }
 
+    /// Modify the comment of a non-trashed host asset.
+    pub(crate) fn modify_host_asset_comment(&self, id: &Uuid, comment: &str) -> bool {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let Some(resource) = inner.resources.get_mut(id) else {
+            return false;
+        };
+        if resource.trashed
+            || resource.resource_type != "asset"
+            || resource.asset_type() != Some("host")
+        {
+            return false;
+        }
+        comment.clone_into(&mut resource.comment);
+        resource.modification_time = now_iso();
+        true
+    }
+
     /// Delete a resource (move to trash or permanently).
     pub fn delete(&self, id: &Uuid, ultimate: bool) -> bool {
         let mut inner = self.inner.write().expect("store lock poisoned");
@@ -304,6 +440,16 @@ impl ResourceStore {
         } else {
             false
         }
+    }
+
+    /// Permanently delete a non-trashed resource only when its type matches.
+    pub(crate) fn delete_permanently_if_type(&self, id: &Uuid, resource_type: &str) -> bool {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let matches = inner
+            .resources
+            .get(id)
+            .is_some_and(|resource| resource.resource_type == resource_type && !resource.trashed);
+        matches && inner.resources.remove(id).is_some()
     }
 
     /// Restore a trashed resource.

--- a/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
+++ b/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Stateful asset behavior aligned with the current public gvmd GMP surface.
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_protocol::Response;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
+    stream.write_all(xml).await.expect("write failed");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = stream.read(&mut buf).await.expect("read failed");
+    buf.truncate(n);
+    Response::new(buf)
+}
+
+async fn connect_and_auth(server: &MockGmpServer) -> UnixStream {
+    let mut stream = UnixStream::connect(server.socket_path().expect("Unix socket path"))
+        .await
+        .expect("connect failed");
+    let auth = send_recv(
+        &mut stream,
+        b"<authenticate><credentials><username>admin</username><password>admin</password></credentials></authenticate>",
+    )
+    .await;
+    assert_eq!(auth.status_code(), Some(200));
+    stream
+}
+
+async fn strict_server(
+    seed: impl FnOnce(&gvm_mock_server::ResourceStore) + Send + 'static,
+) -> MockGmpServer {
+    MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .seed(seed)
+        .unix_socket_auto()
+        .build()
+        .await
+        .expect("server start failed")
+}
+
+fn response_text(response: &Response) -> &str {
+    response.as_str().expect("valid UTF-8 response")
+}
+
+#[tokio::test]
+async fn strict_profile_rejects_non_gvmd_asset_inputs_before_lifecycle_success() {
+    let unrelated_id = Uuid::new_v4();
+    let server = strict_server(move |store| {
+        store.seed(Resource::with_id("task", "not an asset", unrelated_id));
+    })
+    .await;
+    let mut stream = connect_and_auth(&server).await;
+
+    for request in [
+        br#"<create_asset asset_type="host"><name>192.0.2.10</name></create_asset>"#.as_slice(),
+        b"<create_asset><asset_type>host</asset_type><value>192.0.2.10</value></create_asset>",
+        b"<create_asset><asset><name>192.0.2.10</name></asset></create_asset>",
+        b"<create_asset><asset><type>host</type></asset></create_asset>",
+        b"<create_asset><asset><type>os</type><name>Example OS</name></asset></create_asset>",
+        b"<create_asset><asset><type>host</type><name>not-an-ip</name></asset></create_asset>",
+    ] {
+        assert_eq!(
+            send_recv(&mut stream, request).await.status_code(),
+            Some(400)
+        );
+    }
+
+    assert_eq!(
+        send_recv(&mut stream, b"<get_assets/>").await.status_code(),
+        Some(400)
+    );
+    assert_eq!(
+        send_recv(&mut stream, b"<get_assets type=\"firmware\"/>")
+            .await
+            .status_code(),
+        Some(404)
+    );
+    assert_eq!(
+        send_recv(&mut stream, b"<get_assets asset_type=\"host\"/>")
+            .await
+            .status_code(),
+        Some(400)
+    );
+
+    let unrelated_id = unrelated_id.to_string();
+    assert_eq!(
+        send_recv(
+            &mut stream,
+            format!(
+                "<modify_asset asset_id=\"{unrelated_id}\"><comment>x</comment></modify_asset>"
+            )
+            .as_bytes(),
+        )
+        .await
+        .status_code(),
+        Some(404)
+    );
+    assert_eq!(
+        send_recv(
+            &mut stream,
+            format!("<delete_asset asset_id=\"{unrelated_id}\"/>").as_bytes(),
+        )
+        .await
+        .status_code(),
+        Some(404)
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn canonical_host_asset_lifecycle_is_stateful_and_permanently_deleted() {
+    let server = strict_server(|_| {}).await;
+    let mut stream = connect_and_auth(&server).await;
+
+    let create = send_recv(
+        &mut stream,
+        b"<create_asset><asset><type>host</type><name>2001:db8::10</name><comment>edge</comment></asset></create_asset>",
+    )
+    .await;
+    assert_eq!(create.status_code(), Some(201));
+    let id = create.id().expect("created asset id").to_string();
+
+    let alternate_spelling = send_recv(
+        &mut stream,
+        b"<create_asset><asset><type>host</type><name>2001:0db8:0:0:0:0:0:10</name></asset></create_asset>",
+    )
+    .await;
+    assert_eq!(alternate_spelling.status_code(), Some(201));
+
+    let get = send_recv(&mut stream, b"<get_assets type=\"host\"/>").await;
+    assert_eq!(get.status_code(), Some(200));
+    let text = response_text(&get);
+    assert!(text.contains(&format!("<asset id=\"{id}\">")));
+    assert!(text.contains("<owner><name>admin</name></owner>"));
+    assert!(text.contains("<name>2001:db8::10</name>"));
+    assert!(text.contains("<name>2001:0db8:0:0:0:0:0:10</name>"));
+    assert!(text.contains("<comment>edge</comment>"));
+    assert!(text.contains("<creation_time>"));
+    assert!(text.contains("<modification_time>"));
+    assert!(text.contains("<writable>1</writable><in_use>0</in_use>"));
+    assert!(text.contains("<name>ip</name><value>2001:db8::10</value>"));
+    assert!(text.contains("<type>host</type><host><severity><value>"));
+    assert!(text.contains("<asset_count>2<filtered>2</filtered><page>2</page>"));
+    assert!(!text.contains("<asset_type>"));
+
+    let ignored_modify_child = send_recv(
+        &mut stream,
+        format!("<modify_asset asset_id=\"{id}\"><value>192.0.2.10</value></modify_asset>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(ignored_modify_child.status_code(), Some(200));
+    let get_one = send_recv(
+        &mut stream,
+        format!("<get_assets asset_id=\"{id}\" type=\"host\"/>").as_bytes(),
+    )
+    .await;
+    assert!(response_text(&get_one).contains("<comment></comment>"));
+
+    let modify = send_recv(
+        &mut stream,
+        format!("<modify_asset asset_id=\"{id}\"><comment>updated</comment></modify_asset>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify.status_code(), Some(200));
+    let get_one = send_recv(
+        &mut stream,
+        format!("<get_assets asset_id=\"{id}\" type=\"host\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_one.status_code(), Some(200));
+    let text = response_text(&get_one);
+    assert!(text.contains("<comment>updated</comment>"));
+    assert!(text.contains("<asset_count>2<filtered>1</filtered><page>1</page>"));
+
+    let clear_comment = send_recv(
+        &mut stream,
+        format!("<modify_asset asset_id=\"{id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(clear_comment.status_code(), Some(200));
+    let get_one = send_recv(
+        &mut stream,
+        format!("<get_assets asset_id=\"{id}\" type=\"host\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_one.status_code(), Some(200));
+    assert!(response_text(&get_one).contains("<comment></comment>"));
+
+    let delete = send_recv(
+        &mut stream,
+        format!("<delete_asset asset_id=\"{id}\" ultimate=\"0\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete.status_code(), Some(200));
+    assert_eq!(
+        send_recv(
+            &mut stream,
+            format!("<get_assets asset_id=\"{id}\" type=\"host\"/>").as_bytes(),
+        )
+        .await
+        .status_code(),
+        Some(404)
+    );
+    assert_eq!(
+        send_recv(&mut stream, format!("<restore id=\"{id}\"/>").as_bytes())
+            .await
+            .status_code(),
+        Some(404)
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn asset_filters_pagination_and_counts_are_applied_after_type_selection() {
+    let server = strict_server(|store| {
+        for (name, severity) in [
+            ("192.0.2.10", "7.0"),
+            ("192.0.2.20", "4.0"),
+            ("192.0.2.30", "7.0"),
+        ] {
+            let mut host = Resource::new("asset", name);
+            host.set_attr("type", "host");
+            host.set_attr("severity", severity);
+            store.seed(host);
+        }
+    })
+    .await;
+    let mut stream = connect_and_auth(&server).await;
+
+    let paged = send_recv(
+        &mut stream,
+        b"<get_assets type=\"host\" filter=\"severity=7.0 first=2 rows=1\"/>",
+    )
+    .await;
+    let text = response_text(&paged);
+    assert!(text.contains("<name>192.0.2.30</name>"));
+    assert!(!text.contains("<name>192.0.2.10</name>"));
+    assert!(text.contains("<asset_count>3<filtered>2</filtered><page>1</page>"));
+
+    let unpaged = send_recv(
+        &mut stream,
+        b"<get_assets type=\"host\" ignore_pagination=\"1\" filter=\"severity=7.0 rows=1\"/>",
+    )
+    .await;
+    let text = response_text(&unpaged);
+    assert!(text.contains("<name>192.0.2.10</name>"));
+    assert!(text.contains("<name>192.0.2.30</name>"));
+    assert!(text.contains("<asset_count>3<filtered>2</filtered><page>2</page>"));
+
+    let no_match = send_recv(
+        &mut stream,
+        b"<get_assets type=\"host\" filter=\"comment=missing\"/>",
+    )
+    .await;
+    assert!(response_text(&no_match).contains("<asset_count>3<filtered>0</filtered><page>0</page>"));
+
+    assert_eq!(
+        send_recv(
+            &mut stream,
+            b"<get_assets type=\"host\" filt_id=\"00000000-0000-0000-0000-000000000001\"/>",
+        )
+        .await
+        .status_code(),
+        Some(404)
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn seeded_os_assets_render_the_canonical_nested_shape() {
+    let os_id = Uuid::new_v4();
+    let server = strict_server(move |store| {
+        let mut os = Resource::with_id("asset", "cpe:/o:example:linux", os_id);
+        os.comment = "seeded".to_string();
+        os.set_attr("asset_type", "os");
+        os.set_attr("title", "Example Linux");
+        os.set_attr("installs", "0");
+        os.set_attr("all_installs", "0");
+        os.set_attr("latest_severity", "6.1");
+        os.set_attr("highest_severity", "9.8");
+        os.set_attr("average_severity", "7.95");
+        store.seed(os);
+    })
+    .await;
+    let mut stream = connect_and_auth(&server).await;
+
+    let get = send_recv(&mut stream, b"<get_assets type=\"os\"/>").await;
+    assert_eq!(get.status_code(), Some(200));
+    let text = response_text(&get);
+    assert!(text.contains(&format!("<asset id=\"{os_id}\">")));
+    assert!(text.contains("<writable>0</writable><in_use>0</in_use>"));
+    assert!(text.contains("<type>os</type><os>"));
+    assert!(text.contains("<latest_severity><value>6.1</value></latest_severity>"));
+    assert!(text.contains("<highest_severity><value>9.8</value></highest_severity>"));
+    assert!(text.contains("<average_severity><value>7.95</value></average_severity>"));
+    assert!(text.contains("<title>Example Linux</title>"));
+    assert!(text.contains("<installs>0</installs><all_installs>0</all_installs><hosts>0</hosts>"));
+    assert!(!text.contains("<asset_type>"));
+
+    let modify = send_recv(
+        &mut stream,
+        format!("<modify_asset asset_id=\"{os_id}\"><comment>no</comment></modify_asset>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify.status_code(), Some(404));
+
+    let delete = send_recv(
+        &mut stream,
+        format!("<delete_asset asset_id=\"{os_id}\" ultimate=\"0\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete.status_code(), Some(200));
+    let get = send_recv(&mut stream, b"<get_assets type=\"os\"/>").await;
+    assert_eq!(get.status_code(), Some(200));
+    assert!(response_text(&get).contains("<asset_count>0<filtered>0</filtered><page>0</page>"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn referenced_operating_system_assets_cannot_be_deleted() {
+    let os_id = Uuid::new_v4();
+    let server = strict_server(move |store| {
+        let mut os = Resource::with_id("asset", "cpe:/o:example:referenced", os_id);
+        os.set_attr("type", "os");
+        os.set_attr("installs", "1");
+        store.seed(os);
+    })
+    .await;
+    let mut stream = connect_and_auth(&server).await;
+
+    let delete = send_recv(
+        &mut stream,
+        format!("<delete_asset asset_id=\"{os_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete.status_code(), Some(400));
+    assert!(response_text(&delete).contains("Asset is in use"));
+
+    server.shutdown().await;
+}

--- a/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
+++ b/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
@@ -6,7 +6,7 @@
 #![cfg(feature = "unix-socket-tests")]
 #![allow(clippy::unwrap_used, missing_docs)]
 
-use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_mock_server::{AssetInputProfile, GmpVersion, MockGmpServer, Resource, ServerMode};
 use gvm_protocol::Response;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -282,6 +282,71 @@ async fn asset_filters_pagination_and_counts_are_applied_after_type_selection() 
 }
 
 #[tokio::test]
+async fn legacy_asset_errors_trash_filters_and_sorting_are_deterministic() {
+    let first_id = Uuid::new_v4();
+    let trashed_id = Uuid::new_v4();
+    let server = MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .asset_input_profile(AssetInputProfile::LegacyFlatCompatibility)
+        .seed(move |store| {
+            for (id, name, comment, severity) in [
+                (first_id, "192.0.2.10", "zulu", "4.0"),
+                (Uuid::new_v4(), "192.0.2.20", "alpha", "7.0"),
+                (trashed_id, "192.0.2.30", "trash", "1.0"),
+            ] {
+                let mut host = Resource::with_id("asset", name, id);
+                host.comment = comment.to_string();
+                host.set_attr("type", "host");
+                host.set_attr("severity", severity);
+                store.seed(host);
+            }
+            assert!(store.delete(&trashed_id, false));
+        })
+        .unix_socket_auto()
+        .build()
+        .await
+        .expect("server start failed");
+    let mut stream = connect_and_auth(&server).await;
+
+    for request in [
+        b"<create_asset asset_type=\"\"><value>192.0.2.40</value></create_asset>".as_slice(),
+        b"<get_assets type=\"host\" asset_id=\"not-a-uuid\"/>",
+        b"<modify_asset/>",
+        b"<modify_asset asset_id=\"not-a-uuid\"/>",
+        b"<delete_asset/>",
+        b"<delete_asset report_id=\"report-1\"/>",
+        b"<delete_asset asset_id=\"not-a-uuid\"/>",
+    ] {
+        assert_eq!(
+            send_recv(&mut stream, request).await.status_code(),
+            Some(400)
+        );
+    }
+
+    let trashed = send_recv(&mut stream, b"<get_assets type=\"host\" trash=\"1\"/>").await;
+    assert!(response_text(&trashed).contains(&trashed_id.to_string()));
+
+    for filter in [
+        "ignored-token sort-reverse=comment",
+        "sort=type",
+        "sort=severity",
+        &format!("uuid={first_id}"),
+        "type=host",
+    ] {
+        let response = send_recv(
+            &mut stream,
+            format!("<get_assets type=\"host\" filter=\"{filter}\"/>").as_bytes(),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(200));
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn seeded_os_assets_render_the_canonical_nested_shape() {
     let os_id = Uuid::new_v4();
     let server = strict_server(move |store| {
@@ -344,6 +409,10 @@ async fn referenced_operating_system_assets_cannot_be_deleted() {
     })
     .await;
     let mut stream = connect_and_auth(&server).await;
+
+    let get = send_recv(&mut stream, b"<get_assets type=\"os\"/>").await;
+    assert_eq!(get.status_code(), Some(200));
+    assert!(response_text(&get).contains("<in_use>1</in_use>"));
 
     let delete = send_recv(
         &mut stream,

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -262,14 +262,16 @@ async fn stateful_host_asset_uses_gmp_builder_shape() {
     let hosts = send_request(&mut stream, get_hosts(Default::default())).await;
     let hosts_text = hosts.as_str().expect("utf8");
     assert!(hosts_text.contains(&host_id));
-    assert!(hosts_text.contains("<asset_type>host</asset_type>"));
-    assert!(hosts_text.contains("<value>1.1.1.1</value>"));
+    assert!(hosts_text.contains("<type>host</type>"));
+    assert!(hosts_text.contains("<name>ip</name><value>1.1.1.1</value>"));
+    assert!(hosts_text.contains("<host><severity>"));
 
     let host = send_request(&mut stream, get_host(&host_entity_id)).await;
     let host_text = host.as_str().expect("utf8");
     assert!(host_text.contains(&host_id));
-    assert!(host_text.contains("<asset_type>host</asset_type>"));
-    assert!(host_text.contains("<value>1.1.1.1</value>"));
+    assert!(host_text.contains("<type>host</type>"));
+    assert!(host_text.contains("<name>ip</name><value>1.1.1.1</value>"));
+    assert!(host_text.contains("<host><severity>"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
+++ b/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
@@ -9,7 +9,7 @@
 )]
 #![cfg(feature = "unix-socket-tests")]
 
-use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_mock_server::{AssetInputProfile, GmpVersion, MockGmpServer, Resource, ServerMode};
 use gvm_protocol::Response;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
@@ -39,6 +39,7 @@ async fn stateful_server() -> Option<MockGmpServer> {
             .mode(ServerMode::Stateful)
             .version(GmpVersion::V22_5)
             .credentials("admin", "admin")
+            .asset_input_profile(AssetInputProfile::LegacyFlatCompatibility)
             .unix_socket_auto(),
     )
     .await
@@ -73,7 +74,7 @@ async fn get_assets_filters_by_asset_type() {
 
     let os_resp = send_recv(
         &mut stream,
-        b"<create_asset asset_type=\"os\"><name>Ubuntu</name></create_asset>",
+        b"<create_asset><asset_type>os</asset_type><value>Ubuntu</value></create_asset>",
     )
     .await;
     assert_eq!(os_resp.status_code(), Some(201));

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -132,7 +132,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 |---------|--------|-------|
 | get_version (pre-auth) | ✅ | Always allowed without authentication |
 | authenticate (credential validation) | ✅ | Per-session state |
-| get_assets (asset_type filtering) | ✅ | MCP server compatible |
+| direct-host asset lifecycle and canonical `get_assets` | ✅ | Strict gvmd behavior by default; legacy flat inputs are explicit opt-in; report-import/bulk-delete paths are not modeled |
 | get_report (nested results XML) | ✅ | Proper `<report><report><results>` nesting |
 | create_note/override (text + nvt_oid) | ✅ | Non-standard element parsing |
 | create_ticket (result_id + comment) | ✅ | Non-standard element parsing |

--- a/fuzz/fuzz_targets/fuzz_response_parser.rs
+++ b/fuzz/fuzz_targets/fuzz_response_parser.rs
@@ -17,6 +17,8 @@ fuzz_target!(|data: &[u8]| {
         // Try parsing as various response types — all should handle malformed input gracefully
         let _ = gvm_gmp::responses::version::GetVersionResponse::from_response(&response);
         let _ = gvm_gmp::responses::auth::AuthenticateResponse::from_response(&response);
+        let _ = gvm_gmp::responses::asset::GetAssetsResponse::from_response(&response);
+        let _ = gvm_gmp::responses::host::GetHostsResponse::from_response(&response);
         let _ = gvm_gmp::responses::target::GetTargetsResponse::from_response(&response);
         let _ = gvm_gmp::responses::task::GetTasksResponse::from_response(&response);
         let _ = gvm_gmp::responses::report::GetReportsResponse::from_response(&response);

--- a/spec/mcp-server-integration-spec.md
+++ b/spec/mcp-server-integration-spec.md
@@ -76,10 +76,12 @@ Extracted from `clawosiris/openvas-mcp-server` service layer:
 
 ### 2.2 Gaps to Address
 
-#### Gap 1: `get_assets` command
-The MCP server calls `gmp.get_assets(asset_type="host")` and `gmp.get_assets(asset_type="os")`. The mock server's `handle_get` treats this like any `get_*` but `get_assets` uses `asset_type` attribute, not the standard `type_id` pattern.
-
-**Fix:** Add special-case handling in `handle_get` for `get_assets` — route by `asset_type` attribute.
+#### Gap 1: `get_assets` command (resolved)
+Current gvmd and python-gvm use the canonical `type="host|os"` attribute and
+nested asset payloads. The stateful mock now follows that behavior by default,
+including host lifecycle semantics and canonical host/OS responses. Historical
+flat `asset_type`/`value` inputs remain available only through the explicit
+`AssetInputProfile::LegacyFlatCompatibility` profile.
 
 #### Gap 2: `get_results` command
 Called by compliance service: `gmp.get_results(filter_string=...)`. Results are nested inside reports in real GMP but can also be queried directly.
@@ -206,11 +208,12 @@ reports = client.execute(lambda gmp: gmp.get_reports())
 ## 4. Implementation Plan
 
 ### Phase 1: Mock Server Gaps (Rust)
-1. Add special-case handlers for `get_assets`, `get_results`, `get_nvts`
-2. Add `create_note`/`create_override`/`create_ticket` with correct element parsing
-3. Add `modify_ticket` with status support
-4. Improve `get_report` XML structure (nested results)
-5. Ensure per-connection session isolation (already works — verify)
+1. ✅ Add a gvmd-conformant stateful `get_assets` and host lifecycle handler
+2. Add special-case handlers for `get_results` and `get_nvts`
+3. Add `create_note`/`create_override`/`create_ticket` with correct element parsing
+4. Add `modify_ticket` with status support
+5. Improve `get_report` XML structure (nested results)
+6. Ensure per-connection session isolation (already works — verify)
 
 ### Phase 2: Integration Test Harness (Python)
 1. Python test script that starts mock server binary

--- a/spec/openspec.md
+++ b/spec/openspec.md
@@ -597,7 +597,7 @@ Dev dependencies: `tokio-test`, `pretty_assertions`, `rstest`
 | gvm-gmp enum exhaustive tests | 347 |
 | gvm-gmp type tests | 6 |
 | gvm-client unit + integration | 13 |
-| python-gvm integration | 15 steps |
+| python-gvm integration | 21 steps |
 
 ---
 

--- a/tests/integration/test_python_gvm.py
+++ b/tests/integration/test_python_gvm.py
@@ -92,6 +92,29 @@ def main() -> int:
             state: dict[str, str] = {}
 
             with GMP(connection=conn, transform=transform) as gmp:
+                def require_host(comment: str) -> None:
+                    response = gmp.get_host(
+                        host_id=state["host_id"], details=True
+                    )
+                    asset = response.find("asset")
+                    require(asset is not None, "created host asset was not returned")
+                    require(
+                        asset.get("id") == state["host_id"],
+                        "returned host asset had the wrong id",
+                    )
+                    require(
+                        asset.findtext("type") == "host",
+                        "host asset did not use the canonical type element",
+                    )
+                    require(
+                        asset.find("host") is not None,
+                        "host asset did not include the canonical host payload",
+                    )
+                    require(
+                        asset.findtext("comment") == comment,
+                        "host asset comment did not match",
+                    )
+
                 checks = [
                     (
                         "authenticate",
@@ -118,6 +141,33 @@ def main() -> int:
                             ),
                             "created target not returned by get_targets",
                         ),
+                    ),
+                    (
+                        "create_host",
+                        lambda: state.setdefault(
+                            "host_id",
+                            response_id(
+                                gmp.create_host(
+                                    name="192.0.2.20",
+                                    comment="created through python-gvm",
+                                )
+                            ),
+                        ),
+                    ),
+                    (
+                        "get_host_canonical",
+                        lambda: require_host("created through python-gvm"),
+                    ),
+                    (
+                        "modify_host",
+                        lambda: gmp.modify_host(
+                            host_id=state["host_id"],
+                            comment="updated through python-gvm",
+                        ),
+                    ),
+                    (
+                        "get_host_modified",
+                        lambda: require_host("updated through python-gvm"),
                     ),
                     (
                         "create_task",
@@ -199,6 +249,20 @@ def main() -> int:
                     (
                         "delete_note",
                         lambda: gmp.delete_note(note_id=state["note_id"]),
+                    ),
+                    (
+                        "delete_host",
+                        lambda: gmp.delete_host(host_id=state["host_id"]),
+                    ),
+                    (
+                        "get_hosts_after_delete",
+                        lambda: require(
+                            all(
+                                host.get("id") != state["host_id"]
+                                for host in gmp.get_hosts().findall("asset")
+                            ),
+                            "deleted host was still returned by get_hosts",
+                        ),
                     ),
                     (
                         "delete_task",


### PR DESCRIPTION
## Summary

- correct asset and host command builders to emit current gvmd wire shapes: nested direct-host creation, canonical type filtering, comment-only modification, and asset-specific deletion
- add typed asset responses and GmpClient helpers for host and operating-system assets, including host identifiers/details, nested OS hosts, and GET count metadata
- make the stateful mock strict by default while retaining historical flat inputs behind an explicit compatibility profile
- cover exact IPv4/IPv6 identity preservation, filtering, pagination, count semantics, comment lifecycle, permanent host deletion, OS writability, and in-use OS deletion rejection
- extend the public python-gvm transport test from 15 to 21 steps with a canonical host lifecycle

## Scope

This PR covers direct-host create/get/modify/delete and canonical host/OS retrieval. Current gvmd also supports report-import asset creation and report-based bulk deletion; those paths are deliberately not modeled here because they require separate report/link semantics and a deterministic real-server seed path.

## Public conformance evidence

Implementation and fixtures were checked only against public sources:

- gvmd main at 4d61c28ff304d6a044b7f4f62949edba188bac97
- python-gvm main at 2bb100fd03f02e598f046e2032e12550b5b14751

A live gvmd run was not available locally: this host has neither Docker nor Podman, and the current public rust-gvm E2E harness has no asset suite. The PR therefore does not claim live-server execution. It does prove the wire shapes against pinned public source, the strict Unix-socket mock transport, and pinned public python-gvm.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --all-features
- cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings
- cargo +1.85.0 check --workspace --all-features
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- pinned python-gvm integration: all 21 steps passed
- cargo llvm-cov --workspace --all-features --lcov --output-path /tmp/rust-gvm-asset-lcov-final.info
- fuzz_response_parser: 61 seconds, 4,271,418 executions, no crash
- cargo deny check
- cargo audit
- cargo machete
- cargo vet
- python3 scripts/check_workspace_unsafe.py
- Semgrep p/rust, p/security-audit, and p/secrets over tracked files and the two new files
- git diff --check

Known baseline warnings: cargo-deny reports unmatched allowances, and cargo-audit reports the existing allowed yanked transitive crypto-bigint 0.7.4 warning through russh. Cargo-vet produced only its known imports.lock quote-normalization churn, which was inspected and restored.
