### PR TITLE
feat(gmp): type report drill-down responses

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -59,6 +59,10 @@ use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
     get_web_application_target, get_web_application_targets, modify_web_application_target,
 };
+use gvm_gmp::responses::{
+    GetReportApplicationsResponse, GetReportCvesResponse, GetReportHostsResponse,
+    GetReportOperatingSystemsResponse, GetReportPortsResponse,
+};
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
@@ -733,8 +737,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_report_hosts(report_id, opts)).await
+    ) -> Result<GetReportHostsResponse, GvmError> {
+        let response = self.call(get_report_hosts(report_id, opts)).await?;
+        GetReportHostsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get port summaries for a report.
@@ -746,8 +751,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_report_ports(report_id, opts)).await
+    ) -> Result<GetReportPortsResponse, GvmError> {
+        let response = self.call(get_report_ports(report_id, opts)).await?;
+        GetReportPortsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get application summaries for a report.
@@ -759,8 +765,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_report_applications(report_id, opts)).await
+    ) -> Result<GetReportApplicationsResponse, GvmError> {
+        let response = self.call(get_report_applications(report_id, opts)).await?;
+        GetReportApplicationsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get operating system summaries for a report.
@@ -772,9 +779,11 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_report_operating_systems(report_id, opts))
-            .await
+    ) -> Result<GetReportOperatingSystemsResponse, GvmError> {
+        let response = self
+            .call(get_report_operating_systems(report_id, opts))
+            .await?;
+        GetReportOperatingSystemsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get CVE summaries for a report.
@@ -786,8 +795,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_report_cves(report_id, opts)).await
+    ) -> Result<GetReportCvesResponse, GvmError> {
+        let response = self.call(get_report_cves(report_id, opts)).await?;
+        GetReportCvesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     fn raise_for_status(response: Response) -> Result<Response, GvmError> {
@@ -1713,7 +1723,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
-        self.0.get_report_hosts(report_id, opts).await
+        self.0.call(get_report_hosts(report_id, opts)).await
     }
 
     async fn get_report_ports(
@@ -1721,7 +1731,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
-        self.0.get_report_ports(report_id, opts).await
+        self.0.call(get_report_ports(report_id, opts)).await
     }
 
     async fn get_report_applications(
@@ -1729,7 +1739,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
-        self.0.get_report_applications(report_id, opts).await
+        self.0.call(get_report_applications(report_id, opts)).await
     }
 
     async fn get_report_operating_systems(
@@ -1737,7 +1747,9 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
-        self.0.get_report_operating_systems(report_id, opts).await
+        self.0
+            .call(get_report_operating_systems(report_id, opts))
+            .await
     }
 
     async fn get_report_cves(
@@ -1745,7 +1757,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<Response, GvmError> {
-        self.0.get_report_cves(report_id, opts).await
+        self.0.call(get_report_cves(report_id, opts)).await
     }
 
     async fn get_report_vulns(

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -59,10 +59,6 @@ use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
     get_web_application_target, get_web_application_targets, modify_web_application_target,
 };
-use gvm_gmp::responses::{
-    GetReportApplicationsResponse, GetReportCvesResponse, GetReportHostsResponse,
-    GetReportOperatingSystemsResponse, GetReportPortsResponse,
-};
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
@@ -737,9 +733,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<GetReportHostsResponse, GvmError> {
-        let response = self.call(get_report_hosts(report_id, opts)).await?;
-        GetReportHostsResponse::from_response(&response).map_err(GvmError::Parse)
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_hosts(report_id, opts)).await
     }
 
     /// Get port summaries for a report.
@@ -751,9 +746,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<GetReportPortsResponse, GvmError> {
-        let response = self.call(get_report_ports(report_id, opts)).await?;
-        GetReportPortsResponse::from_response(&response).map_err(GvmError::Parse)
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_ports(report_id, opts)).await
     }
 
     /// Get application summaries for a report.
@@ -765,9 +759,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<GetReportApplicationsResponse, GvmError> {
-        let response = self.call(get_report_applications(report_id, opts)).await?;
-        GetReportApplicationsResponse::from_response(&response).map_err(GvmError::Parse)
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_applications(report_id, opts)).await
     }
 
     /// Get operating system summaries for a report.
