### PR TITLE
Fix XML framing and bound streaming input

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,13 @@ gvm-mock-server --mode stateful --version 22.5 --socket /tmp/gvmd.sock
 
 # Or on TCP
 gvm-mock-server --mode stateful --version 22.5 --tcp 127.0.0.1:9390
+
+# Override the default 64 MiB per-request XML limit
+gvm-mock-server --mode echo --tcp 127.0.0.1:9390 --max-request-bytes 1048576
 ```
+
+The request-size limit applies independently to each XML command. XML nesting
+is always limited to 256 elements, including when the byte limit is disabled.
 
 Then connect with python-gvm:
 

--- a/crates/gvm-connection/src/ssh.rs
+++ b/crates/gvm-connection/src/ssh.rs
@@ -205,6 +205,8 @@ pub struct SshConnection {
     config: SshConfig,
     session: Option<client::Handle<SshServerKeyVerifier>>,
     channel: Option<Channel<client::Msg>>,
+    response_reader: gvm_protocol::XmlReader,
+    pending_read: Vec<u8>,
 }
 
 impl std::fmt::Debug for SshConnection {
@@ -220,10 +222,14 @@ impl SshConnection {
     /// Create a new SSH connection with the given config.
     #[must_use]
     pub fn new(config: SshConfig) -> Self {
+        let response_reader = gvm_protocol::XmlReader::with_buffer_limit(config.max_response_bytes);
+        let pending_read = Vec::with_capacity(config.read_buffer_size);
         Self {
             config,
             session: None,
             channel: None,
+            response_reader,
+            pending_read,
         }
     }
 
@@ -237,6 +243,18 @@ impl SshConnection {
 
     fn disconnect_error(error: impl std::fmt::Display) -> ConnectionError {
         ConnectionError::DisconnectFailed(error.to_string())
+    }
+
+    fn invalidate_protocol_read(&mut self, error: &gvm_protocol::ProtocolError) -> ConnectionError {
+        self.invalidate_connection();
+        protocol_read_error(error)
+    }
+
+    fn invalidate_connection(&mut self) {
+        self.channel.take();
+        self.session.take();
+        self.response_reader.reset();
+        self.pending_read.clear();
     }
 
     async fn authenticate(
@@ -354,6 +372,9 @@ impl GvmConnection for SshConnection {
             return Err(ConnectionError::AlreadyConnected);
         }
 
+        self.response_reader.reset();
+        self.pending_read.clear();
+
         let ssh_config = Arc::new(client::Config {
             nodelay: true,
             ..client::Config::default()
@@ -392,6 +413,8 @@ impl GvmConnection for SshConnection {
     }
 
     async fn disconnect(&mut self) -> Result<()> {
+        self.response_reader.reset();
+        self.pending_read.clear();
         if let Some(channel) = self.channel.take() {
             channel.close().await.map_err(Self::disconnect_error)?;
         }
@@ -426,31 +449,52 @@ impl GvmConnection for SshConnection {
     }
 
     async fn read(&mut self) -> Result<Vec<u8>> {
-        let channel = self.channel.as_mut().ok_or(ConnectionError::NotConnected)?;
-        let mut xml_reader =
-            gvm_protocol::XmlReader::with_buffer_limit(self.config.max_response_bytes);
-        let mut response = Vec::with_capacity(self.config.read_buffer_size);
+        if self.channel.is_none() {
+            return Err(ConnectionError::NotConnected);
+        }
+
+        if !self.pending_read.is_empty() {
+            let consumed = match self.response_reader.feed_frame(&self.pending_read) {
+                Ok(consumed) => consumed,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            self.pending_read.drain(..consumed);
+            let frame = match self.response_reader.take_frame() {
+                Ok(frame) => frame,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            if let Some(frame) = frame {
+                return Ok(frame);
+            }
+            debug_assert!(self.pending_read.is_empty());
+        }
 
         loop {
+            let channel = self.channel.as_mut().ok_or(ConnectionError::NotConnected)?;
             let message = tokio::time::timeout(self.config.timeout, channel.wait())
                 .await
                 .map_err(|_| ConnectionError::Timeout(self.config.timeout))?;
 
             match message {
                 Some(ChannelMsg::Data { data }) | Some(ChannelMsg::ExtendedData { data, .. }) => {
-                    response.extend_from_slice(&data);
-                    xml_reader.feed(&data).map_err(|error| {
-                        ConnectionError::ReadFailed(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            error.to_string(),
-                        ))
-                    })?;
+                    let consumed = match self.response_reader.feed_frame(&data) {
+                        Ok(consumed) => consumed,
+                        Err(error) => return Err(self.invalidate_protocol_read(&error)),
+                    };
+                    if consumed < data.len() {
+                        self.pending_read.extend_from_slice(&data[consumed..]);
+                    }
 
-                    if xml_reader.is_complete() {
-                        return Ok(response);
+                    let frame = match self.response_reader.take_frame() {
+                        Ok(frame) => frame,
+                        Err(error) => return Err(self.invalidate_protocol_read(&error)),
+                    };
+                    if let Some(frame) = frame {
+                        return Ok(frame);
                     }
                 }
                 Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                    self.invalidate_connection();
                     return Err(ConnectionError::ReadFailed(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
                         "ssh channel closed",
@@ -474,6 +518,13 @@ impl GvmConnection for SshConnection {
     fn is_connected(&self) -> bool {
         self.session.is_some() && self.channel.is_some()
     }
+}
+
+fn protocol_read_error(error: &gvm_protocol::ProtocolError) -> ConnectionError {
+    ConnectionError::ReadFailed(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        error.to_string(),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/gvm-connection/src/unix.rs
+++ b/crates/gvm-connection/src/unix.rs
@@ -62,19 +62,33 @@ impl UnixSocketConfig {
 }
 
 /// Unix socket connection to gvmd.
-#[derive(Debug)]
 pub struct UnixSocketConnection {
     config: UnixSocketConfig,
     stream: Option<UnixStream>,
+    response_reader: gvm_protocol::XmlReader,
+    pending_read: Vec<u8>,
+}
+
+impl std::fmt::Debug for UnixSocketConnection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UnixSocketConnection")
+            .field("config", &self.config)
+            .field("connected", &self.is_connected())
+            .finish()
+    }
 }
 
 impl UnixSocketConnection {
     /// Create a new Unix socket connection with the given config.
     #[must_use]
     pub fn new(config: UnixSocketConfig) -> Self {
+        let response_reader = gvm_protocol::XmlReader::with_buffer_limit(config.max_response_bytes);
         Self {
             config,
             stream: None,
+            response_reader,
+            pending_read: Vec::new(),
         }
     }
 
@@ -82,6 +96,17 @@ impl UnixSocketConnection {
     #[must_use]
     pub fn with_path(path: impl Into<PathBuf>) -> Self {
         Self::new(UnixSocketConfig::new(path))
+    }
+
+    fn invalidate_protocol_read(&mut self, error: &gvm_protocol::ProtocolError) -> ConnectionError {
+        self.invalidate_connection();
+        protocol_read_error(error)
+    }
+
+    fn invalidate_connection(&mut self) {
+        self.stream.take();
+        self.response_reader.reset();
+        self.pending_read.clear();
     }
 }
 
@@ -91,6 +116,9 @@ impl GvmConnection for UnixSocketConnection {
         if self.stream.is_some() {
             return Err(ConnectionError::AlreadyConnected);
         }
+
+        self.response_reader.reset();
+        self.pending_read.clear();
 
         if !self.config.path.exists() {
             return Err(ConnectionError::SocketNotFound(
@@ -110,6 +138,8 @@ impl GvmConnection for UnixSocketConnection {
     }
 
     async fn disconnect(&mut self) -> Result<()> {
+        self.response_reader.reset();
+        self.pending_read.clear();
         if let Some(mut stream) = self.stream.take() {
             let _ = stream.shutdown().await;
             tracing::debug!("disconnected from {}", self.config.path.display());
@@ -128,33 +158,57 @@ impl GvmConnection for UnixSocketConnection {
     }
 
     async fn read(&mut self) -> Result<Vec<u8>> {
-        let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
+        if self.stream.is_none() {
+            return Err(ConnectionError::NotConnected);
+        }
+
+        if !self.pending_read.is_empty() {
+            let consumed = match self.response_reader.feed_frame(&self.pending_read) {
+                Ok(consumed) => consumed,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            self.pending_read.drain(..consumed);
+            let frame = match self.response_reader.take_frame() {
+                Ok(frame) => frame,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            if let Some(frame) = frame {
+                return Ok(frame);
+            }
+            debug_assert!(self.pending_read.is_empty());
+        }
+
         let mut buf = vec![0_u8; self.config.read_buffer_size];
-        let mut xml_reader =
-            gvm_protocol::XmlReader::with_buffer_limit(self.config.max_response_bytes);
 
         loop {
+            let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
             let n = tokio::time::timeout(self.config.timeout, stream.read(&mut buf))
                 .await
                 .map_err(|_| ConnectionError::Timeout(self.config.timeout))?
                 .map_err(ConnectionError::ReadFailed)?;
 
             if n == 0 {
+                self.invalidate_connection();
                 return Err(ConnectionError::ReadFailed(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
                     "connection closed",
                 )));
             }
 
-            xml_reader.feed(&buf[..n]).map_err(|error| {
-                ConnectionError::ReadFailed(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    error.to_string(),
-                ))
-            })?;
+            let consumed = match self.response_reader.feed_frame(&buf[..n]) {
+                Ok(consumed) => consumed,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            if consumed < n {
+                self.pending_read.extend_from_slice(&buf[consumed..n]);
+            }
 
-            if xml_reader.is_complete() {
-                return Ok(xml_reader.into_data());
+            let frame = match self.response_reader.take_frame() {
+                Ok(frame) => frame,
+                Err(error) => return Err(self.invalidate_protocol_read(&error)),
+            };
+            if let Some(frame) = frame {
+                return Ok(frame);
             }
         }
     }
@@ -162,6 +216,13 @@ impl GvmConnection for UnixSocketConnection {
     fn is_connected(&self) -> bool {
         self.stream.is_some()
     }
+}
+
+fn protocol_read_error(error: &gvm_protocol::ProtocolError) -> ConnectionError {
+    ConnectionError::ReadFailed(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        error.to_string(),
+    ))
 }
 
 #[cfg(test)]
@@ -190,5 +251,17 @@ mod tests {
     fn test_with_path() {
         let conn = UnixSocketConnection::with_path("/tmp/test.sock");
         assert!(!conn.is_connected());
+    }
+
+    #[test]
+    fn test_connection_debug_redacts_pending_response() {
+        let mut conn = UnixSocketConnection::with_path("/tmp/test.sock");
+        conn.pending_read
+            .extend_from_slice(b"<secret>do-not-log</secret>");
+
+        let debug = format!("{conn:?}");
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("do-not-log"));
+        assert!(debug.contains("connected"));
     }
 }

--- a/crates/gvm-connection/tests/ssh_e2e.rs
+++ b/crates/gvm-connection/tests/ssh_e2e.rs
@@ -9,7 +9,7 @@ use std::io::ErrorKind;
 use gvm_connection::{
     ConnectionError, GvmConnection, SshAuth, SshConfig, SshConnection, SshHostKeyPolicy,
 };
-use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
+use gvm_mock_server::{GmpVersion, MockGmpServer, ScenarioMode, ScenarioStep, ServerMode};
 use gvm_protocol::{Request, Response, XmlCommand};
 
 async fn start_mock() -> Option<MockGmpServer> {
@@ -182,6 +182,229 @@ async fn ssh_rejects_wrong_fingerprint() {
 
     let error = conn.connect().await.expect_err("connect should fail");
     assert!(matches!(error, ConnectionError::ConnectFailed(_)));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_coalesced_commands_are_processed_in_order() {
+    let server = start_mock().await;
+    let Some(server) = server else {
+        return;
+    };
+    let mut connection = SshConnection::new(config_for(&server));
+    connection.connect().await.expect("connect");
+
+    connection
+        .send(b"<get_version/><get_tasks/>")
+        .await
+        .expect("coalesced send");
+    let version = Response::new(connection.read().await.expect("version response"));
+    let tasks = Response::new(connection.read().await.expect("tasks response"));
+
+    assert_eq!(
+        version.root_element_name().as_deref(),
+        Some("get_version_response")
+    );
+    assert_eq!(
+        tasks.root_element_name().as_deref(),
+        Some("get_tasks_response")
+    );
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].raw_xml(), b"<get_version/>");
+    assert_eq!(history[1].raw_xml(), b"<get_tasks/>");
+
+    connection.disconnect().await.expect("disconnect");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_coalesced_responses_are_returned_one_frame_at_a_time() {
+    let server = match MockGmpServer::builder()
+        .scenario(
+            ScenarioMode::Strict,
+            vec![ScenarioStep {
+                expect_command: "get_version".to_string(),
+                respond_xml: Some("<first_response/><second_response/>".to_string()),
+            }],
+        )
+        .ssh("127.0.0.1:0")
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let mut connection = SshConnection::new(config_for(&server));
+    connection.connect().await.expect("connect");
+    connection.send(b"<get_version/>").await.expect("send");
+
+    assert_eq!(
+        connection.read().await.expect("first response"),
+        b"<first_response/>"
+    );
+    assert_eq!(
+        connection.read().await.expect("second response"),
+        b"<second_response/>"
+    );
+
+    connection.disconnect().await.expect("disconnect");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_reconnect_on_same_connection_discards_pending_response_tail() {
+    let server = match MockGmpServer::builder()
+        .scenario(
+            ScenarioMode::Strict,
+            vec![ScenarioStep {
+                expect_command: "get_version".to_string(),
+                respond_xml: Some("<current_response/><stale_response/>".to_string()),
+            }],
+        )
+        .ssh("127.0.0.1:0")
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let mut connection = SshConnection::new(config_for(&server));
+
+    connection.connect().await.expect("first connect");
+    connection
+        .send(b"<get_version/>")
+        .await
+        .expect("first send");
+    assert_eq!(
+        connection.read().await.expect("current response"),
+        b"<current_response/>"
+    );
+    connection.disconnect().await.expect("disconnect");
+
+    connection.connect().await.expect("second connect");
+    connection
+        .send(b"<get_version/>")
+        .await
+        .expect("second send");
+    assert_eq!(
+        connection.read().await.expect("fresh current response"),
+        b"<current_response/>"
+    );
+
+    connection.disconnect().await.expect("disconnect");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_malformed_response_invalidates_connection() {
+    let server = match MockGmpServer::builder()
+        .scenario(
+            ScenarioMode::Strict,
+            vec![ScenarioStep {
+                expect_command: "get_version".to_string(),
+                respond_xml: Some("<response></wrong>".to_string()),
+            }],
+        )
+        .ssh("127.0.0.1:0")
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let mut connection = SshConnection::new(config_for(&server));
+    connection.connect().await.expect("connect");
+    connection.send(b"<get_version/>").await.expect("send");
+
+    let error = connection.read().await.expect_err("malformed response");
+    assert!(matches!(
+        error,
+        ConnectionError::ReadFailed(ref source)
+            if source.kind() == ErrorKind::InvalidData
+    ));
+    assert!(!connection.is_connected());
+    assert!(matches!(
+        connection.send(b"<get_version/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_response_limit_is_applied_independently_to_coalesced_frames() {
+    let first = b"<first_response/>";
+    let server = match MockGmpServer::builder()
+        .scenario(
+            ScenarioMode::Strict,
+            vec![ScenarioStep {
+                expect_command: "get_version".to_string(),
+                respond_xml: Some("<first_response/><oversized-response-without-close".to_string()),
+            }],
+        )
+        .ssh("127.0.0.1:0")
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let config = config_for(&server).with_max_response_bytes(Some(first.len()));
+    let mut connection = SshConnection::new(config);
+    connection.connect().await.expect("connect");
+    connection.send(b"<get_version/>").await.expect("send");
+
+    assert_eq!(connection.read().await.expect("first response"), first);
+    let error = connection
+        .read()
+        .await
+        .expect_err("oversized second response");
+    assert!(matches!(
+        error,
+        ConnectionError::ReadFailed(ref source)
+            if source.kind() == ErrorKind::InvalidData
+    ));
+    assert!(!connection.is_connected());
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_mock_rejects_malformed_request_then_closes_channel() {
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Echo)
+        .version(GmpVersion::V22_5)
+        .ssh("127.0.0.1:0")
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let mut connection = SshConnection::new(config_for(&server));
+    connection.connect().await.expect("connect");
+    connection
+        .send(b"<get_version></wrong>")
+        .await
+        .expect("send malformed command");
+
+    let response = Response::new(connection.read().await.expect("rejection response"));
+    assert_eq!(response.status_code(), Some(400));
+    let error = connection.read().await.expect_err("closed SSH channel");
+    assert!(matches!(
+        error,
+        ConnectionError::ReadFailed(ref source)
+            if source.kind() == ErrorKind::UnexpectedEof
+    ));
+    assert!(!connection.is_connected());
+    assert_eq!(server.command_count(), 0);
 
     server.shutdown().await;
 }

--- a/crates/gvm-connection/tests/unix_connection.rs
+++ b/crates/gvm-connection/tests/unix_connection.rs
@@ -4,9 +4,11 @@
 #![allow(clippy::print_stdout, clippy::unwrap_used, missing_docs)]
 #![cfg(feature = "unix-socket-tests")]
 
-use gvm_connection::{GvmConnection, UnixSocketConfig, UnixSocketConnection};
+use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConfig, UnixSocketConnection};
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response, XmlCommand};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
 
 async fn start_mock() -> Option<MockGmpServer> {
     match MockGmpServer::builder()
@@ -157,4 +159,147 @@ async fn double_connect_errors() {
 
     conn.disconnect().await.expect("disconnect failed");
     server.shutdown().await;
+}
+
+#[tokio::test]
+async fn coalesced_responses_are_returned_one_frame_at_a_time() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("coalesced.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept connection");
+        let mut request = [0_u8; 64];
+        let _ = stream.read(&mut request).await.expect("read request");
+        stream
+            .write_all(b"<first_response/><second_response/>")
+            .await
+            .expect("write responses");
+    });
+
+    let mut connection = UnixSocketConnection::new(UnixSocketConfig::new(&socket_path));
+    connection.connect().await.expect("connect");
+    connection.send(b"<request/>").await.expect("send");
+
+    assert_eq!(
+        connection.read().await.expect("first response"),
+        b"<first_response/>"
+    );
+    assert_eq!(
+        connection.read().await.expect("second response"),
+        b"<second_response/>"
+    );
+
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn reconnect_discards_a_pending_response_tail() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("reconnect-tail.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (mut first, _) = listener.accept().await.expect("first connection");
+        let mut request = [0_u8; 64];
+        let _ = first.read(&mut request).await.expect("first request");
+        first
+            .write_all(b"<current_response/><stale_response/>")
+            .await
+            .expect("first responses");
+        drop(first);
+
+        let (mut second, _) = listener.accept().await.expect("second connection");
+        let _ = second.read(&mut request).await.expect("second request");
+        second
+            .write_all(b"<fresh_response/>")
+            .await
+            .expect("fresh response");
+    });
+
+    let mut connection = UnixSocketConnection::new(UnixSocketConfig::new(&socket_path));
+    connection.connect().await.expect("first connect");
+    connection.send(b"<request/>").await.expect("first send");
+    assert_eq!(
+        connection.read().await.expect("current response"),
+        b"<current_response/>"
+    );
+    connection.disconnect().await.expect("disconnect");
+
+    connection.connect().await.expect("second connect");
+    connection.send(b"<request/>").await.expect("second send");
+    assert_eq!(
+        connection.read().await.expect("fresh response"),
+        b"<fresh_response/>"
+    );
+
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn malformed_response_fails_without_waiting_for_eof() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("malformed.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept connection");
+        let mut request = [0_u8; 64];
+        let _ = stream.read(&mut request).await.expect("read request");
+        stream
+            .write_all(b"<response></wrong>")
+            .await
+            .expect("write response");
+    });
+
+    let mut connection = UnixSocketConnection::new(UnixSocketConfig::new(&socket_path));
+    connection.connect().await.expect("connect");
+    connection.send(b"<request/>").await.expect("send");
+
+    let error = connection.read().await.expect_err("malformed response");
+    assert!(matches!(
+        error,
+        ConnectionError::ReadFailed(ref source)
+            if source.kind() == std::io::ErrorKind::InvalidData
+    ));
+    assert!(!connection.is_connected());
+    assert!(matches!(
+        connection.send(b"<request/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn response_limit_is_applied_independently_to_coalesced_frames() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("per-frame-limit.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept connection");
+        let mut request = [0_u8; 64];
+        let _ = stream.read(&mut request).await.expect("read request");
+        stream
+            .write_all(b"<first_response/><oversized-response-without-close")
+            .await
+            .expect("write responses");
+    });
+
+    let first = b"<first_response/>";
+    let config = UnixSocketConfig::new(&socket_path).with_max_response_bytes(Some(first.len()));
+    let mut connection = UnixSocketConnection::new(config);
+    connection.connect().await.expect("connect");
+    connection.send(b"<request/>").await.expect("send");
+
+    assert_eq!(connection.read().await.expect("first response"), first);
+    let error = connection
+        .read()
+        .await
+        .expect_err("oversized second response");
+    assert!(matches!(
+        error,
+        ConnectionError::ReadFailed(ref source)
+            if source.kind() == std::io::ErrorKind::InvalidData
+    ));
+    assert!(!connection.is_connected());
+
+    server.await.expect("server task");
 }

--- a/crates/gvm-mock-server/src/builder.rs
+++ b/crates/gvm-mock-server/src/builder.rs
@@ -11,10 +11,12 @@ use crate::fault::{Fault, FaultEngine};
 use crate::fixtures::FixtureStore;
 use crate::response_gen::LargeReportConfig;
 use crate::scenario::{ScenarioMode, ScenarioStep};
-use crate::server::{MockGmpServer, UnixSocketBinding};
+use crate::server::{MockGmpServer, ServerOptions, UnixSocketBinding};
 use crate::store::ResourceStore;
 use crate::version::GmpVersion;
 use crate::ServerMode;
+
+const DEFAULT_MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024;
 
 /// Builder for [`MockGmpServer`].
 pub struct MockGmpServerBuilder {
@@ -27,6 +29,7 @@ pub struct MockGmpServerBuilder {
     faults: Vec<Fault>,
     scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
     large_report: Option<LargeReportConfig>,
+    max_request_bytes: Option<usize>,
 }
 
 enum Transport {
@@ -51,6 +54,7 @@ impl MockGmpServerBuilder {
             faults: Vec::new(),
             scenario_config: None,
             large_report: None,
+            max_request_bytes: Some(DEFAULT_MAX_REQUEST_BYTES),
         }
     }
 
@@ -157,6 +161,16 @@ impl MockGmpServerBuilder {
         self
     }
 
+    /// Set the maximum size of one XML request.
+    ///
+    /// The default is 64 MiB. Pass `None` to disable the per-request byte
+    /// limit. XML nesting remains independently bounded to 256 elements.
+    #[must_use]
+    pub fn with_max_request_bytes(mut self, max_request_bytes: Option<usize>) -> Self {
+        self.max_request_bytes = max_request_bytes;
+        self
+    }
+
     /// Build and start the mock server.
     ///
     /// # Errors
@@ -172,7 +186,15 @@ impl MockGmpServerBuilder {
             faults,
             scenario_config,
             large_report,
+            max_request_bytes,
         } = self;
+
+        if max_request_bytes == Some(0) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "max_request_bytes must be greater than zero or None",
+            ));
+        }
 
         let fixtures = if mode == ServerMode::Fixture || !fixture_overrides.is_empty() {
             let mut store = FixtureStore::new(version);
@@ -208,6 +230,12 @@ impl MockGmpServerBuilder {
             None
         };
 
+        let options = ServerOptions {
+            scenario_config,
+            large_report,
+            max_request_bytes,
+        };
+
         match transport {
             Transport::UnixSocket(path) => {
                 MockGmpServer::start_unix(
@@ -220,8 +248,7 @@ impl MockGmpServerBuilder {
                     fixtures,
                     store,
                     fault_engine,
-                    scenario_config,
-                    large_report,
+                    options,
                 )
                 .await
             }
@@ -242,8 +269,7 @@ impl MockGmpServerBuilder {
                     fixtures,
                     store,
                     fault_engine,
-                    scenario_config,
-                    large_report,
+                    options,
                 )
                 .await
             }
@@ -255,8 +281,7 @@ impl MockGmpServerBuilder {
                     fixtures,
                     store,
                     fault_engine,
-                    scenario_config,
-                    large_report,
+                    options,
                 )
                 .await
             }
@@ -269,8 +294,7 @@ impl MockGmpServerBuilder {
                     fixtures,
                     store,
                     fault_engine,
-                    scenario_config,
-                    large_report,
+                    options,
                 )
                 .await
             }

--- a/crates/gvm-mock-server/src/listener.rs
+++ b/crates/gvm-mock-server/src/listener.rs
@@ -14,7 +14,7 @@ use crate::fault::FaultEngine;
 use crate::fixtures::FixtureStore;
 use crate::handler::{HandleResult, SessionHandler};
 use crate::history::CommandHistory;
-use crate::response_gen::LargeReportConfig;
+use crate::response_gen::{error_response, LargeReportConfig};
 use crate::scenario::{ScenarioMode, ScenarioStep};
 use crate::store::ResourceStore;
 use crate::version::GmpVersion;
@@ -38,6 +38,8 @@ pub struct ListenerState {
     pub(crate) scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
     /// Large synthetic report configuration.
     pub(crate) large_report: Option<LargeReportConfig>,
+    /// Maximum size of one XML request.
+    pub(crate) max_request_bytes: Option<usize>,
     /// Fault injection engine.
     pub(crate) fault_engine: FaultEngine,
     /// Shutdown signal.
@@ -120,7 +122,7 @@ where
     );
 
     let mut buf = vec![0u8; 16 * 1024];
-    let mut xml_buf = Vec::new();
+    let mut xml_reader = gvm_protocol::XmlReader::with_buffer_limit(state.max_request_bytes);
 
     loop {
         let n = match stream.read(&mut buf).await {
@@ -132,11 +134,13 @@ where
             }
         };
 
-        xml_buf.extend_from_slice(&buf[..n]);
+        let mut offset = 0;
+        while offset < n {
+            let (consumed, result) =
+                try_extract_command(&mut xml_reader, &buf[offset..n], &handler);
+            offset = offset.saturating_add(consumed);
 
-        // Try to find complete XML commands in the buffer.
-        loop {
-            match try_extract_command(&mut xml_buf, &handler) {
+            match result {
                 CommandResult::Response { bytes, delay } => {
                     if let Some(d) = delay {
                         tokio::time::sleep(d).await;
@@ -149,6 +153,11 @@ where
                 CommandResult::NeedMore => break,
                 CommandResult::Disconnect => {
                     tracing::debug!("Fault: disconnecting session {session_id}");
+                    return;
+                }
+                CommandResult::Reject { bytes, reason } => {
+                    tracing::debug!("Rejecting session {session_id} input: {reason}");
+                    let _ = stream.write_all(&bytes).await;
                     return;
                 }
             }
@@ -167,34 +176,46 @@ pub(crate) enum CommandResult {
     NeedMore,
     /// Disconnect (fault injection).
     Disconnect,
+    /// Reject malformed or oversized XML and close the session.
+    Reject { bytes: Vec<u8>, reason: String },
 }
 
 /// Try to extract a complete XML command from the buffer.
-pub(crate) fn try_extract_command(buf: &mut Vec<u8>, handler: &SessionHandler) -> CommandResult {
-    // Simple approach: look for a complete XML element.
-    // We use a quick heuristic — find the root element close.
-    // For self-closing elements: />
-    // For elements with children: find matching close tag.
-
-    let Ok(text) = std::str::from_utf8(buf) else {
-        return CommandResult::NeedMore;
-    };
-    if text.trim_start().is_empty() {
-        return CommandResult::NeedMore;
-    }
-
-    let mut reader = gvm_protocol::XmlReader::new();
-    // TODO: detect malformed XML explicitly instead of waiting for a complete element.
-    let _ = reader.feed(buf);
-
-    if reader.is_complete() {
-        let command_xml = buf.clone();
-        buf.clear();
-        match handler.handle_command(&command_xml) {
-            HandleResult::Respond { bytes, delay } => CommandResult::Response { bytes, delay },
-            HandleResult::Disconnect => CommandResult::Disconnect,
+pub(crate) fn try_extract_command(
+    reader: &mut gvm_protocol::XmlReader,
+    data: &[u8],
+    handler: &SessionHandler,
+) -> (usize, CommandResult) {
+    let consumed = match reader.feed_frame(data) {
+        Ok(consumed) => consumed,
+        Err(error) => {
+            return (
+                0,
+                CommandResult::Reject {
+                    bytes: error_response("unknown", 400, "Malformed or oversized XML request"),
+                    reason: error.to_string(),
+                },
+            );
         }
-    } else {
-        CommandResult::NeedMore
-    }
+    };
+
+    let command_xml = match reader.take_frame() {
+        Ok(Some(command_xml)) => command_xml,
+        Ok(None) => return (consumed, CommandResult::NeedMore),
+        Err(error) => {
+            return (
+                consumed,
+                CommandResult::Reject {
+                    bytes: error_response("unknown", 400, "Malformed or oversized XML request"),
+                    reason: error.to_string(),
+                },
+            );
+        }
+    };
+
+    let result = match handler.handle_command(&command_xml) {
+        HandleResult::Respond { bytes, delay } => CommandResult::Response { bytes, delay },
+        HandleResult::Disconnect => CommandResult::Disconnect,
+    };
+    (consumed, result)
 }

--- a/crates/gvm-mock-server/src/main.rs
+++ b/crates/gvm-mock-server/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     /// TCP address (e.g., 127.0.0.1:9390)
     #[arg(long)]
     tcp: Option<String>,
+
+    /// Maximum size of one XML request in bytes
+    #[arg(long, default_value_t = 64 * 1024 * 1024)]
+    max_request_bytes: usize,
 }
 
 #[tokio::main]
@@ -56,7 +60,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let mut builder = MockGmpServer::builder().mode(mode).version(version);
+    let mut builder = MockGmpServer::builder()
+        .mode(mode)
+        .version(version)
+        .with_max_request_bytes(Some(args.max_request_bytes));
 
     if let Some(socket) = args.socket {
         builder = builder.unix_socket(socket);

--- a/crates/gvm-mock-server/src/server.rs
+++ b/crates/gvm-mock-server/src/server.rs
@@ -29,6 +29,12 @@ pub(crate) struct UnixSocketBinding {
     pub(crate) temp_dir: Option<TempDir>,
 }
 
+pub(crate) struct ServerOptions {
+    pub(crate) scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
+    pub(crate) large_report: Option<LargeReportConfig>,
+    pub(crate) max_request_bytes: Option<usize>,
+}
+
 /// A running mock GMP server.
 pub struct MockGmpServer {
     /// The Unix socket path (if using Unix transport).
@@ -65,9 +71,13 @@ impl MockGmpServer {
         fixtures: Option<FixtureStore>,
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
-        scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
-        large_report: Option<LargeReportConfig>,
+        options: ServerOptions,
     ) -> Result<Self, std::io::Error> {
+        let ServerOptions {
+            scenario_config,
+            large_report,
+            max_request_bytes,
+        } = options;
         let UnixSocketBinding {
             path: socket_path,
             temp_dir,
@@ -91,6 +101,7 @@ impl MockGmpServer {
             store,
             scenario_config,
             large_report,
+            max_request_bytes,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });
@@ -121,9 +132,13 @@ impl MockGmpServer {
         fixtures: Option<FixtureStore>,
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
-        scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
-        large_report: Option<LargeReportConfig>,
+        options: ServerOptions,
     ) -> Result<Self, std::io::Error> {
+        let ServerOptions {
+            scenario_config,
+            large_report,
+            max_request_bytes,
+        } = options;
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
         let history = CommandHistory::new();
@@ -138,6 +153,7 @@ impl MockGmpServer {
             store,
             scenario_config,
             large_report,
+            max_request_bytes,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });
@@ -169,9 +185,13 @@ impl MockGmpServer {
         fixtures: Option<FixtureStore>,
         store: Option<ResourceStore>,
         fault_engine: FaultEngine,
-        scenario_config: Option<(ScenarioMode, Vec<ScenarioStep>)>,
-        large_report: Option<LargeReportConfig>,
+        options: ServerOptions,
     ) -> Result<Self, std::io::Error> {
+        let ServerOptions {
+            scenario_config,
+            large_report,
+            max_request_bytes,
+        } = options;
         let listener = TcpListener::bind(addr).await?;
         let local_addr = listener.local_addr()?;
         let host_key = generate_host_key()?;
@@ -188,6 +208,7 @@ impl MockGmpServer {
             store,
             scenario_config,
             large_report,
+            max_request_bytes,
             fault_engine: fault_engine.clone(),
             shutdown: Arc::clone(&shutdown),
         });

--- a/crates/gvm-mock-server/src/ssh_listener.rs
+++ b/crates/gvm-mock-server/src/ssh_listener.rs
@@ -124,15 +124,19 @@ impl server::Handler for MockSshHandler {
         );
 
         tokio::spawn(async move {
-            let mut xml_buf = Vec::new();
+            let mut xml_reader =
+                gvm_protocol::XmlReader::with_buffer_limit(state.max_request_bytes);
 
             while let Some(msg) = channel.wait().await {
                 match msg {
                     ChannelMsg::Data { data } => {
-                        xml_buf.extend_from_slice(&data);
+                        let mut offset = 0;
+                        while offset < data.len() {
+                            let (consumed, result) =
+                                try_extract_command(&mut xml_reader, &data[offset..], &handler);
+                            offset = offset.saturating_add(consumed);
 
-                        loop {
-                            match try_extract_command(&mut xml_buf, &handler) {
+                            match result {
                                 CommandResult::Response { bytes, delay } => {
                                     if let Some(delay) = delay {
                                         tokio::time::sleep(delay).await;
@@ -150,6 +154,14 @@ impl server::Handler for MockSshHandler {
                                     tracing::debug!(
                                         "Fault: disconnecting SSH session {session_id}"
                                     );
+                                    let _ = channel.close().await;
+                                    return;
+                                }
+                                CommandResult::Reject { bytes, reason } => {
+                                    tracing::debug!(
+                                        "Rejecting SSH session {session_id} input: {reason}"
+                                    );
+                                    let _ = channel.data(&bytes[..]).await;
                                     let _ = channel.close().await;
                                     return;
                                 }

--- a/crates/gvm-mock-server/tests/builder_coverage.rs
+++ b/crates/gvm-mock-server/tests/builder_coverage.rs
@@ -79,3 +79,21 @@ async fn builder_with_credentials() {
     };
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn builder_rejects_zero_request_limit() {
+    let result = MockGmpServer::builder()
+        .with_max_request_bytes(Some(0))
+        .unix_socket_auto()
+        .build()
+        .await;
+    let error = match result {
+        Ok(server) => {
+            server.shutdown().await;
+            panic!("zero request limit must be rejected");
+        }
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+}

--- a/crates/gvm-mock-server/tests/connections.rs
+++ b/crates/gvm-mock-server/tests/connections.rs
@@ -14,28 +14,61 @@
 use std::collections::HashSet;
 
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
-use gvm_protocol::Response;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use gvm_protocol::{Response, XmlReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UnixStream};
 
 /// Helper: send XML and read response via TCP.
 async fn send_recv(stream: &mut TcpStream, xml: &[u8]) -> Response {
     stream.write_all(xml).await.expect("write failed");
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    let mut buf = vec![0u8; 64 * 1024];
-    let n = stream.read(&mut buf).await.expect("read failed");
-    buf.truncate(n);
-    Response::new(buf)
+    let mut frames = read_frames(stream, 1).await;
+    Response::new(frames.remove(0))
 }
 
 /// Helper: send XML and read response via Unix socket.
 async fn send_recv_unix(stream: &mut UnixStream, xml: &[u8]) -> Response {
     stream.write_all(xml).await.expect("write failed");
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    let mut buf = vec![0u8; 64 * 1024];
-    let n = stream.read(&mut buf).await.expect("read failed");
-    buf.truncate(n);
-    Response::new(buf)
+    let mut frames = read_frames(stream, 1).await;
+    Response::new(frames.remove(0))
+}
+
+async fn read_frames<S>(stream: &mut S, expected: usize) -> Vec<Vec<u8>>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut reader = XmlReader::new();
+    let mut frames = Vec::new();
+    let mut buf = [0_u8; 4096];
+
+    while frames.len() < expected {
+        let n = tokio::time::timeout(std::time::Duration::from_secs(2), stream.read(&mut buf))
+            .await
+            .expect("response timeout")
+            .expect("response read");
+        assert_ne!(n, 0, "connection closed before all responses arrived");
+        reader.feed(&buf[..n]).expect("valid response XML");
+
+        while let Some(frame) = reader.take_frame().expect("valid response XML") {
+            frames.push(frame);
+            if frames.len() == expected {
+                break;
+            }
+        }
+    }
+
+    frames
+}
+
+async fn assert_stream_closed<S>(stream: &mut S)
+where
+    S: AsyncRead + Unpin,
+{
+    let mut byte = [0_u8; 1];
+    let n = tokio::time::timeout(std::time::Duration::from_secs(2), stream.read(&mut byte))
+        .await
+        .expect("connection close timeout")
+        .expect("read after rejection");
+    assert_eq!(n, 0, "rejected connection must be closed");
 }
 
 async fn tcp_echo_server() -> Option<MockGmpServer> {
@@ -221,6 +254,213 @@ async fn stateful_session_isolation() {
     let text = tasks_resp.as_str().expect("valid utf8");
     assert!(text.contains("Shared Task"));
     assert!(text.contains("<task_count>1"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn tcp_coalesced_commands_are_processed_in_order() {
+    let Some(server) = tcp_echo_server().await else {
+        return;
+    };
+    let mut stream = TcpStream::connect(server.tcp_addr().expect("TCP address"))
+        .await
+        .expect("connect");
+
+    stream
+        .write_all(b"<get_version/><get_tasks/>")
+        .await
+        .expect("coalesced write");
+    let frames = read_frames(&mut stream, 2).await;
+
+    assert_eq!(
+        Response::new(frames[0].clone())
+            .root_element_name()
+            .as_deref(),
+        Some("get_version_response")
+    );
+    assert_eq!(
+        Response::new(frames[1].clone())
+            .root_element_name()
+            .as_deref(),
+        Some("get_tasks_response")
+    );
+    let history = server.command_history();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].raw_xml(), b"<get_version/>");
+    assert_eq!(history[1].raw_xml(), b"<get_tasks/>");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn unix_coalesced_and_fragmented_commands_preserve_every_frame() {
+    let Some(server) = build_server(
+        MockGmpServer::builder()
+            .mode(ServerMode::Echo)
+            .version(GmpVersion::V22_5)
+            .unix_socket_auto(),
+    )
+    .await
+    else {
+        return;
+    };
+    let mut stream = UnixStream::connect(server.socket_path().expect("socket path"))
+        .await
+        .expect("connect");
+
+    stream
+        .write_all(b"<get_version/><get_tasks/>")
+        .await
+        .expect("coalesced write");
+    let frames = read_frames(&mut stream, 2).await;
+    assert_eq!(
+        Response::new(frames[0].clone())
+            .root_element_name()
+            .as_deref(),
+        Some("get_version_response")
+    );
+    assert_eq!(
+        Response::new(frames[1].clone())
+            .root_element_name()
+            .as_deref(),
+        Some("get_tasks_response")
+    );
+
+    for byte in b"<get_version/>" {
+        stream.write_all(&[*byte]).await.expect("fragmented write");
+    }
+    let fragmented = read_frames(&mut stream, 1).await;
+    assert_eq!(
+        Response::new(fragmented[0].clone()).status_code(),
+        Some(200)
+    );
+    assert_eq!(server.command_count(), 3);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn malformed_requests_are_rejected_without_stopping_tcp_listener() {
+    let Some(server) = tcp_echo_server().await else {
+        return;
+    };
+    let address = server.tcp_addr().expect("TCP address");
+
+    let mut bom = TcpStream::connect(address).await.expect("BOM connection");
+    let bom_response = send_recv(&mut bom, b"\xEF\xBB\xBF<get_version/>").await;
+    assert_eq!(bom_response.status_code(), Some(200));
+    drop(bom);
+
+    for malformed in [
+        b"<get_version></wrong>".as_slice(),
+        b"\xff<get_version/>".as_slice(),
+        b"<get_version>&bogus;</get_version>".as_slice(),
+        b"<?xml?><get_version/>".as_slice(),
+        b"<1bad/>".as_slice(),
+        b"<get_version>&#0;</get_version>".as_slice(),
+        b"<?XML data?><get_version/>".as_slice(),
+    ] {
+        let mut stream = TcpStream::connect(address)
+            .await
+            .expect("malformed connection");
+        stream.write_all(malformed).await.expect("malformed write");
+        let response = read_frames(&mut stream, 1).await;
+        assert_eq!(Response::new(response[0].clone()).status_code(), Some(400));
+        assert_stream_closed(&mut stream).await;
+    }
+
+    let mut fresh = TcpStream::connect(address).await.expect("fresh connection");
+    let fresh_response = send_recv(&mut fresh, b"<get_version/>").await;
+    assert_eq!(fresh_response.status_code(), Some(200));
+    assert_eq!(
+        server.command_count(),
+        2,
+        "rejected input must not reach history"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn malformed_request_is_rejected_and_closed_on_unix_listener() {
+    let Some(server) = build_server(
+        MockGmpServer::builder()
+            .mode(ServerMode::Echo)
+            .version(GmpVersion::V22_5)
+            .unix_socket_auto(),
+    )
+    .await
+    else {
+        return;
+    };
+    let path = server.socket_path().expect("Unix socket path");
+
+    let mut malformed = UnixStream::connect(path)
+        .await
+        .expect("malformed connection");
+    malformed
+        .write_all(b"<get_version></wrong>")
+        .await
+        .expect("malformed write");
+    let response = read_frames(&mut malformed, 1).await;
+    assert_eq!(Response::new(response[0].clone()).status_code(), Some(400));
+    assert_stream_closed(&mut malformed).await;
+
+    let mut fresh = UnixStream::connect(path).await.expect("fresh connection");
+    assert_eq!(
+        send_recv_unix(&mut fresh, b"<get_version/>")
+            .await
+            .status_code(),
+        Some(200)
+    );
+    assert_eq!(server.command_count(), 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn request_limit_is_exact_and_oversize_does_not_stop_listener() {
+    let request = b"<get_version/>";
+    let Some(server) = build_server(
+        MockGmpServer::builder()
+            .mode(ServerMode::Echo)
+            .version(GmpVersion::V22_5)
+            .with_max_request_bytes(Some(request.len()))
+            .tcp("127.0.0.1:0"),
+    )
+    .await
+    else {
+        return;
+    };
+    let address = server.tcp_addr().expect("TCP address");
+
+    let mut exact = TcpStream::connect(address).await.expect("exact connection");
+    let exact_response = send_recv(&mut exact, request).await;
+    assert_eq!(exact_response.status_code(), Some(200));
+
+    let mut oversized = TcpStream::connect(address)
+        .await
+        .expect("oversized connection");
+    oversized
+        .write_all(b"<get_version ></get_version>")
+        .await
+        .expect("oversized write");
+    let oversized_response = read_frames(&mut oversized, 1).await;
+    assert_eq!(
+        Response::new(oversized_response[0].clone()).status_code(),
+        Some(400)
+    );
+    assert_stream_closed(&mut oversized).await;
+
+    let mut fresh = TcpStream::connect(address).await.expect("fresh connection");
+    let fresh_response = send_recv(&mut fresh, request).await;
+    assert_eq!(fresh_response.status_code(), Some(200));
+    assert_eq!(
+        server.command_count(),
+        2,
+        "rejected input must not reach history"
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-protocol/src/xml_reader.rs
+++ b/crates/gvm-protocol/src/xml_reader.rs
@@ -3,16 +3,19 @@
 
 //! Streaming XML reader for detecting GMP response boundaries.
 //!
-//! Reads XML data incrementally and detects when a complete root element
-//! has been received (matching python-gvm's `XmlReader`).
+//! Reads XML data incrementally, validates document structure, and preserves
+//! exact root-element boundaries across transport chunks.
 
 use quick_xml::errors::{Error as XmlError, IllFormedError, SyntaxError};
-use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::escape::resolve_xml_entity;
+use quick_xml::events::{BytesDecl, BytesEnd, BytesRef, BytesStart, BytesText, Event};
+use quick_xml::{Reader, XmlVersion};
 
 use crate::error::ProtocolError;
 
 const DEFAULT_MAX_BUFFER_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_MAX_DEPTH: usize = 256;
+const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 
 /// Streaming XML reader that detects when a complete XML root element has been received.
 ///
@@ -21,10 +24,27 @@ const DEFAULT_MAX_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 pub struct XmlReader {
     buffer: Vec<u8>,
     max_buffer_bytes: Option<usize>,
+    max_depth: usize,
     complete: bool,
-    depth: usize,
     seen_start: bool,
+    declaration_allowed: bool,
     resume_offset: usize,
+    frame_end: Option<usize>,
+    element_names: Vec<Vec<u8>>,
+}
+
+impl std::fmt::Debug for XmlReader {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("XmlReader")
+            .field("buffer_len", &self.buffer.len())
+            .field("max_buffer_bytes", &self.max_buffer_bytes)
+            .field("max_depth", &self.max_depth)
+            .field("complete", &self.complete)
+            .field("frame_end", &self.frame_end)
+            .field("depth", &self.element_names.len())
+            .finish()
+    }
 }
 
 impl XmlReader {
@@ -43,13 +63,22 @@ impl XmlReader {
     /// Create a new `XmlReader` with an optional maximum buffer size.
     #[must_use]
     pub fn with_buffer_limit(max_buffer_bytes: Option<usize>) -> Self {
+        Self::with_limits(max_buffer_bytes, DEFAULT_MAX_DEPTH)
+    }
+
+    /// Create a new `XmlReader` with custom buffer and nesting limits.
+    #[must_use]
+    pub fn with_limits(max_buffer_bytes: Option<usize>, max_depth: usize) -> Self {
         Self {
             buffer: Vec::new(),
             max_buffer_bytes,
+            max_depth,
             complete: false,
-            depth: 0,
             seen_start: false,
+            declaration_allowed: true,
             resume_offset: 0,
+            frame_end: None,
+            element_names: Vec::new(),
         }
     }
 
@@ -68,10 +97,100 @@ impl XmlReader {
         self.check_complete()
     }
 
+    /// Feed only the bytes belonging to the current XML frame.
+    ///
+    /// The returned count is the number of bytes consumed from `data`. Once
+    /// [`XmlReader::is_complete`] is true, any unconsumed suffix belongs to the
+    /// next frame. This method applies the configured size limit to each frame
+    /// independently and never copies an unbounded trailing frame into the
+    /// current reader.
+    ///
+    /// # Errors
+    /// Returns an error if the current frame is malformed, too deeply nested,
+    /// or exceeds the configured buffer limit. Reset the reader before reuse
+    /// after an error.
+    pub fn feed_frame(&mut self, data: &[u8]) -> Result<usize, ProtocolError> {
+        if self.complete {
+            return Ok(0);
+        }
+
+        // `take_frame` can leave an already-buffered tail from `feed`. Parse
+        // that tail before consuming any new bytes so mixed API use cannot
+        // discard a complete buffered frame.
+        self.check_complete()?;
+        if self.complete {
+            return Ok(0);
+        }
+
+        let previous_len = self.buffer.len();
+        let accepted = match self.max_buffer_bytes {
+            Some(max) => data.len().min(max.saturating_sub(previous_len)),
+            None => data.len(),
+        };
+
+        self.buffer.extend_from_slice(&data[..accepted]);
+        self.check_complete()?;
+
+        if let Some(frame_end) = self.frame_end {
+            let consumed = frame_end.saturating_sub(previous_len);
+            self.buffer.truncate(frame_end);
+            return Ok(consumed);
+        }
+
+        if accepted < data.len()
+            || self
+                .max_buffer_bytes
+                .is_some_and(|max| self.buffer.len() >= max)
+        {
+            return Err(ProtocolError::BufferOverflow {
+                max: self.max_buffer_bytes.unwrap_or_default(),
+            });
+        }
+
+        Ok(accepted)
+    }
+
     /// Check if a complete XML root element has been received.
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.complete
+    }
+
+    /// Return the length of the first complete XML frame.
+    #[must_use]
+    pub fn frame_len(&self) -> Option<usize> {
+        self.frame_end
+    }
+
+    /// Return the first complete XML frame, if available.
+    #[must_use]
+    pub fn frame(&self) -> Option<&[u8]> {
+        self.frame_end.map(|end| &self.buffer[..end])
+    }
+
+    /// Return bytes accumulated after the first complete XML frame.
+    #[must_use]
+    pub fn tail(&self) -> Option<&[u8]> {
+        self.frame_end.map(|end| &self.buffer[end..])
+    }
+
+    /// Remove and return the first complete XML frame.
+    ///
+    /// Any trailing bytes remain buffered and are parsed on the next call.
+    ///
+    /// # Errors
+    /// Returns an error if buffered trailing data is malformed when this method
+    /// is called again to extract the next frame.
+    pub fn take_frame(&mut self) -> Result<Option<Vec<u8>>, ProtocolError> {
+        self.check_complete()?;
+        let Some(frame_end) = self.frame_end else {
+            return Ok(None);
+        };
+
+        let tail = self.buffer.split_off(frame_end);
+        let frame = std::mem::replace(&mut self.buffer, tail);
+        self.reset_state();
+        Ok(Some(frame))
     }
 
     /// Return the accumulated data.
@@ -89,10 +208,16 @@ impl XmlReader {
     /// Reset the reader for reuse.
     pub fn reset(&mut self) {
         self.buffer.clear();
+        self.reset_state();
+    }
+
+    fn reset_state(&mut self) {
         self.complete = false;
-        self.depth = 0;
         self.seen_start = false;
+        self.declaration_allowed = true;
         self.resume_offset = 0;
+        self.frame_end = None;
+        self.element_names.clear();
     }
 
     fn check_complete(&mut self) -> Result<(), ProtocolError> {
@@ -100,49 +225,97 @@ impl XmlReader {
             return Ok(());
         }
 
-        let mut reader = Reader::from_reader(&self.buffer[self.resume_offset..]);
-        reader.config_mut().trim_text(false);
-        reader.config_mut().check_end_names = false;
-        reader.config_mut().allow_unmatched_ends = true;
-        let mut event_buf = Vec::new();
-        let mut parsed_len = 0_usize;
+        let unparsed = &self.buffer[self.resume_offset..];
+        let bom_len =
+            usize::from(self.resume_offset == 0 && unparsed.starts_with(UTF8_BOM)) * UTF8_BOM.len();
+        let mut reader = configured_reader(unparsed);
+        let (mut event_buf, mut parsed_len) = (Vec::new(), 0_usize);
 
         loop {
             match reader.read_event_into(&mut event_buf) {
-                Ok(Event::Start(_)) => {
-                    self.seen_start = true;
-                    self.depth += 1;
-                    parsed_len = reader.buffer_position() as usize;
+                Ok(Event::Start(element)) => {
+                    open_element(
+                        &element,
+                        &mut self.seen_start,
+                        &mut self.element_names,
+                        self.max_depth,
+                    )?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
                 }
-                Ok(Event::End(_)) => {
-                    let depth_before_end = self.depth;
-                    self.depth = self.depth.saturating_sub(1);
-                    parsed_len = reader.buffer_position() as usize;
-                    if self.seen_start && depth_before_end > 0 && self.depth == 0 {
+                Ok(Event::End(element)) => {
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                    if close_element(&element, &mut self.element_names)? {
+                        let frame_end =
+                            validated_frame_end(&self.buffer, self.resume_offset, parsed_len)?;
                         self.complete = true;
+                        self.frame_end = Some(frame_end);
                         return Ok(());
                     }
                 }
-                Ok(Event::Empty(_)) => {
-                    parsed_len = reader.buffer_position() as usize;
+                Ok(Event::Empty(element)) => {
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                    validate_empty_element(&element, self.element_names.len(), self.max_depth)?;
                     if !self.seen_start {
-                        // Self-closing root element like <get_version_response status="200"/>
+                        let frame_end =
+                            validated_frame_end(&self.buffer, self.resume_offset, parsed_len)?;
+                        self.seen_start = true;
                         self.complete = true;
+                        self.frame_end = Some(frame_end);
                         return Ok(());
                     }
-                    // Self-closing child element, doesn't affect depth
+                }
+                Ok(Event::Text(text)) => {
+                    if validate_text(&text, self.seen_start, &mut self.declaration_allowed)? {
+                        self.resume_offset += parsed_len;
+                        return Ok(());
+                    }
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                }
+                Ok(Event::CData(data)) => {
+                    validate_cdata(data.as_ref(), self.seen_start)?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                }
+                Ok(Event::DocType(_)) => {
+                    return Err(xml_parse_error("DOCTYPE declarations are not supported"));
+                }
+                Ok(Event::Decl(declaration)) => {
+                    accept_declaration(
+                        &declaration,
+                        self.seen_start,
+                        &mut self.declaration_allowed,
+                    )?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                }
+                Ok(Event::Comment(comment)) => {
+                    validate_misc(
+                        comment.as_ref(),
+                        self.seen_start,
+                        &mut self.declaration_allowed,
+                    )?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                }
+                Ok(Event::PI(instruction)) => {
+                    validate_processing_instruction(
+                        instruction.as_ref(),
+                        self.seen_start,
+                        &mut self.declaration_allowed,
+                    )?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
+                }
+                Ok(Event::GeneralRef(reference)) => {
+                    if !self.seen_start {
+                        return Err(xml_parse_error("entity reference before root element"));
+                    }
+                    validate_reference(&reference)?;
+                    parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::Eof) => {
-                    // Not complete yet
                     self.resume_offset += parsed_len;
                     return Ok(());
                 }
-                Ok(_) => {
-                    parsed_len = reader.buffer_position() as usize;
-                }
                 Err(error) => {
-                    if self.seen_start && !is_incomplete_xml_error(&error) {
-                        return Err(ProtocolError::XmlParse(format!("Malformed XML: {error}")));
+                    if !is_incomplete_xml_error(&error) {
+                        return Err(xml_parse_error(error));
                     }
 
                     self.resume_offset += parsed_len;
@@ -153,6 +326,254 @@ impl XmlReader {
             event_buf.clear();
         }
     }
+}
+
+fn configured_reader(input: &[u8]) -> Reader<&[u8]> {
+    let mut reader = Reader::from_reader(input);
+    reader.config_mut().trim_text(false);
+    reader.config_mut().check_end_names = false;
+    reader.config_mut().allow_unmatched_ends = true;
+    reader.config_mut().check_comments = true;
+    reader
+}
+
+fn validate_misc(
+    data: &[u8],
+    seen_start: bool,
+    declaration_allowed: &mut bool,
+) -> Result<(), ProtocolError> {
+    validate_xml_bytes(data)?;
+    if !seen_start {
+        *declaration_allowed = false;
+    }
+    Ok(())
+}
+
+fn validate_processing_instruction(
+    data: &[u8],
+    seen_start: bool,
+    declaration_allowed: &mut bool,
+) -> Result<(), ProtocolError> {
+    validate_misc(data, seen_start, declaration_allowed)?;
+    let target_end = data
+        .iter()
+        .position(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+        .unwrap_or(data.len());
+    let target = &data[..target_end];
+    validate_name(target)?;
+    if target.eq_ignore_ascii_case(b"xml") {
+        return Err(xml_parse_error(
+            "processing instruction target 'xml' is reserved",
+        ));
+    }
+    Ok(())
+}
+
+fn accept_declaration(
+    declaration: &BytesDecl<'_>,
+    seen_start: bool,
+    declaration_allowed: &mut bool,
+) -> Result<(), ProtocolError> {
+    if seen_start || !*declaration_allowed {
+        return Err(xml_parse_error(
+            "XML declaration must be the first document event",
+        ));
+    }
+    validate_declaration(declaration)?;
+    *declaration_allowed = false;
+    Ok(())
+}
+
+fn validate_cdata(data: &[u8], seen_start: bool) -> Result<(), ProtocolError> {
+    if !seen_start {
+        return Err(xml_parse_error("CDATA before root element"));
+    }
+    validate_xml_bytes(data)
+}
+
+fn open_element(
+    element: &BytesStart<'_>,
+    seen_start: &mut bool,
+    element_names: &mut Vec<Vec<u8>>,
+    max_depth: usize,
+) -> Result<(), ProtocolError> {
+    validate_start(element)?;
+    *seen_start = true;
+    element_names.push(element.name().as_ref().to_vec());
+    if element_names.len() > max_depth {
+        return Err(xml_parse_error(format!(
+            "XML nesting exceeds configured limit of {max_depth}"
+        )));
+    }
+    Ok(())
+}
+
+fn close_element(
+    element: &BytesEnd<'_>,
+    element_names: &mut Vec<Vec<u8>>,
+) -> Result<bool, ProtocolError> {
+    let Some(expected) = element_names.pop() else {
+        return Err(xml_parse_error("unmatched closing tag"));
+    };
+    if expected.as_slice() != element.name().as_ref() {
+        return Err(xml_parse_error("mismatched closing tag"));
+    }
+    Ok(element_names.is_empty())
+}
+
+fn validate_empty_element(
+    element: &BytesStart<'_>,
+    current_depth: usize,
+    max_depth: usize,
+) -> Result<(), ProtocolError> {
+    validate_start(element)?;
+    if current_depth.saturating_add(1) > max_depth {
+        return Err(xml_parse_error(format!(
+            "XML nesting exceeds configured limit of {max_depth}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_text(
+    text: &BytesText<'_>,
+    seen_start: bool,
+    declaration_allowed: &mut bool,
+) -> Result<bool, ProtocolError> {
+    let decoded = match std::str::from_utf8(text.as_ref()) {
+        Ok(text) => text,
+        Err(error) if error.error_len().is_none() => {
+            let prefix = std::str::from_utf8(&text.as_ref()[..error.valid_up_to()])
+                .map_err(xml_parse_error)?;
+            validate_xml_chars(prefix)?;
+            if !seen_start && !prefix.chars().all(is_xml_whitespace) {
+                return Err(xml_parse_error("non-whitespace text before root element"));
+            }
+            if !seen_start && !prefix.is_empty() {
+                *declaration_allowed = false;
+            }
+            return Ok(true);
+        }
+        Err(error) => return Err(xml_parse_error(error)),
+    };
+
+    validate_xml_chars(decoded)?;
+    if !seen_start {
+        if !decoded.chars().all(is_xml_whitespace) {
+            return Err(xml_parse_error("non-whitespace text before root element"));
+        }
+        *declaration_allowed = false;
+    }
+    Ok(false)
+}
+
+fn validate_start(element: &BytesStart<'_>) -> Result<(), ProtocolError> {
+    validate_name(element.name().as_ref())?;
+    validate_xml_bytes(element.as_ref())?;
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(xml_parse_error)?;
+        validate_name(attribute.key.as_ref())?;
+        let value = attribute
+            .normalized_value(XmlVersion::Implicit1_0)
+            .map_err(xml_parse_error)?;
+        validate_xml_chars(&value)?;
+    }
+    Ok(())
+}
+
+fn validate_declaration(declaration: &BytesDecl<'_>) -> Result<(), ProtocolError> {
+    validate_xml_bytes(declaration.as_ref())?;
+    declaration.xml_version().map_err(xml_parse_error)?;
+    if let Some(encoding) = declaration.encoding() {
+        let encoding = encoding.map_err(xml_parse_error)?;
+        if !encoding.eq_ignore_ascii_case(b"utf-8") {
+            return Err(xml_parse_error("only UTF-8 XML declarations are supported"));
+        }
+    }
+    if let Some(standalone) = declaration.standalone() {
+        let standalone = standalone.map_err(xml_parse_error)?;
+        if standalone.as_ref() != b"yes" && standalone.as_ref() != b"no" {
+            return Err(xml_parse_error("standalone must be 'yes' or 'no'"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_reference(reference: &BytesRef<'_>) -> Result<(), ProtocolError> {
+    if let Some(character) = reference.resolve_char_ref().map_err(xml_parse_error)? {
+        return validate_xml_chars(&character.to_string());
+    }
+    let reference = reference.decode().map_err(xml_parse_error)?;
+    if resolve_xml_entity(&reference).is_none() {
+        return Err(xml_parse_error("unknown entity reference"));
+    }
+    Ok(())
+}
+
+fn validate_frame(frame: &[u8]) -> Result<(), ProtocolError> {
+    validate_xml_bytes(frame)
+}
+
+fn validated_frame_end(
+    buffer: &[u8],
+    resume_offset: usize,
+    parsed_len: usize,
+) -> Result<usize, ProtocolError> {
+    let frame_end = resume_offset + parsed_len;
+    validate_frame(&buffer[..frame_end])?;
+    Ok(frame_end)
+}
+
+fn validate_xml_bytes(data: &[u8]) -> Result<(), ProtocolError> {
+    let decoded = std::str::from_utf8(data).map_err(xml_parse_error)?;
+    validate_xml_chars(decoded)
+}
+
+fn validate_xml_chars(data: &str) -> Result<(), ProtocolError> {
+    if data.chars().all(is_xml_char) {
+        Ok(())
+    } else {
+        Err(xml_parse_error("character is not legal in XML 1.0"))
+    }
+}
+
+fn validate_name(name: &[u8]) -> Result<(), ProtocolError> {
+    let name = std::str::from_utf8(name).map_err(xml_parse_error)?;
+    let mut characters = name.chars();
+    if !characters.next().is_some_and(is_xml_name_start) || !characters.all(is_xml_name_character) {
+        return Err(xml_parse_error("invalid XML name"));
+    }
+    Ok(())
+}
+
+fn is_xml_whitespace(character: char) -> bool {
+    matches!(character, ' ' | '\t' | '\r' | '\n')
+}
+
+fn is_xml_char(character: char) -> bool {
+    matches!(
+        character,
+        '\u{9}' | '\u{A}' | '\u{D}' | '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}'
+    )
+}
+
+fn is_xml_name_start(character: char) -> bool {
+    matches!(
+        character,
+        ':' | 'A'..='Z' | '_' | 'a'..='z' | '\u{C0}'..='\u{D6}' | '\u{D8}'..='\u{F6}' | '\u{F8}'..='\u{2FF}' | '\u{370}'..='\u{37D}' | '\u{37F}'..='\u{1FFF}' | '\u{200C}'..='\u{200D}' | '\u{2070}'..='\u{218F}' | '\u{2C00}'..='\u{2FEF}' | '\u{3001}'..='\u{D7FF}' | '\u{F900}'..='\u{FDCF}' | '\u{FDF0}'..='\u{FFFD}' | '\u{10000}'..='\u{EFFFF}'
+    )
+}
+
+fn is_xml_name_character(character: char) -> bool {
+    is_xml_name_start(character)
+        || matches!(
+            character,
+            '-' | '.' | '0'..='9' | '\u{B7}' | '\u{300}'..='\u{36F}' | '\u{203F}'..='\u{2040}'
+        )
+}
+
+fn xml_parse_error(error: impl std::fmt::Display) -> ProtocolError {
+    ProtocolError::XmlParse(format!("Malformed XML: {error}"))
 }
 
 impl Default for XmlReader {
@@ -258,7 +679,7 @@ mod tests {
         reader.feed(b"<root><child>").expect("feed ok");
 
         assert_eq!(reader.resume_offset, b"<root><child>".len());
-        assert_eq!(reader.depth, 2);
+        assert_eq!(reader.element_names.len(), 2);
         assert!(reader.seen_start);
         assert!(!reader.is_complete());
 
@@ -283,23 +704,297 @@ mod tests {
     }
 
     #[test]
-    fn test_unmatched_end_tag_before_start_does_not_complete() {
+    fn test_unmatched_end_tag_before_start_is_rejected() {
         let mut reader = XmlReader::new();
 
-        reader.feed(b"</garbage>").expect("feed ok");
-
-        assert!(!reader.is_complete());
-        assert_eq!(reader.depth, 0);
+        let error = reader.feed(b"</garbage>").expect_err("parse error");
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
     }
 
     #[test]
-    fn test_garbage_end_tag_before_real_response_does_not_complete_prematurely() {
+    fn test_non_whitespace_text_before_root_is_rejected() {
         let mut reader = XmlReader::new();
 
-        reader.feed(b"</garbage>").expect("feed ok");
-        assert!(!reader.is_complete());
+        let error = reader
+            .feed(b"garbage<real_response/>")
+            .expect_err("parse error");
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
 
-        reader.feed(b"<real_response/>").expect("feed ok");
+    #[test]
+    fn test_mismatched_closing_tag_is_rejected_across_chunks() {
+        let mut reader = XmlReader::new();
+
+        reader.feed(b"<root><child>").expect("incomplete XML");
+        let error = reader.feed(b"</root></child>").expect_err("parse error");
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
+
+    #[test]
+    fn test_exact_frame_and_tail_are_preserved() {
+        let mut reader = XmlReader::new();
+
+        reader.feed(b"<one/><two/>").expect("feed ok");
+
+        assert_eq!(reader.frame_len(), Some(b"<one/>".len()));
+        assert_eq!(reader.frame(), Some(b"<one/>".as_slice()));
+        assert_eq!(reader.tail(), Some(b"<two/>".as_slice()));
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<one/>".to_vec())
+        );
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<two/>".to_vec())
+        );
+        assert_eq!(reader.take_frame().expect("valid XML"), None);
+    }
+
+    #[test]
+    fn test_exact_boundary_after_resumed_parse() {
+        let mut reader = XmlReader::new();
+
+        reader.feed(b"<root><child>").expect("incomplete XML");
+        reader
+            .feed(b"value</child></root><next/>")
+            .expect("feed ok");
+
+        assert_eq!(
+            reader.frame(),
+            Some(b"<root><child>value</child></root>".as_slice())
+        );
+        assert_eq!(reader.tail(), Some(b"<next/>".as_slice()));
+    }
+
+    #[test]
+    fn test_valid_prefix_is_part_of_frame() {
+        let mut reader = XmlReader::new();
+        let xml = b"<?xml version=\"1.0\"?> \n<!-- comment --><root/>";
+
+        reader.feed(xml).expect("feed ok");
+
+        assert_eq!(reader.frame(), Some(xml.as_slice()));
+        assert_eq!(reader.tail(), Some(b"".as_slice()));
+    }
+
+    #[test]
+    fn test_declaration_after_whitespace_is_rejected() {
+        let mut reader = XmlReader::new();
+        let error = reader
+            .feed(b" \n<?xml version=\"1.0\"?><root/>")
+            .expect_err("misplaced declaration");
+
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
+
+    #[test]
+    fn test_utf8_bom_is_preserved_in_exact_frame() {
+        let mut reader = XmlReader::new();
+        reader
+            .feed(b"\xEF\xBB\xBF<one/><two/>")
+            .expect("BOM-prefixed XML");
+
+        assert_eq!(reader.frame(), Some(b"\xEF\xBB\xBF<one/>".as_slice()));
+        assert_eq!(reader.tail(), Some(b"<two/>".as_slice()));
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"\xEF\xBB\xBF<one/>".to_vec())
+        );
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<two/>".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_split_utf8_bom_is_chunk_safe() {
+        let mut reader = XmlReader::new();
+        for byte in b"\xEF\xBB\xBF<root/>" {
+            reader.feed(&[*byte]).expect("BOM fragment");
+        }
+
+        assert_eq!(reader.frame(), Some(b"\xEF\xBB\xBF<root/>".as_slice()));
+    }
+
+    #[test]
+    fn test_doctype_is_rejected() {
+        let mut reader = XmlReader::new();
+        let error = reader
+            .feed(b"<!DOCTYPE root><root/>")
+            .expect_err("doctype must be rejected");
+
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
+
+    #[test]
+    fn test_invalid_declaration_is_rejected() {
+        let mut reader = XmlReader::new();
+        let error = reader
+            .feed(b"<?xml?><root/>")
+            .expect_err("declaration version is required");
+
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
+
+    #[test]
+    fn test_invalid_processing_instruction_targets_are_rejected() {
+        for xml in [
+            b"<?XML data?><root/>".as_slice(),
+            b"<?1bad?><root/>".as_slice(),
+            b"<?bad!name?><root/>".as_slice(),
+        ] {
+            let mut reader = XmlReader::new();
+            let error = reader.feed(xml).expect_err("invalid PI target");
+            assert!(matches!(error, ProtocolError::XmlParse(_)));
+        }
+
+        let mut valid = XmlReader::new();
+        valid
+            .feed(b"<?gmp instruction?><root/>")
+            .expect("valid PI target");
+        assert!(valid.is_complete());
+    }
+
+    #[test]
+    fn test_invalid_names_and_references_are_rejected() {
+        for xml in [
+            b"<1bad/>".as_slice(),
+            b"<bad!name/>".as_slice(),
+            b"<root>&bogus;</root>".as_slice(),
+            b"<root>&#0;</root>".as_slice(),
+            b"<root value=\"&bogus;\"/>".as_slice(),
+        ] {
+            let mut reader = XmlReader::new();
+            let error = reader.feed(xml).expect_err("malformed XML");
+            assert!(matches!(error, ProtocolError::XmlParse(_)));
+        }
+
+        let mut valid = XmlReader::new();
+        valid
+            .feed(b"<root value=\"&amp;\">&lt;&#65;</root>")
+            .expect("predefined and legal numeric references");
+        assert!(valid.is_complete());
+    }
+
+    #[test]
+    fn test_xml_illegal_characters_are_rejected() {
+        for xml in [
+            b"\x0B<root/>".as_slice(),
+            "\u{A0}<root/>".as_bytes(),
+            b"<root>\x0B</root>".as_slice(),
+            b"<root><![CDATA[\x0B]]></root>".as_slice(),
+        ] {
+            let mut reader = XmlReader::new();
+            let error = reader.feed(xml).expect_err("illegal XML character");
+            assert!(matches!(error, ProtocolError::XmlParse(_)));
+        }
+    }
+
+    #[test]
+    fn test_incomplete_utf8_cannot_mask_invalid_prefix() {
+        let data = [0, 0, 2, 2, 0, 0, 52, 0, 127, 223];
+        let mut single = XmlReader::new();
+        assert!(matches!(
+            single.feed(&data),
+            Err(ProtocolError::XmlParse(_))
+        ));
+
+        let mut chunked = XmlReader::new();
+        let mut error = None;
+        for byte in data {
+            if let Err(found) = chunked.feed(&[byte]) {
+                error = Some(found);
+                break;
+            }
+        }
+        assert!(matches!(error, Some(ProtocolError::XmlParse(_))));
+    }
+
+    #[test]
+    fn test_debug_output_redacts_buffer_contents() {
+        let mut reader = XmlReader::new();
+        reader
+            .feed(b"<secret>do-not-log</secret>")
+            .expect("valid XML");
+
+        let debug = format!("{reader:?}");
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("do-not-log"));
+        assert!(debug.contains("buffer_len"));
+    }
+
+    #[test]
+    fn test_depth_limit_is_enforced() {
+        let mut reader = XmlReader::with_limits(None, 2);
+        let error = reader
+            .feed(b"<one><two><three/></two></one>")
+            .expect_err("depth must be bounded");
+
+        assert!(matches!(error, ProtocolError::XmlParse(_)));
+    }
+
+    #[test]
+    fn test_feed_frame_consumes_only_first_frame() {
+        let mut reader = XmlReader::with_max_buffer(6);
+        let input = b"<one/><second-response/>";
+
+        let consumed = reader.feed_frame(input).expect("first frame within limit");
+
+        assert_eq!(consumed, b"<one/>".len());
+        assert_eq!(reader.data(), b"<one/>");
+        assert_eq!(&input[consumed..], b"<second-response/>");
+    }
+
+    #[test]
+    fn test_feed_frame_does_not_discard_a_buffered_tail() {
+        let mut reader = XmlReader::new();
+        reader.feed(b"<one/><two/><three/>").expect("feed ok");
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<one/>".to_vec())
+        );
+
+        assert_eq!(reader.feed_frame(b"<four/>").expect("buffered frame"), 0);
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<two/>".to_vec())
+        );
+        assert_eq!(reader.feed_frame(b"<four/>").expect("buffered frame"), 0);
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<three/>".to_vec())
+        );
+
+        assert_eq!(reader.feed_frame(b"<four/>").expect("new frame"), 7);
+        assert_eq!(
+            reader.take_frame().expect("valid XML"),
+            Some(b"<four/>".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_feed_frame_accepts_exact_limit_and_rejects_incomplete_limit() {
+        let mut exact = XmlReader::with_max_buffer(6);
+        assert_eq!(exact.feed_frame(b"<one/>").expect("exact limit"), 6);
+        assert!(exact.is_complete());
+
+        let mut incomplete = XmlReader::with_max_buffer(6);
+        let error = incomplete
+            .feed_frame(b"<root>")
+            .expect_err("incomplete frame at limit");
+        assert!(matches!(error, ProtocolError::BufferOverflow { max: 6 }));
+    }
+
+    #[test]
+    fn test_incomplete_multibyte_text_across_chunks() {
+        let mut reader = XmlReader::new();
+        let xml = "<root>Grüße</root>".as_bytes();
+        let split = xml.iter().position(|byte| *byte == 0xC3).expect("umlaut") + 1;
+
+        reader.feed(&xml[..split]).expect("incomplete UTF-8");
+        assert!(!reader.is_complete());
+        reader.feed(&xml[split..]).expect("complete UTF-8");
+
         assert!(reader.is_complete());
     }
 }

--- a/crates/gvm-protocol/src/xml_reader.rs
+++ b/crates/gvm-protocol/src/xml_reader.rs
@@ -17,6 +17,252 @@ const DEFAULT_MAX_BUFFER_BYTES: usize = 64 * 1024 * 1024;
 const DEFAULT_MAX_DEPTH: usize = 256;
 const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 
+#[derive(Debug)]
+enum PendingToken {
+    Tag {
+        scan_offset: usize,
+        quote: Option<u8>,
+    },
+    Sequence {
+        scan_offset: usize,
+        terminator: TokenTerminator,
+        matched: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TokenTerminator {
+    ProcessingInstruction,
+    Comment,
+    CData,
+    Reference,
+}
+
+impl PendingToken {
+    fn from_error(error: &XmlError, scan_offset: usize) -> Option<Self> {
+        match error {
+            XmlError::Syntax(
+                SyntaxError::UnclosedTag
+                | SyntaxError::UnclosedSingleQuotedAttributeValue
+                | SyntaxError::UnclosedDoubleQuotedAttributeValue,
+            ) => Some(Self::Tag {
+                scan_offset,
+                quote: None,
+            }),
+            XmlError::Syntax(SyntaxError::UnclosedPI | SyntaxError::UnclosedXmlDecl) => {
+                Some(Self::Sequence {
+                    scan_offset,
+                    terminator: TokenTerminator::ProcessingInstruction,
+                    matched: 0,
+                })
+            }
+            XmlError::Syntax(SyntaxError::UnclosedComment) => Some(Self::Sequence {
+                scan_offset,
+                terminator: TokenTerminator::Comment,
+                matched: 0,
+            }),
+            XmlError::Syntax(SyntaxError::UnclosedCData) => Some(Self::Sequence {
+                scan_offset,
+                terminator: TokenTerminator::CData,
+                matched: 0,
+            }),
+            XmlError::IllFormed(IllFormedError::UnclosedReference) => Some(Self::Sequence {
+                scan_offset,
+                terminator: TokenTerminator::Reference,
+                matched: 0,
+            }),
+            _ => None,
+        }
+    }
+
+    fn scan_until_ready(&mut self, buffer: &[u8]) -> bool {
+        match self {
+            Self::Tag { scan_offset, quote } => {
+                for byte in &buffer[*scan_offset..] {
+                    *scan_offset += 1;
+                    match (*quote, *byte) {
+                        (None, b'\'' | b'"') => *quote = Some(*byte),
+                        (Some(active), current) if active == current => *quote = None,
+                        (None, b'>') => return true,
+                        _ => {}
+                    }
+                }
+                false
+            }
+            Self::Sequence {
+                scan_offset,
+                terminator,
+                matched,
+            } => {
+                let needle = terminator.bytes();
+                for byte in &buffer[*scan_offset..] {
+                    *scan_offset += 1;
+                    while *matched > 0 && needle[*matched] != *byte {
+                        *matched = terminator.fallback(*matched);
+                    }
+                    if needle[*matched] == *byte {
+                        *matched += 1;
+                        if *matched == needle.len() {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
+impl TokenTerminator {
+    fn bytes(self) -> &'static [u8] {
+        match self {
+            Self::ProcessingInstruction => b"?>",
+            Self::Comment => b"-->",
+            Self::CData => b"]]>",
+            Self::Reference => b";",
+        }
+    }
+
+    fn fallback(self, matched: usize) -> usize {
+        match (self, matched) {
+            (Self::Comment | Self::CData, 2) => 1,
+            _ => 0,
+        }
+    }
+}
+
+struct FrameProgress<'a> {
+    max_depth: usize,
+    complete: &'a mut bool,
+    seen_start: &'a mut bool,
+    declaration_allowed: &'a mut bool,
+    resume_offset: &'a mut usize,
+    frame_end: &'a mut Option<usize>,
+    element_names: &'a mut Vec<Vec<u8>>,
+    trailing_text_brackets: &'a mut u8,
+    pending_token: &'a mut Option<PendingToken>,
+}
+
+impl FrameProgress<'_> {
+    fn accept_start(&mut self, element: &BytesStart<'_>) -> Result<(), ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        open_element(element, self.seen_start, self.element_names, self.max_depth)
+    }
+
+    fn accept_end(
+        &mut self,
+        element: &BytesEnd<'_>,
+        buffer: &[u8],
+        parsed_len: usize,
+    ) -> Result<bool, ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        let Some(end) = closing_frame_end(
+            element,
+            self.element_names,
+            buffer,
+            *self.resume_offset,
+            parsed_len,
+        )?
+        else {
+            return Ok(false);
+        };
+        *self.complete = true;
+        *self.frame_end = Some(end);
+        Ok(true)
+    }
+
+    fn accept_empty(
+        &mut self,
+        element: &BytesStart<'_>,
+        buffer: &[u8],
+        parsed_len: usize,
+    ) -> Result<bool, ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        let Some(end) = empty_frame_end(
+            element,
+            *self.seen_start,
+            self.element_names.len(),
+            self.max_depth,
+            buffer,
+            *self.resume_offset,
+            parsed_len,
+        )?
+        else {
+            return Ok(false);
+        };
+        *self.seen_start = true;
+        *self.complete = true;
+        *self.frame_end = Some(end);
+        Ok(true)
+    }
+
+    fn accept_text(
+        &mut self,
+        text: &BytesText<'_>,
+        parsed_len: usize,
+    ) -> Result<bool, ProtocolError> {
+        if !validate_text(
+            text,
+            *self.seen_start,
+            self.declaration_allowed,
+            self.trailing_text_brackets,
+        )? {
+            return Ok(false);
+        }
+        *self.resume_offset += parsed_len;
+        Ok(true)
+    }
+
+    fn accept_declaration(&mut self, declaration: &BytesDecl<'_>) -> Result<(), ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        accept_declaration(declaration, *self.seen_start, self.declaration_allowed)
+    }
+
+    fn accept_comment(&mut self, comment: &[u8]) -> Result<(), ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        validate_misc(comment, *self.seen_start, self.declaration_allowed)
+    }
+
+    fn accept_processing_instruction(&mut self, instruction: &[u8]) -> Result<(), ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        validate_processing_instruction(instruction, *self.seen_start, self.declaration_allowed)
+    }
+
+    fn accept_reference(&mut self, reference: &BytesRef<'_>) -> Result<(), ProtocolError> {
+        *self.trailing_text_brackets = 0;
+        if !*self.seen_start {
+            return Err(xml_parse_error("entity reference before root element"));
+        }
+        validate_reference(reference)
+    }
+
+    fn suspend_eof(&mut self, parsed_len: usize) {
+        *self.resume_offset += parsed_len;
+    }
+
+    fn suspend_incomplete_token(
+        &mut self,
+        error: &XmlError,
+        parsed_len: usize,
+        buffer: &[u8],
+    ) -> Result<(), ProtocolError> {
+        if matches!(error, XmlError::Syntax(SyntaxError::UnclosedDoctype)) {
+            return Err(xml_parse_error("DOCTYPE declarations are not supported"));
+        }
+        if !is_incomplete_xml_error(error) {
+            return Err(xml_parse_error(error));
+        }
+
+        *self.resume_offset += parsed_len;
+        if let Some(mut token) = PendingToken::from_error(error, *self.resume_offset) {
+            let ready = token.scan_until_ready(buffer);
+            debug_assert!(!ready, "quick-xml reported a complete token as incomplete");
+            *self.pending_token = Some(token);
+        }
+        Ok(())
+    }
+}
+
 /// Streaming XML reader that detects when a complete XML root element has been received.
 ///
 /// Feed data incrementally via [`XmlReader::feed`] and check [`XmlReader::is_complete`] to know when
@@ -31,6 +277,8 @@ pub struct XmlReader {
     resume_offset: usize,
     frame_end: Option<usize>,
     element_names: Vec<Vec<u8>>,
+    trailing_text_brackets: u8,
+    pending_token: Option<PendingToken>,
 }
 
 impl std::fmt::Debug for XmlReader {
@@ -43,6 +291,7 @@ impl std::fmt::Debug for XmlReader {
             .field("complete", &self.complete)
             .field("frame_end", &self.frame_end)
             .field("depth", &self.element_names.len())
+            .field("pending_token", &self.pending_token.is_some())
             .finish()
     }
 }
@@ -79,6 +328,8 @@ impl XmlReader {
             resume_offset: 0,
             frame_end: None,
             element_names: Vec::new(),
+            trailing_text_brackets: 0,
+            pending_token: None,
         }
     }
 
@@ -218,6 +469,38 @@ impl XmlReader {
         self.resume_offset = 0;
         self.frame_end = None;
         self.element_names.clear();
+        self.trailing_text_brackets = 0;
+        self.pending_token = None;
+    }
+
+    fn frame_progress(&mut self) -> (&[u8], FrameProgress<'_>) {
+        let Self {
+            buffer,
+            max_depth,
+            complete,
+            seen_start,
+            declaration_allowed,
+            resume_offset,
+            frame_end,
+            element_names,
+            trailing_text_brackets,
+            pending_token,
+            ..
+        } = self;
+        (
+            buffer,
+            FrameProgress {
+                max_depth: *max_depth,
+                complete,
+                seen_start,
+                declaration_allowed,
+                resume_offset,
+                frame_end,
+                element_names,
+                trailing_text_brackets,
+                pending_token,
+            },
+        )
     }
 
     fn check_complete(&mut self) -> Result<(), ProtocolError> {
@@ -225,101 +508,74 @@ impl XmlReader {
             return Ok(());
         }
 
-        let unparsed = &self.buffer[self.resume_offset..];
-        let bom_len =
-            usize::from(self.resume_offset == 0 && unparsed.starts_with(UTF8_BOM)) * UTF8_BOM.len();
+        if let Some(token) = &mut self.pending_token {
+            if !token.scan_until_ready(&self.buffer) {
+                return Ok(());
+            }
+            self.pending_token = None;
+        }
+
+        let (buffer, mut progress) = self.frame_progress();
+        let unparsed = &buffer[*progress.resume_offset..];
+        let bom_len = usize::from(*progress.resume_offset == 0 && unparsed.starts_with(UTF8_BOM))
+            * UTF8_BOM.len();
         let mut reader = configured_reader(unparsed);
         let (mut event_buf, mut parsed_len) = (Vec::new(), 0_usize);
 
         loop {
             match reader.read_event_into(&mut event_buf) {
                 Ok(Event::Start(element)) => {
-                    open_element(
-                        &element,
-                        &mut self.seen_start,
-                        &mut self.element_names,
-                        self.max_depth,
-                    )?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
+                    progress.accept_start(&element)?;
                 }
                 Ok(Event::End(element)) => {
                     parsed_len = bom_len + reader.buffer_position() as usize;
-                    if close_element(&element, &mut self.element_names)? {
-                        let frame_end =
-                            validated_frame_end(&self.buffer, self.resume_offset, parsed_len)?;
-                        self.complete = true;
-                        self.frame_end = Some(frame_end);
+                    if progress.accept_end(&element, buffer, parsed_len)? {
                         return Ok(());
                     }
                 }
                 Ok(Event::Empty(element)) => {
                     parsed_len = bom_len + reader.buffer_position() as usize;
-                    validate_empty_element(&element, self.element_names.len(), self.max_depth)?;
-                    if !self.seen_start {
-                        let frame_end =
-                            validated_frame_end(&self.buffer, self.resume_offset, parsed_len)?;
-                        self.seen_start = true;
-                        self.complete = true;
-                        self.frame_end = Some(frame_end);
+                    if progress.accept_empty(&element, buffer, parsed_len)? {
                         return Ok(());
                     }
                 }
                 Ok(Event::Text(text)) => {
-                    if validate_text(&text, self.seen_start, &mut self.declaration_allowed)? {
-                        self.resume_offset += parsed_len;
+                    if progress.accept_text(&text, parsed_len)? {
                         return Ok(());
                     }
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::CData(data)) => {
-                    validate_cdata(data.as_ref(), self.seen_start)?;
+                    *progress.trailing_text_brackets = 0;
+                    validate_cdata(data.as_ref(), *progress.seen_start)?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::DocType(_)) => {
                     return Err(xml_parse_error("DOCTYPE declarations are not supported"));
                 }
                 Ok(Event::Decl(declaration)) => {
-                    accept_declaration(
-                        &declaration,
-                        self.seen_start,
-                        &mut self.declaration_allowed,
-                    )?;
+                    progress.accept_declaration(&declaration)?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::Comment(comment)) => {
-                    validate_misc(
-                        comment.as_ref(),
-                        self.seen_start,
-                        &mut self.declaration_allowed,
-                    )?;
+                    progress.accept_comment(comment.as_ref())?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::PI(instruction)) => {
-                    validate_processing_instruction(
-                        instruction.as_ref(),
-                        self.seen_start,
-                        &mut self.declaration_allowed,
-                    )?;
+                    progress.accept_processing_instruction(instruction.as_ref())?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::GeneralRef(reference)) => {
-                    if !self.seen_start {
-                        return Err(xml_parse_error("entity reference before root element"));
-                    }
-                    validate_reference(&reference)?;
+                    progress.accept_reference(&reference)?;
                     parsed_len = bom_len + reader.buffer_position() as usize;
                 }
                 Ok(Event::Eof) => {
-                    self.resume_offset += parsed_len;
+                    progress.suspend_eof(parsed_len);
                     return Ok(());
                 }
                 Err(error) => {
-                    if !is_incomplete_xml_error(&error) {
-                        return Err(xml_parse_error(error));
-                    }
-
-                    self.resume_offset += parsed_len;
-                    return Ok(());
+                    return progress.suspend_incomplete_token(&error, parsed_len, buffer);
                 }
             }
 
@@ -421,6 +677,18 @@ fn close_element(
     Ok(element_names.is_empty())
 }
 
+fn closing_frame_end(
+    element: &BytesEnd<'_>,
+    element_names: &mut Vec<Vec<u8>>,
+    buffer: &[u8],
+    resume_offset: usize,
+    parsed_len: usize,
+) -> Result<Option<usize>, ProtocolError> {
+    close_element(element, element_names)?
+        .then(|| validated_frame_end(buffer, resume_offset, parsed_len))
+        .transpose()
+}
+
 fn validate_empty_element(
     element: &BytesStart<'_>,
     current_depth: usize,
@@ -435,10 +703,26 @@ fn validate_empty_element(
     Ok(())
 }
 
+fn empty_frame_end(
+    element: &BytesStart<'_>,
+    seen_start: bool,
+    current_depth: usize,
+    max_depth: usize,
+    buffer: &[u8],
+    resume_offset: usize,
+    parsed_len: usize,
+) -> Result<Option<usize>, ProtocolError> {
+    validate_empty_element(element, current_depth, max_depth)?;
+    (!seen_start)
+        .then(|| validated_frame_end(buffer, resume_offset, parsed_len))
+        .transpose()
+}
+
 fn validate_text(
     text: &BytesText<'_>,
     seen_start: bool,
     declaration_allowed: &mut bool,
+    trailing_brackets: &mut u8,
 ) -> Result<bool, ProtocolError> {
     let decoded = match std::str::from_utf8(text.as_ref()) {
         Ok(text) => text,
@@ -446,6 +730,7 @@ fn validate_text(
             let prefix = std::str::from_utf8(&text.as_ref()[..error.valid_up_to()])
                 .map_err(xml_parse_error)?;
             validate_xml_chars(prefix)?;
+            validate_character_data(prefix.as_bytes(), trailing_brackets)?;
             if !seen_start && !prefix.chars().all(is_xml_whitespace) {
                 return Err(xml_parse_error("non-whitespace text before root element"));
             }
@@ -458,6 +743,7 @@ fn validate_text(
     };
 
     validate_xml_chars(decoded)?;
+    validate_character_data(decoded.as_bytes(), trailing_brackets)?;
     if !seen_start {
         if !decoded.chars().all(is_xml_whitespace) {
             return Err(xml_parse_error("non-whitespace text before root element"));
@@ -473,6 +759,11 @@ fn validate_start(element: &BytesStart<'_>) -> Result<(), ProtocolError> {
     for attribute in element.attributes() {
         let attribute = attribute.map_err(xml_parse_error)?;
         validate_name(attribute.key.as_ref())?;
+        if attribute.value.contains(&b'<') {
+            return Err(xml_parse_error(
+                "attribute values cannot contain a literal '<'",
+            ));
+        }
         let value = attribute
             .normalized_value(XmlVersion::Implicit1_0)
             .map_err(xml_parse_error)?;
@@ -483,17 +774,70 @@ fn validate_start(element: &BytesStart<'_>) -> Result<(), ProtocolError> {
 
 fn validate_declaration(declaration: &BytesDecl<'_>) -> Result<(), ProtocolError> {
     validate_xml_bytes(declaration.as_ref())?;
-    declaration.xml_version().map_err(xml_parse_error)?;
-    if let Some(encoding) = declaration.encoding() {
-        let encoding = encoding.map_err(xml_parse_error)?;
-        if !encoding.eq_ignore_ascii_case(b"utf-8") {
-            return Err(xml_parse_error("only UTF-8 XML declarations are supported"));
+    let content = std::str::from_utf8(declaration.as_ref()).map_err(xml_parse_error)?;
+    let start = BytesStart::from_content(content, b"xml".len());
+    let mut fields = 0_usize;
+    let mut saw_encoding = false;
+
+    for attribute in start.attributes() {
+        let attribute = attribute.map_err(xml_parse_error)?;
+        if attribute.value.contains(&b'<') {
+            return Err(xml_parse_error(
+                "XML declaration values cannot contain a literal '<'",
+            ));
         }
+
+        match (fields, attribute.key.as_ref()) {
+            (0, b"version") if attribute.value.as_ref() == b"1.0" => {}
+            (0, b"version") => {
+                return Err(xml_parse_error("only XML version 1.0 is supported"));
+            }
+            (0, _) => {
+                return Err(xml_parse_error(
+                    "version must be the first XML declaration attribute",
+                ));
+            }
+            (1, b"encoding") if attribute.value.eq_ignore_ascii_case(b"utf-8") => {
+                saw_encoding = true;
+            }
+            (1, b"encoding") => {
+                return Err(xml_parse_error("only UTF-8 XML declarations are supported"));
+            }
+            (1, b"standalone") if matches!(attribute.value.as_ref(), b"yes" | b"no") => {}
+            (2, b"standalone")
+                if saw_encoding && matches!(attribute.value.as_ref(), b"yes" | b"no") => {}
+            (_, b"standalone") => {
+                return Err(xml_parse_error(
+                    "standalone must follow version and optional encoding and be 'yes' or 'no'",
+                ));
+            }
+            (_, b"encoding") => {
+                return Err(xml_parse_error(
+                    "encoding must follow version and precede standalone",
+                ));
+            }
+            (_, b"version") => {
+                return Err(xml_parse_error("version may appear only once"));
+            }
+            _ => return Err(xml_parse_error("unknown XML declaration attribute")),
+        }
+        fields += 1;
     }
-    if let Some(standalone) = declaration.standalone() {
-        let standalone = standalone.map_err(xml_parse_error)?;
-        if standalone.as_ref() != b"yes" && standalone.as_ref() != b"no" {
-            return Err(xml_parse_error("standalone must be 'yes' or 'no'"));
+
+    if fields == 0 {
+        return Err(xml_parse_error("XML declaration version is required"));
+    }
+    Ok(())
+}
+
+fn validate_character_data(data: &[u8], trailing_brackets: &mut u8) -> Result<(), ProtocolError> {
+    for byte in data {
+        match *byte {
+            b']' => *trailing_brackets = trailing_brackets.saturating_add(1).min(2),
+            b'>' if *trailing_brackets == 2 => {
+                return Err(xml_parse_error("character data cannot contain ']]>'"));
+            }
+            _ => *trailing_brackets = 0,
         }
     }
     Ok(())
@@ -603,6 +947,21 @@ fn is_incomplete_xml_error(error: &XmlError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_rejected_single_and_byte_chunks(xml: &[u8]) {
+        let mut single = XmlReader::new();
+        assert!(matches!(single.feed(xml), Err(ProtocolError::XmlParse(_))));
+
+        let mut chunked = XmlReader::new();
+        let mut error = None;
+        for byte in xml {
+            if let Err(found) = chunked.feed(&[*byte]) {
+                error = Some(found);
+                break;
+            }
+        }
+        assert!(matches!(error, Some(ProtocolError::XmlParse(_))));
+    }
 
     // XMLR-001
     #[test]
@@ -837,6 +1196,39 @@ mod tests {
     }
 
     #[test]
+    fn test_declaration_grammar_is_strict_across_chunks() {
+        for xml in [
+            br#"<?xml version="1.0" bogus="x"?><root/>"#.as_slice(),
+            br#"<?xml version="1.0" standalone="yes" encoding="UTF-8"?><root/>"#.as_slice(),
+            br#"<?xml version="1.0" version="1.1"?><root/>"#.as_slice(),
+            br#"<?xml version="1.1"?><root/>"#.as_slice(),
+        ] {
+            assert_rejected_single_and_byte_chunks(xml);
+        }
+
+        for xml in [
+            br#"<?xml version="1.0"?><root/>"#.as_slice(),
+            br#"<?xml version="1.0" encoding="UTF-8"?><root/>"#.as_slice(),
+            br#"<?xml version="1.0" standalone="no"?><root/>"#.as_slice(),
+            br#"<?xml version="1.0" encoding="utf-8" standalone="yes"?><root/>"#.as_slice(),
+        ] {
+            let mut reader = XmlReader::new();
+            reader.feed(xml).expect("valid XML 1.0 declaration");
+            assert!(reader.is_complete());
+        }
+    }
+
+    #[test]
+    fn test_forbidden_character_data_and_attribute_literals_are_rejected() {
+        for xml in [
+            b"<root>]]></root>".as_slice(),
+            br#"<root a="x<y"/>"#.as_slice(),
+        ] {
+            assert_rejected_single_and_byte_chunks(xml);
+        }
+    }
+
+    #[test]
     fn test_invalid_processing_instruction_targets_are_rejected() {
         for xml in [
             b"<?XML data?><root/>".as_slice(),
@@ -983,6 +1375,25 @@ mod tests {
             .feed_frame(b"<root>")
             .expect_err("incomplete frame at limit");
         assert!(matches!(error, ProtocolError::BufferOverflow { max: 6 }));
+    }
+
+    #[test]
+    fn test_incomplete_attribute_scanner_advances_only_over_new_bytes() {
+        let mut reader = XmlReader::new();
+        reader.feed(br#"<root value=""#).expect("incomplete tag");
+
+        for _ in 0..1_024 {
+            reader.feed(&[b'a'; 64]).expect("incomplete attribute");
+            let scan_offset = match reader.pending_token.as_ref() {
+                Some(PendingToken::Tag { scan_offset, .. }) => *scan_offset,
+                token => panic!("expected pending tag, got {token:?}"),
+            };
+            assert_eq!(scan_offset, reader.buffer.len());
+        }
+
+        reader.feed(br#""/>"#).expect("completed tag");
+        assert!(reader.is_complete());
+        assert!(reader.pending_token.is_none());
     }
 
     #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -196,6 +196,8 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | `--version 22.4\|22.5\|22.6\|22.7` | ✅ |
 | `--socket <path>` | ✅ |
 | `--tcp <addr:port>` | ✅ |
+| `--max-request-bytes <bytes>` | ✅ (64 MiB default) |
+| XML nesting limit | ✅ (256 elements) |
 | Cross-platform binaries | ✅ (5 targets in CI) |
 | GHCR release image | ✅ `ghcr.io/clawosiris/gvm-mock-server:<tag>` |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,13 +12,13 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|
-| `gvm-protocol` | ✅ Implemented | ~2,190 | 67 | XML command builder, response parser, streaming reader |
+| `gvm-protocol` | ✅ Implemented | ~2,330 | 67 | XML command builder, response parser, streaming reader |
 | `gvm-mock-server` | ✅ Implemented | ~5,850 | 266 | Programmable mock GMP server |
 | `gvm-connection` | ✅ Unix + SSH done | ~1,070 | 45 | Async transport layer (Unix socket + SSH implemented) |
 | `gvm-gmp` | ✅ Implemented | ~19,800 | 838 | Typed GMP command builders and response models |
 | `gvm-client` | ✅ Implemented | ~3,590 | 62 | High-level async client with version negotiation and typed methods |
 
-**Total: ~32,500 lines of Rust, 1,278 tests**
+**Total: ~32,640 lines of Rust, 1,278 tests**
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-05-25
+Last updated: 2026-07-15
 
 ## Support Direction
 
@@ -12,13 +12,13 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|
-| `gvm-protocol` | ✅ Implemented | ~860 | 37 | XML command builder, response parser, streaming reader |
-| `gvm-mock-server` | ✅ Implemented | ~3,600 | 198 | Programmable mock GMP server |
-| `gvm-connection` | ✅ Unix + SSH done | ~640 | 20 | Async transport layer (Unix socket + SSH implemented) |
-| `gvm-gmp` | ✅ Implemented | ~4,430 | 480 | Typed GMP command builders (29 modules, 23 enums, full rustdoc) |
-| `gvm-client` | ✅ Implemented | ~950 | 10 | High-level async client with version negotiation and typed methods |
+| `gvm-protocol` | ✅ Implemented | ~2,190 | 67 | XML command builder, response parser, streaming reader |
+| `gvm-mock-server` | ✅ Implemented | ~5,850 | 266 | Programmable mock GMP server |
+| `gvm-connection` | ✅ Unix + SSH done | ~1,070 | 45 | Async transport layer (Unix socket + SSH implemented) |
+| `gvm-gmp` | ✅ Implemented | ~19,800 | 838 | Typed GMP command builders and response models |
+| `gvm-client` | ✅ Implemented | ~3,590 | 62 | High-level async client with version negotiation and typed methods |
 
-**Total: ~10,500 lines of Rust, 633+ tests**
+**Total: ~32,500 lines of Rust, 1,278 tests**
 
 ---
 
@@ -57,6 +57,10 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | Elements with children | ✅ | `<get_tasks_response>...</get_tasks_response>` |
 | Chunked delivery | ✅ | Feed partial data, detect completion |
 | Nested same-name elements | ✅ | `<report><report>...</report></report>` |
+| Exact frame boundaries | ✅ | Preserve coalesced bytes for the next response |
+| Input size limit | ✅ | 64 MiB per frame by default; configurable |
+| Nesting limit | ✅ | 256 elements per frame by default; configurable |
+| Strict XML 1.0 checks | ✅ | Reject malformed declarations, names, references, and forbidden literals |
 | Reset for reuse | ✅ | `reader.reset()` |
 
 ---
@@ -197,7 +201,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | `--socket <path>` | ✅ |
 | `--tcp <addr:port>` | ✅ |
 | `--max-request-bytes <bytes>` | ✅ (64 MiB default) |
-| XML nesting limit | ✅ (256 elements) |
+| XML nesting limit | ✅ (256 elements per frame; enforced across protocol, client, and mock readers) |
 | Cross-platform binaries | ✅ (5 targets in CI) |
 | GHCR release image | ✅ `ghcr.io/clawosiris/gvm-mock-server:<tag>` |
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,8 +76,9 @@ dependencies = [
 
 [[package]]
 name = "gvm-gmp"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
+ "base64",
  "gvm-protocol",
  "quick-xml",
  "serde",
@@ -80,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-protocol"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "quick-xml",
  "thiserror",
@@ -129,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -41,7 +41,7 @@ cargo +nightly fuzz run fuzz_streaming_reader
 | `fuzz_xml_parser` | P0 | Tests `gvm-protocol::Response` construction from arbitrary bytes |
 | `fuzz_response_parser` | P0 | Tests typed response parsers in `gvm-gmp::responses` |
 | `fuzz_xml_node_builder` | P1 | Grammar-based fuzzing of `parse_document()` with structured XML |
-| `fuzz_streaming_reader` | P1 | Tests `XmlReader` with chunked input delivery patterns |
+| `fuzz_streaming_reader` | P1 | Checks exact frame extraction and single-vs-chunked equivalence for `XmlReader` |
 
 ## Corpus
 

--- a/fuzz/fuzz_targets/fuzz_streaming_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_streaming_reader.rs
@@ -56,8 +56,7 @@ struct ChunkedXmlInput {
 }
 
 impl ChunkedXmlInput {
-    fn chunk_boundaries(&self) -> Vec<usize> {
-        let len = self.data.len();
+    fn chunk_boundaries(&self, len: usize) -> Vec<usize> {
         if len == 0 {
             return vec![0];
         }
@@ -89,50 +88,152 @@ impl ChunkedXmlInput {
     }
 }
 
-fuzz_target!(|input: ChunkedXmlInput| {
-    // Create reader with optional buffer limit
-    let mut reader = match input.max_buffer {
+#[derive(Debug, PartialEq, Eq)]
+enum ReaderOutcome {
+    Error,
+    Parsed {
+        frames: Vec<Vec<u8>>,
+        remainder: Vec<u8>,
+    },
+}
+
+fn new_reader(max_buffer: Option<usize>) -> XmlReader {
+    match max_buffer {
         Some(max) => XmlReader::with_max_buffer(max),
         None => XmlReader::new(),
-    };
+    }
+}
 
-    let boundaries = input.chunk_boundaries();
-    let mut prev = 0;
+fn run_aggregate_reader(input: &ChunkedXmlInput, boundaries: &[usize]) -> ReaderOutcome {
+    let mut reader = new_reader(input.max_buffer);
+    let mut previous = 0;
 
-    for boundary in boundaries {
-        if boundary > input.data.len() {
-            break;
+    for &boundary in boundaries {
+        if boundary > input.data.len() || boundary < previous {
+            return ReaderOutcome::Error;
         }
 
-        let chunk = &input.data[prev..boundary];
-        prev = boundary;
-
-        // Feed chunk — errors are expected for malformed XML or buffer overflow
-        match reader.feed(chunk) {
-            Ok(()) => {
-                // Check completion state — should never panic
-                let _ = reader.is_complete();
-            }
-            Err(_) => {
-                // Error is acceptable (malformed XML, buffer overflow, etc.)
-                // Just ensure we don't panic
-                break;
-            }
+        if reader.feed(&input.data[previous..boundary]).is_err() {
+            return ReaderOutcome::Error;
         }
+        previous = boundary;
 
-        // If complete, verify we can access data without panic
-        if reader.is_complete() {
-            let _ = reader.data();
-            break;
+        if let Some(frame_len) = reader.frame_len() {
+            assert!(frame_len <= reader.data().len());
+            assert_eq!(reader.frame().map(<[u8]>::len), Some(frame_len));
+            assert_eq!(
+                reader.tail().map(<[u8]>::len),
+                Some(reader.data().len() - frame_len)
+            );
         }
     }
 
-    // Final state checks — should never panic
-    let _ = reader.is_complete();
-    let _ = reader.data();
+    let mut frames = Vec::new();
+    loop {
+        match reader.take_frame() {
+            Ok(Some(frame)) => {
+                assert!(!frame.is_empty());
+                frames.push(frame);
+            }
+            Ok(None) => break,
+            Err(_) => return ReaderOutcome::Error,
+        }
+    }
 
-    // Test reset doesn't panic
+    let remainder = reader.data().to_vec();
+    let mut reconstructed = frames.concat();
+    reconstructed.extend_from_slice(&remainder);
+    assert_eq!(reconstructed, input.data);
+
     reader.reset();
     assert!(!reader.is_complete());
     assert!(reader.data().is_empty());
+
+    ReaderOutcome::Parsed { frames, remainder }
+}
+
+fn run_frame_reader(data: &[u8], max_buffer: Option<usize>, boundaries: &[usize]) -> ReaderOutcome {
+    let mut reader = new_reader(max_buffer);
+    let mut frames = Vec::new();
+    let mut previous = 0;
+
+    for &boundary in boundaries {
+        if boundary > data.len() || boundary < previous {
+            return ReaderOutcome::Error;
+        }
+
+        let mut offset = previous;
+        while offset < boundary {
+            let available = boundary - offset;
+            let consumed = match reader.feed_frame(&data[offset..boundary]) {
+                Ok(consumed) => consumed,
+                Err(_) => return ReaderOutcome::Error,
+            };
+            assert!(consumed <= available);
+            offset += consumed;
+
+            match reader.take_frame() {
+                Ok(Some(frame)) => {
+                    assert!(!frame.is_empty());
+                    assert!(consumed > 0, "a completed frame must make progress");
+                    frames.push(frame);
+                }
+                Ok(None) => {
+                    assert_eq!(
+                        offset, boundary,
+                        "an incomplete frame must consume the available chunk"
+                    );
+                }
+                Err(_) => return ReaderOutcome::Error,
+            }
+        }
+        previous = boundary;
+    }
+
+    let remainder = reader.data().to_vec();
+    let mut reconstructed = frames.concat();
+    reconstructed.extend_from_slice(&remainder);
+    assert_eq!(reconstructed, data);
+
+    ReaderOutcome::Parsed { frames, remainder }
+}
+
+fn well_formed_frames(seed: &[u8]) -> Vec<u8> {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    if seed.is_empty() {
+        return b"<frame/>".to_vec();
+    }
+
+    let mut xml = Vec::with_capacity(seed.len().saturating_mul(2).saturating_add(512));
+    for chunk in seed.chunks(32) {
+        xml.extend_from_slice(b"<frame>");
+        for byte in chunk {
+            xml.push(HEX[(byte >> 4) as usize]);
+            xml.push(HEX[(byte & 0x0f) as usize]);
+        }
+        xml.extend_from_slice(b"</frame>");
+    }
+    xml
+}
+
+fuzz_target!(|input: ChunkedXmlInput| {
+    let raw_boundaries = input.chunk_boundaries(input.data.len());
+
+    // Arbitrary malformed input is a no-panic, bounds, and reconstruction
+    // exercise. A streaming parser may reject an incomplete malformed prefix
+    // earlier than a single-chunk parser, so error timing is not compared.
+    let _ = run_aggregate_reader(&input, &raw_boundaries);
+    let _ = run_aggregate_reader(&input, &[input.data.len()]);
+    let _ = run_frame_reader(&input.data, input.max_buffer, &raw_boundaries);
+    let _ = run_frame_reader(&input.data, input.max_buffer, &[input.data.len()]);
+
+    // For complete well-formed frame sequences, production `feed_frame`
+    // behavior must be independent of transport chunk boundaries.
+    let valid = well_formed_frames(&input.data);
+    let valid_boundaries = input.chunk_boundaries(valid.len());
+    let chunked = run_frame_reader(&valid, input.max_buffer, &valid_boundaries);
+    let single = run_frame_reader(&valid, input.max_buffer, &[valid.len()]);
+
+    assert_eq!(chunked, single);
 });


### PR DESCRIPTION
## Summary

- preserve exact first-frame boundaries and coalesced response tails across the protocol reader and Unix/SSH clients
- apply the 64 MiB default byte limit and 256-element nesting limit independently to each XML frame, with additive configuration APIs
- reject malformed XML 1.0 constructs early, including invalid declarations/names/references, DOCTYPEs, reserved PI targets, literal `<` in attributes, and `]]>` in character data
- avoid repeated rescanning of incomplete tags, declarations, comments, CDATA, and references by tracking linear parser progress across chunks
- process fragmented and coalesced commands on mock Unix/TCP/SSH sessions; malformed or oversized requests receive a generic 400 response and close only the affected session
- reset buffered tails on reconnect and invalidate a client connection after a framing/protocol error

## Compatibility and scope

The public API changes are additive. Existing constructors retain a 64 MiB per-frame default, while callers can select a custom or disabled byte limit. XML depth remains bounded at 256 elements by default.

This PR addresses XML framing and bounded transport input. It does not add application-level report streaming or change GMP command/response models.

Refs #172

## Public evidence

Implementation and validation used only public sources:

- rust-gvm `devel` at `03a0e38118c8ccab538dad145e52eb5163b801b4`
- python-gvm at `2bb100fd03f02e598f046e2032e12550b5b14751`
- the public XML 1.0 grammar and quick-xml behavior represented by the repository's locked `quick-xml` 0.41.0 dependency

Transport behavior was exercised through real Unix sockets and SSH channels against the public `gvm-mock-server`, plus the pinned public python-gvm client lifecycle.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 test --workspace`
- `cargo +1.85.0 check --workspace --all-features`
- pinned public python-gvm Unix integration: all 15 steps passed
- `cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info`
- `cargo deny check`
- `cargo audit`
- `cargo machete`
- `cargo vet`
- `python3 scripts/check_workspace_unsafe.py`
- Semgrep `p/rust`, `p/security-audit`, and `p/secrets`: 0 findings
- `git diff --check`

A randomized fuzz campaign was not run on the final head. The streaming harness compiled earlier in the implementation slice; final-head deterministic regressions cover exact frame/tail reconstruction, single- and multi-chunk malformed input, and linear progress across a long incomplete attribute.

Known baseline warnings: cargo-deny reports unmatched allowances, cargo-audit reports the existing allowed yanked transitive `crypto-bigint 0.7.4` warning through `russh`, and MSRV tests emit pre-existing missing-docs warnings in integration crates. Cargo-vet produced only its known `imports.lock` quote-normalization churn, which was inspected and restored.
