### PR TITLE
docs(journal): record 2026-07-20 activity

### DIFF
--- a/journal/2026-07-20.md
+++ b/journal/2026-07-20.md
@@ -1,0 +1,10 @@
+# 2026-07-20 — Dependency Refreshes Split on the Vet Gate
+
+## Dependency Movement
+- Dependabot opened PR [#368](https://github.com/clawosiris/rust-gvm/pull/368) to refresh six Cargo dependencies, including `tokio` 1.53.0, `uuid` 1.24.0, and `rustls` 0.23.42; the superseded single-package UUID PR [#355](https://github.com/clawosiris/rust-gvm/pull/355) was closed.
+- Dependabot also opened PR [#369](https://github.com/clawosiris/rust-gvm/pull/369) to update three workflow dependencies, including the major `actions/setup-go` move from v6 to v7 and CodeQL upload-sarif 4.37.1.
+
+## Validation State
+- PR #369 is green across its visible CI and security checks.
+- PR #368 passes CI, Cargo Audit, Cargo Deny, Semgrep, and the geiger gates, but remains blocked by `Cargo Vet`: the new dependency graph introduces an estimated 13,065-line audit backlog, including `tokio` 1.52.3 → 1.53.0 and `syn` 2.0.118 → 3.0.1 review deltas.
+- Neither dependency refresh has reached `main`; the Cargo update requires vet coverage or an explicit trust decision before it is merge-ready.


### PR DESCRIPTION
## Summary

- record the new Cargo and GitHub Actions dependency update lanes
- capture the green Actions refresh and the actionable Cargo Vet blocker
- note that neither update has reached `main`
