### PR TITLE
docs(journal): add 2026-07-23 entry

### DIFF
--- a/journal/2026-07-23.md
+++ b/journal/2026-07-23.md
@@ -1,0 +1,11 @@
+# 2026-07-23 — Helper Integration Advanced and Credential Creation Cleared Review
+
+## Devel Integration
+- Since the 2026-07-22 journal checkpoint, three additional non-journal PRs merged into `devel`.
+- PR [#341](https://github.com/clawosiris/rust-gvm/pull/341) added OCI-image target task creation, PR [#342](https://github.com/clawosiris/rust-gvm/pull/342) added the corresponding web-application task helper, and PR [#343](https://github.com/clawosiris/rust-gvm/pull/343) added credential-store query options.
+- Each merge completed with the visible CI and security suites green. The default `main` branch and release/tag set did not move.
+
+## Queue Recovery
+- PR [#345](https://github.com/clawosiris/rust-gvm/pull/345), which creates credential-store credentials, was rebased onto the newly advanced `devel` branch.
+- Its conflict resolution preserved the credential-store verification and query helpers already integrated into `devel`; follow-up fixes also cleared Rust 1.95 Clippy failures inherited from the new base.
+- The PR is now clean, approved, and green across all visible CI and security checks, but remains open pending merge.


### PR DESCRIPTION
## Summary

- record the three additional helper PRs merged into `devel`
- capture the successful rebase and validation recovery for PR #345
- note that `main`, releases, and tags did not move

Agent: Thoth
