### PR TITLE
Enforce task graph fidelity in the stateful mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ with GMP(connection=conn, transform=EtreeCheckCommandTransform()) as gmp:
     print(targets)
 ```
 
+Stateful task creation requires an existing target. If omitted, the config and
+scanner references use the mock's seeded Full and fast config
+(`daba56c8-73ec-11df-a475-002264764cea`) and OpenVAS scanner
+(`08b69003-5fc2-4037-a479-93b440211c73`). Explicit target, config, scanner,
+and imported-report task IDs must resolve to the expected resource type.
+Referenced resources cannot be deleted while a live task uses them.
+
+Task actions are synchronous mock transitions; they do not run a scanner.
+`start_task` creates one linked report, `stop_task` marks both resources
+Stopped, and `resume_task` continues that same report.
+
 ## Mock Server
 
 The mock server is the most developed component. It's designed to be a drop-in test server for any GMP client library — Rust, Python, Go, or shell scripts.
@@ -249,7 +260,7 @@ The mock server is the most developed component. It's designed to be a drop-in t
 - **4 server modes** — from simple echo to full stateful CRUD
 - **Unix socket, TCP, and TLS listeners** — TLS uses a generated certificate and can optionally require a trusted client certificate
 - **Per-session authentication** — supports python-gvm's two-connection flow (version probe + auth session)
-- **Task lifecycle** — New → Running → Stopped → Done state machine
+- **Task lifecycle** — deterministic New → Running → Stopped transitions with linked report resumption
 - **Fault injection** — disconnect, delay, malformed XML, error codes, truncated responses
 - **Scenario playback** — deterministic scripted sequences for regression tests
 - **Command history** — inspect what the server received after tests

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -2204,7 +2204,12 @@ async fn typed_report_import_uses_mock_server_stateful_create_command() {
         .expect("authenticate should succeed");
     server.clear_history();
 
-    let task_id = EntityId::new("task-import").expect("valid id");
+    let import_task = client
+        .create_import_task("Report Import Task", None)
+        .await
+        .expect("import task should succeed");
+    let task_id = import_task.id;
+    server.clear_history();
     let report_xml = r#"<report id="imported-report"><name>Imported</name></report>"#;
     let created = client
         .import_report(
@@ -2227,7 +2232,7 @@ async fn typed_report_import_uses_mock_server_stateful_create_command() {
         .expect("get_reports should succeed");
     let readback_xml = readback.as_str().expect("response XML should be UTF-8");
     assert!(readback_xml.contains(&format!("id=\"{}\"", created.id)));
-    assert!(readback_xml.contains("<task_id>task-import</task_id>"));
+    assert!(readback_xml.contains(&format!("<task_id>{task_id}</task_id>")));
     assert!(readback_xml.contains("<in_assets>1</in_assets>"));
 
     let history = server.command_history();
@@ -2239,7 +2244,7 @@ async fn typed_report_import_uses_mock_server_stateful_create_command() {
     assert_eq!(
         import_command,
         format!(
-            r#"<create_report><task id="task-import"/><in_assets>1</in_assets>{report_xml}</create_report>"#
+            r#"<create_report><task id="{task_id}"/><in_assets>1</in_assets>{report_xml}</create_report>"#
         )
     );
 
@@ -2332,10 +2337,10 @@ async fn full_crud_lifecycle_succeeds() {
         .expect("create_target should succeed");
     let target_id = target_response.id().expect("target id");
 
-    let config_id = "550e8400-e29b-41d4-a716-446655440001"
+    let config_id = "daba56c8-73ec-11df-a475-002264764cea"
         .parse()
         .expect("entity id");
-    let scanner_id = "550e8400-e29b-41d4-a716-446655440002"
+    let scanner_id = "08b69003-5fc2-4037-a479-93b440211c73"
         .parse()
         .expect("entity id");
     let target_entity_id = target_id.parse().expect("entity id");
@@ -2457,10 +2462,10 @@ async fn typed_trashcan_helpers_restore_deleted_task() {
         .await
         .expect("create_target should succeed");
     let target_id = target_response.id;
-    let config_id = "550e8400-e29b-41d4-a716-446655440001"
+    let config_id = "daba56c8-73ec-11df-a475-002264764cea"
         .parse()
         .expect("entity id");
-    let scanner_id = "550e8400-e29b-41d4-a716-446655440002"
+    let scanner_id = "08b69003-5fc2-4037-a479-93b440211c73"
         .parse()
         .expect("entity id");
 
@@ -2525,10 +2530,10 @@ async fn typed_resume_task_returns_report_id() {
         .expect("create_target should succeed");
     let target_id = target_response.id;
 
-    let config_id = "550e8400-e29b-41d4-a716-446655440001"
+    let config_id = "daba56c8-73ec-11df-a475-002264764cea"
         .parse()
         .expect("entity id");
-    let scanner_id = "550e8400-e29b-41d4-a716-446655440002"
+    let scanner_id = "08b69003-5fc2-4037-a479-93b440211c73"
         .parse()
         .expect("entity id");
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -2266,7 +2266,11 @@ async fn typed_report_drilldowns_parse_stateful_mock_responses() {
         .await
         .expect("authenticate should succeed");
 
-    let task_id = EntityId::new("task-drilldown").expect("valid id");
+    let task_id = client
+        .create_import_task("Report Drilldown Task", None)
+        .await
+        .expect("import task should succeed")
+        .id;
     let created = client
         .import_report(
             r#"<report id="drilldown-report"><name>Drilldown</name></report>"#,

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::print_stderr, missing_docs)]
 #![cfg(feature = "unix-socket-tests")]
 
-use gvm_client::GmpNext;
 use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
     CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
@@ -13,6 +12,7 @@ use gvm_client::{
     GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
     ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
+use gvm_client::{GmpClient, GmpNext};
 use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
 use gvm_gmp::commands::credentials::{create_credential, verify_credential_store, CredentialOpts};
@@ -47,16 +47,33 @@ fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
     UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
 }
 
+async fn delete_task(server: &MockGmpServer, task_id: &EntityId) {
+    let mut client = GmpClient::connect(unix_connection(server))
+        .await
+        .expect("task cleanup client should connect");
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("task cleanup authentication should succeed");
+    client
+        .call(gvm_gmp::commands::tasks::delete_task(task_id, true))
+        .await
+        .expect("delete referencing task should succeed");
+}
+
 async fn assert_create_agent_group_task_round_trip<C>(
     client: &mut GmpNext<C>,
     server: &MockGmpServer,
     agent_group_id: &EntityId,
-) where
+) -> EntityId
+where
     C: GvmConnection + Send,
 {
     server.clear_history();
 
-    let scanner_id = EntityId::new("scanner-1").expect("valid id");
+    let scanner_id = EntityId::new("08b69003-5fc2-4037-a479-93b440211c73").expect("valid id");
     let task_response = client
         .create_agent_group_task(
             "Client Agent Group Task",
@@ -79,22 +96,24 @@ async fn assert_create_agent_group_task_round_trip<C>(
     assert_eq!(
         String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8"),
         format!(
-            "<create_task><name>Client Agent Group Task</name><usage_type>scan</usage_type><agent_group id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
+            "<create_task><name>Client Agent Group Task</name><usage_type>scan</usage_type><agent_group id=\"{}\"/><scanner id=\"08b69003-5fc2-4037-a479-93b440211c73\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
             agent_group_id.as_str()
         )
     );
+    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
 }
 
 async fn assert_create_oci_image_target_task_round_trip<C>(
     client: &mut GmpNext<C>,
     server: &MockGmpServer,
     oci_image_target_id: &EntityId,
-) where
+) -> EntityId
+where
     C: GvmConnection + Send,
 {
     server.clear_history();
 
-    let scanner_id = id("scanner-1");
+    let scanner_id = id("08b69003-5fc2-4037-a479-93b440211c73");
     let task_response = client
         .create_container_image_task(
             "Client OCI Target Task",
@@ -117,19 +136,20 @@ async fn assert_create_oci_image_target_task_round_trip<C>(
     assert_eq!(
         String::from_utf8(command.raw_xml().to_vec()).expect("history should be UTF-8"),
         format!(
-            "<create_task><name>Client OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id=\"{}\"/><scanner id=\"scanner-1\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
+            "<create_task><name>Client OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id=\"{}\"/><scanner id=\"08b69003-5fc2-4037-a479-93b440211c73\"/><comment>task through client</comment><alterable>1</alterable></create_task>",
             oci_image_target_id.as_str()
         )
     );
+    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
 }
 
 async fn assert_create_web_application_task_round_trip(
     client: &mut GmpNext<UnixSocketConnection>,
     server: &MockGmpServer,
     target_id: &EntityId,
-) {
+) -> EntityId {
     server.clear_history();
-    let scanner_id = EntityId::new("scanner-web-1").expect("valid id");
+    let scanner_id = EntityId::new("08b69003-5fc2-4037-a479-93b440211c73").expect("valid id");
     let task_response = client
         .create_web_application_task(
             "Client Web Task",
@@ -150,9 +170,10 @@ async fn assert_create_web_application_task_round_trip(
     assert_eq!(
         raw_xml,
         format!(
-            "<create_task><name>Client Web Task</name><usage_type>scan</usage_type><web_application_target id=\"{target_id}\"/><scanner id=\"scanner-web-1\"/><comment>created from versioned client</comment></create_task>"
+            "<create_task><name>Client Web Task</name><usage_type>scan</usage_type><web_application_target id=\"{target_id}\"/><scanner id=\"08b69003-5fc2-4037-a479-93b440211c73\"/><comment>created from versioned client</comment></create_task>"
         )
     );
+    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
 }
 
 #[tokio::test]
@@ -477,7 +498,8 @@ async fn next_client_agent_groups_round_trip() {
     assert_eq!(create_response.status, 201);
     let agent_group_id = create_response.id;
 
-    assert_create_agent_group_task_round_trip(&mut client, &server, &agent_group_id).await;
+    let task_id =
+        assert_create_agent_group_task_round_trip(&mut client, &server, &agent_group_id).await;
 
     let clone_response = client
         .clone_agent_group(&agent_group_id)
@@ -531,6 +553,7 @@ async fn next_client_agent_groups_round_trip() {
         Some("0 */10 * * *")
     );
 
+    delete_task(&server, &task_id).await;
     let delete_response = client
         .delete_agent_group(&agent_group_id, true)
         .await
@@ -775,7 +798,8 @@ async fn next_client_oci_image_targets_round_trip() {
     assert_eq!(create_response.status_code(), Some(201));
     let target_id = EntityId::new(create_response.id().expect("created id")).expect("valid id");
 
-    assert_create_oci_image_target_task_round_trip(&mut client, &server, &target_id).await;
+    let task_id =
+        assert_create_oci_image_target_task_round_trip(&mut client, &server, &target_id).await;
 
     let get_response = client
         .get_oci_image_target(&target_id, Some(true))
@@ -827,6 +851,7 @@ async fn next_client_oci_image_targets_round_trip() {
     );
     assert!(modified_xml.contains("<credential_id>credential-oci-2</credential_id>"));
 
+    delete_task(&server, &task_id).await;
     let delete_response = client
         .delete_oci_image_target(&target_id, true)
         .await
@@ -896,7 +921,8 @@ async fn next_client_web_application_targets_round_trip() {
     assert!(get_xml.contains("<exclude_urls>https://example.com/logout</exclude_urls>"));
     assert!(get_xml.contains("<credential_id>credential-web-1</credential_id>"));
 
-    assert_create_web_application_task_round_trip(&mut client, &server, &target_id).await;
+    let task_id =
+        assert_create_web_application_task_round_trip(&mut client, &server, &target_id).await;
 
     let clone_response = client
         .clone_web_application_target(&target_id)
@@ -937,6 +963,7 @@ async fn next_client_web_application_targets_round_trip() {
     assert!(modified_xml.contains("<exclude_urls>https://updated.example/logout</exclude_urls>"));
     assert!(modified_xml.contains("<credential_id>credential-web-2</credential_id>"));
 
+    delete_task(&server, &task_id).await;
     let delete_response = client
         .delete_web_application_target(&target_id, true)
         .await

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1688,11 +1688,8 @@ fn optional_child_uuid(
 }
 
 fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> {
-    let target_id = cmd
-        .children
-        .iter()
-        .find(|child| child.name == "target")
-        .and_then(|child| child.attributes.get("id"));
+    let target = cmd.children.iter().find(|child| child.name == "target");
+    let target_id = target.and_then(|child| child.attributes.get("id"));
     let specialized_target = specialized_task_target(cmd)?;
     if target_id.map(String::as_str) == Some("0") {
         if specialized_target.is_some() {
@@ -1706,7 +1703,7 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
         });
     }
     if let Some(specialized_target) = specialized_target {
-        if target_id.is_some() {
+        if target.is_some() {
             return Err("A task cannot have multiple target types");
         }
         return Ok(TaskReferences {
@@ -2180,6 +2177,16 @@ mod tests {
         );
         assert_eq!(
             task_reference_updates(&regular_and_specialized),
+            Err("A task cannot have multiple target types")
+        );
+
+        let empty_regular_and_specialized = parse_command(
+            format!("<create_task><target/><agent_group id=\"{agent_group_id}\"/></create_task>")
+                .as_bytes(),
+        )
+        .expect("parse empty regular and specialized targets");
+        assert_eq!(
+            task_references(&empty_regular_and_specialized),
             Err("A task cannot have multiple target types")
         );
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1691,9 +1691,22 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
         .children
         .iter()
         .find(|child| child.name == "target")
-        .and_then(|child| child.attributes.get("id"))
-        .ok_or("A target is required")?;
-    if target_id == "0" {
+        .and_then(|child| child.attributes.get("id"));
+    if target_id.map(String::as_str) == Some("0") {
+        return Ok(TaskReferences {
+            target: None,
+            config: None,
+            scanner: None,
+        });
+    }
+    if target_id.is_none()
+        && cmd.children.iter().any(|child| {
+            matches!(
+                child.name.as_str(),
+                "agent_group" | "oci_image_target" | "web_application_target"
+            )
+        })
+    {
         return Ok(TaskReferences {
             target: None,
             config: None,

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -19,7 +19,10 @@ use crate::response_gen::{
     generate_xml_report_export, is_known_command, LargeReportConfig, REPORT_EXPORT_XML_FORMAT_ID,
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
-use crate::store::{AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, TaskStatus};
+use crate::store::{
+    AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, StoreError,
+    TaskReferenceUpdates, TaskReferences, TaskStatus, DEFAULT_CONFIG_ID, DEFAULT_SCANNER_ID,
+};
 use crate::util::{xml_escape, xml_escape_attr};
 use crate::version::{command_available, GmpVersion};
 use crate::ServerMode;
@@ -547,14 +550,17 @@ impl SessionHandler {
         // Check for clone (copy element)
         if let Some(copy_id) = parse_element_text(raw_xml, "copy") {
             if let Ok(uuid) = Uuid::parse_str(&copy_id) {
-                if let Some(new_id) = store.clone_resource(&uuid) {
-                    return format!(
-                        "<{}_response status=\"201\" \
-                         status_text=\"OK, resource created\" \
-                         id=\"{new_id}\"/>",
-                        cmd.name
-                    )
-                    .into_bytes();
+                match store.clone_typed(&uuid, resource_type) {
+                    Ok(new_id) => {
+                        return format!(
+                            "<{}_response status=\"201\" \
+                             status_text=\"OK, resource created\" \
+                             id=\"{new_id}\"/>",
+                            cmd.name
+                        )
+                        .into_bytes();
+                    }
+                    Err(error) => return store_error_response(&cmd.name, error),
                 }
             }
             return error_response(&cmd.name, 404, "Resource to clone not found");
@@ -732,14 +738,20 @@ impl SessionHandler {
             resource.set_attr("status", TaskStatus::New.as_str());
         }
 
+        let report_task_id = if resource_type == "report" {
+            match optional_child_uuid(cmd, "task") {
+                Ok(task_id) => task_id,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            }
+        } else {
+            None
+        };
+
         if resource_type == "report" {
-            if let Some(task_id) = cmd.child_attr("task", "id") {
-                resource.set_attr("task_id", task_id);
-                if let Ok(task_uuid) = Uuid::parse_str(task_id) {
-                    if let Some(task) = store.get(&task_uuid) {
-                        if let Some(usage_type) = task.attr("usage_type") {
-                            resource.set_attr("usage_type", usage_type);
-                        }
+            if let Some(task_id) = report_task_id {
+                if let Some(task) = store.get_typed(&task_id, "task") {
+                    if let Some(usage_type) = task.attr("usage_type") {
+                        resource.set_attr("usage_type", usage_type);
                     }
                 }
             }
@@ -802,7 +814,23 @@ impl SessionHandler {
             }
         }
 
-        let id = store.create(resource);
+        let id = match resource_type {
+            "task" => {
+                let references = match task_references(cmd) {
+                    Ok(references) => references,
+                    Err(message) => return error_response(&cmd.name, 400, message),
+                };
+                match store.create_task(resource, references) {
+                    Ok(id) => id,
+                    Err(error) => return store_error_response(&cmd.name, error),
+                }
+            }
+            "report" => match store.create_linked_report(resource, report_task_id) {
+                Ok(id) => id,
+                Err(error) => return store_error_response(&cmd.name, error),
+            },
+            _ => store.create(resource),
+        };
         format!(
             "<{}_response status=\"201\" \
              status_text=\"OK, resource created\" \
@@ -846,7 +874,7 @@ impl SessionHandler {
         let id_attr = format!("{resource_type}_id");
         if let Some(id_str) = cmd.attr(&id_attr) {
             if let Ok(uuid) = Uuid::parse_str(id_str) {
-                if let Some(resource) = store.get(&uuid) {
+                if let Some(resource) = store.get_typed(&uuid, resource_type) {
                     if !usage_type_matches(&resource, requested_usage_type) {
                         return error_response(&cmd.name, 404, "Resource not found");
                     }
@@ -979,6 +1007,14 @@ impl SessionHandler {
         let new_credential_store_id = parse_element_text(raw_xml, "credential_store_id");
         let new_vault_id = parse_element_text(raw_xml, "vault_id");
         let new_host_identifier = parse_element_text(raw_xml, "host_identifier");
+        let task_reference_updates = if resource_type == "task" {
+            match task_reference_updates(cmd) {
+                Ok(references) => references,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            }
+        } else {
+            TaskReferenceUpdates::default()
+        };
         let (
             new_service_url,
             new_service_cacert,
@@ -1040,7 +1076,7 @@ impl SessionHandler {
             }
         }
 
-        let modified = store.modify(&uuid, |r| {
+        let update_resource = |r: &mut Resource| {
             if matches!(resource_type, "note" | "override") {
                 if let Some(ref text) = new_text {
                     r.name.clone_from(text);
@@ -1141,7 +1177,17 @@ impl SessionHandler {
                     r.set_attr("status", status);
                 }
             }
-        });
+        };
+
+        if resource_type == "task" {
+            return match store.modify_task(&uuid, task_reference_updates, update_resource) {
+                Ok(()) => format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name)
+                    .into_bytes(),
+                Err(error) => store_error_response(&cmd.name, error),
+            };
+        }
+
+        let modified = store.modify_typed(&uuid, resource_type, update_resource);
 
         if modified {
             format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
@@ -1178,10 +1224,11 @@ impl SessionHandler {
 
         let ultimate = cmd.attr("ultimate") == Some("1");
 
-        if store.delete(&uuid, ultimate) {
-            format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
-        } else {
-            error_response(&cmd.name, 404, "Resource not found")
+        match store.delete_typed(&uuid, resource_type, ultimate) {
+            Ok(()) => {
+                format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
+            }
+            Err(error) => store_error_response(&cmd.name, error),
         }
     }
 
@@ -1193,34 +1240,14 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
-        let (current_status, task_name) = store
-            .get(&uuid)
-            .map(|r| (r.attr("status").map(String::from), r.name))
-            .unwrap_or((None, "Task Report".to_string()));
-
-        match current_status.as_deref() {
-            Some("New") | Some("Stopped") | Some("Done") => {
-                let report_id = Uuid::new_v4();
-                let mut report =
-                    Resource::with_id("report", &format!("Report for {task_name}"), report_id);
-                report.set_attr("task_id", &uuid.to_string());
-                let _ = store.create(report);
-                store.modify(&uuid, |r| {
-                    r.set_attr("status", TaskStatus::Running.as_str());
-                    r.set_attr("report_id", &report_id.to_string());
-                });
-                format!(
-                    "<start_task_response status=\"202\" status_text=\"OK\">\
+        match store.start_task(&uuid) {
+            Ok(report_id) => format!(
+                "<start_task_response status=\"202\" status_text=\"OK\">\
                      <report_id>{report_id}</report_id>\
                      </start_task_response>"
-                )
-                .into_bytes()
-            }
-            Some("Running") | Some("Requested") => {
-                error_response(&cmd.name, 409, "Task is already running")
-            }
-            None => error_response(&cmd.name, 404, "Task not found"),
-            _ => error_response(&cmd.name, 409, "Task cannot be started in current state"),
+            )
+            .into_bytes(),
+            Err(error) => store_error_response(&cmd.name, error),
         }
     }
 
@@ -1232,20 +1259,9 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
-        let current_status = store
-            .get(&uuid)
-            .and_then(|r| r.attr("status").map(String::from));
-
-        match current_status.as_deref() {
-            Some("Running") | Some("Requested") => {
-                store.modify(&uuid, |r| {
-                    r.set_attr("status", TaskStatus::Stopped.as_str());
-                });
-                b"<stop_task_response status=\"200\" status_text=\"OK\"/>".to_vec()
-            }
-            Some("Stopped") => error_response(&cmd.name, 409, "Task is already stopped"),
-            None => error_response(&cmd.name, 404, "Task not found"),
-            _ => error_response(&cmd.name, 409, "Task cannot be stopped in current state"),
+        match store.stop_task(&uuid) {
+            Ok(()) => b"<stop_task_response status=\"200\" status_text=\"OK\"/>".to_vec(),
+            Err(error) => store_error_response(&cmd.name, error),
         }
     }
 
@@ -1257,36 +1273,14 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
-        let (current_status, task_name) = store
-            .get(&uuid)
-            .map(|r| (r.attr("status").map(String::from), r.name))
-            .unwrap_or((None, "Task Report".to_string()));
-
-        match current_status.as_deref() {
-            Some("Stopped") => {
-                let report_id = Uuid::new_v4();
-                let mut report =
-                    Resource::with_id("report", &format!("Report for {task_name}"), report_id);
-                report.set_attr("task_id", &uuid.to_string());
-                let _ = store.create(report);
-                store.modify(&uuid, |r| {
-                    r.set_attr("status", TaskStatus::Running.as_str());
-                    r.set_attr("report_id", &report_id.to_string());
-                });
-                format!(
-                    "<resume_task_response status=\"202\" status_text=\"OK\">\
+        match store.resume_task(&uuid) {
+            Ok(report_id) => format!(
+                "<resume_task_response status=\"202\" status_text=\"OK\">\
                      <report_id>{report_id}</report_id>\
                      </resume_task_response>"
-                )
-                .into_bytes()
-            }
-            Some("Running") => error_response(&cmd.name, 409, "Task is already running"),
-            None => error_response(&cmd.name, 404, "Task not found"),
-            _ => error_response(
-                &cmd.name,
-                409,
-                "Task can only be resumed from Stopped state",
-            ),
+            )
+            .into_bytes(),
+            Err(error) => store_error_response(&cmd.name, error),
         }
     }
 
@@ -1298,12 +1292,11 @@ impl SessionHandler {
             return error_response("restore", 400, "Invalid UUID");
         };
 
-        if store.restore(&uuid) {
-            "<restore_response status=\"200\" status_text=\"OK\"/>"
+        match store.restore_checked(&uuid) {
+            Ok(()) => "<restore_response status=\"200\" status_text=\"OK\"/>"
                 .as_bytes()
-                .to_vec()
-        } else {
-            error_response("restore", 404, "Resource not found in trashcan")
+                .to_vec(),
+            Err(error) => store_error_response("restore", error),
         }
     }
 
@@ -1336,6 +1329,14 @@ impl SessionHandler {
             .collect();
         let count = results.len();
         let results_xml: String = results.iter().map(render_report_result_xml).collect();
+        let report_metadata: String = ["task_id", "status", "usage_type"]
+            .into_iter()
+            .filter_map(|key| {
+                report
+                    .attr(key)
+                    .map(|value| format!("<{key}>{}</{key}>", xml_escape(value)))
+            })
+            .collect();
 
         format!(
             "<{name}_response status=\"200\" status_text=\"OK\">\
@@ -1344,6 +1345,7 @@ impl SessionHandler {
              <comment>{comment}</comment>\
              <creation_time>{creation_time}</creation_time>\
              <modification_time>{modification_time}</modification_time>\
+             {report_metadata}\
              <report id=\"{id}\">\
              <results max=\"100\" start=\"1\">{results_xml}</results>\
              <result_count><full>{count}</full><filtered>{count}</filtered></result_count>\
@@ -1369,7 +1371,7 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
-        if store.get(&report_uuid).is_none() {
+        if store.get_typed(&report_uuid, "report").is_none() {
             return error_response(&cmd.name, 404, "Resource not found");
         }
 
@@ -1655,6 +1657,80 @@ fn usage_type_matches(resource: &Resource, requested_usage_type: Option<&str>) -
     match requested_usage_type {
         Some(usage_type) => resource.attr("usage_type") == Some(usage_type),
         None => true,
+    }
+}
+
+fn optional_child_uuid(
+    cmd: &ParsedCommand,
+    child_name: &'static str,
+) -> Result<Option<Uuid>, &'static str> {
+    let Some(child) = cmd.children.iter().find(|child| child.name == child_name) else {
+        return Ok(None);
+    };
+    let Some(id) = child.attributes.get("id") else {
+        return Err(match child_name {
+            "target" => "Missing target id",
+            "config" => "Missing config id",
+            "scanner" => "Missing scanner id",
+            "task" => "Missing task id",
+            _ => "Missing resource id",
+        });
+    };
+    Uuid::parse_str(id).map(Some).map_err(|_| match child_name {
+        "target" => "Invalid target UUID",
+        "config" => "Invalid config UUID",
+        "scanner" => "Invalid scanner UUID",
+        "task" => "Invalid task UUID",
+        _ => "Invalid resource UUID",
+    })
+}
+
+fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> {
+    let target_id = cmd
+        .children
+        .iter()
+        .find(|child| child.name == "target")
+        .and_then(|child| child.attributes.get("id"))
+        .ok_or("A target is required")?;
+    if target_id == "0" {
+        return Ok(TaskReferences {
+            target: None,
+            config: None,
+            scanner: None,
+        });
+    }
+    let target = optional_child_uuid(cmd, "target")?.ok_or("A target is required")?;
+    let config = optional_child_uuid(cmd, "config")?.unwrap_or(DEFAULT_CONFIG_ID);
+    let scanner = optional_child_uuid(cmd, "scanner")?.unwrap_or(DEFAULT_SCANNER_ID);
+    Ok(TaskReferences {
+        target: Some(target),
+        config: Some(config),
+        scanner: Some(scanner),
+    })
+}
+
+fn task_reference_updates(cmd: &ParsedCommand) -> Result<TaskReferenceUpdates, &'static str> {
+    Ok(TaskReferenceUpdates {
+        target: optional_child_uuid(cmd, "target")?,
+        config: optional_child_uuid(cmd, "config")?,
+        scanner: optional_child_uuid(cmd, "scanner")?,
+    })
+}
+
+fn store_error_response(command_name: &str, error: StoreError) -> Vec<u8> {
+    match error {
+        StoreError::NotFound(resource_type) => {
+            error_response(command_name, 404, &format!("{resource_type} not found"))
+        }
+        StoreError::InUse(resource_type) => {
+            error_response(command_name, 409, &format!("{resource_type} is in use"))
+        }
+        StoreError::InvalidState(message) => error_response(command_name, 409, message),
+        StoreError::Inconsistent(resource_type) => error_response(
+            command_name,
+            409,
+            &format!("Task graph is inconsistent: {resource_type}"),
+        ),
     }
 }
 
@@ -1987,5 +2063,46 @@ fn singularize_resource_type(plural: &str) -> &str {
         "results" => "result",
         s if s.ends_with('s') => &s[..s.len() - 1],
         s => s,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_parser::parse_command;
+
+    #[test]
+    fn optional_child_uuid_reports_specific_missing_and_invalid_ids() {
+        for (child_name, missing_message, invalid_message) in [
+            ("target", "Missing target id", "Invalid target UUID"),
+            ("config", "Missing config id", "Invalid config UUID"),
+            ("scanner", "Missing scanner id", "Invalid scanner UUID"),
+            ("task", "Missing task id", "Invalid task UUID"),
+            ("resource", "Missing resource id", "Invalid resource UUID"),
+        ] {
+            let missing = parse_command(format!("<command><{child_name}/></command>").as_bytes())
+                .expect("parse missing-id command");
+            assert_eq!(
+                optional_child_uuid(&missing, child_name),
+                Err(missing_message)
+            );
+
+            let invalid = parse_command(
+                format!("<command><{child_name} id=\"not-a-uuid\"/></command>").as_bytes(),
+            )
+            .expect("parse invalid-id command");
+            assert_eq!(
+                optional_child_uuid(&invalid, child_name),
+                Err(invalid_message)
+            );
+        }
+    }
+
+    #[test]
+    fn inconsistent_store_errors_are_rendered_as_conflicts() {
+        let response = store_error_response("start_task", StoreError::Inconsistent("task report"));
+        let response = String::from_utf8(response).expect("UTF-8 response");
+        assert!(response.contains("status=\"409\""));
+        assert!(response.contains("Task graph is inconsistent: task report"));
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -20,8 +20,9 @@ use crate::response_gen::{
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 use crate::store::{
-    AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, StoreError,
-    TaskReferenceUpdates, TaskReferences, TaskStatus, DEFAULT_CONFIG_ID, DEFAULT_SCANNER_ID,
+    AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, SpecializedTaskTarget,
+    StoreError, TaskReferenceUpdates, TaskReferences, TaskStatus, DEFAULT_CONFIG_ID,
+    DEFAULT_SCANNER_ID,
 };
 use crate::util::{xml_escape, xml_escape_attr};
 use crate::version::{command_available, GmpVersion};
@@ -1692,25 +1693,27 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
         .iter()
         .find(|child| child.name == "target")
         .and_then(|child| child.attributes.get("id"));
+    let specialized_target = specialized_task_target(cmd)?;
     if target_id.map(String::as_str) == Some("0") {
+        if specialized_target.is_some() {
+            return Err("A task cannot have multiple target types");
+        }
         return Ok(TaskReferences {
             target: None,
+            specialized_target: None,
             config: None,
             scanner: None,
         });
     }
-    if target_id.is_none()
-        && cmd.children.iter().any(|child| {
-            matches!(
-                child.name.as_str(),
-                "agent_group" | "oci_image_target" | "web_application_target"
-            )
-        })
-    {
+    if let Some(specialized_target) = specialized_target {
+        if target_id.is_some() {
+            return Err("A task cannot have multiple target types");
+        }
         return Ok(TaskReferences {
             target: None,
-            config: None,
-            scanner: None,
+            specialized_target: Some(specialized_target),
+            config: optional_child_uuid(cmd, "config")?,
+            scanner: Some(optional_child_uuid(cmd, "scanner")?.ok_or("A scanner is required")?),
         });
     }
     let target = optional_child_uuid(cmd, "target")?.ok_or("A target is required")?;
@@ -1718,17 +1721,51 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
     let scanner = optional_child_uuid(cmd, "scanner")?.unwrap_or(DEFAULT_SCANNER_ID);
     Ok(TaskReferences {
         target: Some(target),
+        specialized_target: None,
         config: Some(config),
         scanner: Some(scanner),
     })
 }
 
 fn task_reference_updates(cmd: &ParsedCommand) -> Result<TaskReferenceUpdates, &'static str> {
+    let target = optional_child_uuid(cmd, "target")?;
+    let specialized_target = specialized_task_target(cmd)?;
+    if target.is_some() && specialized_target.is_some() {
+        return Err("A task cannot have multiple target types");
+    }
     Ok(TaskReferenceUpdates {
-        target: optional_child_uuid(cmd, "target")?,
+        target,
+        specialized_target,
         config: optional_child_uuid(cmd, "config")?,
         scanner: optional_child_uuid(cmd, "scanner")?,
     })
+}
+
+fn specialized_task_target(
+    cmd: &ParsedCommand,
+) -> Result<Option<SpecializedTaskTarget>, &'static str> {
+    let mut targets = cmd.children.iter().filter_map(|child| {
+        let kind = match child.name.as_str() {
+            "agent_group" => SpecializedTaskTarget::AgentGroup,
+            "oci_image_target" => SpecializedTaskTarget::OciImageTarget,
+            "web_application_target" => SpecializedTaskTarget::WebApplicationTarget,
+            _ => return None,
+        };
+        Some((child, kind))
+    });
+    let Some((child, kind)) = targets.next() else {
+        return Ok(None);
+    };
+    if targets.next().is_some() {
+        return Err("A task cannot have multiple specialized targets");
+    }
+    let id = child
+        .attributes
+        .get("id")
+        .filter(|id| !id.is_empty())
+        .ok_or("Missing specialized target id")?;
+    let id = Uuid::parse_str(id).map_err(|_| "Invalid specialized target UUID")?;
+    Ok(Some(kind(id)))
 }
 
 fn store_error_response(command_name: &str, error: StoreError) -> Vec<u8> {
@@ -2110,6 +2147,53 @@ mod tests {
                 Err(invalid_message)
             );
         }
+    }
+
+    #[test]
+    fn task_reference_parsing_rejects_competing_target_shapes() {
+        let target_id = Uuid::new_v4();
+        let agent_group_id = Uuid::new_v4();
+        let oci_target_id = Uuid::new_v4();
+
+        let import_and_specialized = parse_command(
+            format!(
+                "<create_task><target id=\"0\"/><agent_group id=\"{agent_group_id}\"/></create_task>"
+            )
+            .as_bytes(),
+        )
+        .expect("parse import and specialized targets");
+        assert_eq!(
+            task_references(&import_and_specialized),
+            Err("A task cannot have multiple target types")
+        );
+
+        let regular_and_specialized = parse_command(
+            format!(
+                "<create_task><target id=\"{target_id}\"/><agent_group id=\"{agent_group_id}\"/></create_task>"
+            )
+            .as_bytes(),
+        )
+        .expect("parse regular and specialized targets");
+        assert_eq!(
+            task_references(&regular_and_specialized),
+            Err("A task cannot have multiple target types")
+        );
+        assert_eq!(
+            task_reference_updates(&regular_and_specialized),
+            Err("A task cannot have multiple target types")
+        );
+
+        let multiple_specialized = parse_command(
+            format!(
+                "<create_task><agent_group id=\"{agent_group_id}\"/><oci_image_target id=\"{oci_target_id}\"/></create_task>"
+            )
+            .as_bytes(),
+        )
+        .expect("parse multiple specialized targets");
+        assert_eq!(
+            task_references(&multiple_specialized),
+            Err("A task cannot have multiple specialized targets")
+        );
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -873,27 +873,28 @@ impl SessionHandler {
         // Check for single resource by ID
         let id_attr = format!("{resource_type}_id");
         if let Some(id_str) = cmd.attr(&id_attr) {
-            if let Ok(uuid) = Uuid::parse_str(id_str) {
-                if let Some(resource) = store.get_typed(&uuid, resource_type) {
-                    if !usage_type_matches(&resource, requested_usage_type) {
-                        return error_response(&cmd.name, 404, "Resource not found");
-                    }
-                    if cmd.name == "get_reports" {
-                        return self.render_single_report_response(cmd, &resource, store);
-                    }
-                    let xml = if cmd.name == "get_integration_configs" {
-                        resource.to_integration_config_xml(cmd.attr("details") == Some("1"))
-                    } else {
-                        resource.to_xml()
-                    };
-                    return format!(
-                        "<{}_response status=\"200\" status_text=\"OK\">\
-                         {xml}\
-                         </{}_response>",
-                        cmd.name, cmd.name
-                    )
-                    .into_bytes();
+            let Ok(uuid) = Uuid::parse_str(id_str) else {
+                return error_response(&cmd.name, 400, "Invalid UUID");
+            };
+            if let Some(resource) = store.get_typed(&uuid, resource_type) {
+                if !usage_type_matches(&resource, requested_usage_type) {
+                    return error_response(&cmd.name, 404, "Resource not found");
                 }
+                if cmd.name == "get_reports" {
+                    return self.render_single_report_response(cmd, &resource, store);
+                }
+                let xml = if cmd.name == "get_integration_configs" {
+                    resource.to_integration_config_xml(cmd.attr("details") == Some("1"))
+                } else {
+                    resource.to_xml()
+                };
+                return format!(
+                    "<{}_response status=\"200\" status_text=\"OK\">\
+                     {xml}\
+                     </{}_response>",
+                    cmd.name, cmd.name
+                )
+                .into_bytes();
             }
             return error_response(&cmd.name, 404, "Resource not found");
         }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -38,9 +38,9 @@ pub(crate) const DEFAULT_CONFIG_ID: Uuid =
 pub(crate) const DEFAULT_SCANNER_ID: Uuid =
     Uuid::from_u128(0x08b6_9003_5fc2_4037_a479_93b4_4021_1c73);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StoreError {
-    NotFound(&'static str),
+    NotFound(String),
     InUse(&'static str),
     InvalidState(&'static str),
     Inconsistent(&'static str),
@@ -398,7 +398,7 @@ fn active_typed_resource<'a>(
         .resources
         .get(id)
         .filter(|resource| !resource.trashed && resource.resource_type == resource_type)
-        .ok_or(StoreError::NotFound(resource_type))
+        .ok_or_else(|| StoreError::NotFound(resource_type.to_string()))
 }
 
 fn validate_task_reference(
@@ -730,7 +730,7 @@ impl ResourceStore {
             .get(id)
             .filter(|resource| resource.resource_type == resource_type)
             .cloned()
-            .ok_or(StoreError::NotFound("resource"))?;
+            .ok_or_else(|| StoreError::NotFound(resource_type.to_string()))?;
 
         if resource.trashed && !ultimate {
             return Ok(());
@@ -866,7 +866,7 @@ impl ResourceStore {
             .get(id)
             .filter(|resource| resource.trashed)
             .cloned()
-            .ok_or(StoreError::NotFound("resource"))?;
+            .ok_or_else(|| StoreError::NotFound("resource".to_string()))?;
 
         if resource.resource_type == "task" {
             validate_stored_task_references(&inner, &resource)?;
@@ -942,7 +942,7 @@ impl ResourceStore {
             .get(id)
             .filter(|resource| !resource.trashed && resource.resource_type == resource_type)
             .cloned()
-            .ok_or(StoreError::NotFound("resource"))?;
+            .ok_or_else(|| StoreError::NotFound(resource_type.to_string()))?;
         if resource_type == "task" {
             validate_stored_task_references(&inner, &original)?;
         }
@@ -1572,7 +1572,7 @@ mod tests {
         let missing_task_report_id = store.create(missing_task_report);
         assert_eq!(
             store.clone_typed(&missing_task_report_id, "report"),
-            Err(StoreError::NotFound("task"))
+            Err(StoreError::NotFound("task".to_string()))
         );
 
         let import_task_id = store

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -47,8 +47,40 @@ pub(crate) enum StoreError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SpecializedTaskTarget {
+    AgentGroup(Uuid),
+    OciImageTarget(Uuid),
+    WebApplicationTarget(Uuid),
+}
+
+impl SpecializedTaskTarget {
+    fn resource_type(self) -> &'static str {
+        match self {
+            Self::AgentGroup(_) => "agent_group",
+            Self::OciImageTarget(_) => "oci_image_target",
+            Self::WebApplicationTarget(_) => "web_application_target",
+        }
+    }
+
+    fn attr_name(self) -> &'static str {
+        match self {
+            Self::AgentGroup(_) => "agent_group_id",
+            Self::OciImageTarget(_) => "oci_image_target_id",
+            Self::WebApplicationTarget(_) => "web_application_target_id",
+        }
+    }
+
+    fn id(self) -> Uuid {
+        match self {
+            Self::AgentGroup(id) | Self::OciImageTarget(id) | Self::WebApplicationTarget(id) => id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TaskReferences {
     pub target: Option<Uuid>,
+    pub specialized_target: Option<SpecializedTaskTarget>,
     pub config: Option<Uuid>,
     pub scanner: Option<Uuid>,
 }
@@ -56,13 +88,17 @@ pub(crate) struct TaskReferences {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct TaskReferenceUpdates {
     pub target: Option<Uuid>,
+    pub specialized_target: Option<SpecializedTaskTarget>,
     pub config: Option<Uuid>,
     pub scanner: Option<Uuid>,
 }
 
 impl TaskReferenceUpdates {
     fn is_empty(self) -> bool {
-        self.target.is_none() && self.config.is_none() && self.scanner.is_none()
+        self.target.is_none()
+            && self.specialized_target.is_none()
+            && self.config.is_none()
+            && self.scanner.is_none()
     }
 }
 
@@ -420,28 +456,38 @@ fn stored_task_reference(
 }
 
 fn validate_stored_task_references(inner: &StoreInner, task: &Resource) -> Result<(), StoreError> {
-    if task.attr("import_task") == Some("1") || task_has_specialized_target(task) {
+    if task.attr("import_task") == Some("1") {
         return Ok(());
     }
-    for (key, resource_type) in [
-        ("target_id", "target"),
-        ("config_id", "config"),
-        ("scanner_id", "scanner"),
-    ] {
+
+    let specialized: Vec<_> = [
+        ("agent_group_id", "agent_group"),
+        ("oci_image_target_id", "oci_image_target"),
+        ("web_application_target_id", "web_application_target"),
+    ]
+    .into_iter()
+    .filter(|(key, _)| task.attr(key).is_some())
+    .collect();
+    if specialized.len() > 1 {
+        return Err(StoreError::Inconsistent("task target"));
+    }
+    let mut required = if let Some(reference) = specialized.first() {
+        vec![*reference, ("scanner_id", "scanner")]
+    } else {
+        vec![
+            ("target_id", "target"),
+            ("config_id", "config"),
+            ("scanner_id", "scanner"),
+        ]
+    };
+    if !specialized.is_empty() && task.attr("config_id").is_some() {
+        required.push(("config_id", "config"));
+    }
+    for (key, resource_type) in required {
         let id = stored_task_reference(task, key, resource_type)?;
         validate_task_reference(inner, &id, resource_type)?;
     }
     Ok(())
-}
-
-fn task_has_specialized_target(task: &Resource) -> bool {
-    [
-        "agent_group_id",
-        "oci_image_target_id",
-        "web_application_target_id",
-    ]
-    .iter()
-    .any(|key| task.attr(key).is_some())
 }
 
 fn task_is_active(task: &Resource) -> bool {
@@ -525,6 +571,10 @@ impl ResourceStore {
             validate_task_reference(&inner, &target, "target")?;
             task.set_attr("target_id", &target.to_string());
         }
+        if let Some(target) = references.specialized_target {
+            validate_task_reference(&inner, &target.id(), target.resource_type())?;
+            task.set_attr(target.attr_name(), &target.id().to_string());
+        }
         if let Some(config) = references.config {
             validate_task_reference(&inner, &config, "config")?;
             task.set_attr("config_id", &config.to_string());
@@ -533,7 +583,7 @@ impl ResourceStore {
             validate_task_reference(&inner, &scanner, "scanner")?;
             task.set_attr("scanner_id", &scanner.to_string());
         }
-        if references.target.is_none() && !task_has_specialized_target(&task) {
+        if references.target.is_none() && references.specialized_target.is_none() {
             task.set_attr("import_task", "1");
             task.set_attr("status", TaskStatus::Done.as_str());
         } else {
@@ -669,6 +719,9 @@ impl ResourceStore {
         if let Some(target) = references.target {
             validate_task_reference(&inner, &target, "target")?;
         }
+        if let Some(target) = references.specialized_target {
+            validate_task_reference(&inner, &target.id(), target.resource_type())?;
+        }
         if let Some(config) = references.config {
             validate_task_reference(&inner, &config, "config")?;
         }
@@ -682,6 +735,24 @@ impl ResourceStore {
             .expect("validated task should remain present while locked");
         if let Some(target) = references.target {
             task.set_attr("target_id", &target.to_string());
+            for key in [
+                "agent_group_id",
+                "oci_image_target_id",
+                "web_application_target_id",
+            ] {
+                task.attrs.remove(key);
+            }
+        }
+        if let Some(target) = references.specialized_target {
+            task.attrs.remove("target_id");
+            for key in [
+                "agent_group_id",
+                "oci_image_target_id",
+                "web_application_target_id",
+            ] {
+                task.attrs.remove(key);
+            }
+            task.set_attr(target.attr_name(), &target.id().to_string());
         }
         if let Some(config) = references.config {
             task.set_attr("config_id", &config.to_string());
@@ -748,6 +819,11 @@ impl ResourceStore {
 
         let task_reference = match resource_type {
             "target" => Some(("target_id", "target")),
+            "agent_group" => Some(("agent_group_id", "agent_group")),
+            "oci_image_target" => Some(("oci_image_target_id", "oci_image_target")),
+            "web_application_target" => {
+                Some(("web_application_target_id", "web_application_target"))
+            }
             "config" => Some(("config_id", "config")),
             "scanner" => Some(("scanner_id", "scanner")),
             _ => None,
@@ -1172,6 +1248,7 @@ mod tests {
                 Resource::new("task", name),
                 TaskReferences {
                     target: Some(target_id),
+                    specialized_target: None,
                     config: Some(DEFAULT_CONFIG_ID),
                     scanner: Some(DEFAULT_SCANNER_ID),
                 },
@@ -1483,6 +1560,7 @@ mod tests {
                 &task_id,
                 TaskReferenceUpdates {
                     target: Some(target_id),
+                    specialized_target: None,
                     config: Some(config_id),
                     scanner: Some(scanner_id),
                 },
@@ -1590,6 +1668,7 @@ mod tests {
                 Resource::new("task", "Imported"),
                 TaskReferences {
                     target: None,
+                    specialized_target: None,
                     config: None,
                     scanner: None,
                 },
@@ -1605,6 +1684,35 @@ mod tests {
         assert_eq!(
             store.start_task(&import_task_id),
             Err(StoreError::InvalidState("Import tasks cannot be started"))
+        );
+    }
+
+    #[test]
+    fn cloning_rejects_corrupt_specialized_task_graphs() {
+        let store = ResourceStore::new();
+        let agent_group_id = store.create(Resource::new("agent_group", "Agents"));
+        let oci_target_id = store.create(Resource::new("oci_image_target", "OCI"));
+
+        let mut multiple_targets = Resource::new("task", "Multiple specialized targets");
+        multiple_targets.set_attr("agent_group_id", &agent_group_id.to_string());
+        multiple_targets.set_attr("oci_image_target_id", &oci_target_id.to_string());
+        multiple_targets.set_attr("scanner_id", &DEFAULT_SCANNER_ID.to_string());
+        multiple_targets.set_attr("status", TaskStatus::New.as_str());
+        let multiple_targets_id = store.create(multiple_targets);
+        assert_eq!(
+            store.clone_typed(&multiple_targets_id, "task"),
+            Err(StoreError::Inconsistent("task target"))
+        );
+
+        let mut missing_config = Resource::new("task", "Missing optional config");
+        missing_config.set_attr("agent_group_id", &agent_group_id.to_string());
+        missing_config.set_attr("scanner_id", &DEFAULT_SCANNER_ID.to_string());
+        missing_config.set_attr("config_id", &Uuid::new_v4().to_string());
+        missing_config.set_attr("status", TaskStatus::New.as_str());
+        let missing_config_id = store.create(missing_config);
+        assert_eq!(
+            store.clone_typed(&missing_config_id, "task"),
+            Err(StoreError::NotFound("config".to_string()))
         );
     }
 

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -420,7 +420,7 @@ fn stored_task_reference(
 }
 
 fn validate_stored_task_references(inner: &StoreInner, task: &Resource) -> Result<(), StoreError> {
-    if task.attr("import_task") == Some("1") {
+    if task.attr("import_task") == Some("1") || task_has_specialized_target(task) {
         return Ok(());
     }
     for (key, resource_type) in [
@@ -432,6 +432,16 @@ fn validate_stored_task_references(inner: &StoreInner, task: &Resource) -> Resul
         validate_task_reference(inner, &id, resource_type)?;
     }
     Ok(())
+}
+
+fn task_has_specialized_target(task: &Resource) -> bool {
+    [
+        "agent_group_id",
+        "oci_image_target_id",
+        "web_application_target_id",
+    ]
+    .iter()
+    .any(|key| task.attr(key).is_some())
 }
 
 fn task_is_active(task: &Resource) -> bool {
@@ -523,7 +533,7 @@ impl ResourceStore {
             validate_task_reference(&inner, &scanner, "scanner")?;
             task.set_attr("scanner_id", &scanner.to_string());
         }
-        if references.target.is_none() {
+        if references.target.is_none() && !task_has_specialized_target(&task) {
             task.set_attr("import_task", "1");
             task.set_attr("status", TaskStatus::Done.as_str());
         } else {

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -833,7 +833,7 @@ impl ResourceStore {
             let referenced = inner.resources.values().any(|candidate| {
                 candidate.resource_type == "task"
                     && candidate.attr(reference_key) == Some(id.as_str())
-                    && (ultimate || !candidate.trashed)
+                    && !candidate.trashed
             });
             if referenced {
                 return Err(StoreError::InUse(referenced_type));
@@ -1616,6 +1616,40 @@ mod tests {
             .expect("delete task graph");
         assert!(store.get(&report_id).is_none());
         assert!(store.get(&result_id).is_none());
+    }
+
+    #[test]
+    fn trashed_tasks_do_not_block_permanent_reference_deletion() {
+        let store = ResourceStore::new();
+        let target_id = store.create(Resource::new("target", "Disposable Target"));
+        let config_id = store.create(Resource::new("config", "Disposable Config"));
+        let scanner_id = store.create(Resource::new("scanner", "Disposable Scanner"));
+        let task_id = store
+            .create_task(
+                Resource::new("task", "Trashed Task"),
+                TaskReferences {
+                    target: Some(target_id),
+                    specialized_target: None,
+                    config: Some(config_id),
+                    scanner: Some(scanner_id),
+                },
+            )
+            .expect("create task");
+
+        store
+            .delete_typed(&task_id, "task", false)
+            .expect("trash task");
+
+        for (id, resource_type) in [
+            (target_id, "target"),
+            (config_id, "config"),
+            (scanner_id, "scanner"),
+        ] {
+            store
+                .delete_typed(&id, resource_type, true)
+                .expect("trashed task must not block permanent deletion");
+            assert!(store.get(&id).is_none());
+        }
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -33,6 +33,39 @@ pub(crate) enum DeleteAssetResult {
     NotFound,
 }
 
+pub(crate) const DEFAULT_CONFIG_ID: Uuid =
+    Uuid::from_u128(0xdaba_56c8_73ec_11df_a475_0022_6476_4cea);
+pub(crate) const DEFAULT_SCANNER_ID: Uuid =
+    Uuid::from_u128(0x08b6_9003_5fc2_4037_a479_93b4_4021_1c73);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StoreError {
+    NotFound(&'static str),
+    InUse(&'static str),
+    InvalidState(&'static str),
+    Inconsistent(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TaskReferences {
+    pub target: Option<Uuid>,
+    pub config: Option<Uuid>,
+    pub scanner: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct TaskReferenceUpdates {
+    pub target: Option<Uuid>,
+    pub config: Option<Uuid>,
+    pub scanner: Option<Uuid>,
+}
+
+impl TaskReferenceUpdates {
+    fn is_empty(self) -> bool {
+        self.target.is_none() && self.config.is_none() && self.scanner.is_none()
+    }
+}
+
 /// Task status in the lifecycle state machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskStatus {
@@ -48,6 +81,8 @@ pub enum TaskStatus {
     Stopped,
     /// Completed successfully.
     Done,
+    /// Interrupted before completion and eligible for resumption.
+    Interrupted,
 }
 
 impl TaskStatus {
@@ -60,6 +95,7 @@ impl TaskStatus {
             Self::StopRequested => "Stop Requested",
             Self::Stopped => "Stopped",
             Self::Done => "Done",
+            Self::Interrupted => "Interrupted",
         }
     }
 }
@@ -340,7 +376,69 @@ fn default_resources() -> HashMap<Uuid, Resource> {
     integration_config.set_attr("oidc_provider_client_secret", "mock-client-secret");
     resources.insert(integration_config.id, integration_config);
 
+    let mut config = Resource::with_id("config", "Full and fast", DEFAULT_CONFIG_ID);
+    config.comment = "Mock default scan config".to_string();
+    config.set_attr("usage_type", "scan");
+    resources.insert(config.id, config);
+
+    let mut scanner = Resource::with_id("scanner", "OpenVAS Default", DEFAULT_SCANNER_ID);
+    scanner.comment = "Mock default scanner".to_string();
+    scanner.set_attr("type", "OpenVAS");
+    resources.insert(scanner.id, scanner);
+
     resources
+}
+
+fn active_typed_resource<'a>(
+    inner: &'a StoreInner,
+    id: &Uuid,
+    resource_type: &'static str,
+) -> Result<&'a Resource, StoreError> {
+    inner
+        .resources
+        .get(id)
+        .filter(|resource| !resource.trashed && resource.resource_type == resource_type)
+        .ok_or(StoreError::NotFound(resource_type))
+}
+
+fn validate_task_reference(
+    inner: &StoreInner,
+    id: &Uuid,
+    resource_type: &'static str,
+) -> Result<(), StoreError> {
+    active_typed_resource(inner, id, resource_type).map(|_| ())
+}
+
+fn stored_task_reference(
+    task: &Resource,
+    key: &'static str,
+    resource_type: &'static str,
+) -> Result<Uuid, StoreError> {
+    task.attr(key)
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .ok_or(StoreError::Inconsistent(resource_type))
+}
+
+fn validate_stored_task_references(inner: &StoreInner, task: &Resource) -> Result<(), StoreError> {
+    if task.attr("import_task") == Some("1") {
+        return Ok(());
+    }
+    for (key, resource_type) in [
+        ("target_id", "target"),
+        ("config_id", "config"),
+        ("scanner_id", "scanner"),
+    ] {
+        let id = stored_task_reference(task, key, resource_type)?;
+        validate_task_reference(inner, &id, resource_type)?;
+    }
+    Ok(())
+}
+
+fn task_is_active(task: &Resource) -> bool {
+    matches!(
+        task.attr("status"),
+        Some("Requested" | "Running" | "Stop Requested")
+    )
 }
 
 impl ResourceStore {
@@ -407,10 +505,61 @@ impl ResourceStore {
         id
     }
 
+    pub(crate) fn create_task(
+        &self,
+        mut task: Resource,
+        references: TaskReferences,
+    ) -> Result<Uuid, StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        if let Some(target) = references.target {
+            validate_task_reference(&inner, &target, "target")?;
+            task.set_attr("target_id", &target.to_string());
+        }
+        if let Some(config) = references.config {
+            validate_task_reference(&inner, &config, "config")?;
+            task.set_attr("config_id", &config.to_string());
+        }
+        if let Some(scanner) = references.scanner {
+            validate_task_reference(&inner, &scanner, "scanner")?;
+            task.set_attr("scanner_id", &scanner.to_string());
+        }
+        if references.target.is_none() {
+            task.set_attr("import_task", "1");
+            task.set_attr("status", TaskStatus::Done.as_str());
+        } else {
+            task.set_attr("status", TaskStatus::New.as_str());
+        }
+        task.modification_time = now_iso();
+        let id = task.id;
+        inner.resources.insert(id, task);
+        Ok(id)
+    }
+
+    pub(crate) fn create_linked_report(
+        &self,
+        mut report: Resource,
+        task_id: Option<Uuid>,
+    ) -> Result<Uuid, StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        if let Some(task_id) = task_id {
+            active_typed_resource(&inner, &task_id, "task")?;
+            report.set_attr("task_id", &task_id.to_string());
+        }
+        report.modification_time = now_iso();
+        let id = report.id;
+        inner.resources.insert(id, report);
+        Ok(id)
+    }
+
     /// Get a resource by UUID.
     pub fn get(&self, id: &Uuid) -> Option<Resource> {
         let inner = self.inner.read().expect("store lock poisoned");
         inner.resources.get(id).filter(|r| !r.trashed).cloned()
+    }
+
+    pub(crate) fn get_typed(&self, id: &Uuid, resource_type: &str) -> Option<Resource> {
+        self.get(id)
+            .filter(|resource| resource.resource_type == resource_type)
     }
 
     /// Get all resources of a given type (non-trashed).
@@ -470,6 +619,71 @@ impl ResourceStore {
         true
     }
 
+    pub(crate) fn modify_typed<F>(&self, id: &Uuid, resource_type: &str, f: F) -> bool
+    where
+        F: FnOnce(&mut Resource),
+    {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let Some(resource) = inner
+            .resources
+            .get_mut(id)
+            .filter(|resource| !resource.trashed && resource.resource_type == resource_type)
+        else {
+            return false;
+        };
+        f(resource);
+        resource.modification_time = now_iso();
+        true
+    }
+
+    pub(crate) fn modify_task<F>(
+        &self,
+        id: &Uuid,
+        references: TaskReferenceUpdates,
+        f: F,
+    ) -> Result<(), StoreError>
+    where
+        F: FnOnce(&mut Resource),
+    {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let status = active_typed_resource(&inner, id, "task")?
+            .attr("status")
+            .ok_or(StoreError::Inconsistent("task status"))?
+            .to_string();
+
+        if !references.is_empty() && status != TaskStatus::New.as_str() {
+            return Err(StoreError::InvalidState(
+                "Task references can only be changed while the task is New",
+            ));
+        }
+        if let Some(target) = references.target {
+            validate_task_reference(&inner, &target, "target")?;
+        }
+        if let Some(config) = references.config {
+            validate_task_reference(&inner, &config, "config")?;
+        }
+        if let Some(scanner) = references.scanner {
+            validate_task_reference(&inner, &scanner, "scanner")?;
+        }
+
+        let task = inner
+            .resources
+            .get_mut(id)
+            .expect("validated task should remain present while locked");
+        if let Some(target) = references.target {
+            task.set_attr("target_id", &target.to_string());
+        }
+        if let Some(config) = references.config {
+            task.set_attr("config_id", &config.to_string());
+        }
+        if let Some(scanner) = references.scanner {
+            task.set_attr("scanner_id", &scanner.to_string());
+        }
+        f(task);
+        task.modification_time = now_iso();
+        Ok(())
+    }
+
     /// Delete a resource (move to trash or permanently).
     pub fn delete(&self, id: &Uuid, ultimate: bool) -> bool {
         let mut inner = self.inner.write().expect("store lock poisoned");
@@ -504,6 +718,135 @@ impl ResourceStore {
         DeleteAssetResult::Deleted
     }
 
+    pub(crate) fn delete_typed(
+        &self,
+        id: &Uuid,
+        resource_type: &str,
+        ultimate: bool,
+    ) -> Result<(), StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let resource = inner
+            .resources
+            .get(id)
+            .filter(|resource| resource.resource_type == resource_type)
+            .cloned()
+            .ok_or(StoreError::NotFound("resource"))?;
+
+        if resource.trashed && !ultimate {
+            return Ok(());
+        }
+
+        let task_reference = match resource_type {
+            "target" => Some(("target_id", "target")),
+            "config" => Some(("config_id", "config")),
+            "scanner" => Some(("scanner_id", "scanner")),
+            _ => None,
+        };
+        if let Some((reference_key, referenced_type)) = task_reference {
+            let id = id.to_string();
+            let referenced = inner.resources.values().any(|candidate| {
+                candidate.resource_type == "task"
+                    && candidate.attr(reference_key) == Some(id.as_str())
+                    && (ultimate || !candidate.trashed)
+            });
+            if referenced {
+                return Err(StoreError::InUse(referenced_type));
+            }
+        }
+
+        if resource_type == "task" && !resource.trashed && task_is_active(&resource) {
+            if let Some(report_id) = resource
+                .attr("report_id")
+                .and_then(|report_id| Uuid::parse_str(report_id).ok())
+            {
+                if let Some(report) = inner.resources.get_mut(&report_id) {
+                    report.set_attr("status", TaskStatus::Stopped.as_str());
+                    report.modification_time = now_iso();
+                }
+            }
+            if let Some(task) = inner.resources.get_mut(id) {
+                task.set_attr("status", TaskStatus::Stopped.as_str());
+                task.modification_time = now_iso();
+            }
+        }
+
+        if resource_type == "report" {
+            let report_id = id.to_string();
+            let linked_tasks: Vec<Uuid> = inner
+                .resources
+                .values()
+                .filter(|candidate| {
+                    candidate.resource_type == "task"
+                        && candidate.attr("report_id") == Some(report_id.as_str())
+                })
+                .map(|candidate| candidate.id)
+                .collect();
+            if linked_tasks.iter().any(|task_id| {
+                inner
+                    .resources
+                    .get(task_id)
+                    .is_some_and(|task| !task.trashed && task_is_active(task))
+            }) {
+                return Err(StoreError::InUse("report"));
+            }
+            for task_id in linked_tasks {
+                if let Some(task) = inner.resources.get_mut(&task_id) {
+                    task.attrs.remove("report_id");
+                    task.set_attr("status", TaskStatus::New.as_str());
+                    task.modification_time = now_iso();
+                }
+            }
+        }
+
+        if resource_type == "task" {
+            let task_id = id.to_string();
+            let report_ids: Vec<Uuid> = inner
+                .resources
+                .values()
+                .filter(|candidate| {
+                    candidate.resource_type == "report"
+                        && candidate.attr("task_id") == Some(task_id.as_str())
+                })
+                .map(|candidate| candidate.id)
+                .collect();
+            let report_id_strings: Vec<String> = report_ids.iter().map(Uuid::to_string).collect();
+            let result_ids: Vec<Uuid> = inner
+                .resources
+                .values()
+                .filter(|candidate| {
+                    candidate.resource_type == "result"
+                        && candidate.attr("report_id").is_some_and(|candidate_id| {
+                            report_id_strings
+                                .iter()
+                                .any(|report_id| report_id == candidate_id)
+                        })
+                })
+                .map(|candidate| candidate.id)
+                .collect();
+
+            if ultimate {
+                for dependent_id in report_ids.into_iter().chain(result_ids) {
+                    inner.resources.remove(&dependent_id);
+                }
+            } else {
+                for dependent_id in report_ids.into_iter().chain(result_ids) {
+                    if let Some(dependent) = inner.resources.get_mut(&dependent_id) {
+                        dependent.trashed = true;
+                        dependent.modification_time = now_iso();
+                    }
+                }
+            }
+        }
+
+        if ultimate {
+            inner.resources.remove(id);
+        } else if let Some(resource) = inner.resources.get_mut(id) {
+            resource.trashed = true;
+            resource.modification_time = now_iso();
+        }
+        Ok(())
+    }
+
     /// Restore a trashed resource.
     pub fn restore(&self, id: &Uuid) -> bool {
         let mut inner = self.inner.write().expect("store lock poisoned");
@@ -514,6 +857,58 @@ impl ResourceStore {
             }
         }
         false
+    }
+
+    pub(crate) fn restore_checked(&self, id: &Uuid) -> Result<(), StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let resource = inner
+            .resources
+            .get(id)
+            .filter(|resource| resource.trashed)
+            .cloned()
+            .ok_or(StoreError::NotFound("resource"))?;
+
+        if resource.resource_type == "task" {
+            validate_stored_task_references(&inner, &resource)?;
+            let task_id = id.to_string();
+            let report_ids: Vec<Uuid> = inner
+                .resources
+                .values()
+                .filter(|candidate| {
+                    candidate.resource_type == "report"
+                        && candidate.attr("task_id") == Some(task_id.as_str())
+                })
+                .map(|candidate| candidate.id)
+                .collect();
+            let report_id_strings: Vec<String> = report_ids.iter().map(Uuid::to_string).collect();
+            let result_ids: Vec<Uuid> = inner
+                .resources
+                .values()
+                .filter(|candidate| {
+                    candidate.resource_type == "result"
+                        && candidate.attr("report_id").is_some_and(|report_id| {
+                            report_id_strings
+                                .iter()
+                                .any(|candidate_id| candidate_id == report_id)
+                        })
+                })
+                .map(|candidate| candidate.id)
+                .collect();
+            for dependent_id in report_ids.into_iter().chain(result_ids) {
+                if let Some(dependent) = inner.resources.get_mut(&dependent_id) {
+                    dependent.trashed = false;
+                    dependent.modification_time = now_iso();
+                }
+            }
+        }
+
+        let resource = inner
+            .resources
+            .get_mut(id)
+            .expect("validated resource should remain present while locked");
+        resource.trashed = false;
+        resource.modification_time = now_iso();
+        Ok(())
     }
 
     /// Empty the trashcan (permanently remove all trashed resources).
@@ -538,6 +933,161 @@ impl ResourceStore {
         let new_id = copy.id;
         inner.resources.insert(new_id, copy);
         Some(new_id)
+    }
+
+    pub(crate) fn clone_typed(&self, id: &Uuid, resource_type: &str) -> Result<Uuid, StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let original = inner
+            .resources
+            .get(id)
+            .filter(|resource| !resource.trashed && resource.resource_type == resource_type)
+            .cloned()
+            .ok_or(StoreError::NotFound("resource"))?;
+        if resource_type == "task" {
+            validate_stored_task_references(&inner, &original)?;
+        }
+        if let Some(task_id) = original
+            .attr("task_id")
+            .filter(|_| resource_type == "report")
+        {
+            let task_id =
+                Uuid::parse_str(task_id).map_err(|_| StoreError::Inconsistent("report task"))?;
+            active_typed_resource(&inner, &task_id, "task")?;
+        }
+
+        let mut copy = original;
+        copy.id = Uuid::new_v4();
+        if resource_type == "task" {
+            let status = if copy.attr("import_task") == Some("1") {
+                TaskStatus::Done
+            } else {
+                TaskStatus::New
+            };
+            copy.set_attr("status", status.as_str());
+            copy.attrs.remove("report_id");
+        }
+        let now = now_iso();
+        copy.creation_time = now.clone();
+        copy.modification_time = now;
+        let new_id = copy.id;
+        inner.resources.insert(new_id, copy);
+        Ok(new_id)
+    }
+
+    pub(crate) fn start_task(&self, id: &Uuid) -> Result<Uuid, StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let task = active_typed_resource(&inner, id, "task")?.clone();
+        if task.attr("import_task") == Some("1") {
+            return Err(StoreError::InvalidState("Import tasks cannot be started"));
+        }
+        validate_stored_task_references(&inner, &task)?;
+
+        match task.attr("status") {
+            Some("New" | "Stopped" | "Done" | "Interrupted") => {}
+            Some("Running" | "Requested") => {
+                return Err(StoreError::InvalidState("Task is already running"));
+            }
+            Some(_) => {
+                return Err(StoreError::InvalidState(
+                    "Task cannot be started in current state",
+                ));
+            }
+            None => return Err(StoreError::Inconsistent("task status")),
+        }
+
+        let report_id = Uuid::new_v4();
+        let mut report =
+            Resource::with_id("report", &format!("Report for {}", task.name), report_id);
+        report.set_attr("task_id", &id.to_string());
+        report.set_attr("status", TaskStatus::Running.as_str());
+        if let Some(usage_type) = task.attr("usage_type") {
+            report.set_attr("usage_type", usage_type);
+        }
+        inner.resources.insert(report_id, report);
+
+        let task = inner
+            .resources
+            .get_mut(id)
+            .expect("validated task should remain present while locked");
+        task.set_attr("status", TaskStatus::Running.as_str());
+        task.set_attr("report_id", &report_id.to_string());
+        task.modification_time = now_iso();
+        Ok(report_id)
+    }
+
+    pub(crate) fn stop_task(&self, id: &Uuid) -> Result<(), StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let task = active_typed_resource(&inner, id, "task")?.clone();
+        match task.attr("status") {
+            Some("Running" | "Requested") => {}
+            Some("Stopped") => return Err(StoreError::InvalidState("Task is already stopped")),
+            Some(_) => {
+                return Err(StoreError::InvalidState(
+                    "Task cannot be stopped in current state",
+                ));
+            }
+            None => return Err(StoreError::Inconsistent("task status")),
+        }
+
+        let report_id = stored_task_reference(&task, "report_id", "report")?;
+        let report = active_typed_resource(&inner, &report_id, "report")?;
+        let task_id = id.to_string();
+        if report.attr("task_id") != Some(task_id.as_str()) {
+            return Err(StoreError::Inconsistent("task report"));
+        }
+
+        let report = inner
+            .resources
+            .get_mut(&report_id)
+            .expect("validated report should remain present while locked");
+        report.set_attr("status", TaskStatus::Stopped.as_str());
+        report.modification_time = now_iso();
+        let task = inner
+            .resources
+            .get_mut(id)
+            .expect("validated task should remain present while locked");
+        task.set_attr("status", TaskStatus::Stopped.as_str());
+        task.modification_time = now_iso();
+        Ok(())
+    }
+
+    pub(crate) fn resume_task(&self, id: &Uuid) -> Result<Uuid, StoreError> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        let task = active_typed_resource(&inner, id, "task")?.clone();
+        validate_stored_task_references(&inner, &task)?;
+        match task.attr("status") {
+            Some("Stopped" | "Interrupted") => {}
+            Some("Running" | "Requested") => {
+                return Err(StoreError::InvalidState("Task is already running"));
+            }
+            Some(_) => {
+                return Err(StoreError::InvalidState(
+                    "Task can only be resumed from Stopped or Interrupted state",
+                ));
+            }
+            None => return Err(StoreError::Inconsistent("task status")),
+        }
+
+        let report_id = stored_task_reference(&task, "report_id", "report")?;
+        let report = active_typed_resource(&inner, &report_id, "report")?;
+        let task_id = id.to_string();
+        if report.attr("task_id") != Some(task_id.as_str()) {
+            return Err(StoreError::Inconsistent("task report"));
+        }
+
+        let report = inner
+            .resources
+            .get_mut(&report_id)
+            .expect("validated report should remain present while locked");
+        report.set_attr("status", TaskStatus::Running.as_str());
+        report.modification_time = now_iso();
+        let task = inner
+            .resources
+            .get_mut(id)
+            .expect("validated task should remain present while locked");
+        task.set_attr("status", TaskStatus::Running.as_str());
+        task.modification_time = now_iso();
+        Ok(report_id)
     }
 
     /// List resources of a type, filtered by a simple `name=value` filter string.
@@ -605,6 +1155,20 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
+    fn create_valid_task(store: &ResourceStore, name: &str) -> Uuid {
+        let target_id = store.create(Resource::new("target", &format!("{name} Target")));
+        store
+            .create_task(
+                Resource::new("task", name),
+                TaskReferences {
+                    target: Some(target_id),
+                    config: Some(DEFAULT_CONFIG_ID),
+                    scanner: Some(DEFAULT_SCANNER_ID),
+                },
+            )
+            .expect("valid task graph")
+    }
+
     #[test]
     fn test_create_and_get() {
         let store = ResourceStore::new();
@@ -624,7 +1188,7 @@ mod tests {
 
         assert_eq!(store.list("task").len(), 2);
         assert_eq!(store.list("target").len(), 1);
-        assert_eq!(store.list("config").len(), 0);
+        assert_eq!(store.list("config").len(), 1);
     }
 
     #[test]
@@ -894,5 +1458,216 @@ mod tests {
             .iter()
             .all(|resource| resource.resource_type == "task"));
         assert!(tasks.iter().any(|resource| resource.id == id));
+    }
+
+    #[test]
+    fn typed_task_modification_updates_and_validates_every_reference() {
+        let store = ResourceStore::new();
+        let task_id = create_valid_task(&store, "Mutable");
+        let target_id = store.create(Resource::new("target", "Replacement Target"));
+        let config_id = store.create(Resource::new("config", "Replacement Config"));
+        let scanner_id = store.create(Resource::new("scanner", "Replacement Scanner"));
+
+        store
+            .modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    target: Some(target_id),
+                    config: Some(config_id),
+                    scanner: Some(scanner_id),
+                },
+                |_| {},
+            )
+            .expect("New task references should be replaceable");
+
+        let task = store.get(&task_id).expect("task");
+        assert_eq!(task.attr("target_id"), Some(target_id.to_string().as_str()));
+        assert_eq!(task.attr("config_id"), Some(config_id.to_string().as_str()));
+        assert_eq!(
+            task.attr("scanner_id"),
+            Some(scanner_id.to_string().as_str())
+        );
+        assert!(!store.modify_typed(&target_id, "task", |_| {}));
+    }
+
+    #[test]
+    fn task_delete_and_restore_cascade_to_reports_and_results() {
+        let store = ResourceStore::new();
+        let task_id = create_valid_task(&store, "Cascading");
+        let report_id = store.start_task(&task_id).expect("start task");
+        let mut result = Resource::new("result", "Linked Result");
+        result.set_attr("report_id", &report_id.to_string());
+        let result_id = store.create(result);
+        store.stop_task(&task_id).expect("stop task");
+
+        store
+            .delete_typed(&task_id, "task", false)
+            .expect("trash task");
+        store
+            .delete_typed(&task_id, "task", false)
+            .expect("trashing an already trashed task is idempotent");
+        assert!(store
+            .list_trashed("report")
+            .iter()
+            .any(|r| r.id == report_id));
+        assert!(store
+            .list_trashed("result")
+            .iter()
+            .any(|r| r.id == result_id));
+
+        store.restore_checked(&task_id).expect("restore task graph");
+        assert!(store.get(&report_id).is_some());
+        assert!(store.get(&result_id).is_some());
+
+        store
+            .delete_typed(&task_id, "task", true)
+            .expect("delete task graph");
+        assert!(store.get(&report_id).is_none());
+        assert!(store.get(&result_id).is_none());
+    }
+
+    #[test]
+    fn deleting_an_active_task_tolerates_a_missing_report_reference() {
+        let store = ResourceStore::new();
+        let task_id = create_valid_task(&store, "Active Without Report");
+        assert!(store.modify(&task_id, |task| {
+            task.set_attr("status", TaskStatus::Running.as_str());
+            task.attrs.remove("report_id");
+        }));
+
+        store
+            .delete_typed(&task_id, "task", true)
+            .expect("synchronous mock deletion should still remove the task");
+        assert!(store.get(&task_id).is_none());
+    }
+
+    #[test]
+    fn cloning_validates_linked_reports_and_preserves_import_task_state() {
+        let store = ResourceStore::new();
+        let task_id = create_valid_task(&store, "Report Owner");
+        let report_id = store
+            .create_linked_report(Resource::new("report", "Linked"), Some(task_id))
+            .expect("linked report");
+        let report_copy = store
+            .clone_typed(&report_id, "report")
+            .expect("clone linked report");
+        assert_eq!(
+            store
+                .get(&report_copy)
+                .expect("report copy")
+                .attr("task_id"),
+            Some(task_id.to_string().as_str())
+        );
+
+        let mut malformed_report = Resource::new("report", "Malformed Link");
+        malformed_report.set_attr("task_id", "not-a-uuid");
+        let malformed_report_id = store.create(malformed_report);
+        assert_eq!(
+            store.clone_typed(&malformed_report_id, "report"),
+            Err(StoreError::Inconsistent("report task"))
+        );
+
+        let mut missing_task_report = Resource::new("report", "Missing Task");
+        missing_task_report.set_attr("task_id", &Uuid::new_v4().to_string());
+        let missing_task_report_id = store.create(missing_task_report);
+        assert_eq!(
+            store.clone_typed(&missing_task_report_id, "report"),
+            Err(StoreError::NotFound("task"))
+        );
+
+        let import_task_id = store
+            .create_task(
+                Resource::new("task", "Imported"),
+                TaskReferences {
+                    target: None,
+                    config: None,
+                    scanner: None,
+                },
+            )
+            .expect("import task");
+        let import_copy = store
+            .clone_typed(&import_task_id, "task")
+            .expect("clone import task");
+        assert_eq!(
+            store.get(&import_copy).expect("import copy").attr("status"),
+            Some(TaskStatus::Done.as_str())
+        );
+        assert_eq!(
+            store.start_task(&import_task_id),
+            Err(StoreError::InvalidState("Import tasks cannot be started"))
+        );
+    }
+
+    #[test]
+    fn lifecycle_rejects_corrupt_or_inapplicable_states_atomically() {
+        let store = ResourceStore::new();
+
+        let invalid_state_id = create_valid_task(&store, "Invalid State");
+        assert!(store.modify(&invalid_state_id, |task| {
+            task.set_attr("status", "Paused");
+        }));
+        assert_eq!(
+            store.start_task(&invalid_state_id),
+            Err(StoreError::InvalidState(
+                "Task cannot be started in current state"
+            ))
+        );
+        assert_eq!(
+            store.stop_task(&invalid_state_id),
+            Err(StoreError::InvalidState(
+                "Task cannot be stopped in current state"
+            ))
+        );
+        assert_eq!(
+            store.resume_task(&invalid_state_id),
+            Err(StoreError::InvalidState(
+                "Task can only be resumed from Stopped or Interrupted state"
+            ))
+        );
+
+        let missing_status_id = create_valid_task(&store, "Missing Status");
+        assert!(store.modify(&missing_status_id, |task| {
+            task.attrs.remove("status");
+        }));
+        for result in [
+            store.start_task(&missing_status_id).map(|_| ()),
+            store.stop_task(&missing_status_id),
+            store.resume_task(&missing_status_id).map(|_| ()),
+        ] {
+            assert_eq!(result, Err(StoreError::Inconsistent("task status")));
+        }
+
+        let mismatched_report_id = create_valid_task(&store, "Mismatched Report");
+        let report_id = store.start_task(&mismatched_report_id).expect("start task");
+        assert!(store.modify(&report_id, |report| {
+            report.set_attr("task_id", &Uuid::new_v4().to_string());
+        }));
+        assert_eq!(
+            store.stop_task(&mismatched_report_id),
+            Err(StoreError::Inconsistent("task report"))
+        );
+        assert!(store.modify(&report_id, |report| {
+            report.set_attr("task_id", &mismatched_report_id.to_string());
+        }));
+        store.stop_task(&mismatched_report_id).expect("stop task");
+        assert!(store.modify(&report_id, |report| {
+            report.set_attr("task_id", &Uuid::new_v4().to_string());
+        }));
+        assert_eq!(
+            store.resume_task(&mismatched_report_id),
+            Err(StoreError::Inconsistent("task report"))
+        );
+        assert!(store.modify(&report_id, |report| {
+            report.set_attr("task_id", &mismatched_report_id.to_string());
+        }));
+        assert!(store.modify(&mismatched_report_id, |task| {
+            task.set_attr("status", TaskStatus::Interrupted.as_str());
+        }));
+        assert_eq!(
+            store
+                .resume_task(&mismatched_report_id)
+                .expect("resume interrupted task"),
+            report_id
+        );
     }
 }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -845,7 +845,11 @@ impl ResourceStore {
                 .attr("report_id")
                 .and_then(|report_id| Uuid::parse_str(report_id).ok())
             {
-                if let Some(report) = inner.resources.get_mut(&report_id) {
+                let task_id = id.to_string();
+                if let Some(report) = inner.resources.get_mut(&report_id).filter(|report| {
+                    report.resource_type == "report"
+                        && report.attr("task_id") == Some(task_id.as_str())
+                }) {
                     report.set_attr("status", TaskStatus::Stopped.as_str());
                     report.modification_time = now_iso();
                 }
@@ -1627,6 +1631,34 @@ mod tests {
             .delete_typed(&task_id, "task", true)
             .expect("synchronous mock deletion should still remove the task");
         assert!(store.get(&task_id).is_none());
+    }
+
+    #[test]
+    fn deleting_an_active_task_does_not_mutate_an_unrelated_report_reference() {
+        let store = ResourceStore::new();
+        let task_id = create_valid_task(&store, "Corrupt Report Link");
+        let other_task_id = create_valid_task(&store, "Report Owner");
+        let other_report_id = store.start_task(&other_task_id).expect("start other task");
+        assert!(store.modify(&task_id, |task| {
+            task.set_attr("status", TaskStatus::Running.as_str());
+            task.set_attr("report_id", &other_report_id.to_string());
+        }));
+
+        store
+            .delete_typed(&task_id, "task", true)
+            .expect("delete corrupt task");
+
+        let other_report = store
+            .get(&other_report_id)
+            .expect("unrelated report remains");
+        assert_eq!(
+            other_report.attr("task_id"),
+            Some(other_task_id.to_string().as_str())
+        );
+        assert_eq!(
+            other_report.attr("status"),
+            Some(TaskStatus::Running.as_str())
+        );
     }
 
     #[test]

--- a/crates/gvm-mock-server/tests/connections.rs
+++ b/crates/gvm-mock-server/tests/connections.rs
@@ -228,9 +228,16 @@ async fn stateful_session_isolation() {
     .await;
     assert_eq!(auth_resp.status_code(), Some(200));
 
+    let target_resp = send_recv(
+        &mut client_a,
+        b"<create_target><name>Shared Target</name><hosts>127.0.0.1</hosts></create_target>",
+    )
+    .await;
+    let target_id = target_resp.id().expect("target should have id");
     let create_resp = send_recv(
         &mut client_a,
-        b"<create_task><name>Shared Task</name><target id=\"t1\"/></create_task>",
+        format!("<create_task><name>Shared Task</name><target id=\"{target_id}\"/></create_task>")
+            .as_bytes(),
     )
     .await;
     assert_eq!(create_resp.status_code(), Some(201));

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -81,6 +81,27 @@ fn extract_id(resp: &Response) -> String {
     resp.id().expect("response should contain id")
 }
 
+async fn create_task(stream: &mut UnixStream, name: &str, usage_type: &str) -> String {
+    let target = send_recv(
+        stream,
+        format!(
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    let target_id = extract_id(&target);
+    let task = send_recv(
+        stream,
+        format!(
+            "<create_task><name>{name}</name><usage_type>{usage_type}</usage_type><target id=\"{target_id}\"/></create_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    extract_id(&task)
+}
+
 fn id(value: &str) -> EntityId {
     EntityId::new(value).expect("valid id")
 }
@@ -482,17 +503,8 @@ async fn stateful_audits_round_trip_with_usage_type_filtering() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let audit_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Audit One</name><usage_type>audit</usage_type><target id=\"t1\"/><config id=\"c1\"/><scanner id=\"s1\"/></create_task>",
-    )
-    .await;
-    let audit_id = extract_id(&audit_resp);
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Scan One</name><usage_type>scan</usage_type><target id=\"t2\"/><config id=\"c2\"/><scanner id=\"s2\"/></create_task>",
-    )
-    .await;
+    let audit_id = create_task(&mut stream, "Audit One", "audit").await;
+    create_task(&mut stream, "Scan One", "scan").await;
 
     let audits = send_recv(&mut stream, br#"<get_tasks usage_type="audit"/>"#).await;
     let audits_text = audits.as_str().expect("utf8");
@@ -815,18 +827,8 @@ async fn stateful_audit_reports_filter_by_usage_type() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let audit_task = send_recv(
-        &mut stream,
-        b"<create_task><name>Audit Task</name><usage_type>audit</usage_type><target id=\"t1\"/><config id=\"c1\"/><scanner id=\"s1\"/></create_task>",
-    )
-    .await;
-    let scan_task = send_recv(
-        &mut stream,
-        b"<create_task><name>Scan Task</name><usage_type>scan</usage_type><target id=\"t2\"/><config id=\"c2\"/><scanner id=\"s2\"/></create_task>",
-    )
-    .await;
-    let audit_task_id = extract_id(&audit_task);
-    let scan_task_id = extract_id(&scan_task);
+    let audit_task_id = create_task(&mut stream, "Audit Task", "audit").await;
+    let scan_task_id = create_task(&mut stream, "Scan Task", "scan").await;
 
     let audit_report = send_recv(
         &mut stream,
@@ -865,9 +867,14 @@ async fn stateful_import_report_persists_task_and_in_assets() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
+    let task_id = create_task(&mut stream, "Imported Report Task", "scan").await;
+
     let create = send_recv(
         &mut stream,
-        br#"<create_report><task id="task-import"/><report id="imported-report"><name>Imported</name><in_assets>0</in_assets></report><in_assets>1</in_assets></create_report>"#,
+        format!(
+            "<create_report><task id=\"{task_id}\"/><report id=\"imported-report\"><name>Imported</name><in_assets>0</in_assets></report><in_assets>1</in_assets></create_report>"
+        )
+        .as_bytes(),
     )
     .await;
     let create_text = create.as_str().expect("response XML should be UTF-8");
@@ -878,7 +885,7 @@ async fn stateful_import_report_persists_task_and_in_assets() {
     let listed_text = listed.as_str().expect("response XML should be UTF-8");
 
     assert!(
-        listed_text.contains("<task_id>task-import</task_id>"),
+        listed_text.contains(&format!("<task_id>{task_id}</task_id>")),
         "{listed_text}"
     );
     assert!(

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -492,6 +492,13 @@ async fn stateful_policies_round_trip_with_usage_type_filtering() {
     assert!(get_one_text.contains("<usage_type>policy</usage_type>"));
     assert!(get_one_text.contains("<comment>updated</comment>"));
 
+    let wrong_usage_type = send_recv(
+        &mut stream,
+        format!("<get_configs config_id=\"{policy_id}\" usage_type=\"scan\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_usage_type.status_code(), Some(404));
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-mock-server/tests/stateful_filtering.rs
+++ b/crates/gvm-mock-server/tests/stateful_filtering.rs
@@ -54,6 +54,24 @@ async fn connect(server: &MockGmpServer) -> UnixStream {
     UnixStream::connect(path).await.expect("connect failed")
 }
 
+async fn create_task(stream: &mut UnixStream, name: &str) -> Response {
+    let target = send_recv(
+        stream,
+        format!(
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    let target_id = target.id().expect("target should have id");
+    send_recv(
+        stream,
+        format!("<create_task><name>{name}</name><target id=\"{target_id}\"/></create_task>")
+            .as_bytes(),
+    )
+    .await
+}
+
 // FILT-001: Filter by name equality
 #[tokio::test]
 async fn filter_by_name_equality() {
@@ -64,16 +82,8 @@ async fn filter_by_name_equality() {
     auth_admin(&mut stream).await;
 
     // Create two tasks with different names (single-word for simple filter)
-    send_recv(
-        &mut stream,
-        b"<create_task><name>AlphaTask</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
-    send_recv(
-        &mut stream,
-        b"<create_task><name>BetaTask</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    create_task(&mut stream, "AlphaTask").await;
+    create_task(&mut stream, "BetaTask").await;
 
     // Filter by name=AlphaTask
     let resp = send_recv(&mut stream, br#"<get_tasks filter="name=AlphaTask"/>"#).await;
@@ -97,11 +107,7 @@ async fn filter_no_match_returns_empty() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Existing</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    create_task(&mut stream, "Existing").await;
 
     let resp = send_recv(&mut stream, br#"<get_tasks filter="name=Nonexistent"/>"#).await;
     assert_eq!(resp.status_code(), Some(200));
@@ -123,16 +129,8 @@ async fn no_filter_returns_all() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Task A</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Task B</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    create_task(&mut stream, "Task A").await;
+    create_task(&mut stream, "Task B").await;
 
     let resp = send_recv(&mut stream, b"<get_tasks/>").await;
     assert_eq!(resp.status_code(), Some(200));
@@ -153,11 +151,7 @@ async fn trash_filter_returns_only_trashed() {
     auth_admin(&mut stream).await;
 
     // Create and trash one task
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Trashed Task</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Trashed Task").await;
     let create_text = create_resp.as_str().expect("utf8");
     let marker = "id=\"";
     let start = create_text.find(marker).unwrap() + marker.len();
@@ -173,11 +167,7 @@ async fn trash_filter_returns_only_trashed() {
     .await;
 
     // Create another task (not trashed)
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Active Task</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    create_task(&mut stream, "Active Task").await;
 
     // Normal get should only show Active Task
     let normal_resp = send_recv(&mut stream, b"<get_tasks/>").await;

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -216,6 +216,14 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
     assert!(text.contains("<agent_group_id>ag1</agent_group_id>"));
     assert!(text.contains("<scanner_id>s1</scanner_id>"));
 
+    let start_resp = send_recv(
+        &mut stream,
+        format!("<start_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(start_resp.status_code(), Some(202));
+    assert!(start_resp.as_str().unwrap().contains("<report_id>"));
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -297,6 +297,10 @@ async fn stateful_create_then_get_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
+    let invalid_id = send_recv(&mut stream, b"<get_tasks task_id=\"not-a-uuid\"/>").await;
+    assert_eq!(invalid_id.status_code(), Some(400));
+    assert!(invalid_id.status_text().unwrap().contains("Invalid UUID"));
+
     let create_resp = create_task(&mut stream, "My Task").await;
     let task_id = create_resp.id().expect("should have id");
 

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -51,6 +51,24 @@ async fn connect_and_auth(server: &MockGmpServer) -> UnixStream {
     stream
 }
 
+async fn create_task(stream: &mut UnixStream, name: &str) -> Response {
+    let target = send_recv(
+        stream,
+        format!(
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    let target_id = target.id().expect("target should have id");
+    send_recv(
+        stream,
+        format!("<create_task><name>{name}</name><target id=\"{target_id}\"/></create_task>")
+            .as_bytes(),
+    )
+    .await
+}
+
 // STATE-001: Command before auth returns 401
 #[tokio::test]
 async fn stateful_command_before_auth_returns_401() {
@@ -151,10 +169,20 @@ async fn stateful_create_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
+    let target = send_recv(
+        &mut stream,
+        b"<create_target><name>Test Target</name><hosts>127.0.0.1</hosts></create_target>",
+    )
+    .await;
+    let target_id = target.id().expect("target should have id");
     let resp = send_recv(
         &mut stream,
-        br#"<create_task><name>Test Task</name><target id="t1"/><config id="c1"/><scanner id="s1"/></create_task>"#,
-    ).await;
+        format!(
+            "<create_task><name>Test Task</name><target id=\"{target_id}\"/><config id=\"daba56c8-73ec-11df-a475-002264764cea\"/><scanner id=\"08b69003-5fc2-4037-a479-93b440211c73\"/></create_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
     assert_eq!(resp.status_code(), Some(201));
     assert!(resp.id().is_some());
 
@@ -269,11 +297,7 @@ async fn stateful_create_then_get_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>My Task</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "My Task").await;
     let task_id = create_resp.id().expect("should have id");
 
     let get_resp = send_recv(
@@ -297,16 +321,8 @@ async fn stateful_list_tasks() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Task A</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
-    send_recv(
-        &mut stream,
-        b"<create_task><name>Task B</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    create_task(&mut stream, "Task A").await;
+    create_task(&mut stream, "Task B").await;
 
     let resp = send_recv(&mut stream, b"<get_tasks/>").await;
     assert_eq!(resp.status_code(), Some(200));
@@ -343,11 +359,7 @@ async fn stateful_modify_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Old Name</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Old Name").await;
     let task_id = create_resp.id().expect("should have id");
 
     let modify_resp = send_recv(
@@ -377,11 +389,7 @@ async fn stateful_delete_task_to_trash() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Doomed</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Doomed").await;
     let task_id = create_resp.id().expect("should have id");
 
     let delete_resp = send_recv(
@@ -446,11 +454,7 @@ async fn stateful_clone_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Original</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Original").await;
     let task_id = create_resp.id().expect("should have id");
 
     let clone_resp = send_recv(
@@ -488,11 +492,7 @@ async fn stateful_start_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Runnable</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Runnable").await;
     let task_id = create_resp.id().expect("should have id");
 
     let start_resp = send_recv(
@@ -526,11 +526,7 @@ async fn stateful_stop_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Stoppable</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Stoppable").await;
     let task_id = create_resp.id().expect("should have id");
 
     send_recv(
@@ -565,11 +561,7 @@ async fn stateful_resume_task() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Resumable</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Resumable").await;
     let task_id = create_resp.id().expect("should have id");
 
     send_recv(
@@ -609,11 +601,7 @@ async fn stateful_start_running_task_conflict() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Running</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Running").await;
     let task_id = create_resp.id().expect("should have id");
 
     send_recv(
@@ -676,11 +664,7 @@ async fn stateful_trash_and_restore() {
     };
     let mut stream = connect_and_auth(&server).await;
 
-    let create_resp = send_recv(
-        &mut stream,
-        b"<create_task><name>Trashed</name><target id=\"t1\"/></create_task>",
-    )
-    .await;
+    let create_resp = create_task(&mut stream, "Trashed").await;
     let task_id = create_resp.id().expect("should have id");
 
     // Delete to trash

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -16,6 +16,8 @@ use gvm_protocol::Response;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
+const DEFAULT_SCANNER_ID: &str = "08b69003-5fc2-4037-a479-93b440211c73";
+
 async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
     stream.write_all(xml).await.expect("write failed");
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -191,14 +193,40 @@ async fn stateful_create_task() {
 
 #[tokio::test]
 async fn stateful_create_agent_group_task_preserves_agent_group_id() {
-    let Some(server) = stateful_server().await else {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
         return;
     };
     let mut stream = connect_and_auth(&server).await;
 
+    let missing_id = send_recv(
+        &mut stream,
+        br#"<create_task><name>Invalid Agent Group Task</name><agent_group/><scanner id="08b69003-5fc2-4037-a479-93b440211c73"/></create_task>"#,
+    )
+    .await;
+    assert_eq!(missing_id.status_code(), Some(400));
+
+    let agent_group = send_recv(
+        &mut stream,
+        b"<create_agent_group><name>Agent Group One</name></create_agent_group>",
+    )
+    .await;
+    let agent_group_id = agent_group.id().expect("agent group should have id");
+    let invalid_scanner = send_recv(
+        &mut stream,
+        format!(
+            "<create_task><name>Invalid Scanner Task</name><agent_group id=\"{agent_group_id}\"/><scanner id=\"not-a-uuid\"/></create_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(invalid_scanner.status_code(), Some(400));
+
     let create_resp = send_recv(
         &mut stream,
-        br#"<create_task><name>Agent Group Task</name><usage_type>scan</usage_type><agent_group id="ag1"/><scanner id="s1"/></create_task>"#,
+        format!(
+            "<create_task><name>Agent Group Task</name><usage_type>scan</usage_type><agent_group id=\"{agent_group_id}\"/><scanner id=\"{DEFAULT_SCANNER_ID}\"/></create_task>"
+        )
+        .as_bytes(),
     )
     .await;
     assert_eq!(create_resp.status_code(), Some(201));
@@ -213,8 +241,38 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
 
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("Agent Group Task"));
-    assert!(text.contains("<agent_group_id>ag1</agent_group_id>"));
-    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+    assert!(text.contains(&format!(
+        "<agent_group_id>{agent_group_id}</agent_group_id>"
+    )));
+    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
+
+    let replacement = send_recv(
+        &mut stream,
+        b"<create_agent_group><name>Agent Group Two</name></create_agent_group>",
+    )
+    .await;
+    let replacement_id = replacement.id().expect("agent group should have id");
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><agent_group id=\"{replacement_id}\"/></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+
+    let get_modified = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(get_modified
+        .as_str()
+        .expect("valid utf8")
+        .contains(&format!(
+            "<agent_group_id>{replacement_id}</agent_group_id>"
+        )));
 
     let start_resp = send_recv(
         &mut stream,
@@ -224,19 +282,46 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
     assert_eq!(start_resp.status_code(), Some(202));
     assert!(start_resp.as_str().unwrap().contains("<report_id>"));
 
+    let modify_running = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><agent_group id=\"{agent_group_id}\"/></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_running.status_code(), Some(409));
+
+    let delete_referenced = send_recv(
+        &mut stream,
+        format!("<delete_agent_group agent_group_id=\"{replacement_id}\" ultimate=\"1\"/>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(delete_referenced.status_code(), Some(409));
+
     server.shutdown().await;
 }
 
 #[tokio::test]
 async fn stateful_create_oci_image_target_task_preserves_target_id() {
-    let Some(server) = stateful_server().await else {
+    let Some(server) = stateful_server_with_version(GmpVersion::V22_8).await else {
         return;
     };
     let mut stream = connect_and_auth(&server).await;
 
+    let target = send_recv(
+        &mut stream,
+        b"<create_oci_image_target><name>OCI One</name></create_oci_image_target>",
+    )
+    .await;
+    let target_id = target.id().expect("OCI target should have id");
     let create_resp = send_recv(
         &mut stream,
-        br#"<create_task><name>OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id="oci1"/><scanner id="s1"/></create_task>"#,
+        format!(
+            "<create_task><name>OCI Target Task</name><usage_type>scan</usage_type><oci_image_target id=\"{target_id}\"/><scanner id=\"{DEFAULT_SCANNER_ID}\"/></create_task>"
+        )
+        .as_bytes(),
     )
     .await;
     assert_eq!(create_resp.status_code(), Some(201));
@@ -251,8 +336,10 @@ async fn stateful_create_oci_image_target_task_preserves_target_id() {
 
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("OCI Target Task"));
-    assert!(text.contains("<oci_image_target_id>oci1</oci_image_target_id>"));
-    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+    assert!(text.contains(&format!(
+        "<oci_image_target_id>{target_id}</oci_image_target_id>"
+    )));
+    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
 
     server.shutdown().await;
 }
@@ -266,7 +353,7 @@ async fn stateful_create_web_application_task_preserves_target_id() {
 
     let missing_id = send_recv(
         &mut stream,
-        br#"<create_task><name>Invalid Web Task</name><web_application_target/><scanner id="s1"/></create_task>"#,
+        br#"<create_task><name>Invalid Web Task</name><web_application_target/><scanner id="08b69003-5fc2-4037-a479-93b440211c73"/></create_task>"#,
     )
     .await;
     assert_eq!(missing_id.status_code(), Some(400));
@@ -275,9 +362,18 @@ async fn stateful_create_web_application_task_preserves_target_id() {
         .expect("status text")
         .contains("web_application_target id"));
 
+    let target = send_recv(
+        &mut stream,
+        b"<create_web_application_target><name>Web One</name></create_web_application_target>",
+    )
+    .await;
+    let target_id = target.id().expect("web target should have id");
     let create_resp = send_recv(
         &mut stream,
-        br#"<create_task><name>Web Task</name><usage_type>scan</usage_type><web_application_target id="wt1"/><scanner id="s1"/></create_task>"#,
+        format!(
+            "<create_task><name>Web Task</name><usage_type>scan</usage_type><web_application_target id=\"{target_id}\"/><scanner id=\"{DEFAULT_SCANNER_ID}\"/></create_task>"
+        )
+        .as_bytes(),
     )
     .await;
     assert_eq!(create_resp.status_code(), Some(201));
@@ -291,8 +387,10 @@ async fn stateful_create_web_application_task_preserves_target_id() {
     assert_eq!(get_resp.status_code(), Some(200));
 
     let text = get_resp.as_str().expect("valid utf8");
-    assert!(text.contains("<web_application_target_id>wt1</web_application_target_id>"));
-    assert!(text.contains("<scanner_id>s1</scanner_id>"));
+    assert!(text.contains(&format!(
+        "<web_application_target_id>{target_id}</web_application_target_id>"
+    )));
+    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -149,7 +149,7 @@ async fn matrix_configs_create_get_list() {
     let list_text = list_resp.as_str().expect("valid utf8");
     assert!(list_text.contains(&config_id));
     assert!(list_text.contains("Matrix Config"));
-    assert!(list_text.contains("<config_count>1") || list_text.contains("<filtered>1</filtered>"));
+    assert!(list_text.contains("<config_count>2") || list_text.contains("<filtered>2</filtered>"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -252,7 +252,7 @@ async fn referenced_resources_cannot_be_removed_or_addressed_as_another_type() {
         format!("<delete_target target_id=\"{target_id}\" ultimate=\"1\"/>").as_bytes(),
     )
     .await;
-    assert_eq!(ultimate_target.status_code(), Some(409));
+    assert_eq!(ultimate_target.status_code(), Some(200));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Deterministic task/resource graph integrity coverage for Stateful mode.
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_protocol::Response;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+const DEFAULT_CONFIG_ID: &str = "daba56c8-73ec-11df-a475-002264764cea";
+const DEFAULT_SCANNER_ID: &str = "08b69003-5fc2-4037-a479-93b440211c73";
+
+async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
+    stream.write_all(xml).await.expect("write failed");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let mut buffer = vec![0_u8; 64 * 1024];
+    let size = stream.read(&mut buffer).await.expect("read failed");
+    buffer.truncate(size);
+    Response::new(buffer)
+}
+
+async fn server() -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server start failed: {error}"),
+    }
+}
+
+async fn connect_and_auth(server: &MockGmpServer) -> UnixStream {
+    let mut stream = UnixStream::connect(server.socket_path().expect("socket path"))
+        .await
+        .expect("connect failed");
+    let response = send_recv(
+        &mut stream,
+        b"<authenticate><credentials><username>admin</username><password>admin</password></credentials></authenticate>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+    stream
+}
+
+fn id(response: &Response) -> String {
+    response.id().expect("response id")
+}
+
+fn report_id(response: &Response) -> String {
+    let text = response.as_str().expect("UTF-8 response");
+    let start = text.find("<report_id>").expect("report_id start") + "<report_id>".len();
+    let end = text[start..].find("</report_id>").expect("report_id end") + start;
+    text[start..end].to_string()
+}
+
+async fn create_target(stream: &mut UnixStream, name: &str) -> String {
+    let response = send_recv(
+        stream,
+        format!("<create_target><name>{name}</name><hosts>127.0.0.1</hosts></create_target>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    id(&response)
+}
+
+async fn create_task(stream: &mut UnixStream, name: &str, target_id: &str) -> String {
+    let response = send_recv(
+        stream,
+        format!("<create_task><name>{name}</name><target id=\"{target_id}\"/></create_task>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    id(&response)
+}
+
+#[tokio::test]
+async fn task_creation_rejects_missing_malformed_and_wrong_type_references() {
+    let Some(server) = server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let missing_target = send_recv(
+        &mut stream,
+        b"<create_task><name>No Target</name></create_task>",
+    )
+    .await;
+    assert_eq!(missing_target.status_code(), Some(400));
+
+    let malformed_target = send_recv(
+        &mut stream,
+        b"<create_task><name>Bad Target</name><target id=\"not-a-uuid\"/></create_task>",
+    )
+    .await;
+    assert_eq!(malformed_target.status_code(), Some(400));
+
+    let absent_target = send_recv(
+        &mut stream,
+        b"<create_task><name>Absent Target</name><target id=\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\"/></create_task>",
+    )
+    .await;
+    assert_eq!(absent_target.status_code(), Some(404));
+
+    let wrong_type = send_recv(
+        &mut stream,
+        format!(
+            "<create_task><name>Wrong Target Type</name><target id=\"{DEFAULT_CONFIG_ID}\"/></create_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_type.status_code(), Some(404));
+
+    let tasks = send_recv(&mut stream, b"<get_tasks/>").await;
+    assert!(tasks
+        .as_str()
+        .expect("UTF-8 response")
+        .contains("<task_count>0"));
+
+    let target_id = create_target(&mut stream, "Valid Target").await;
+    let task_id = create_task(&mut stream, "Valid Task", &target_id).await;
+
+    for command in [
+        format!("<modify_task task_id=\"{task_id}\"><target/></modify_task>"),
+        format!("<modify_task task_id=\"{task_id}\"><config/></modify_task>"),
+        format!("<modify_task task_id=\"{task_id}\"><scanner/></modify_task>"),
+        format!("<modify_task task_id=\"{task_id}\"><scanner id=\"not-a-uuid\"/></modify_task>"),
+    ] {
+        let response = send_recv(&mut stream, command.as_bytes()).await;
+        assert_eq!(response.status_code(), Some(400), "{command}");
+    }
+
+    for command in [
+        "<create_report><task/></create_report>",
+        "<create_report><task id=\"not-a-uuid\"/></create_report>",
+    ] {
+        let response = send_recv(&mut stream, command.as_bytes()).await;
+        assert_eq!(response.status_code(), Some(400), "{command}");
+    }
+
+    let wrong_typed_get = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_typed_get.status_code(), Some(404));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn corrupt_seeded_task_graph_is_rejected_instead_of_cloned() {
+    let mut corrupt_task = Resource::new("task", "Corrupt Seed");
+    corrupt_task.set_attr("status", "New");
+    let corrupt_task_id = corrupt_task.id;
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .seed(move |store| store.seed(corrupt_task))
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server start failed: {error}"),
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let response = send_recv(
+        &mut stream,
+        format!("<create_task><copy>{corrupt_task_id}</copy><name>Copy</name></create_task>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(409));
+    assert!(response
+        .as_str()
+        .expect("UTF-8 response")
+        .contains("Task graph is inconsistent: target"));
+
+    let absent_id = Uuid::new_v4();
+    let absent_clone = send_recv(
+        &mut stream,
+        format!("<create_task><copy>{absent_id}</copy></create_task>").as_bytes(),
+    )
+    .await;
+    assert_eq!(absent_clone.status_code(), Some(404));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn referenced_resources_cannot_be_removed_or_addressed_as_another_type() {
+    let Some(server) = server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    let target_id = create_target(&mut stream, "Linked Target").await;
+    let task_id = create_task(&mut stream, "Linked Task", &target_id).await;
+
+    for command in [
+        format!("<delete_target target_id=\"{target_id}\" ultimate=\"0\"/>"),
+        format!("<delete_config config_id=\"{DEFAULT_CONFIG_ID}\" ultimate=\"0\"/>"),
+        format!("<delete_scanner scanner_id=\"{DEFAULT_SCANNER_ID}\" ultimate=\"0\"/>"),
+    ] {
+        let response = send_recv(&mut stream, command.as_bytes()).await;
+        assert_eq!(response.status_code(), Some(409), "{command}");
+    }
+
+    let wrong_typed_delete = send_recv(
+        &mut stream,
+        format!("<delete_target target_id=\"{task_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_typed_delete.status_code(), Some(404));
+
+    let delete_task = send_recv(
+        &mut stream,
+        format!("<delete_task task_id=\"{task_id}\" ultimate=\"0\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete_task.status_code(), Some(200));
+    let trash_target = send_recv(
+        &mut stream,
+        format!("<delete_target target_id=\"{target_id}\" ultimate=\"0\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(trash_target.status_code(), Some(200));
+
+    let restore_task = send_recv(
+        &mut stream,
+        format!("<restore id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(restore_task.status_code(), Some(404));
+    let ultimate_target = send_recv(
+        &mut stream,
+        format!("<delete_target target_id=\"{target_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(ultimate_target.status_code(), Some(409));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn task_reference_updates_are_validated_and_only_allowed_while_new() {
+    let Some(server) = server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    let first_target_id = create_target(&mut stream, "First Target").await;
+    let second_target_id = create_target(&mut stream, "Second Target").await;
+    let task_id = create_task(&mut stream, "Mutable Task", &first_target_id).await;
+
+    let wrong_type = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><target id=\"{DEFAULT_CONFIG_ID}\"/></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_type.status_code(), Some(404));
+
+    let update = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><target id=\"{second_target_id}\"/></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(update.status_code(), Some(200));
+    let task = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(task
+        .as_str()
+        .expect("UTF-8 response")
+        .contains(&format!("<target_id>{second_target_id}</target_id>")));
+
+    let old_target_delete = send_recv(
+        &mut stream,
+        format!("<delete_target target_id=\"{first_target_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(old_target_delete.status_code(), Some(200));
+
+    let start = send_recv(
+        &mut stream,
+        format!("<start_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(start.status_code(), Some(202));
+    let running_update = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><target id=\"{second_target_id}\"/></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(running_update.status_code(), Some(409));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stop_and_resume_preserve_one_report_and_update_both_statuses() {
+    let Some(server) = server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    let target_id = create_target(&mut stream, "Lifecycle Target").await;
+    let task_id = create_task(&mut stream, "Lifecycle Task", &target_id).await;
+
+    let start = send_recv(
+        &mut stream,
+        format!("<start_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let started_report_id = report_id(&start);
+    let active_delete = send_recv(
+        &mut stream,
+        format!("<delete_report report_id=\"{started_report_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(active_delete.status_code(), Some(409));
+
+    let stop = send_recv(
+        &mut stream,
+        format!("<stop_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(stop.status_code(), Some(200));
+    let stopped_report = send_recv(
+        &mut stream,
+        format!("<get_reports report_id=\"{started_report_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(stopped_report
+        .as_str()
+        .expect("UTF-8 response")
+        .contains("<status>Stopped</status>"));
+
+    let resume = send_recv(
+        &mut stream,
+        format!("<resume_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(report_id(&resume), started_report_id);
+    let reports = send_recv(&mut stream, b"<get_reports/>").await;
+    assert!(reports
+        .as_str()
+        .expect("UTF-8 response")
+        .contains("<report_count>1"));
+
+    send_recv(
+        &mut stream,
+        format!("<stop_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let delete_stopped_report = send_recv(
+        &mut stream,
+        format!("<delete_report report_id=\"{started_report_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete_stopped_report.status_code(), Some(200));
+    let task = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let task_text = task.as_str().expect("UTF-8 response");
+    assert!(task_text.contains("<status>New</status>"));
+    assert!(!task_text.contains("<report_id>"));
+    let resume_without_report = send_recv(
+        &mut stream,
+        format!("<resume_task task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(resume_without_report.status_code(), Some(409));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn imported_reports_require_an_existing_task_and_task_deletion_cascades() {
+    let Some(server) = server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    let target_id = create_target(&mut stream, "Import Target").await;
+    let task_id = create_task(&mut stream, "Import Task", &target_id).await;
+
+    let wrong_type = send_recv(
+        &mut stream,
+        format!("<create_report><task id=\"{target_id}\"/></create_report>").as_bytes(),
+    )
+    .await;
+    assert_eq!(wrong_type.status_code(), Some(404));
+
+    let linked_report = send_recv(
+        &mut stream,
+        format!("<create_report><task id=\"{task_id}\"/></create_report>").as_bytes(),
+    )
+    .await;
+    assert_eq!(linked_report.status_code(), Some(201));
+    let linked_report_id = id(&linked_report);
+
+    let delete_task = send_recv(
+        &mut stream,
+        format!("<delete_task task_id=\"{task_id}\" ultimate=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(delete_task.status_code(), Some(200));
+    let report = send_recv(
+        &mut stream,
+        format!("<get_reports report_id=\"{linked_report_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(report.status_code(), Some(404));
+
+    server.shutdown().await;
+}

--- a/crates/gvm-mock-server/tests/stateful_task_lifecycle.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_lifecycle.rs
@@ -57,6 +57,25 @@ async fn create_and_get_id(
     rest[..end].to_string()
 }
 
+async fn create_task_id(stream: &mut UnixStream, name: &str) -> String {
+    let target_id = create_and_get_id(
+        stream,
+        format!(
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+        )
+        .as_bytes(),
+        "create_target",
+    )
+    .await;
+    create_and_get_id(
+        stream,
+        format!("<create_task><name>{name}</name><target id=\"{target_id}\"/></create_task>")
+            .as_bytes(),
+        "create_task",
+    )
+    .await
+}
+
 async fn stateful_server() -> Option<MockGmpServer> {
     match MockGmpServer::builder()
         .mode(ServerMode::Stateful)
@@ -99,12 +118,7 @@ async fn task_start_new_task() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Start</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Start").await;
 
     let start_resp = send_recv(
         &mut stream,
@@ -137,12 +151,7 @@ async fn task_stop_running_task() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Stop</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Stop").await;
 
     send_recv(
         &mut stream,
@@ -179,23 +188,29 @@ async fn task_resume_stopped_task() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Resume</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Resume").await;
 
-    send_recv(
+    let start_resp = send_recv(
         &mut stream,
         format!("<start_task task_id=\"{task_id}\"/>").as_bytes(),
     )
     .await;
+    let started_report_id = extract_report_id(start_resp.as_str().expect("valid utf8")).to_string();
     send_recv(
         &mut stream,
         format!("<stop_task task_id=\"{task_id}\"/>").as_bytes(),
     )
     .await;
+
+    let stopped_report = send_recv(
+        &mut stream,
+        format!("<get_reports report_id=\"{started_report_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(stopped_report
+        .as_str()
+        .expect("valid utf8")
+        .contains("<status>Stopped</status>"));
 
     let resume_resp = send_recv(
         &mut stream,
@@ -203,6 +218,17 @@ async fn task_resume_stopped_task() {
     )
     .await;
     assert_eq!(resume_resp.status_code(), Some(202));
+    assert_eq!(
+        extract_report_id(resume_resp.as_str().expect("valid utf8")),
+        started_report_id,
+        "resume_task should continue the stopped report"
+    );
+
+    let reports = send_recv(&mut stream, b"<get_reports/>").await;
+    assert!(reports
+        .as_str()
+        .expect("valid utf8")
+        .contains("<report_count>1"));
 
     let get_resp = send_recv(
         &mut stream,
@@ -226,12 +252,7 @@ async fn task_start_already_running_returns_409() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Start Conflict</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Start Conflict").await;
 
     send_recv(
         &mut stream,
@@ -257,12 +278,7 @@ async fn task_stop_already_stopped_returns_409() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Stop Conflict</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Stop Conflict").await;
 
     send_recv(
         &mut stream,
@@ -293,12 +309,7 @@ async fn task_resume_non_stopped_returns_409() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Lifecycle Resume Conflict</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Lifecycle Resume Conflict").await;
 
     send_recv(
         &mut stream,
@@ -324,12 +335,7 @@ async fn task_get_shows_current_status() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Status Progression</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Status Progression").await;
 
     let new_resp = send_recv(
         &mut stream,
@@ -382,12 +388,7 @@ async fn task_start_returns_report_id() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let task_id = create_and_get_id(
-        &mut stream,
-        b"<create_task><name>Report Id</name><target id=\"t1\"/></create_task>",
-        "create_task",
-    )
-    .await;
+    let task_id = create_task_id(&mut stream, "Report Id").await;
 
     let start_resp = send_recv(
         &mut stream,

--- a/crates/gvm-mock-server/tests/store_extended.rs
+++ b/crates/gvm-mock-server/tests/store_extended.rs
@@ -39,12 +39,12 @@ fn crud_configs() {
     assert_eq!(config.name, "Base Config");
 
     let configs = store.list("config");
-    assert_eq!(configs.len(), 1);
-    assert_eq!(configs[0].id, id);
+    assert_eq!(configs.len(), 2);
+    assert!(configs.iter().any(|config| config.id == id));
 
     assert!(store.delete(&id, true));
     assert!(store.get(&id).is_none());
-    assert!(store.list("config").is_empty());
+    assert_eq!(store.list("config").len(), 1);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn crud_scanners() {
     assert_ne!(id, cloned_id);
     assert!(store.get(&id).is_some());
     assert!(store.get(&cloned_id).is_some());
-    assert_eq!(store.list("scanner").len(), 2);
+    assert_eq!(store.list("scanner").len(), 3);
 }
 
 #[test]
@@ -109,10 +109,10 @@ fn crud_mixed_types() {
 
     assert_eq!(tasks.len(), 1);
     assert_eq!(targets.len(), 1);
-    assert_eq!(configs.len(), 1);
+    assert_eq!(configs.len(), 2);
     assert_eq!(tasks[0].id, task_id);
     assert_eq!(targets[0].id, target_id);
-    assert_eq!(configs[0].id, config_id);
+    assert!(configs.iter().any(|config| config.id == config_id));
 }
 
 #[test]

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -512,7 +512,7 @@ async fn assert_web_application_targets_and_tasks_work_on_next(stream: &mut Unix
         create_web_application_task(
             "Version Gated Web Task",
             &web_target_id,
-            &id("scanner-web-gate"),
+            &id("08b69003-5fc2-4037-a479-93b440211c73"),
             CreateWebApplicationTaskOpts::default(),
         ),
     )

--- a/tests/integration/test_python_gvm.py
+++ b/tests/integration/test_python_gvm.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable
 
 from gvm.connections import UnixSocketConnection
+from gvm.errors import GvmError
 from gvm.protocols.gmp import GMP
 from gvm.transforms import EtreeCheckCommandTransform
 
@@ -50,6 +51,14 @@ def response_id(response) -> str:
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
+
+
+def require_gvm_error(fn: Callable[[], None], message: str) -> None:
+    try:
+        fn()
+    except GvmError:
+        return
+    raise AssertionError(message)
 
 
 def run_step(name: str, fn: Callable[[], None]) -> bool:
@@ -213,6 +222,31 @@ def main() -> int:
                                 for task in gmp.get_tasks().findall("task")
                             ),
                             "task status was not Stopped after stop_task",
+                        ),
+                    ),
+                    (
+                        "resume_task",
+                        lambda: state.setdefault(
+                            "resumed_report_id",
+                            gmp.resume_task(task_id=state["task_id"]).findtext("report_id") or "",
+                        ),
+                    ),
+                    (
+                        "resume_reuses_report",
+                        lambda: require(
+                            state["resumed_report_id"] == state["report_id"],
+                            "resume_task did not reuse the stopped report",
+                        ),
+                    ),
+                    (
+                        "stop_resumed_task",
+                        lambda: gmp.stop_task(task_id=state["task_id"]),
+                    ),
+                    (
+                        "referenced_target_delete_rejected",
+                        lambda: require_gvm_error(
+                            lambda: gmp.delete_target(target_id=state["target_id"]),
+                            "delete_target should reject a target referenced by a live task",
                         ),
                     ),
                     (


### PR DESCRIPTION
## Summary

- validate task target, config, and scanner references atomically and reject missing or wrong-type resource IDs
- prevent referenced resources from being removed, keep trash/restore/delete cascades graph-consistent, and make typed CRUD reject cross-resource UUIDs
- link task and report lifecycle transitions so stop updates both resources and resume continues the stopped/interrupted report
- support gvmd-style import tasks with target ID `0`, validate imported-report task links, and seed the public default scan config and scanner IDs
- document the mock's synchronous, no-scanner lifecycle behavior and exercise it through Rust and python-gvm transports

## Public parity basis

The behavior was checked against public `greenbone/gvmd` source at `f26daeb971bf25fa6d65b21189ea25038b46fb5f` and public `greenbone/python-gvm` main at `2bb100fd03f02e598f046e2032e12550b5b14751`. The cross-language system test uses the public PyPI `python-gvm` 27.5.0 release.

The mock intentionally models task actions as synchronous state transitions and does not launch a scanner. Active task deletion therefore performs the stop-and-cascade operation synchronously while preserving gvmd's externally relevant graph invariants.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- stable workspace default and all-feature tests
- Rust 1.85 workspace all-feature check and tests
- real Unix-socket workflow with public `python-gvm` 27.5.0
- workspace LLVM coverage plus `diff-cover`: 779 changed executable lines, 0 missing, 100% patch coverage
- `cargo deny check`, `cargo audit`, `cargo machete`, `cargo vet`
- workspace unsafe gate: 0 unsafe uses in every workspace crate
- suppression-disabled Semgrep (`p/rust`, `p/security-audit`, `p/secrets`): 0 findings
- staged Gitleaks: 0 findings

## Validation limits

No live gvmd database/scanner stack was executed locally; parity with gvmd was established from the pinned public source plus deterministic mock-server and real-client transport tests. No fuzz campaign was run; the changed graph and lifecycle surface is covered by deterministic success, error, corruption, and rollback cases with 100% patch coverage.
