### PR TITLE
feat(gmp): type OCI and web target responses

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -192,7 +192,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         CreateOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
-    /// Send a clone `create_oci_image_target` request and return a typed
+    /// Send a `clone_oci_image_target` request and return a typed
     /// [`CreateOciImageTargetResponse`].
     ///
     /// # Errors
@@ -285,7 +285,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         CreateWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
-    /// Send a clone `create_web_application_target` request and return a typed
+    /// Send a `clone_web_application_target` request and return a typed
     /// [`CreateWebApplicationTargetResponse`].
     ///
     /// # Errors

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -26,6 +26,11 @@ use gvm_gmp::commands::notes::{create_note, get_notes, GetNotesOpts, NoteOpts};
 use gvm_gmp::commands::nvts::{
     get_nvt_families, get_nvts, get_scan_config_nvt, get_scan_config_nvts, GetNvtsOpts,
 };
+use gvm_gmp::commands::oci_image_targets::{
+    clone_oci_image_target, create_oci_image_target, delete_oci_image_target, get_oci_image_target,
+    get_oci_image_targets, modify_oci_image_target, CreateOciImageTargetOpts,
+    GetOciImageTargetsOpts, ModifyOciImageTargetOpts,
+};
 use gvm_gmp::commands::overrides::{
     create_override, get_overrides, GetOverridesOpts, OverrideOpts,
 };
