### PR TITLE
Align integration configuration request and response fidelity

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -30,6 +30,10 @@ use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFilt
 use gvm_gmp::commands::groups::{create_group, get_groups, GetGroupsOpts, GroupOpts};
 use gvm_gmp::commands::help::help;
 use gvm_gmp::commands::hosts::{create_host, get_hosts, GetHostsOpts, HostOpts};
+use gvm_gmp::commands::integration_configs::{
+    get_integration_config, get_integration_configs, modify_integration_config,
+    GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
+};
 use gvm_gmp::commands::notes::{create_note, get_notes, GetNotesOpts, NoteOpts};
 use gvm_gmp::commands::nvts::{
     get_nvt_families, get_nvts, get_scan_config_nvt, get_scan_config_nvts, GetNvtsOpts,
@@ -116,21 +120,22 @@ use gvm_gmp::responses::{
     DescribeAuthResponse, EmptyTrashcanResponse, GetAlertsResponse, GetAssetsResponse,
     GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
     GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
-    GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetNotesResponse,
-    GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse, GetOverridesResponse,
-    GetPermissionsResponse, GetPortListsResponse, GetReportApplicationsResponse,
-    GetReportClosedCvesResponse, GetReportConfigsResponse, GetReportCvesResponse,
-    GetReportErrorsResponse, GetReportFormatsResponse, GetReportHostsResponse,
-    GetReportOperatingSystemsResponse, GetReportPortsResponse, GetReportTlsCertificatesResponse,
-    GetReportVulnsResponse, GetReportsResponse, GetResultsResponse, GetRolesResponse,
-    GetScanConfigsResponse, GetScannersResponse, GetSchedulesResponse, GetSettingsResponse,
-    GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
-    GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
-    GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
-    ModifyAssetResponse, ModifyCredentialResponse, ModifyOciImageTargetResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ModifyWebApplicationTargetResponse,
-    ReportExport, RestoreResponse, ResumeTaskResponse, StartTaskResponse, SyncConfigResponse,
-    VerifyCredentialStoreResponse, VerifyScannerResponse,
+    GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse,
+    GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
+    GetOverridesResponse, GetPermissionsResponse, GetPortListsResponse,
+    GetReportApplicationsResponse, GetReportClosedCvesResponse, GetReportConfigsResponse,
+    GetReportCvesResponse, GetReportErrorsResponse, GetReportFormatsResponse,
+    GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
+    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse,
+    GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
+    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
+    GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
+    GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
+    GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse, ModifyCredentialResponse,
+    ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyScanConfigResponse,
+    ModifyScannerResponse, ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse,
+    ResumeTaskResponse, StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse,
+    VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::CredentialStoreCredentialType;
@@ -1605,6 +1610,59 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn create_host(&mut self, opts: HostOpts) -> Result<CreateHostResponse, GvmError> {
         let response = self.send(create_host(opts)).await?;
         CreateHostResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    // ── Integration Configurations ────────────────────────────────────────────
+
+    /// Send a single `get_integration_config` request and return a typed response.
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_integration_config`] method.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_integration_config_parsed(
+        &mut self,
+        integration_config_id: &EntityId,
+        details: Option<bool>,
+    ) -> Result<GetIntegrationConfigsResponse, GvmError> {
+        let response = self
+            .send(get_integration_config(integration_config_id, details))
+            .await?;
+        GetIntegrationConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_integration_configs` request and return a typed response.
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::get_integration_configs`] method.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_integration_configs_parsed(
+        &mut self,
+        opts: GetIntegrationConfigsOpts,
+    ) -> Result<GetIntegrationConfigsResponse, GvmError> {
+        let response = self.send(get_integration_configs(opts)).await?;
+        GetIntegrationConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_integration_config` request and return a typed response.
+    ///
+    /// The `_parsed` suffix distinguishes this helper from the raw
+    /// [`GmpClient::modify_integration_config`] method.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_integration_config_parsed(
+        &mut self,
+        integration_config_id: &EntityId,
+        opts: ModifyIntegrationConfigOpts,
+    ) -> Result<ModifyIntegrationConfigResponse, GvmError> {
+        let response = self
+            .send(modify_integration_config(integration_config_id, opts))
+            .await?;
+        ModifyIntegrationConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Assets ──────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -835,7 +835,10 @@ async fn next_commands_work_on_v22_8() {
             &integration_config_id,
             gvm_client::ModifyIntegrationConfigOpts {
                 service_url: Some("https://updated.example".into()),
-                ..Default::default()
+                service_cacert: Some("UPDATED-CA".into()),
+                oidc_provider_url: Some("https://updated-oidc.example".into()),
+                oidc_provider_client_id: Some("updated-client".into()),
+                oidc_provider_client_secret: Some("updated-secret".into()),
             },
         )
         .await
@@ -854,6 +857,68 @@ async fn next_commands_work_on_v22_8() {
         .await
         .expect_err("missing report should return server error through alias");
     assert!(matches!(alias_error, GvmError::Server { status: 404, .. }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_integration_configs_round_trip_over_unix_transport() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authenticate should succeed");
+
+    let integration_config_id =
+        EntityId::new("00000000-0000-0000-0000-000000000100").expect("valid id");
+    let get_response = client
+        .get_integration_config_parsed(&integration_config_id, Some(true))
+        .await
+        .expect("detailed integration config should parse");
+    assert_eq!(get_response.items.len(), 1);
+    assert_eq!(
+        get_response.items[0]
+            .service
+            .as_ref()
+            .map(|service| service.url.as_str()),
+        Some("https://service.example.invalid")
+    );
+    assert_eq!(
+        get_response.items[0]
+            .oidc
+            .as_ref()
+            .map(|oidc| oidc.client_id.as_str()),
+        Some("mock-client-id")
+    );
+
+    let list_response = client
+        .get_integration_configs_parsed(Default::default())
+        .await
+        .expect("integration config list should parse");
+    assert_eq!(list_response.counts.total, Some(1));
+    assert!(list_response.items[0].service.is_none());
+    assert!(list_response.items[0].oidc.is_none());
+
+    let modify_response = client
+        .modify_integration_config_parsed(
+            &integration_config_id,
+            gvm_client::ModifyIntegrationConfigOpts {
+                service_url: Some("https://typed.example".into()),
+                service_cacert: Some("TYPED-CA".into()),
+                oidc_provider_url: Some("https://typed-oidc.example".into()),
+                oidc_provider_client_id: Some("typed-client".into()),
+                oidc_provider_client_secret: Some("typed-secret".into()),
+            },
+        )
+        .await
+        .expect("typed modify response should parse");
+    assert_eq!(modify_response.status, 200);
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/integration_configs.rs
+++ b/crates/gvm-gmp/src/commands/integration_configs.rs
@@ -17,7 +17,11 @@ pub struct GetIntegrationConfigsOpts {
     pub filter_id: Option<EntityId>,
 }
 
-/// Options for `modify_integration_config` requests.
+/// Options for a full `modify_integration_config` replacement.
+///
+/// gvmd requires the service URL, OIDC URL, client ID, and client secret
+/// together when any configurable value is non-empty. Leaving every field
+/// unset clears the integration configuration.
 #[derive(Debug, Clone, Default)]
 pub struct ModifyIntegrationConfigOpts {
     /// Optional integration service URL.
@@ -56,7 +60,7 @@ pub fn get_integration_config(
     cmd
 }
 
-/// Build a `modify_integration_config` request.
+/// Build a schema-complete `modify_integration_config` request.
 #[must_use]
 pub fn modify_integration_config(
     integration_config_id: &EntityId,
@@ -65,35 +69,24 @@ pub fn modify_integration_config(
     let mut cmd = XmlCommand::new("modify_integration_config")
         .attribute("uuid", integration_config_id.as_str());
 
-    if opts.service_url.is_some() || opts.service_cacert.is_some() {
-        let service = cmd.add_element("service");
-        if let Some(service_url) = opts.service_url.as_deref() {
-            service.add_child_with_text("url", service_url);
-        }
-        if let Some(service_cacert) = opts.service_cacert.as_deref() {
-            service.add_child_with_text("cacert", service_cacert);
-        }
-    }
+    let service = cmd.add_element("service");
+    service.add_child_with_text("url", opts.service_url.as_deref().unwrap_or_default());
+    service.add_child_with_text("cacert", opts.service_cacert.as_deref().unwrap_or_default());
 
-    if opts.oidc_provider_url.is_some()
-        || opts.oidc_provider_client_id.is_some()
-        || opts.oidc_provider_client_secret.is_some()
-    {
-        let oidc = cmd.add_element("oidc");
-        if let Some(oidc_provider_url) = opts.oidc_provider_url.as_deref() {
-            oidc.add_child_with_text("oidc_provider_url", oidc_provider_url);
-        }
+    let oidc = cmd.add_element("oidc");
+    oidc.add_child_with_text("url", opts.oidc_provider_url.as_deref().unwrap_or_default());
 
-        if opts.oidc_provider_client_id.is_some() || opts.oidc_provider_client_secret.is_some() {
-            let client = oidc.add_child("client");
-            if let Some(client_id) = opts.oidc_provider_client_id.as_deref() {
-                client.add_child_with_text("id", client_id);
-            }
-            if let Some(client_secret) = opts.oidc_provider_client_secret.as_deref() {
-                client.add_child_with_text("secret", client_secret);
-            }
-        }
-    }
+    let client = oidc.add_child("client");
+    client.add_child_with_text(
+        "id",
+        opts.oidc_provider_client_id.as_deref().unwrap_or_default(),
+    );
+    client.add_child_with_text(
+        "secret",
+        opts.oidc_provider_client_secret
+            .as_deref()
+            .unwrap_or_default(),
+    );
 
     cmd
 }
@@ -135,11 +128,11 @@ mod tests {
                     oidc_provider_client_secret: Some("client-secret".into()),
                 }
             )),
-            "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert>CERT</cacert></service><oidc><oidc_provider_url>https://oidc.example</oidc_provider_url><client><id>client-id</id><secret>client-secret</secret></client></oidc></modify_integration_config>"
+            "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert>CERT</cacert></service><oidc><url>https://oidc.example</url><client><id>client-id</id><secret>client-secret</secret></client></oidc></modify_integration_config>"
         );
         assert_eq!(
             xml(modify_integration_config(&id("ic1"), Default::default())),
-            "<modify_integration_config uuid=\"ic1\"/>"
+            "<modify_integration_config uuid=\"ic1\"><service><url></url><cacert></cacert></service><oidc><url></url><client><id></id><secret></secret></client></oidc></modify_integration_config>"
         );
     }
 }

--- a/crates/gvm-gmp/src/responses/integration_config.rs
+++ b/crates/gvm-gmp/src/responses/integration_config.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Integration-configuration response models.
+
+use gvm_protocol::Response;
+
+use crate::responses::common::{
+    count_info, parse_document, parse_entity_meta, status_from_response, ActionResponse, CountInfo,
+    EntityMeta, ParseError, XmlNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct IntegrationConfigService {
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct IntegrationConfigOidc {
+    pub url: String,
+    pub client_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct IntegrationConfig {
+    pub meta: EntityMeta,
+    pub service: Option<IntegrationConfigService>,
+    pub oidc: Option<IntegrationConfigOidc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetIntegrationConfigsResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub items: Vec<IntegrationConfig>,
+    pub counts: CountInfo,
+}
+
+impl IntegrationConfigService {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            url: node.required_child_text("url")?,
+        })
+    }
+}
+
+impl IntegrationConfigOidc {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let client = node
+            .child("client")
+            .ok_or_else(|| ParseError::MissingElement("oidc.client".to_string()))?;
+        Ok(Self {
+            url: node.required_child_text("url")?,
+            client_id: client.required_child_text("id")?,
+        })
+    }
+}
+
+impl IntegrationConfig {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        Ok(Self {
+            meta: parse_entity_meta(node)?,
+            service: node
+                .child("service")
+                .map(IntegrationConfigService::from_node)
+                .transpose()?,
+            oidc: node
+                .child("oidc")
+                .map(IntegrationConfigOidc::from_node)
+                .transpose()?,
+        })
+    }
+}
+
+impl GetIntegrationConfigsResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("integration_config")
+            .map(IntegrationConfig::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+            counts: count_info(&root, "integration_config_count")?,
+        })
+    }
+}
+
+pub type ModifyIntegrationConfigResponse = ActionResponse;
+
+#[cfg(test)]
+mod tests {
+    use gvm_protocol::Response;
+
+    use super::*;
+
+    #[test]
+    fn parses_detailed_integration_config() {
+        let response = Response::from(
+            r#"<get_integration_configs_response status="200" status_text="OK">
+                <integration_config id="ic-1">
+                    <owner><name>admin</name></owner>
+                    <name>Security Intelligence</name>
+                    <comment>Primary integration</comment>
+                    <creation_time>2026-03-20T15:21:22Z</creation_time>
+                    <modification_time>2026-03-20T15:27:56Z</modification_time>
+                    <writable>1</writable>
+                    <in_use>0</in_use>
+                    <service><url>https://service.example</url></service>
+                    <oidc>
+                        <url>https://oidc.example</url>
+                        <client><id>client-id</id></client>
+                    </oidc>
+                </integration_config>
+                <integration_config_count>1<filtered>1</filtered><page>1</page></integration_config_count>
+            </get_integration_configs_response>"#,
+        );
+
+        let parsed =
+            GetIntegrationConfigsResponse::from_response(&response).expect("response parses");
+
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.items.len(), 1);
+        assert_eq!(parsed.counts.total, Some(1));
+        assert_eq!(parsed.items[0].meta.name, "Security Intelligence");
+        assert_eq!(
+            parsed.items[0]
+                .service
+                .as_ref()
+                .map(|service| service.url.as_str()),
+            Some("https://service.example")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .oidc
+                .as_ref()
+                .map(|oidc| oidc.client_id.as_str()),
+            Some("client-id")
+        );
+    }
+
+    #[test]
+    fn parses_summary_and_empty_list_responses() {
+        let summary = Response::from(
+            r#"<get_integration_configs_response status="200" status_text="OK">
+                <integration_config id="ic-1"><name>Summary</name></integration_config>
+            </get_integration_configs_response>"#,
+        );
+        let parsed =
+            GetIntegrationConfigsResponse::from_response(&summary).expect("summary parses");
+        assert_eq!(parsed.items.len(), 1);
+        assert!(parsed.items[0].service.is_none());
+        assert!(parsed.items[0].oidc.is_none());
+        assert_eq!(parsed.counts, CountInfo::default());
+
+        let empty = Response::from(
+            r#"<get_integration_configs_response status="200" status_text="OK"><integration_config_count>0<filtered>0</filtered><page>0</page></integration_config_count></get_integration_configs_response>"#,
+        );
+        let parsed = GetIntegrationConfigsResponse::from_response(&empty).expect("empty parses");
+        assert!(parsed.items.is_empty());
+        assert_eq!(parsed.counts.total, Some(0));
+    }
+
+    #[test]
+    fn rejects_incomplete_details_and_server_errors() {
+        let incomplete = Response::from(
+            r#"<get_integration_configs_response status="200" status_text="OK"><integration_config id="ic-1"><name>Broken</name><oidc><url>https://oidc.example</url></oidc></integration_config></get_integration_configs_response>"#,
+        );
+        assert!(matches!(
+            GetIntegrationConfigsResponse::from_response(&incomplete),
+            Err(ParseError::MissingElement(field)) if field == "oidc.client"
+        ));
+
+        let error = Response::from(
+            r#"<get_integration_configs_response status="404" status_text="Not found"/>"#,
+        );
+        assert!(matches!(
+            GetIntegrationConfigsResponse::from_response(&error),
+            Err(ParseError::ServerError {
+                status: 404,
+                message
+            }) if message == "Not found"
+        ));
+    }
+
+    #[test]
+    fn parses_modify_response() {
+        let response = Response::from(
+            r#"<modify_integration_config_response status="200" status_text="OK"/>"#,
+        );
+        let parsed = ModifyIntegrationConfigResponse::from_response(&response)
+            .expect("modify response parses");
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.status_text, "OK");
+    }
+}

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -19,6 +19,7 @@ pub mod feed;
 pub mod filter;
 pub mod group;
 pub mod host;
