### PR TITLE
feat(gmp): type agent and agent-group responses

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -59,6 +59,12 @@ use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
     get_web_application_target, get_web_application_targets, modify_web_application_target,
 };
+use gvm_gmp::responses::{
+    CloneAgentGroupResponse, CreateAgentGroupResponse, DeleteAgentGroupResponse,
+    DeleteAgentResponse, GetAgentGroupsResponse, GetAgentInstallerInstructionResponse,
+    GetAgentSupportBundleResponse, GetAgentsResponse, ModifyAgentControlScanConfigResponse,
+    ModifyAgentGroupResponse, ModifyAgentResponse, SyncAgentsResponse,
+};
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
 
@@ -377,8 +383,9 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
-    pub async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError> {
-        self.call(get_agents(opts)).await
+    pub async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<GetAgentsResponse, GvmError> {
+        let response = self.call(get_agents(opts)).await?;
+        GetAgentsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get a single agent.
@@ -386,8 +393,9 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
-    pub async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError> {
-        self.call(get_agent(agent_id)).await
+    pub async fn get_agent(&mut self, agent_id: &EntityId) -> Result<GetAgentsResponse, GvmError> {
+        let response = self.call(get_agent(agent_id)).await?;
+        GetAgentsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Modify one or more agents.
@@ -399,8 +407,9 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_ids: &[EntityId],
         opts: ModifyAgentOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(modify_agent(agent_ids, opts)).await
+    ) -> Result<ModifyAgentResponse, GvmError> {
+        let response = self.call(modify_agent(agent_ids, opts)).await?;
+        ModifyAgentResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Delete one or more agents.
@@ -408,8 +417,12 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
-    pub async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError> {
-        self.call(delete_agent(agent_ids)).await
+    pub async fn delete_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+    ) -> Result<DeleteAgentResponse, GvmError> {
+        let response = self.call(delete_agent(agent_ids)).await?;
+        DeleteAgentResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Synchronize agents.
@@ -417,8 +430,9 @@ impl<C: GvmConnection> GmpClient<C> {
     /// # Errors
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
-    pub async fn sync_agents(&mut self) -> Result<Response, GvmError> {
-        self.call(sync_agents()).await
+    pub async fn sync_agents(&mut self) -> Result<SyncAgentsResponse, GvmError> {
+        let response = self.call(sync_agents()).await?;
+        SyncAgentsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Modify the agent-control scan configuration defaults.
@@ -430,9 +444,11 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_control_id: &EntityId,
         opts: ModifyAgentControlScanConfigOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(modify_agent_control_scan_config(agent_control_id, opts))
-            .await
+    ) -> Result<ModifyAgentControlScanConfigResponse, GvmError> {
+        let response = self
+            .call(modify_agent_control_scan_config(agent_control_id, opts))
+            .await?;
+        ModifyAgentControlScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get agent installer instructions.
@@ -445,11 +461,13 @@ impl<C: GvmConnection> GmpClient<C> {
         scanner_id: &EntityId,
         language: AgentInstallerLanguage,
         origin_url: &str,
-    ) -> Result<Response, GvmError> {
-        self.call(get_agent_installer_instruction(
-            scanner_id, language, origin_url,
-        ))
-        .await
+    ) -> Result<GetAgentInstallerInstructionResponse, GvmError> {
+        let response = self
+            .call(get_agent_installer_instruction(
+                scanner_id, language, origin_url,
+            ))
+            .await?;
+        GetAgentInstallerInstructionResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get an agent support bundle.
@@ -461,8 +479,11 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_uuid: &EntityId,
         days: Option<u32>,
-    ) -> Result<Response, GvmError> {
-        self.call(get_agent_support_bundle(agent_uuid, days)).await
+    ) -> Result<GetAgentSupportBundleResponse, GvmError> {
+        let response = self
+            .call(get_agent_support_bundle(agent_uuid, days))
+            .await?;
+        GetAgentSupportBundleResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Create an agent group.
@@ -476,14 +497,16 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_ids: &[EntityId],
         scheduler_cron_time: &str,
         opts: CreateAgentGroupOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(create_agent_group(
-            name,
-            agent_ids,
-            scheduler_cron_time,
-            opts,
-        ))
-        .await
+    ) -> Result<CreateAgentGroupResponse, GvmError> {
+        let response = self
+            .call(create_agent_group(
+                name,
+                agent_ids,
+                scheduler_cron_time,
+                opts,
+            ))
+            .await?;
+        CreateAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Clone an agent group.
@@ -494,8 +517,9 @@ impl<C: GvmConnection> GmpClient<C> {
     pub async fn clone_agent_group(
         &mut self,
         agent_group_id: &EntityId,
-    ) -> Result<Response, GvmError> {
-        self.call(clone_agent_group(agent_group_id)).await
+    ) -> Result<CloneAgentGroupResponse, GvmError> {
+        let response = self.call(clone_agent_group(agent_group_id)).await?;
+        CloneAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Get a single agent group.
@@ -506,8 +530,9 @@ impl<C: GvmConnection> GmpClient<C> {
     pub async fn get_agent_group(
         &mut self,
         agent_group_id: &EntityId,
-    ) -> Result<Response, GvmError> {
-        self.call(get_agent_group(agent_group_id)).await
+    ) -> Result<GetAgentGroupsResponse, GvmError> {
+        let response = self.call(get_agent_group(agent_group_id)).await?;
+        GetAgentGroupsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// List agent groups.
@@ -518,8 +543,9 @@ impl<C: GvmConnection> GmpClient<C> {
     pub async fn get_agent_groups(
         &mut self,
         opts: GetAgentGroupsOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(get_agent_groups(opts)).await
+    ) -> Result<GetAgentGroupsResponse, GvmError> {
+        let response = self.call(get_agent_groups(opts)).await?;
+        GetAgentGroupsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Modify an agent group.
@@ -532,13 +558,15 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_group_id: &EntityId,
         scheduler_cron_time: &str,
         opts: ModifyAgentGroupOpts,
-    ) -> Result<Response, GvmError> {
-        self.call(modify_agent_group(
-            agent_group_id,
-            scheduler_cron_time,
-            opts,
-        ))
-        .await
+    ) -> Result<ModifyAgentGroupResponse, GvmError> {
+        let response = self
+            .call(modify_agent_group(
+                agent_group_id,
+                scheduler_cron_time,
+                opts,
+            ))
+            .await?;
+        ModifyAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Delete an agent group.
@@ -550,9 +578,11 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_group_id: &EntityId,
         ultimate: bool,
-    ) -> Result<Response, GvmError> {
-        self.call(delete_agent_group(agent_group_id, ultimate))
-            .await
+    ) -> Result<DeleteAgentGroupResponse, GvmError> {
+        let response = self
+            .call(delete_agent_group(agent_group_id, ultimate))
+            .await?;
+        DeleteAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Create an OCI image target.
@@ -945,30 +975,33 @@ pub trait Gmp226Commands {
 #[async_trait::async_trait]
 pub trait GmpNextCommands {
     /// List agents.
-    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError>;
+    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<GetAgentsResponse, GvmError>;
 
     /// Get a single agent.
-    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError>;
+    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<GetAgentsResponse, GvmError>;
 
     /// Modify one or more agents.
     async fn modify_agent(
         &mut self,
         agent_ids: &[EntityId],
         opts: ModifyAgentOpts,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<ModifyAgentResponse, GvmError>;
 
     /// Delete one or more agents.
-    async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError>;
+    async fn delete_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+    ) -> Result<DeleteAgentResponse, GvmError>;
 
     /// Synchronize agents.
-    async fn sync_agents(&mut self) -> Result<Response, GvmError>;
+    async fn sync_agents(&mut self) -> Result<SyncAgentsResponse, GvmError>;
 
     /// Modify the agent-control scan configuration defaults.
     async fn modify_agent_control_scan_config(
         &mut self,
         agent_control_id: &EntityId,
         opts: ModifyAgentControlScanConfigOpts,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<ModifyAgentControlScanConfigResponse, GvmError>;
 
     /// Get agent installer instructions.
     async fn get_agent_installer_instruction(
@@ -976,14 +1009,14 @@ pub trait GmpNextCommands {
         scanner_id: &EntityId,
         language: AgentInstallerLanguage,
         origin_url: &str,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<GetAgentInstallerInstructionResponse, GvmError>;
 
     /// Get an agent support bundle.
     async fn get_agent_support_bundle(
         &mut self,
         agent_uuid: &EntityId,
         days: Option<u32>,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<GetAgentSupportBundleResponse, GvmError>;
 
     /// Create an agent group.
     async fn create_agent_group(
@@ -992,7 +1025,7 @@ pub trait GmpNextCommands {
         agent_ids: &[EntityId],
         scheduler_cron_time: &str,
         opts: CreateAgentGroupOpts,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<CreateAgentGroupResponse, GvmError>;
 
     /// Create a task that scans an agent group.
     async fn create_agent_group_task(
@@ -1004,13 +1037,22 @@ pub trait GmpNextCommands {
     ) -> Result<Response, GvmError>;
 
     /// Clone an agent group.
-    async fn clone_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError>;
+    async fn clone_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<CloneAgentGroupResponse, GvmError>;
 
     /// Get a single agent group.
-    async fn get_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError>;
+    async fn get_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<GetAgentGroupsResponse, GvmError>;
 
     /// List agent groups.
-    async fn get_agent_groups(&mut self, opts: GetAgentGroupsOpts) -> Result<Response, GvmError>;
+    async fn get_agent_groups(
+        &mut self,
+        opts: GetAgentGroupsOpts,
+    ) -> Result<GetAgentGroupsResponse, GvmError>;
 
     /// Modify an agent group.
     async fn modify_agent_group(
@@ -1018,14 +1060,14 @@ pub trait GmpNextCommands {
         agent_group_id: &EntityId,
         scheduler_cron_time: &str,
         opts: ModifyAgentGroupOpts,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<ModifyAgentGroupResponse, GvmError>;
 
     /// Delete an agent group.
     async fn delete_agent_group(
         &mut self,
         agent_group_id: &EntityId,
         ultimate: bool,
-    ) -> Result<Response, GvmError>;
+    ) -> Result<DeleteAgentGroupResponse, GvmError>;
 
     /// Create an OCI image target.
     async fn create_oci_image_target(
@@ -1424,11 +1466,11 @@ impl_gmp226_commands!(GmpNext);
 
 #[async_trait::async_trait]
 impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
-    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<Response, GvmError> {
+    async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<GetAgentsResponse, GvmError> {
         self.0.get_agents(opts).await
     }
 
-    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<Response, GvmError> {
+    async fn get_agent(&mut self, agent_id: &EntityId) -> Result<GetAgentsResponse, GvmError> {
         self.0.get_agent(agent_id).await
     }
 
@@ -1436,15 +1478,18 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         &mut self,
         agent_ids: &[EntityId],
         opts: ModifyAgentOpts,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<ModifyAgentResponse, GvmError> {
         self.0.modify_agent(agent_ids, opts).await
     }
 
-    async fn delete_agent(&mut self, agent_ids: &[EntityId]) -> Result<Response, GvmError> {
+    async fn delete_agent(
+        &mut self,
+        agent_ids: &[EntityId],
+    ) -> Result<DeleteAgentResponse, GvmError> {
         self.0.delete_agent(agent_ids).await
     }
 
-    async fn sync_agents(&mut self) -> Result<Response, GvmError> {
+    async fn sync_agents(&mut self) -> Result<SyncAgentsResponse, GvmError> {
         self.0.sync_agents().await
     }
 
@@ -1452,7 +1497,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         &mut self,
         agent_control_id: &EntityId,
         opts: ModifyAgentControlScanConfigOpts,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<ModifyAgentControlScanConfigResponse, GvmError> {
         self.0
             .modify_agent_control_scan_config(agent_control_id, opts)
             .await
@@ -1463,7 +1508,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         scanner_id: &EntityId,
         language: AgentInstallerLanguage,
         origin_url: &str,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<GetAgentInstallerInstructionResponse, GvmError> {
         self.0
             .get_agent_installer_instruction(scanner_id, language, origin_url)
             .await
@@ -1473,7 +1518,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         &mut self,
         agent_uuid: &EntityId,
         days: Option<u32>,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<GetAgentSupportBundleResponse, GvmError> {
         self.0.get_agent_support_bundle(agent_uuid, days).await
     }
 
@@ -1483,7 +1528,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         agent_ids: &[EntityId],
         scheduler_cron_time: &str,
         opts: CreateAgentGroupOpts,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<CreateAgentGroupResponse, GvmError> {
         self.0
             .create_agent_group(name, agent_ids, scheduler_cron_time, opts)
             .await
@@ -1506,15 +1551,24 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
             .await
     }
 
-    async fn clone_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError> {
+    async fn clone_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<CloneAgentGroupResponse, GvmError> {
         self.0.clone_agent_group(agent_group_id).await
     }
 
-    async fn get_agent_group(&mut self, agent_group_id: &EntityId) -> Result<Response, GvmError> {
+    async fn get_agent_group(
+        &mut self,
+        agent_group_id: &EntityId,
+    ) -> Result<GetAgentGroupsResponse, GvmError> {
         self.0.get_agent_group(agent_group_id).await
     }
 
-    async fn get_agent_groups(&mut self, opts: GetAgentGroupsOpts) -> Result<Response, GvmError> {
+    async fn get_agent_groups(
+        &mut self,
+        opts: GetAgentGroupsOpts,
+    ) -> Result<GetAgentGroupsResponse, GvmError> {
         self.0.get_agent_groups(opts).await
     }
 
@@ -1523,7 +1577,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         agent_group_id: &EntityId,
         scheduler_cron_time: &str,
         opts: ModifyAgentGroupOpts,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<ModifyAgentGroupResponse, GvmError> {
         self.0
             .modify_agent_group(agent_group_id, scheduler_cron_time, opts)
             .await
@@ -1533,7 +1587,7 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         &mut self,
         agent_group_id: &EntityId,
         ultimate: bool,
-    ) -> Result<Response, GvmError> {
+    ) -> Result<DeleteAgentGroupResponse, GvmError> {
         self.0.delete_agent_group(agent_group_id, ultimate).await
     }
 

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -474,9 +474,8 @@ async fn next_client_agent_groups_round_trip() {
         )
         .await
         .expect("create_agent_group should succeed");
-    assert_eq!(create_response.status_code(), Some(201));
-    let agent_group_id = EntityId::new(create_response.id().expect("created id"))
-        .expect("server id should be valid");
+    assert_eq!(create_response.status, 201);
+    let agent_group_id = create_response.id;
 
     assert_create_agent_group_task_round_trip(&mut client, &server, &agent_group_id).await;
 
@@ -484,25 +483,25 @@ async fn next_client_agent_groups_round_trip() {
         .clone_agent_group(&agent_group_id)
         .await
         .expect("clone_agent_group should succeed");
-    assert_eq!(clone_response.status_code(), Some(201));
+    assert_eq!(clone_response.status, 201);
 
     let get_response = client
         .get_agent_group(&agent_group_id)
         .await
         .expect("get_agent_group should succeed");
-    let get_text = get_response.as_str().expect("valid UTF-8 XML");
-    assert!(get_text.contains("Client Agent Group"));
-    assert!(get_text.contains("<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"));
+    assert_eq!(get_response.items.len(), 1);
+    assert_eq!(get_response.items[0].meta.name, "Client Agent Group");
+    assert_eq!(
+        get_response.items[0].scheduler_cron_time.as_deref(),
+        Some("0 */5 * * *")
+    );
 
     let list_response = client
         .get_agent_groups(Default::default())
         .await
         .expect("get_agent_groups should succeed");
-    assert_eq!(list_response.status_code(), Some(200));
-    assert!(list_response
-        .as_str()
-        .expect("valid UTF-8 XML")
-        .contains("<agent_group_count>2"));
+    assert_eq!(list_response.status, 200);
+    assert_eq!(list_response.counts.total, Some(2));
 
     let modify_response = client
         .modify_agent_group(
@@ -516,22 +515,27 @@ async fn next_client_agent_groups_round_trip() {
         )
         .await
         .expect("modify_agent_group should succeed");
-    assert_eq!(modify_response.status_code(), Some(200));
+    assert_eq!(modify_response.status, 200);
 
     let updated_response = client
         .get_agent_group(&agent_group_id)
         .await
         .expect("updated get_agent_group should succeed");
-    let updated_text = updated_response.as_str().expect("valid UTF-8 XML");
-    assert!(updated_text.contains("Updated Agent Group"));
-    assert!(updated_text.contains("<comment>modified through client</comment>"));
-    assert!(updated_text.contains("<scheduler_cron_time>0 */10 * * *</scheduler_cron_time>"));
+    assert_eq!(updated_response.items[0].meta.name, "Updated Agent Group");
+    assert_eq!(
+        updated_response.items[0].meta.comment.as_deref(),
+        Some("modified through client")
+    );
+    assert_eq!(
+        updated_response.items[0].scheduler_cron_time.as_deref(),
+        Some("0 */10 * * *")
+    );
 
     let delete_response = client
         .delete_agent_group(&agent_group_id, true)
         .await
         .expect("delete_agent_group should succeed");
-    assert_eq!(delete_response.status_code(), Some(200));
+    assert_eq!(delete_response.status, 200);
 
     let error = client
         .get_agent_group(&agent_group_id)
@@ -657,7 +661,7 @@ async fn next_client_agent_commands_round_trip() {
         })
         .await
         .expect("get_agents should succeed");
-    assert_eq!(agents.status_code(), Some(200));
+    assert_eq!(agents.status, 200);
 
     let missing_agent = client
         .get_agent(&id("ffffffff-ffff-ffff-ffff-ffffffffffff"))
@@ -681,13 +685,13 @@ async fn next_client_agent_commands_round_trip() {
         )
         .await
         .expect("modify_agent should succeed");
-    assert_eq!(modify.status_code(), Some(200));
+    assert_eq!(modify.status, 200);
 
     let sync = client
         .sync_agents()
         .await
         .expect("sync_agents should succeed");
-    assert_eq!(sync.status_code(), Some(200));
+    assert_eq!(sync.status, 200);
 
     let control_config = client
         .modify_agent_control_scan_config(
@@ -699,7 +703,7 @@ async fn next_client_agent_commands_round_trip() {
         )
         .await
         .expect("modify_agent_control_scan_config should succeed");
-    assert_eq!(control_config.status_code(), Some(200));
+    assert_eq!(control_config.status, 200);
 
     let instruction = client
         .get_agent_installer_instruction(
@@ -709,23 +713,24 @@ async fn next_client_agent_commands_round_trip() {
         )
         .await
         .expect("get_agent_installer_instruction should succeed");
-    let instruction_xml = instruction.as_str().expect("valid UTF-8 XML");
-    assert!(instruction_xml.contains("<language>en</language>"));
-    assert!(instruction_xml.contains("<instruction>"));
+    assert_eq!(instruction.language, "en");
+    assert!(instruction.instruction.contains("mock agent"));
 
     let bundle = client
         .get_agent_support_bundle(&agent_ids[0], Some(7))
         .await
         .expect("get_agent_support_bundle should succeed");
-    let bundle_xml = bundle.as_str().expect("valid UTF-8 XML");
-    assert!(bundle_xml.contains("<content_type>application/octet-stream</content_type>"));
-    assert!(bundle_xml.contains("<content encoding=\"base64\">"));
+    assert_eq!(
+        bundle.file.content_type.as_deref(),
+        Some("application/octet-stream")
+    );
+    assert_eq!(bundle.file.content, b"hello-mock");
 
     let delete = client
         .delete_agent(&agent_ids)
         .await
         .expect("delete_agent should succeed");
-    assert_eq!(delete.status_code(), Some(200));
+    assert_eq!(delete.status, 200);
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/responses/agent.rs
+++ b/crates/gvm-gmp/src/responses/agent.rs
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Agent response models.
+
+use base64::Engine as _;
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, optional_u32, parse_bool, parse_document, parse_entity_meta, parse_named_entity,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError, XmlNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Agent {
+    pub meta: EntityMeta,
+    pub authorized: Option<bool>,
+    pub update_to_latest: Option<bool>,
+    pub status: Option<String>,
+    pub version: Option<String>,
+    pub last_update_time: Option<String>,
+    pub last_contact_time: Option<String>,
+    pub scanner: Option<NamedEntity>,
+    pub config: Option<AgentConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentConfig {
+    pub agent_control: Option<AgentControlConfig>,
+    pub agent_script_executor: Option<AgentScriptExecutorConfig>,
+    pub heartbeat: Option<AgentHeartbeatConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentControlConfig {
+    pub retry: Option<AgentRetryConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentRetryConfig {
+    pub attempts: Option<u32>,
+    pub delay_in_seconds: Option<u32>,
+    pub max_jitter_in_seconds: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentScriptExecutorConfig {
+    pub bulk_size: Option<u32>,
+    pub bulk_throttle_time_in_ms: Option<u32>,
+    pub indexer_dir_depth: Option<u32>,
+    pub scheduler_cron_time: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentHeartbeatConfig {
+    pub interval_in_seconds: Option<u32>,
+    pub miss_until_inactive: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAgentsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<Agent>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAgentInstallerInstructionResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub language: String,
+    pub instruction: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAgentSupportBundleResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub file: AgentSupportBundle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentSupportBundle {
+    pub name: String,
+    pub content_type: Option<String>,
+    pub size: Option<u32>,
+    pub content: Vec<u8>,
+    pub encoding: Option<String>,
+}
+
+impl Agent {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            authorized: optional_bool(node, "authorized")?,
+            update_to_latest: optional_bool(node, "update_to_latest")?,
+            status: node.optional_child_text("status"),
+            version: node.optional_child_text("version"),
+            last_update_time: node.optional_child_text("last_update_time"),
+            last_contact_time: node.optional_child_text("last_contact_time"),
+            scanner: parse_named_entity(node, "scanner")?,
+            config: node
+                .child("config")
+                .map(AgentConfig::from_node)
+                .transpose()?,
+        })
+    }
+}
+
+impl AgentConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            agent_control: node
+                .child("agent_control")
+                .map(AgentControlConfig::from_node)
+                .transpose()?,
+            agent_script_executor: node
+                .child("agent_script_executor")
+                .map(AgentScriptExecutorConfig::from_node)
+                .transpose()?,
+            heartbeat: node
+                .child("heartbeat")
+                .map(AgentHeartbeatConfig::from_node)
+                .transpose()?,
+        })
+    }
+}
+
+impl AgentControlConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            retry: node
+                .child("retry")
+                .map(AgentRetryConfig::from_node)
+                .transpose()?,
+        })
+    }
+}
+
+impl AgentRetryConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            attempts: optional_u32(node, "attempts", "retry.attempts")?,
+            delay_in_seconds: optional_u32(node, "delay_in_seconds", "retry.delay_in_seconds")?,
+            max_jitter_in_seconds: optional_u32(
+                node,
+                "max_jitter_in_seconds",
+                "retry.max_jitter_in_seconds",
+            )?,
+        })
+    }
+}
+
+impl AgentScriptExecutorConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            bulk_size: optional_u32(node, "bulk_size", "agent_script_executor.bulk_size")?,
+            bulk_throttle_time_in_ms: optional_u32(
+                node,
+                "bulk_throttle_time_in_ms",
+                "agent_script_executor.bulk_throttle_time_in_ms",
+            )?,
+            indexer_dir_depth: optional_u32(
+                node,
+                "indexer_dir_depth",
+                "agent_script_executor.indexer_dir_depth",
+            )?,
+            scheduler_cron_time: node
+                .child("scheduler_cron_time")
+                .map(|schedule| {
+                    schedule
+                        .children_named("item")
+                        .map(|item| item.text.clone())
+                        .filter(|item| !item.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        })
+    }
+}
+
+impl AgentHeartbeatConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            interval_in_seconds: optional_u32(
+                node,
+                "interval_in_seconds",
+                "heartbeat.interval_in_seconds",
+            )?,
+            miss_until_inactive: optional_u32(
+                node,
+                "miss_until_inactive",
+                "heartbeat.miss_until_inactive",
+            )?,
+        })
+    }
+}
+
+impl GetAgentsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("agent")
+            .map(Agent::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "agent_count")?,
+        })
+    }
+}
+
+impl GetAgentInstallerInstructionResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        Ok(Self {
+            status,
+            status_text,
+            language: root.required_child_text("language")?,
+            instruction: root.required_child_text("instruction")?,
+        })
+    }
+}
+
+impl GetAgentSupportBundleResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let file = root
+            .child("file")
+            .ok_or_else(|| ParseError::MissingElement("file".to_string()))?;
+        Ok(Self {
+            status,
+            status_text,
+            file: AgentSupportBundle::from_node(file)?,
+        })
+    }
+}
+
+impl AgentSupportBundle {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let content_node = node
+            .child("content")
+            .ok_or_else(|| ParseError::MissingElement("file.content".to_string()))?;
+        let encoding = content_node.attr("encoding").map(ToString::to_string);
+        let content = match encoding.as_deref() {
+            Some("base64") => base64::engine::general_purpose::STANDARD
+                .decode(strip_ascii_whitespace(&content_node.text))
+                .map_err(|_| ParseError::InvalidValue {
+                    field: "file.content".to_string(),
+                    value: content_node.text.clone(),
+                })?,
+            Some(other) => {
+                return Err(ParseError::InvalidValue {
+                    field: "file.content.encoding".to_string(),
+                    value: other.to_string(),
+                });
+            }
+            None => content_node.text.as_bytes().to_vec(),
+        };
+        let size = optional_u32(node, "size", "file.size")?;
+        if let Some(expected) = size {
+            if content.len() != expected as usize {
+                return Err(ParseError::InvalidValue {
+                    field: "file.size".to_string(),
+                    value: expected.to_string(),
+                });
+            }
+        }
+        Ok(Self {
+            name: node.required_child_text("name")?,
+            content_type: node.optional_child_text("content_type"),
+            size,
+            content,
+            encoding,
+        })
+    }
+}
+
+fn optional_bool(node: &XmlNode, name: &str) -> Result<Option<bool>, ParseError> {
+    node.optional_child_text(name)
+        .map(|value| parse_bool(&value, name))
+        .transpose()
+}
+
+fn strip_ascii_whitespace(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .collect()
+}
+
+pub type ModifyAgentResponse = ActionResponse;
+pub type DeleteAgentResponse = ActionResponse;
+pub type SyncAgentsResponse = ActionResponse;
+pub type ModifyAgentControlScanConfigResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_agents_with_config() {
+        let response = Response::from(
+            r#"<get_agents_response status="200" status_text="OK">
+                <agent id="agent-1">
+                    <owner><name>admin</name></owner>
+                    <name>Agent One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <authorized>1</authorized>
+                    <update_to_latest>0</update_to_latest>
+                    <status>active</status>
+                    <version>1.2.3</version>
+                    <last_update_time>2026-01-03T00:00:00Z</last_update_time>
+                    <last_contact_time>2026-01-04T00:00:00Z</last_contact_time>
+                    <scanner id="scanner-1"><name>Agent Controller</name></scanner>
+                    <config>
+                        <agent_control>
+                            <retry>
+                                <attempts>3</attempts>
+                                <delay_in_seconds>10</delay_in_seconds>
+                                <max_jitter_in_seconds>5</max_jitter_in_seconds>
+                            </retry>
+                        </agent_control>
+                        <agent_script_executor>
+                            <bulk_size>20</bulk_size>
+                            <bulk_throttle_time_in_ms>100</bulk_throttle_time_in_ms>
+                            <indexer_dir_depth>4</indexer_dir_depth>
+                            <scheduler_cron_time><item>0 */6 * * *</item><item>30 */6 * * *</item></scheduler_cron_time>
+                        </agent_script_executor>
+                        <heartbeat>
+                            <interval_in_seconds>60</interval_in_seconds>
+                            <miss_until_inactive>3</miss_until_inactive>
+                        </heartbeat>
+                    </config>
+                </agent>
+                <agent id="agent-2"><name>Agent Two</name><authorized>false</authorized></agent>
+                <agent_count>2<filtered>2</filtered><page>1</page></agent_count>
+            </get_agents_response>"#,
+        );
+
+        let parsed = GetAgentsResponse::from_response(&response).expect("agents parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        let agent = &parsed.items[0];
+        assert_eq!(agent.meta.name, "Agent One");
+        assert_eq!(agent.authorized, Some(true));
+        assert_eq!(agent.update_to_latest, Some(false));
+        assert_eq!(agent.status.as_deref(), Some("active"));
+        assert_eq!(
+            agent.scanner.as_ref().map(|scanner| scanner.name.as_str()),
+            Some("Agent Controller")
+        );
+        let executor = agent
+            .config
+            .as_ref()
+            .and_then(|config| config.agent_script_executor.as_ref())
+            .expect("executor config");
+        assert_eq!(
+            executor.scheduler_cron_time,
+            vec!["0 */6 * * *", "30 */6 * * *"]
+        );
+        assert_eq!(parsed.items[1].authorized, Some(false));
+    }
+
+    #[test]
+    fn parses_empty_agents() {
+        let response = Response::from(
+            r#"<get_agents_response status="200" status_text="OK"><agent_count>0<filtered>0</filtered></agent_count></get_agents_response>"#,
+        );
+
+        let parsed = GetAgentsResponse::from_response(&response).expect("agents parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_installer_instruction() {
+        let response = Response::from(
+            r#"<get_agent_installer_instruction_response status="200" status_text="OK"><language>en</language><instruction>Install it.</instruction></get_agent_installer_instruction_response>"#,
+        );
+
+        let parsed = GetAgentInstallerInstructionResponse::from_response(&response)
+            .expect("instruction parses");
+
+        assert_eq!(parsed.language, "en");
+        assert_eq!(parsed.instruction, "Install it.");
+    }
+
+    #[test]
+    fn parses_base64_support_bundle() {
+        let response = Response::from(
+            r#"<get_agent_support_bundle_response status="200" status_text="OK">
+                <file>
+                    <name>bundle.tar.gz</name>
+                    <content_type>application/octet-stream</content_type>
+                    <size>10</size>
+                    <content encoding="base64">aGVs bG8t&#10;bW9jaw==</content>
+                </file>
+            </get_agent_support_bundle_response>"#,
+        );
+
+        let parsed =
+            GetAgentSupportBundleResponse::from_response(&response).expect("support bundle parses");
+
+        assert_eq!(parsed.file.name, "bundle.tar.gz");
+        assert_eq!(
+            parsed.file.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+        assert_eq!(parsed.file.size, Some(10));
+        assert_eq!(parsed.file.content, b"hello-mock");
+        assert_eq!(parsed.file.encoding.as_deref(), Some("base64"));
+    }
+
+    #[test]
+    fn rejects_support_bundle_size_mismatch() {
+        let response = Response::from(
+            r#"<get_agent_support_bundle_response status="200" status_text="OK">
+                <file><name>bundle</name><size>11</size><content encoding="base64">aGVsbG8tbW9jaw==</content></file>
+            </get_agent_support_bundle_response>"#,
+        );
+
+        let error = GetAgentSupportBundleResponse::from_response(&response)
+            .expect_err("size mismatch rejected");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, .. } if field == "file.size"
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_support_bundle_base64() {
+        let response = Response::from(
+            r#"<get_agent_support_bundle_response status="200" status_text="OK">
+                <file><name>bundle</name><content encoding="base64">not-base64***</content></file>
+            </get_agent_support_bundle_response>"#,
+        );
+
+        let error = GetAgentSupportBundleResponse::from_response(&response)
+            .expect_err("invalid base64 rejected");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, .. } if field == "file.content"
+        ));
+    }
+
+    #[test]
+    fn rejects_semantically_incomplete_support_bundle() {
+        let response = Response::from(
+            r#"<get_agent_support_bundle_response status="200" status_text="OK"><file><content>data</content></file></get_agent_support_bundle_response>"#,
+        );
+
+        let error = GetAgentSupportBundleResponse::from_response(&response)
+            .expect_err("missing name rejected");
+
+        assert!(matches!(error, ParseError::MissingElement(field) if field == "name"));
+    }
+}

--- a/crates/gvm-gmp/src/responses/agent.rs
+++ b/crates/gvm-gmp/src/responses/agent.rs
@@ -191,7 +191,7 @@ impl AgentScriptExecutorConfig {
                 .map(|schedule| {
                     schedule
                         .children_named("item")
-                        .map(|item| item.text.clone())
+                        .map(|item| item.text.trim().to_owned())
                         .filter(|item| !item.is_empty())
                         .collect()
                 })
@@ -357,7 +357,11 @@ mod tests {
                             <bulk_size>20</bulk_size>
                             <bulk_throttle_time_in_ms>100</bulk_throttle_time_in_ms>
                             <indexer_dir_depth>4</indexer_dir_depth>
-                            <scheduler_cron_time><item>0 */6 * * *</item><item>30 */6 * * *</item></scheduler_cron_time>
+                            <scheduler_cron_time>
+                                <item> 0 */6 * * * </item>
+                                <item>30 */6 * * *</item>
+                                <item>   </item>
+                            </scheduler_cron_time>
                         </agent_script_executor>
                         <heartbeat>
                             <interval_in_seconds>60</interval_in_seconds>

--- a/crates/gvm-gmp/src/responses/agent_group.rs
+++ b/crates/gvm-gmp/src/responses/agent_group.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Agent group response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError, XmlNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentGroup {
+    pub meta: EntityMeta,
+    pub scheduler_cron_time: Option<String>,
+    pub agents: Vec<NamedEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetAgentGroupsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<AgentGroup>,
+    pub counts: CountInfo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CreateAgentGroupResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+}
+
+impl AgentGroup {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            scheduler_cron_time: node.optional_child_text("scheduler_cron_time"),
+            agents: parse_agents(node)?,
+        })
+    }
+}
+
+impl GetAgentGroupsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("agent_group")
+            .map(AgentGroup::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "agent_group_count")?,
+        })
+    }
+}
+
+impl CreateAgentGroupResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+        })
+    }
+}
+
+fn parse_agents(node: &XmlNode) -> Result<Vec<NamedEntity>, ParseError> {
+    let Some(agents) = node.child("agents") else {
+        return Ok(Vec::new());
+    };
+    agents
+        .children_named("agent")
+        .map(|agent| {
+            let raw_id = agent
+                .attr("id")
+                .ok_or_else(|| ParseError::MissingElement("agents.agent.id".to_string()))?;
+            Ok(NamedEntity {
+                id: parse_entity_id(raw_id, "agents.agent.id")?,
+                name: agent.optional_child_text("name").unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+pub type CloneAgentGroupResponse = CreateAgentGroupResponse;
+pub type ModifyAgentGroupResponse = ActionResponse;
+pub type DeleteAgentGroupResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_multiple_agent_groups() {
+        let response = Response::from(
+            r#"<get_agent_groups_response status="200" status_text="OK">
+                <agent_group id="group-1">
+                    <owner><name>admin</name></owner>
+                    <name>Group One</name>
+                    <comment>first</comment>
+                    <creation_time>2026-01-01T00:00:00Z</creation_time>
+                    <modification_time>2026-01-02T00:00:00Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <scheduler_cron_time>0 */5 * * *</scheduler_cron_time>
+                    <agents>
+                        <agent id="agent-1"><name>Agent One</name></agent>
+                        <agent id="agent-2"><name>Agent Two</name></agent>
+                    </agents>
+                </agent_group>
+                <agent_group id="group-2"><name>Group Two</name></agent_group>
+                <agent_group_count>2<filtered>2</filtered><page>1</page></agent_group_count>
+            </get_agent_groups_response>"#,
+        );
+
+        let parsed = GetAgentGroupsResponse::from_response(&response).expect("agent groups parse");
+
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.counts.total, Some(2));
+        assert_eq!(parsed.counts.filtered, Some(2));
+        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.items[0].meta.name, "Group One");
+        assert_eq!(
+            parsed.items[0].scheduler_cron_time.as_deref(),
+            Some("0 */5 * * *")
+        );
+        assert_eq!(parsed.items[0].agents.len(), 2);
+        assert_eq!(parsed.items[0].agents[0].name, "Agent One");
+        assert!(parsed.items[1].agents.is_empty());
+    }
+
+    #[test]
+    fn parses_empty_agent_groups() {
+        let response = Response::from(
+            r#"<get_agent_groups_response status="200" status_text="OK"><agent_group_count>0<filtered>0</filtered></agent_group_count></get_agent_groups_response>"#,
+        );
+
+        let parsed = GetAgentGroupsResponse::from_response(&response).expect("agent groups parse");
+
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn parses_create_agent_group_response() {
+        let response = Response::from(
+            r#"<create_agent_group_response status="201" status_text="OK, resource created" id="group-1"/>"#,
+        );
+
+        let parsed = CreateAgentGroupResponse::from_response(&response).expect("create parses");
+
+        assert_eq!(parsed.id.as_str(), "group-1");
+    }
+
+    #[test]
+    fn rejects_agent_without_id() {
+        let response = Response::from(
+            r#"<get_agent_groups_response status="200" status_text="OK">
+                <agent_group id="group-1"><name>Group</name><agents><agent><name>Agent</name></agent></agents></agent_group>
+            </get_agent_groups_response>"#,
+        );
+
+        let error =
+            GetAgentGroupsResponse::from_response(&response).expect_err("missing id rejected");
+
+        assert!(matches!(
+            error,
+            ParseError::MissingElement(field) if field == "agents.agent.id"
+        ));
+    }
+}

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -6,6 +6,8 @@
 #![allow(missing_docs)]
 #![allow(clippy::missing_errors_doc)]
 
+pub mod agent;
+pub mod agent_group;
 pub mod aggregates;
 pub mod alert;
 pub mod asset;
@@ -46,6 +48,16 @@ pub mod user_settings;
 pub mod version;
 pub mod web_application_target;
 
+pub use agent::{
+    Agent, AgentConfig, AgentControlConfig, AgentHeartbeatConfig, AgentRetryConfig,
+    AgentScriptExecutorConfig, AgentSupportBundle, DeleteAgentResponse,
+    GetAgentInstallerInstructionResponse, GetAgentSupportBundleResponse, GetAgentsResponse,
+    ModifyAgentControlScanConfigResponse, ModifyAgentResponse, SyncAgentsResponse,
+};
+pub use agent_group::{
+    AgentGroup, CloneAgentGroupResponse, CreateAgentGroupResponse, DeleteAgentGroupResponse,
+    GetAgentGroupsResponse, ModifyAgentGroupResponse,
+};
 pub use aggregates::{AggregateGroup, AggregateStats, AggregateSubgroup, GetAggregatesResponse};
 pub use alert::{
     Alert, CreateAlertResponse, DeleteAlertResponse, GetAlertsResponse, ModifyAlertResponse,


### PR DESCRIPTION
## Summary
- add typed agent and agent-group response models, including list metadata and action/create response envelopes
- parse installer instructions and support bundles with base64 decoding plus size validation
- update Next client agent/agent-group methods and tests to return typed values

## Tests
- cargo fmt --check
- cargo test -p gvm-gmp agent --lib
- cargo test -p gvm-client --features unix-socket-tests
- cargo test -p gvm-gmp
- cargo check --workspace --all-features

Closes #373