@@ -779,11 +772,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<GetReportOperatingSystemsResponse, GvmError> {
-        let response = self
-            .call(get_report_operating_systems(report_id, opts))
-            .await?;
-        GetReportOperatingSystemsResponse::from_response(&response).map_err(GvmError::Parse)
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_operating_systems(report_id, opts))
+            .await
     }
 
     /// Get CVE summaries for a report.
@@ -795,9 +786,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
-    ) -> Result<GetReportCvesResponse, GvmError> {
-        let response = self.call(get_report_cves(report_id, opts)).await?;
-        GetReportCvesResponse::from_response(&response).map_err(GvmError::Parse)
+    ) -> Result<Response, GvmError> {
+        self.call(get_report_cves(report_id, opts)).await
     }
 
     fn raise_for_status(response: Response) -> Result<Response, GvmError> {

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -56,9 +56,11 @@ use gvm_gmp::commands::report_formats::{
     GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    get_report_closed_cves, get_report_errors, get_report_export, get_report_export_with_opts,
-    get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns, get_reports,
-    import_report, GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts, ImportReportOpts,
+    get_report_applications, get_report_closed_cves, get_report_cves, get_report_errors,
+    get_report_export, get_report_export_with_opts, get_report_hosts, get_report_operating_systems,
+    get_report_ports, get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns,
+    get_reports, import_report, GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts,
+    ImportReportOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -116,13 +118,15 @@ use gvm_gmp::responses::{
     GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
     GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
     GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse, GetOverridesResponse,
-    GetPermissionsResponse, GetPortListsResponse, GetReportClosedCvesResponse,
-    GetReportConfigsResponse, GetReportErrorsResponse, GetReportFormatsResponse,
-    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse,
-    GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
-    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
-    GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
-    GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
+    GetPermissionsResponse, GetPortListsResponse, GetReportApplicationsResponse,
+    GetReportClosedCvesResponse,
+    GetReportConfigsResponse, GetReportCvesResponse, GetReportErrorsResponse,
+    GetReportFormatsResponse, GetReportHostsResponse, GetReportOperatingSystemsResponse,
+    GetReportPortsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
+    GetReportsResponse, GetResultsResponse, GetRolesResponse, GetScanConfigsResponse,
+    GetScannersResponse, GetSchedulesResponse, GetSettingsResponse, GetTagsResponse,
+    GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
+    GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
     GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse, ModifyCredentialResponse,
     ModifyOciImageTargetResponse, ModifyScanConfigResponse, ModifyScannerResponse,
     ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
@@ -842,6 +846,78 @@ impl<C: GvmConnection + Send> GmpClient<C> {
             .send(get_report_tls_certificates(report_id, opts))
             .await?;
         GetReportTlsCertificatesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_hosts` request and return a typed
+    /// [`GetReportHostsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_hosts_parsed(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportHostsResponse, GvmError> {
+        let response = self.send(get_report_hosts(report_id, opts)).await?;
+        GetReportHostsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_ports` request and return a typed
+    /// [`GetReportPortsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_ports_parsed(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportPortsResponse, GvmError> {
+        let response = self.send(get_report_ports(report_id, opts)).await?;
+        GetReportPortsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_applications` request and return a typed
+    /// [`GetReportApplicationsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_applications_parsed(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportApplicationsResponse, GvmError> {
+        let response = self.send(get_report_applications(report_id, opts)).await?;
+        GetReportApplicationsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_operating_systems` request and return a typed
+    /// [`GetReportOperatingSystemsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_operating_systems_parsed(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportOperatingSystemsResponse, GvmError> {
+        let response = self
+            .send(get_report_operating_systems(report_id, opts))
+            .await?;
+        GetReportOperatingSystemsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_report_cves` request and return a typed
+    /// [`GetReportCvesResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_report_cves_parsed(
+        &mut self,
+        report_id: &EntityId,
+        opts: GetReportDetailsOpts,
+    ) -> Result<GetReportCvesResponse, GvmError> {
+        let response = self.send(get_report_cves(report_id, opts)).await?;
+        GetReportCvesResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a `get_report_errors` request and return a typed [`GetReportErrorsResponse`].

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -119,18 +119,18 @@ use gvm_gmp::responses::{
     GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
     GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse, GetOverridesResponse,
     GetPermissionsResponse, GetPortListsResponse, GetReportApplicationsResponse,
-    GetReportClosedCvesResponse,
-    GetReportConfigsResponse, GetReportCvesResponse, GetReportErrorsResponse,
-    GetReportFormatsResponse, GetReportHostsResponse, GetReportOperatingSystemsResponse,
-    GetReportPortsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
-    GetReportsResponse, GetResultsResponse, GetRolesResponse, GetScanConfigsResponse,
-    GetScannersResponse, GetSchedulesResponse, GetSettingsResponse, GetTagsResponse,
-    GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
-    GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
-    GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse, ModifyCredentialResponse,
-    ModifyOciImageTargetResponse, ModifyScanConfigResponse, ModifyScannerResponse,
-    ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
-    StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
+    GetReportClosedCvesResponse, GetReportConfigsResponse, GetReportCvesResponse,
+    GetReportErrorsResponse, GetReportFormatsResponse, GetReportHostsResponse,
+    GetReportOperatingSystemsResponse, GetReportPortsResponse, GetReportTlsCertificatesResponse,
+    GetReportVulnsResponse, GetReportsResponse, GetResultsResponse, GetRolesResponse,
+    GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
+    GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
+    GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
+    GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
+    ModifyAssetResponse, ModifyCredentialResponse, ModifyOciImageTargetResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ModifyWebApplicationTargetResponse,
+    ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
+    VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::CredentialStoreCredentialType;
@@ -851,6 +851,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Send a `get_report_hosts` request and return a typed
     /// [`GetReportHostsResponse`].
     ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_report_hosts`] method.
+    ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_report_hosts_parsed(
@@ -864,6 +867,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
 
     /// Send a `get_report_ports` request and return a typed
     /// [`GetReportPortsResponse`].
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_report_ports`] method.
     ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
@@ -879,6 +885,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Send a `get_report_applications` request and return a typed
     /// [`GetReportApplicationsResponse`].
     ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_report_applications`] method.
+    ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_report_applications_parsed(
@@ -892,6 +901,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
 
     /// Send a `get_report_operating_systems` request and return a typed
     /// [`GetReportOperatingSystemsResponse`].
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_report_operating_systems`] method.
     ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
@@ -908,6 +920,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
 
     /// Send a `get_report_cves` request and return a typed
     /// [`GetReportCvesResponse`].
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_report_cves`] method.
     ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1847,6 +1847,65 @@ async fn typed_report_import_uses_mock_server_stateful_create_command() {
 }
 
 #[tokio::test]
+async fn typed_report_drilldowns_parse_stateful_mock_responses() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let task_id = EntityId::new("task-drilldown").expect("valid id");
+    let created = client
+        .import_report(
+            r#"<report id="drilldown-report"><name>Drilldown</name></report>"#,
+            &task_id,
+            ImportReportOpts::default(),
+        )
+        .await
+        .expect("report import should succeed");
+
+    let hosts = client
+        .get_report_hosts(&created.id, Default::default())
+        .await
+        .expect("report hosts should parse");
+    assert_eq!(hosts.items.len(), 2);
+    assert_eq!(hosts.items[0].name.as_deref(), Some("192.0.2.10"));
+
+    let ports = client
+        .get_report_ports(&created.id, Default::default())
+        .await
+        .expect("report ports should parse");
+    assert_eq!(ports.items[0].name.as_deref(), Some("22/tcp"));
+
+    let applications = client
+        .get_report_applications(&created.id, Default::default())
+        .await
+        .expect("report applications should parse");
+    assert_eq!(applications.items[0].name.as_deref(), Some("OpenSSH"));
+
+    let operating_systems = client
+        .get_report_operating_systems(&created.id, Default::default())
+        .await
+        .expect("report operating systems should parse");
+    assert_eq!(operating_systems.items[0].name.as_deref(), Some("Debian"));
+
+    let cves = client
+        .get_report_cves(&created.id, Default::default())
+        .await
+        .expect("report cves should parse");
+    assert_eq!(cves.items[0].name.as_deref(), Some("CVE-2026-0001"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn full_crud_lifecycle_succeeds() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1872,32 +1872,32 @@ async fn typed_report_drilldowns_parse_stateful_mock_responses() {
         .expect("report import should succeed");
 
     let hosts = client
-        .get_report_hosts(&created.id, Default::default())
+        .get_report_hosts_parsed(&created.id, Default::default())
         .await
         .expect("report hosts should parse");
     assert_eq!(hosts.items.len(), 2);
     assert_eq!(hosts.items[0].name.as_deref(), Some("192.0.2.10"));
 
     let ports = client
-        .get_report_ports(&created.id, Default::default())
+        .get_report_ports_parsed(&created.id, Default::default())
         .await
         .expect("report ports should parse");
     assert_eq!(ports.items[0].name.as_deref(), Some("22/tcp"));
 
     let applications = client
-        .get_report_applications(&created.id, Default::default())
+        .get_report_applications_parsed(&created.id, Default::default())
         .await
         .expect("report applications should parse");
     assert_eq!(applications.items[0].name.as_deref(), Some("OpenSSH"));
 
     let operating_systems = client
-        .get_report_operating_systems(&created.id, Default::default())
+        .get_report_operating_systems_parsed(&created.id, Default::default())
         .await
         .expect("report operating systems should parse");
     assert_eq!(operating_systems.items[0].name.as_deref(), Some("Debian"));
 
     let cves = client
-        .get_report_cves(&created.id, Default::default())
+        .get_report_cves_parsed(&created.id, Default::default())
         .await
         .expect("report cves should parse");
     assert_eq!(cves.items[0].name.as_deref(), Some("CVE-2026-0001"));

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -91,9 +91,12 @@ pub use permission::{
 };
 pub use port_list::{CreatePortListResponse, GetPortListsResponse, PortList};
 pub use report::{
-    CreateReportResponse, DeleteReportResponse, GetReportClosedCvesResponse,
-    GetReportErrorsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
-    GetReportsResponse, Report, ReportClosedCve, ReportError, ReportExport, ReportTlsCertificate,
+    CreateReportResponse, DeleteReportResponse, GetReportApplicationsResponse,
+    GetReportClosedCvesResponse, GetReportCvesResponse, GetReportErrorsResponse,
+    GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
+    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse, Report,
+    ReportApplicationSummary, ReportClosedCve, ReportCveSummary, ReportError, ReportExport,
+    ReportHostSummary, ReportOperatingSystemSummary, ReportPortSummary, ReportTlsCertificate,
     ReportVulnerability, ResultCount, Severity,
 };
 pub use report_config::{

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -169,6 +169,101 @@ pub struct GetReportClosedCvesResponse {
     pub counts: CountInfo,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportHostSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportPortSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportApplicationSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportOperatingSystemSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ReportCveSummary {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub severity: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportHostsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportHostSummary>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportPortsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportPortSummary>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportApplicationsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportApplicationSummary>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportOperatingSystemsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportOperatingSystemSummary>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetReportCvesResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<ReportCveSummary>,
+    pub counts: CountInfo,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -354,6 +449,26 @@ impl ReportClosedCve {
     }
 }
 
+macro_rules! impl_report_summary {
+    ($item:ident) => {
+        impl $item {
+            fn from_node(node: &crate::responses::common::XmlNode) -> Self {
+                Self {
+                    id: node.attr("id").map(ToString::to_string),
+                    name: node.optional_child_text("name"),
+                    severity: node.optional_child_text("severity"),
+                }
+            }
+        }
+    };
+}
+
+impl_report_summary!(ReportHostSummary);
+impl_report_summary!(ReportPortSummary);
+impl_report_summary!(ReportApplicationSummary);
+impl_report_summary!(ReportOperatingSystemSummary);
+impl_report_summary!(ReportCveSummary);
+
 macro_rules! impl_report_detail_response {
     ($response:ident, $item:ident, [$($item_name:literal),+], $count_name:literal) => {
         impl $response {
@@ -392,6 +507,36 @@ impl_report_detail_response!(
     ReportClosedCve,
     ["closed_cve", "cve"],
     "closed_cve_count"
+);
+impl_report_detail_response!(
+    GetReportHostsResponse,
+    ReportHostSummary,
+    ["host"],
+    "host_count"
+);
+impl_report_detail_response!(
+    GetReportPortsResponse,
+    ReportPortSummary,
+    ["port"],
+    "port_count"
+);
+impl_report_detail_response!(
+    GetReportApplicationsResponse,
+    ReportApplicationSummary,
+    ["application"],
+    "application_count"
+);
+impl_report_detail_response!(
+    GetReportOperatingSystemsResponse,
+    ReportOperatingSystemSummary,
+    ["operating_system"],
+    "operating_system_count"
+);
+impl_report_detail_response!(
+    GetReportCvesResponse,
+    ReportCveSummary,
+    ["cve"],
+    "cve_count"
 );
 
 impl GetReportTlsCertificatesResponse {
@@ -915,6 +1060,70 @@ mod tests {
         assert_eq!(parsed.items.len(), 1);
         assert_eq!(parsed.items[0].cve.as_deref(), Some("CVE-2025-9999"));
         assert_eq!(parsed.items[0].severity.as_deref(), Some("5.0"));
+    }
+
+    #[test]
+    fn parses_report_summary_drilldowns() {
+        let hosts = GetReportHostsResponse::from_response(&Response::from(
+            r#"<get_report_hosts_response status="200" status_text="OK">
+                <host id="host-1"><name>192.0.2.10</name><severity>7.5</severity></host>
+                <host_count>1<filtered>1</filtered><page>1</page></host_count>
+            </get_report_hosts_response>"#,
+        ))
+        .expect("hosts parse");
+        assert_eq!(hosts.items[0].name.as_deref(), Some("192.0.2.10"));
+        assert_eq!(hosts.items[0].severity.as_deref(), Some("7.5"));
+        assert_eq!(hosts.counts.page, Some(1));
+
+        let ports = GetReportPortsResponse::from_response(&Response::from(
+            r#"<get_report_ports_response status="200" status_text="OK">
+                <port id="port-1"><name>443/tcp</name><severity>4.2</severity></port>
+                <port_count>1<filtered>1</filtered></port_count>
+            </get_report_ports_response>"#,
+        ))
+        .expect("ports parse");
+        assert_eq!(ports.items[0].name.as_deref(), Some("443/tcp"));
+
+        let applications = GetReportApplicationsResponse::from_response(&Response::from(
+            r#"<get_report_applications_response status="200" status_text="OK">
+                <application id="app-1"><name>OpenSSH</name><severity>6.5</severity></application>
+                <application_count>1<filtered>1</filtered></application_count>
+            </get_report_applications_response>"#,
+        ))
+        .expect("applications parse");
+        assert_eq!(applications.items[0].name.as_deref(), Some("OpenSSH"));
+
+        let operating_systems =
+            GetReportOperatingSystemsResponse::from_response(&Response::from(
+                r#"<get_report_operating_systems_response status="200" status_text="OK">
+                    <operating_system id="os-1"><name>Debian</name><severity>5.5</severity></operating_system>
+                    <operating_system_count>1<filtered>1</filtered></operating_system_count>
+                </get_report_operating_systems_response>"#,
+            ))
+            .expect("operating systems parse");
+        assert_eq!(operating_systems.items[0].name.as_deref(), Some("Debian"));
+
+        let cves = GetReportCvesResponse::from_response(&Response::from(
+            r#"<get_report_cves_response status="200" status_text="OK">
+                <cve id="cve-1"><name>CVE-2026-0001</name><severity>8.0</severity></cve>
+                <cve_count>1<filtered>1</filtered></cve_count>
+            </get_report_cves_response>"#,
+        ))
+        .expect("cves parse");
+        assert_eq!(cves.items[0].name.as_deref(), Some("CVE-2026-0001"));
+    }
+
+    #[test]
+    fn parses_empty_report_summary_drilldown() {
+        let response = Response::from(
+            r#"<get_report_hosts_response status="200" status_text="OK"><host_count>0<filtered>0</filtered></host_count></get_report_hosts_response>"#,
+        );
+
+        let parsed = GetReportHostsResponse::from_response(&response).expect("hosts parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+        assert_eq!(parsed.counts.filtered, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## What Problem This Solves

Adds typed response models for report host, port, application, operating-system, and CVE drill-down commands so downstream consumers do not have to parse GMP XML for those report subresources.

## Why This Change Was Made

`rust-gvm-api` needs stable typed contracts for the report subresource routes reserved by clawosiris/rust-gvm-api#344. The existing typed report models covered reports, vulnerabilities, TLS certificates, errors, and closed CVEs, but not the five newer summary payloads.

## User Impact

Consumers can call the high-level `GmpClient` report drill-down methods and receive typed Rust models with count metadata. The report-scoped summary types are exported separately from global asset/SecInfo types.

## Evidence

- `cargo test -p gvm-gmp report_summary_drilldown`
- `cargo test -p gvm-client --features unix-socket-tests typed_report_drilldowns_parse_stateful_mock_responses`
- `cargo test -p gvm-client --features unix-socket-tests report`

Fixes clawosiris/rust-gvm#374

Agent: Codex worker