+pub mod integration_config;
 pub mod note;
 pub mod nvt;
 pub mod oci_image_target;
@@ -84,6 +85,10 @@ pub use group::{
 pub use host::{
     AssetSource, CreateHostResponse, DeleteHostResponse, GetHostsResponse, Host, HostDetail,
     HostIdentifier, HostOperatingSystem, ModifyHostResponse,
+};
+pub use integration_config::{
+    GetIntegrationConfigsResponse, IntegrationConfig, IntegrationConfigOidc,
+    IntegrationConfigService, ModifyIntegrationConfigResponse,
 };
 pub use note::{
     CreateNoteResponse, DeleteNoteResponse, GetNotesResponse, ModifyNoteResponse, Note,

--- a/crates/gvm-gmp/tests/test_integration_configs.rs
+++ b/crates/gvm-gmp/tests/test_integration_configs.rs
@@ -31,7 +31,7 @@ fn test_get_integration_configs_variants() {
 fn test_modify_integration_config_variants() {
     assert_eq!(
         xml(modify_integration_config(&id("ic1"), Default::default())),
-        "<modify_integration_config uuid=\"ic1\"/>"
+        "<modify_integration_config uuid=\"ic1\"><service><url></url><cacert></cacert></service><oidc><url></url><client><id></id><secret></secret></client></oidc></modify_integration_config>"
     );
     assert_eq!(
         xml(modify_integration_config(
@@ -42,6 +42,6 @@ fn test_modify_integration_config_variants() {
                 ..Default::default()
             },
         )),
-        "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url></service><oidc><client><id>client-id</id></client></oidc></modify_integration_config>"
+        "<modify_integration_config uuid=\"ic1\"><service><url>https://service.example</url><cacert></cacert></service><oidc><url></url><client><id>client-id</id><secret></secret></client></oidc></modify_integration_config>"
     );
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -853,7 +853,11 @@ impl SessionHandler {
                     if cmd.name == "get_reports" {
                         return self.render_single_report_response(cmd, &resource, store);
                     }
-                    let xml = resource.to_xml();
+                    let xml = if cmd.name == "get_integration_configs" {
+                        resource.to_integration_config_xml(cmd.attr("details") == Some("1"))
+                    } else {
+                        resource.to_xml()
+                    };
                     return format!(
                         "<{}_response status=\"200\" status_text=\"OK\">\
                          {xml}\
@@ -909,7 +913,15 @@ impl SessionHandler {
         }
 
         let count = resources.len();
-        let items: String = resources.iter().map(|r| r.to_xml()).collect();
+        let items: String = if cmd.name == "get_integration_configs" {
+            let details = cmd.attr("details") == Some("1");
+            resources
+                .iter()
+                .map(|resource| resource.to_integration_config_xml(details))
+                .collect()
+        } else {
+            resources.iter().map(|resource| resource.to_xml()).collect()
+        };
 
         format!(
             "<{name}_response status=\"200\" status_text=\"OK\">\
@@ -977,13 +989,56 @@ impl SessionHandler {
             (
                 nested_child_text(cmd, &["service", "url"]),
                 nested_child_text(cmd, &["service", "cacert"]),
-                nested_child_text(cmd, &["oidc", "oidc_provider_url"]),
+                nested_child_text(cmd, &["oidc", "url"]),
                 nested_child_text(cmd, &["oidc", "client", "id"]),
                 nested_child_text(cmd, &["oidc", "client", "secret"]),
             )
         } else {
             (None, None, None, None, None)
         };
+
+        if resource_type == "integration_config" {
+            for (value, field) in [
+                (&new_service_url, "service <url>"),
+                (&new_oidc_provider_url, "oidc <url>"),
+                (&new_oidc_client_id, "oidc client <id>"),
+                (&new_oidc_client_secret, "oidc client <secret>"),
+            ] {
+                if value.is_none() {
+                    return error_response(
+                        &cmd.name,
+                        400,
+                        &format!("Invalid arguments: missing {field}"),
+                    );
+                }
+            }
+
+            let all_empty = [
+                new_service_url.as_deref(),
+                new_service_cacert.as_deref(),
+                new_oidc_provider_url.as_deref(),
+                new_oidc_client_id.as_deref(),
+                new_oidc_client_secret.as_deref(),
+            ]
+            .into_iter()
+            .all(|value| value.is_none_or(|value| value.trim().is_empty()));
+            if !all_empty {
+                for (value, field) in [
+                    (new_service_url.as_deref(), "service <url>"),
+                    (new_oidc_provider_url.as_deref(), "oidc <url>"),
+                    (new_oidc_client_id.as_deref(), "oidc client <id>"),
+                    (new_oidc_client_secret.as_deref(), "oidc client <secret>"),
+                ] {
+                    if value.is_none_or(|value| value.trim().is_empty()) {
+                        return error_response(
+                            &cmd.name,
+                            400,
+                            &format!("Invalid arguments: missing {field}"),
+                        );
+                    }
+                }
+            }
+        }
 
         let modified = store.modify(&uuid, |r| {
             if matches!(resource_type, "note" | "override") {

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -255,6 +255,37 @@ impl Resource {
         xml.push_str(&format!("</{}>", self.resource_type));
         xml
     }
+
+    /// Generate the canonical gvmd representation for an integration configuration.
+    pub(crate) fn to_integration_config_xml(&self, details: bool) -> String {
+        let mut xml = format!(
+            "<integration_config id=\"{id}\">\
+             <owner><name>admin</name></owner>\
+             <name>{name}</name>\
+             <comment>{comment}</comment>\
+             <creation_time>{ct}</creation_time>\
+             <modification_time>{mt}</modification_time>\
+             <writable>1</writable>\
+             <in_use>0</in_use>\
+             <permissions><permission><name>Everything</name></permission></permissions>",
+            id = self.id,
+            name = xml_escape(&self.name),
+            comment = xml_escape(&self.comment),
+            ct = self.creation_time,
+            mt = self.modification_time,
+        );
+        if details {
+            xml.push_str(&format!(
+                "<service><url>{service_url}</url></service>\
+                 <oidc><url>{oidc_url}</url><client><id>{client_id}</id></client></oidc>",
+                service_url = xml_escape(self.attr("service_url").unwrap_or_default()),
+                oidc_url = xml_escape(self.attr("oidc_provider_url").unwrap_or_default()),
+                client_id = xml_escape(self.attr("oidc_provider_client_id").unwrap_or_default()),
+            ));
+        }
+        xml.push_str("</integration_config>");
+        xml
+    }
 }
 
 /// Thread-safe resource store.

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -349,19 +349,7 @@ async fn version_22_8_accepts_next_commands() {
     let mut stream = connect(&server).await;
     authenticate_admin(&mut stream).await;
 
-    let get_response = send_recv(
-        &mut stream,
-        get_integration_config(&id("00000000-0000-0000-0000-000000000100"), Some(true)),
-    )
-    .await;
-    assert_eq!(get_response.status_code(), Some(200));
-
-    let list_response = send_recv(&mut stream, get_integration_configs(Default::default())).await;
-    assert_eq!(list_response.status_code(), Some(200));
-    assert!(list_response
-        .as_str()
-        .expect("utf8")
-        .contains("Default Integration Config"));
+    assert_integration_configs_work_on_next(&mut stream).await;
 
     let agent_group_response = send_recv(
         &mut stream,
@@ -382,40 +370,7 @@ async fn version_22_8_accepts_next_commands() {
         .expect("utf8")
         .contains("Version Gated Agent Group"));
 
-    let modify_response = send_recv(
-        &mut stream,
-        modify_integration_config(
-            &id("00000000-0000-0000-0000-000000000100"),
-            gvm_gmp::commands::integration_configs::ModifyIntegrationConfigOpts {
-                service_url: Some("https://updated.example".into()),
-                ..Default::default()
-            },
-        ),
-    )
-    .await;
-    assert_eq!(modify_response.status_code(), Some(200));
-
-    let modified_get_response = send_recv(
-        &mut stream,
-        get_integration_config(&id("00000000-0000-0000-0000-000000000100"), Some(true)),
-    )
-    .await;
-    let modified_xml = modified_get_response.as_str().expect("utf8");
-    assert!(modified_xml.contains("<service_url>https://updated.example</service_url>"));
-    assert!(modified_xml.contains("<service_cacert>MOCK-CA-CERT</service_cacert>"));
-    assert!(
-        modified_xml.contains("<oidc_provider_client_id>mock-client-id</oidc_provider_client_id>")
-    );
-
-    let missing_uuid_response =
-        send_recv(&mut stream, XmlCommand::new("modify_integration_config")).await;
-    assert_eq!(missing_uuid_response.status_code(), Some(400));
-    assert!(missing_uuid_response
-        .status_text()
-        .expect("status text")
-        .contains("uuid"));
-
-    let report_helper = send_recv(
+    let report_response = send_recv(
         &mut stream,
         get_report_cves(
             &id("00000000-0000-0000-0000-000000000200"),
@@ -423,7 +378,7 @@ async fn version_22_8_accepts_next_commands() {
         ),
     )
     .await;
-    assert_eq!(report_helper.status_code(), Some(404));
+    assert_eq!(report_response.status_code(), Some(404));
 
     assert_credential_store_verify_works_on_next(&mut stream).await;
     assert_credential_store_credentials_work_on_next(&mut stream).await;
@@ -431,6 +386,96 @@ async fn version_22_8_accepts_next_commands() {
     assert_oci_image_targets_work_on_next(&mut stream).await;
 
     server.shutdown().await;
+}
+
+async fn assert_integration_configs_work_on_next(stream: &mut UnixStream) {
+    let integration_config_id = id("00000000-0000-0000-0000-000000000100");
+    let get_response = send_recv(
+        stream,
+        get_integration_config(&integration_config_id, Some(true)),
+    )
+    .await;
+    assert_eq!(get_response.status_code(), Some(200));
+
+    let list_response = send_recv(stream, get_integration_configs(Default::default())).await;
+    assert_eq!(list_response.status_code(), Some(200));
+    assert!(list_response
+        .as_str()
+        .expect("utf8")
+        .contains("Default Integration Config"));
+
+    let modify_response = send_recv(
+        stream,
+        modify_integration_config(
+            &integration_config_id,
+            gvm_gmp::commands::integration_configs::ModifyIntegrationConfigOpts {
+                service_url: Some("https://updated.example".into()),
+                service_cacert: Some("UPDATED-CA".into()),
+                oidc_provider_url: Some("https://updated-oidc.example".into()),
+                oidc_provider_client_id: Some("updated-client".into()),
+                oidc_provider_client_secret: Some("updated-secret".into()),
+            },
+        ),
+    )
+    .await;
+    assert_eq!(modify_response.status_code(), Some(200));
+
+    let modified_get_response = send_recv(
+        stream,
+        get_integration_config(&integration_config_id, Some(true)),
+    )
+    .await;
+    let modified_xml = modified_get_response.as_str().expect("utf8");
+    assert!(modified_xml.contains("<service><url>https://updated.example</url></service>"));
+    assert!(modified_xml.contains(
+        "<oidc><url>https://updated-oidc.example</url><client><id>updated-client</id></client></oidc>"
+    ));
+    assert!(!modified_xml.contains("MOCK-CA-CERT"));
+    assert!(!modified_xml.contains("mock-client-secret"));
+
+    let missing_uuid_response =
+        send_recv(stream, XmlCommand::new("modify_integration_config")).await;
+    assert_eq!(missing_uuid_response.status_code(), Some(400));
+    assert!(missing_uuid_response
+        .status_text()
+        .expect("status text")
+        .contains("uuid"));
+
+    let malformed_modify = send_recv(
+        stream,
+        XmlCommand::new("modify_integration_config")
+            .attribute("uuid", "00000000-0000-0000-0000-000000000100"),
+    )
+    .await;
+    assert_eq!(malformed_modify.status_code(), Some(400));
+    assert!(malformed_modify
+        .status_text()
+        .expect("status text")
+        .contains("service"));
+
+    let partial_modify = send_recv(
+        stream,
+        modify_integration_config(
+            &integration_config_id,
+            gvm_gmp::commands::integration_configs::ModifyIntegrationConfigOpts {
+                service_url: Some("https://partial.example".into()),
+                ..Default::default()
+            },
+        ),
+    )
+    .await;
+    assert_eq!(partial_modify.status_code(), Some(400));
+    assert!(partial_modify
+        .status_text()
+        .expect("status text")
+        .contains("oidc"));
+
+    let clear_response = send_recv(
+        stream,
+        modify_integration_config(&integration_config_id, Default::default()),
+    )
+    .await;
+    assert_eq!(clear_response.status_code(), Some(200));
 }
 
 async fn assert_web_application_targets_and_tasks_work_on_next(stream: &mut UnixStream) {


### PR DESCRIPTION
## Summary

- add typed parsed helpers and response models for integration configurations while preserving the existing raw client API
- align modify requests with current gvmd full-replacement semantics and the canonical `oidc/url` wire shape
- make the stateful mock validate and render canonical nested integration-configuration details without returning credentials or CA certificate material
- cover typed parsing and round trips over the real Unix client transport

## Public compatibility evidence

The request and response shape was checked against the current public gvmd implementation and GMP schema:

- https://github.com/greenbone/gvmd/blob/main/src/gmp_integration_configs.c
- https://github.com/greenbone/gvmd/blob/main/src/manage_sql_integration_configs.c
- https://github.com/greenbone/gvmd/blob/main/src/GMP.xml.in

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --no-fail-fast`
- `cargo test --workspace --all-features --no-fail-fast`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo +1.85.0 check --workspace --all-features`
- `cargo +1.85.0 test --workspace --all-features --no-fail-fast`
- full python-gvm Unix, TLS, and mTLS integration suite via `make test-integration`
- `cargo deny check`, `cargo audit`, `cargo machete`, and `cargo vet`
- workspace unsafe-usage check: all five crates report `used_unsafe=0`
- Semgrep Rust/security/secrets scan with `--disable-nosem --error`: no findings
- staged Gitleaks scan: no findings
- SBOM generation/postprocessing and SBOM quality unit tests
- `cargo llvm-cov` plus `diff-cover --compare-branch=upstream/devel --fail-under=100`: 186/186 changed executable lines covered

## Validation boundaries

- No live gvmd instance was available; compatibility was verified against current public gvmd source/schema and exercised through the real client transport against `gvm-mock-server`.
- Fuzzing was not run under the current project restriction; deterministic regressions and transport tests cover this changed surface.
- Local `sbomqs` was unavailable; SBOM generation/postprocessing and repository SBOM quality tests passed, and the repository CI quality job remains authoritative.