### PR TITLE
docs(journal): add 2026-07-15 entry

### DIFF
--- a/journal/2026-07-15.md
+++ b/journal/2026-07-15.md
@@ -1,0 +1,13 @@
+# 2026-07-15 — The Helper Delivery Wave Landed on `devel` While `main` Only Took the Actions Refresh
+
+## Delivery Wave
+- Since the published 2026-07-13 journal entry, `main` only moved once: Dependabot PR [#357](https://github.com/clawosiris/rust-gvm/pull/357) merged on 2026-07-14 to refresh the GitHub Actions dependency group, and no new release or tag shipped.
+- The larger state change happened on `devel`, where seven non-journal PRs merged back-to-back on 2026-07-14: [#338](https://github.com/clawosiris/rust-gvm/pull/338), [#339](https://github.com/clawosiris/rust-gvm/pull/339), [#347](https://github.com/clawosiris/rust-gvm/pull/347), [#349](https://github.com/clawosiris/rust-gvm/pull/349), [#350](https://github.com/clawosiris/rust-gvm/pull/350), [#351](https://github.com/clawosiris/rust-gvm/pull/351), and [#352](https://github.com/clawosiris/rust-gvm/pull/352).
+- That merge wave matters because it converts the previously published current-GVMD helper queue into landed implementation across agent commands, import helpers, scan-config policy/NVT helpers, secinfo `get_info`, and the vulnerability-alias surface instead of leaving those slices as only pending `devel` work.
+
+## Queue Shape
+- The open non-journal queue is narrower after that batch. The remaining previously open helper PRs are now concentrated in the credential-store and import-scan-config slices, rather than spread across the broader helper surface.
+- The repo also opened a fresh non-journal `devel` lane with PR [#359](https://github.com/clawosiris/rust-gvm/pull/359), "Conform asset lifecycle with current gvmd," which pushes the follow-up work from generic helper exposure into behavioral conformance with live GVMD expectations.
+
+## Validation
+- There is no new actionable CI or security regression to add on top of the 2026-07-13 `russh` blocker entry. The new `main` push for [#357](https://github.com/clawosiris/rust-gvm/pull/357) and the newly opened PR [#359](https://github.com/clawosiris/rust-gvm/pull/359) both ran green CI and security workflows, while the older `russh` PR [#356](https://github.com/clawosiris/rust-gvm/pull/356) remains the same already-journaled blocker rather than a fresh state change.


### PR DESCRIPTION
## Summary
- add the 2026-07-15 rust-gvm journal entry
- capture the 2026-07-14 devel helper merge wave and the lone mainline actions refresh
- note that no new actionable CI or security regression appeared beyond the already-journaled russh blocker

Agent: Thoth