### PR TITLE
docs(journal): add 2026-07-21 entry

### DIFF
--- a/journal/2026-07-21.md
+++ b/journal/2026-07-21.md
@@ -1,0 +1,13 @@
+# 2026-07-21 — Typed GMP Follow-Through Entered Implementation
+
+## Backlog Direction
+- Four focused issues [#371](https://github.com/clawosiris/rust-gvm/issues/371)–[#374](https://github.com/clawosiris/rust-gvm/issues/374) split the remaining downstream response-model work into generic assets/configs, OCI and web targets, agents, and report drill-downs.
+- The new slices turn the broad coverage roadmap in [#172](https://github.com/clawosiris/rust-gvm/issues/172) into explicit typed-boundary deliverables for `rust-gvm-api`, with raw GMP XML parsing kept inside `rust-gvm`.
+
+## Implementation Movement
+- PR [#375](https://github.com/clawosiris/rust-gvm/pull/375) opened against `devel` and implements the OCI-image and web-application target slice from issue #372.
+- The PR adds public typed list/single models, typed lifecycle envelopes, and parsed client convenience methods while retaining the existing raw methods for source compatibility.
+
+## Validation State
+- PR #375 is green in both visible `CI` and `Security` workflows.
+- The change remains open and awaiting review; no corresponding commit has reached the default branch.


### PR DESCRIPTION
Records the typed GMP response-model backlog split and the first green implementation PR opened after the previous journal cutoff.