@@ -83,25 +88,34 @@ use gvm_gmp::commands::tls_certificates::{
 use gvm_gmp::commands::trashcan::{empty_trashcan, restore_from_trashcan};
 use gvm_gmp::commands::users::{create_user, get_users, GetUsersOpts, UserOpts};
 use gvm_gmp::commands::version::get_version;
+use gvm_gmp::commands::web_application_targets::{
+    clone_web_application_target, create_web_application_target, delete_web_application_target,
+    get_web_application_target, get_web_application_targets, modify_web_application_target,
+    CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
+};
 use gvm_gmp::responses::{
     AuthenticateResponse, CreateAlertResponse, CreateCredentialResponse, CreateFilterResponse,
-    CreateGroupResponse, CreateHostResponse, CreateNoteResponse, CreateOverrideResponse,
-    CreatePermissionResponse, CreatePortListResponse, CreateReportConfigResponse,
-    CreateReportFormatResponse, CreateReportResponse, CreateRoleResponse, CreateScanConfigResponse,
-    CreateScannerResponse, CreateScheduleResponse, CreateTagResponse, CreateTargetResponse,
-    CreateTaskResponse, CreateTicketResponse, CreateTlsCertificateResponse, CreateUserResponse,
-    DeleteScanConfigResponse, DeleteScannerResponse, DescribeAuthResponse, EmptyTrashcanResponse,
+    CreateGroupResponse, CreateHostResponse, CreateNoteResponse, CreateOciImageTargetResponse,
+    CreateOverrideResponse, CreatePermissionResponse, CreatePortListResponse,
+    CreateReportConfigResponse, CreateReportFormatResponse, CreateReportResponse,
+    CreateRoleResponse, CreateScanConfigResponse, CreateScannerResponse, CreateScheduleResponse,
+    CreateTagResponse, CreateTargetResponse, CreateTaskResponse, CreateTicketResponse,
+    CreateTlsCertificateResponse, CreateUserResponse, CreateWebApplicationTargetResponse,
+    DeleteOciImageTargetResponse, DeleteScanConfigResponse, DeleteScannerResponse,
+    DeleteWebApplicationTargetResponse, DescribeAuthResponse, EmptyTrashcanResponse,
     GetAlertsResponse, GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
     GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
     GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
-    GetNvtFamiliesResponse, GetNvtsResponse, GetOverridesResponse, GetPermissionsResponse,
-    GetPortListsResponse, GetReportClosedCvesResponse, GetReportConfigsResponse,
-    GetReportErrorsResponse, GetReportFormatsResponse, GetReportTlsCertificatesResponse,
-    GetReportVulnsResponse, GetReportsResponse, GetResultsResponse, GetRolesResponse,
-    GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
-    GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
-    GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
-    GetVulnerabilitiesResponse, HelpResponse, ModifyScanConfigResponse, ModifyScannerResponse,
+    GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse, GetOverridesResponse,
+    GetPermissionsResponse, GetPortListsResponse, GetReportClosedCvesResponse,
+    GetReportConfigsResponse, GetReportErrorsResponse, GetReportFormatsResponse,
+    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse,
+    GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
+    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
+    GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
+    GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
+    GetWebApplicationTargetsResponse, HelpResponse, ModifyOciImageTargetResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ModifyWebApplicationTargetResponse,
     ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
     VerifyScannerResponse,
 };
@@ -159,6 +173,198 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<CreateTargetResponse, GvmError> {
         let response = self.send(create_target(name, opts)).await?;
         CreateTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_oci_image_target` request and return a typed
+    /// [`CreateOciImageTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn create_oci_image_target_parsed(
+        &mut self,
+        name: &str,
+        image_references: &[String],
+        opts: CreateOciImageTargetOpts,
+    ) -> Result<CreateOciImageTargetResponse, GvmError> {
+        let response = self
+            .send(create_oci_image_target(name, image_references, opts))
+            .await?;
+        CreateOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a clone `create_oci_image_target` request and return a typed
+    /// [`CreateOciImageTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn clone_oci_image_target_parsed(
+        &mut self,
+        oci_image_target_id: &EntityId,
+    ) -> Result<CreateOciImageTargetResponse, GvmError> {
+        let response = self
+            .send(clone_oci_image_target(oci_image_target_id))
+            .await?;
+        CreateOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_oci_image_targets` request for one target and return a typed
+    /// [`GetOciImageTargetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_oci_image_target_parsed(
+        &mut self,
+        oci_image_target_id: &EntityId,
+        tasks: Option<bool>,
+    ) -> Result<GetOciImageTargetsResponse, GvmError> {
+        let response = self
+            .send(get_oci_image_target(oci_image_target_id, tasks))
+            .await?;
+        GetOciImageTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_oci_image_targets` request and return a typed
+    /// [`GetOciImageTargetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_oci_image_targets_parsed(
+        &mut self,
+        opts: GetOciImageTargetsOpts,
+    ) -> Result<GetOciImageTargetsResponse, GvmError> {
+        let response = self.send(get_oci_image_targets(opts)).await?;
+        GetOciImageTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_oci_image_target` request and return a typed
+    /// [`ModifyOciImageTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_oci_image_target_parsed(
+        &mut self,
+        oci_image_target_id: &EntityId,
+        opts: ModifyOciImageTargetOpts,
+    ) -> Result<ModifyOciImageTargetResponse, GvmError> {
+        let response = self
+            .send(modify_oci_image_target(oci_image_target_id, opts))
+            .await?;
+        ModifyOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `delete_oci_image_target` request and return a typed
+    /// [`DeleteOciImageTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn delete_oci_image_target_parsed(
+        &mut self,
+        oci_image_target_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<DeleteOciImageTargetResponse, GvmError> {
+        let response = self
+            .send(delete_oci_image_target(oci_image_target_id, ultimate))
+            .await?;
+        DeleteOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `create_web_application_target` request and return a typed
+    /// [`CreateWebApplicationTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn create_web_application_target_parsed(
+        &mut self,
+        name: &str,
+        urls: &[String],
+        opts: CreateWebApplicationTargetOpts,
+    ) -> Result<CreateWebApplicationTargetResponse, GvmError> {
+        let response = self
+            .send(create_web_application_target(name, urls, opts))
+            .await?;
+        CreateWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a clone `create_web_application_target` request and return a typed
+    /// [`CreateWebApplicationTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn clone_web_application_target_parsed(
+        &mut self,
+        web_application_target_id: &EntityId,
+    ) -> Result<CreateWebApplicationTargetResponse, GvmError> {
+        let response = self
+            .send(clone_web_application_target(web_application_target_id))
+            .await?;
+        CreateWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_web_application_targets` request for one target and return a
+    /// typed [`GetWebApplicationTargetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_web_application_target_parsed(
+        &mut self,
+        web_application_target_id: &EntityId,
+        tasks: Option<bool>,
+    ) -> Result<GetWebApplicationTargetsResponse, GvmError> {
+        let response = self
+            .send(get_web_application_target(web_application_target_id, tasks))
+            .await?;
+        GetWebApplicationTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_web_application_targets` request and return a typed
+    /// [`GetWebApplicationTargetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_web_application_targets_parsed(
+        &mut self,
+        opts: GetWebApplicationTargetsOpts,
+    ) -> Result<GetWebApplicationTargetsResponse, GvmError> {
+        let response = self.send(get_web_application_targets(opts)).await?;
+        GetWebApplicationTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_web_application_target` request and return a typed
+    /// [`ModifyWebApplicationTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_web_application_target_parsed(
+        &mut self,
+        web_application_target_id: &EntityId,
+        opts: ModifyWebApplicationTargetOpts,
+    ) -> Result<ModifyWebApplicationTargetResponse, GvmError> {
+        let response = self
+            .send(modify_web_application_target(
+                web_application_target_id,
+                opts,
+            ))
+            .await?;
+        ModifyWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `delete_web_application_target` request and return a typed
+    /// [`DeleteWebApplicationTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn delete_web_application_target_parsed(
+        &mut self,
+        web_application_target_id: &EntityId,
+        ultimate: bool,
+    ) -> Result<DeleteWebApplicationTargetResponse, GvmError> {
+        let response = self
+            .send(delete_web_application_target(
+                web_application_target_id,
+                ultimate,
+            ))
+            .await?;
+        DeleteWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Scan Configs ──────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -5,8 +5,9 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    GmpClient, GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, WireTraceDirection,
-    WireTraceEvent,
+    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, GmpClient, GmpNextCommands,
+    GmpVersioned, GvmError, ImportReportOpts, ModifyOciImageTargetOpts,
+    ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
@@ -1599,6 +1600,144 @@ async fn typed_resume_task_returns_report_id() {
         .call(delete_target(&target_id, true))
         .await
         .expect("delete_target should succeed");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_oci_image_target_lifecycle_succeeds() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created = client
+        .create_oci_image_target_parsed(
+            "OCI Target",
+            &["registry.example/app:1".to_string()],
+            CreateOciImageTargetOpts {
+                comment: Some("created".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_oci_image_target should succeed");
+
+    let fetched = client
+        .get_oci_image_target_parsed(&created.id, Some(true))
+        .await
+        .expect("get_oci_image_target should succeed");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.id, created.id);
+    assert_eq!(
+        fetched.items[0].image_references,
+        vec!["registry.example/app:1".to_string()]
+    );
+
+    let modified = client
+        .modify_oci_image_target_parsed(
+            &created.id,
+            ModifyOciImageTargetOpts {
+                name: Some("OCI Target Updated".to_string()),
+                image_references: vec!["registry.example/app:2".to_string()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_oci_image_target should succeed");
+    assert_eq!(modified.status, 200);
+
+    let cloned = client
+        .clone_oci_image_target_parsed(&created.id)
+        .await
+        .expect("clone_oci_image_target should succeed");
+    assert_eq!(cloned.status, 201);
+
+    let deleted = client
+        .delete_oci_image_target_parsed(&created.id, true)
+        .await
+        .expect("delete_oci_image_target should succeed");
+    assert_eq!(deleted.status, 200);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_web_application_target_lifecycle_succeeds() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created = client
+        .create_web_application_target_parsed(
+            "Web Target",
+            &["https://example.com".to_string()],
+            CreateWebApplicationTargetOpts {
+                comment: Some("created".to_string()),
+                exclude_urls: vec!["https://example.com/logout".to_string()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_web_application_target should succeed");
+
+    let fetched = client
+        .get_web_application_target_parsed(&created.id, Some(true))
+        .await
+        .expect("get_web_application_target should succeed");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].meta.id, created.id);
+    assert_eq!(
+        fetched.items[0].urls,
+        vec!["https://example.com".to_string()]
+    );
+    assert_eq!(
+        fetched.items[0].exclude_urls,
+        vec!["https://example.com/logout".to_string()]
+    );
+
+    let modified = client
+        .modify_web_application_target_parsed(
+            &created.id,
+            ModifyWebApplicationTargetOpts {
+                name: Some("Web Target Updated".to_string()),
+                urls: vec!["https://example.com/app".to_string()],
+                exclude_urls: vec!["https://example.com/logout".to_string()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_web_application_target should succeed");
+    assert_eq!(modified.status, 200);
+
+    let cloned = client
+        .clone_web_application_target_parsed(&created.id)
+        .await
+        .expect("clone_web_application_target should succeed");
+    assert_eq!(cloned.status, 201);
+
+    let deleted = client
+        .delete_web_application_target_parsed(&created.id, true)
+        .await
+        .expect("delete_web_application_target should succeed");
+    assert_eq!(deleted.status, 200);
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -18,6 +18,7 @@ pub mod group;
 pub mod host;
 pub mod note;
 pub mod nvt;
+pub mod oci_image_target;
 pub mod override_;
 pub mod permission;
 pub mod port_list;
@@ -42,6 +43,7 @@ pub mod trashcan;
 pub mod user;
 pub mod user_settings;
 pub mod version;
+pub mod web_application_target;
 
 pub use aggregates::{AggregateGroup, AggregateStats, AggregateSubgroup, GetAggregatesResponse};
 pub use alert::{
@@ -68,6 +70,10 @@ pub use note::{
     CreateNoteResponse, DeleteNoteResponse, GetNotesResponse, ModifyNoteResponse, Note,
 };
 pub use nvt::{GetNvtFamiliesResponse, GetNvtsResponse, Nvt, NvtFamily};
+pub use oci_image_target::{
+    CreateOciImageTargetResponse, DeleteOciImageTargetResponse, GetOciImageTargetsResponse,
+    ModifyOciImageTargetResponse, OciImageTarget,
+};
 pub use override_::{
     CreateOverrideResponse, DeleteOverrideResponse, GetOverridesResponse, ModifyOverrideResponse,
     Override,
@@ -137,3 +143,7 @@ pub use user::{
 };
 pub use user_settings::{GetUserSettingsResponse, ModifyUserSettingResponse, UserSetting};
 pub use version::GetVersionResponse;
+pub use web_application_target::{
+    CreateWebApplicationTargetResponse, DeleteWebApplicationTargetResponse,
+    GetWebApplicationTargetsResponse, ModifyWebApplicationTargetResponse, WebApplicationTarget,
+};

--- a/crates/gvm-gmp/src/responses/oci_image_target.rs
+++ b/crates/gvm-gmp/src/responses/oci_image_target.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! OCI image target response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    parse_entity_ref, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
+    ParseError, XmlNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OciImageTarget {
+    pub meta: EntityMeta,
+    pub image_references: Vec<String>,
+    pub credential: Option<NamedEntity>,
+    pub tasks: Vec<NamedEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetOciImageTargetsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<OciImageTarget>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateOciImageTargetResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl OciImageTarget {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            image_references: node
+                .optional_child_text("image_references")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
+            credential: parse_entity_ref(node, "credential")?,
+            tasks: parse_tasks(node)?,
+        })
+    }
+}
+
+impl GetOciImageTargetsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("oci_image_target")
+            .map(OciImageTarget::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "oci_image_target_count")?,
+        })
+    }
+}
+
+impl CreateOciImageTargetResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyOciImageTargetResponse = ActionResponse;
+pub type DeleteOciImageTargetResponse = ActionResponse;
+
+fn parse_tasks(node: &XmlNode) -> Result<Vec<NamedEntity>, ParseError> {
+    let Some(tasks) = node.child("tasks") else {
+        return Ok(Vec::new());
+    };
+    tasks
+        .children_named("task")
+        .map(|task| {
+            let raw_id = task
+                .attr("id")
+                .ok_or_else(|| ParseError::MissingElement("tasks.task.id".to_string()))?;
+            Ok(NamedEntity {
+                id: parse_entity_id(raw_id, "tasks.task.id")?,
+                name: task.optional_child_text("name").unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_oci_image_targets() {
+        let response = Response::from(
+            r#"<get_oci_image_targets_response status="200" status_text="OK">
+                <oci_image_target id="oci-1">
+                    <owner><name>admin</name></owner>
+                    <name>OCI One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <image_references>registry.example/app:1, registry.example/app:2, </image_references>
+                    <credential id="cred-1"><name>Registry</name></credential>
+                    <tasks><task id="task-1"><name>Scan OCI</name></task></tasks>
+                </oci_image_target>
+                <oci_image_target id="oci-2">
+                    <name>OCI Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </oci_image_target>
+                <oci_image_target_count>2<filtered>2</filtered><page>1</page></oci_image_target_count>
+            </get_oci_image_targets_response>"#,
+        );
+
+        let parsed = GetOciImageTargetsResponse::from_response(&response).expect("targets parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(
+            parsed.items[0].image_references,
+            vec![
+                "registry.example/app:1".to_string(),
+                "registry.example/app:2".to_string()
+            ]
+        );
+        assert_eq!(
+            parsed.items[0]
+                .credential
+                .as_ref()
+                .map(|credential| credential.name.as_str()),
+            Some("Registry")
+        );
+        assert_eq!(parsed.items[0].tasks[0].name, "Scan OCI");
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_oci_image_targets() {
+        let response = Response::from(
+            r#"<get_oci_image_targets_response status="200" status_text="OK"><oci_image_target_count>0<filtered>0</filtered></oci_image_target_count></get_oci_image_targets_response>"#,
+        );
+
+        let parsed = GetOciImageTargetsResponse::from_response(&response).expect("targets parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_oci_image_target_response() {
+        let response = Response::from(
+            r#"<create_oci_image_target_response status="201" status_text="OK, resource created" id="oci-1"/>"#,
+        );
+
+        let parsed = CreateOciImageTargetResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "oci-1");
+    }
+
+    #[test]
+    fn rejects_malformed_task_reference() {
+        let response = Response::from(
+            r#"<get_oci_image_targets_response status="200" status_text="OK">
+                <oci_image_target id="oci-1">
+                    <name>OCI One</name>
+                    <tasks><task><name>missing id</name></task></tasks>
+                </oci_image_target>
+            </get_oci_image_targets_response>"#,
+        );
+
+        let error =
+            GetOciImageTargetsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(error, ParseError::MissingElement(field) if field == "tasks.task.id"));
+    }
+}

--- a/crates/gvm-gmp/src/responses/web_application_target.rs
+++ b/crates/gvm-gmp/src/responses/web_application_target.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Web application target response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
+    parse_entity_ref, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
+    ParseError, XmlNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct WebApplicationTarget {
+    pub meta: EntityMeta,
+    pub urls: Vec<String>,
+    pub exclude_urls: Vec<String>,
+    pub credential: Option<NamedEntity>,
+    pub tasks: Vec<NamedEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetWebApplicationTargetsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<WebApplicationTarget>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateWebApplicationTargetResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl WebApplicationTarget {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            urls: node
+                .optional_child_text("urls")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
+            exclude_urls: node
+                .optional_child_text("exclude_urls")
+                .map(|value| parse_csv_list(&value))
+                .unwrap_or_default(),
+            credential: parse_entity_ref(node, "credential")?,
+            tasks: parse_tasks(node)?,
+        })
+    }
+}
+
+impl GetWebApplicationTargetsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("web_application_target")
+            .map(WebApplicationTarget::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "web_application_target_count")?,
+        })
+    }
+}
+
+impl CreateWebApplicationTargetResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+pub type ModifyWebApplicationTargetResponse = ActionResponse;
+pub type DeleteWebApplicationTargetResponse = ActionResponse;
+
+fn parse_tasks(node: &XmlNode) -> Result<Vec<NamedEntity>, ParseError> {
+    let Some(tasks) = node.child("tasks") else {
+        return Ok(Vec::new());
+    };
+    tasks
+        .children_named("task")
+        .map(|task| {
+            let raw_id = task
+                .attr("id")
+                .ok_or_else(|| ParseError::MissingElement("tasks.task.id".to_string()))?;
+            Ok(NamedEntity {
+                id: parse_entity_id(raw_id, "tasks.task.id")?,
+                name: task.optional_child_text("name").unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_web_application_targets() {
+        let response = Response::from(
+            r#"<get_web_application_targets_response status="200" status_text="OK">
+                <web_application_target id="web-1">
+                    <owner><name>admin</name></owner>
+                    <name>Web One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <urls>https://example.com, https://example.com/app, </urls>
+                    <exclude_urls>https://example.com/logout</exclude_urls>
+                    <credential id="cred-1"><name>HTTP</name></credential>
+                    <tasks><task id="task-1"><name>Scan Web</name></task></tasks>
+                </web_application_target>
+                <web_application_target id="web-2">
+                    <name>Web Two</name>
+                    <writable>0</writable>
+                    <in_use>1</in_use>
+                </web_application_target>
+                <web_application_target_count>2<filtered>2</filtered><page>1</page></web_application_target_count>
+            </get_web_application_targets_response>"#,
+        );
+
+        let parsed =
+            GetWebApplicationTargetsResponse::from_response(&response).expect("targets parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(
+            parsed.items[0].urls,
+            vec![
+                "https://example.com".to_string(),
+                "https://example.com/app".to_string()
+            ]
+        );
+        assert_eq!(
+            parsed.items[0].exclude_urls,
+            vec!["https://example.com/logout".to_string()]
+        );
+        assert_eq!(
+            parsed.items[0]
+                .credential
+                .as_ref()
+                .map(|credential| credential.name.as_str()),
+            Some("HTTP")
+        );
+        assert_eq!(parsed.items[0].tasks[0].name, "Scan Web");
+        assert!(parsed.items[1].meta.in_use);
+    }
+
+    #[test]
+    fn parses_empty_web_application_targets() {
+        let response = Response::from(
+            r#"<get_web_application_targets_response status="200" status_text="OK"><web_application_target_count>0<filtered>0</filtered></web_application_target_count></get_web_application_targets_response>"#,
+        );
+
+        let parsed =
+            GetWebApplicationTargetsResponse::from_response(&response).expect("targets parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_web_application_target_response() {
+        let response = Response::from(
+            r#"<create_web_application_target_response status="201" status_text="OK, resource created" id="web-1"/>"#,
+        );
+
+        let parsed =
+            CreateWebApplicationTargetResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "web-1");
+    }
+
+    #[test]
+    fn rejects_malformed_task_reference() {
+        let response = Response::from(
+            r#"<get_web_application_targets_response status="200" status_text="OK">
+                <web_application_target id="web-1">
+                    <name>Web One</name>
+                    <tasks><task><name>missing id</name></task></tasks>
+                </web_application_target>
+            </get_web_application_targets_response>"#,
+        );
+
+        let error =
+            GetWebApplicationTargetsResponse::from_response(&response).expect_err("error expected");
+
+        assert!(matches!(error, ParseError::MissingElement(field) if field == "tasks.task.id"));
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`get_oci_image_targets` and `get_web_application_targets` had command builders and raw client methods, but no typed response surface for downstream adapters.

## Why This Change Was Made

This adds public typed response models for OCI image targets and web application targets, including list/single response parsing, create/action envelopes, optional credentials, task references, image reference collections, and URL collections. Existing raw client methods remain source-compatible; typed consumers can use the new `*_parsed` convenience methods.

## User Impact

Downstream gateways can consume OCI image target and web application target CRUD/list responses without parsing GMP XML locally.

## Evidence

- `cargo fmt --check`
- `cargo test -p gvm-gmp oci_image_target`
- `cargo test -p gvm-gmp web_application_target`
- `cargo test -p gvm-client --features unix-socket-tests typed_oci_image_target_lifecycle_succeeds`
- `cargo test -p gvm-client --features unix-socket-tests typed_web_application_target_lifecycle_succeeds`
- `cargo check -p gvm-client`

Fixes clawosiris/rust-gvm#372

Agent: Codex CLI for #372
