### PR TITLE
Correct feature discovery response fidelity

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -25,6 +25,7 @@ use gvm_gmp::commands::credentials::{
     CredentialStoreCredentialOpts, GetCredentialStoresOpts, GetCredentialsOpts,
     ModifyCredentialStoreCredentialOpts,
 };
+use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{create_group, get_groups, GetGroupsOpts, GroupOpts};
@@ -119,10 +120,10 @@ use gvm_gmp::responses::{
     DeleteScanConfigResponse, DeleteScannerResponse, DeleteWebApplicationTargetResponse,
     DescribeAuthResponse, EmptyTrashcanResponse, GetAlertsResponse, GetAssetsResponse,
     GetCertBundAdvisoriesResponse, GetCpesResponse, GetCredentialStoresResponse,
-    GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeedsResponse,
-    GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse,
-    GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
-    GetOverridesResponse, GetPermissionsResponse, GetPortListsResponse,
+    GetCredentialsResponse, GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeaturesResponse,
+    GetFeedsResponse, GetFiltersResponse, GetGroupsResponse, GetHostsResponse,
+    GetIntegrationConfigsResponse, GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse,
+    GetOciImageTargetsResponse, GetOverridesResponse, GetPermissionsResponse, GetPortListsResponse,
     GetReportApplicationsResponse, GetReportClosedCvesResponse, GetReportConfigsResponse,
     GetReportCvesResponse, GetReportErrorsResponse, GetReportFormatsResponse,
     GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
@@ -1849,6 +1850,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     }
 
     // ── System ────────────────────────────────────────────────────────────────
+
+    /// Send a `get_features` request and return a typed
+    /// [`GetFeaturesResponse`].
+    ///
+    /// The `_parsed` suffix avoids conflicting with the raw
+    /// [`crate::Gmp226Commands::get_features`] versioned-client method.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_features_parsed(&mut self) -> Result<GetFeaturesResponse, GvmError> {
+        let response = self.send(get_features()).await?;
+        GetFeaturesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
 
     /// Send a `get_settings` request and return a typed [`GetSettingsResponse`].
     ///

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -168,6 +168,47 @@ async fn connect_negotiates_supported_versions() {
 }
 
 #[tokio::test]
+async fn typed_feature_discovery_parses_current_gvmd_shape_over_unix_transport() {
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Fixture)
+        .version(MockVersion::V22_8)
+        .unix_socket_auto()
+        .override_response(
+            "get_features",
+            "<get_features_response status=\"200\" status_text=\"OK\">\
+             <feature compiled_in=\"1\" enabled=\"1\"><name>ENABLE_AGENTS</name></feature>\
+             <feature compiled_in=\"1\" enabled=\"0\"><name>ENABLE_JWT_AUTH</name></feature>\
+             </get_features_response>",
+        )
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    let response = client
+        .get_features_parsed()
+        .await
+        .expect("typed feature discovery should parse");
+
+    assert_eq!(response.features.len(), 2);
+    assert_eq!(response.features[0].name, "ENABLE_AGENTS");
+    assert!(response.features[0].compiled_in);
+    assert!(response.features[0].enabled);
+    assert_eq!(response.features[1].name, "ENABLE_JWT_AUTH");
+    assert!(response.features[1].compiled_in);
+    assert!(!response.features[1].enabled);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn unsupported_version_returns_error() {
     let Some(server) = fixture_server_with_version_response("21.4").await else {
         return;

--- a/crates/gvm-gmp/src/responses/features.rs
+++ b/crates/gvm-gmp/src/responses/features.rs
@@ -5,13 +5,16 @@
 
 use gvm_protocol::Response;
 
-use crate::responses::common::{parse_document, status_from_response, ParseError, XmlNode};
+use crate::responses::common::{
+    parse_bool, parse_document, status_from_response, ParseError, XmlNode,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Feature {
     pub name: String,
+    pub compiled_in: bool,
     pub enabled: bool,
 }
 
@@ -27,11 +30,19 @@ pub struct GetFeaturesResponse {
 impl Feature {
     fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
         let name = node.required_child_text("name")?;
+        let compiled_in = node
+            .attr("compiled_in")
+            .ok_or_else(|| ParseError::MissingElement("feature.compiled_in".to_string()))
+            .and_then(|value| parse_bool(value, "feature.compiled_in"))?;
         let enabled = node
-            .child_text("_enabled")
-            .map(|text| text == "1" || text.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        Ok(Self { name, enabled })
+            .attr("enabled")
+            .ok_or_else(|| ParseError::MissingElement("feature.enabled".to_string()))
+            .and_then(|value| parse_bool(value, "feature.enabled"))?;
+        Ok(Self {
+            name,
+            compiled_in,
+            enabled,
+        })
     }
 }
 
@@ -61,9 +72,9 @@ mod tests {
     fn parses_features_response() {
         let response = Response::from(
             r#"<get_features_response status="200" status_text="OK">
-                <feature><name>SCAP</name><_enabled>1</_enabled></feature>
-                <feature><name>CERT_BUND</name><_enabled>1</_enabled></feature>
-                <feature><name>ENTERPRISE</name><_enabled>0</_enabled></feature>
+                <feature compiled_in="1" enabled="1"><name>ENABLE_OPENVASD</name></feature>
+                <feature compiled_in="true" enabled="1"><name>ENABLE_AGENTS</name></feature>
+                <feature compiled_in="0" enabled="false"><name>ENABLE_JWT_AUTH</name></feature>
             </get_features_response>"#,
         );
 
@@ -71,8 +82,11 @@ mod tests {
 
         assert_eq!(parsed.status, 200);
         assert_eq!(parsed.features.len(), 3);
-        assert_eq!(parsed.features[0].name, "SCAP");
+        assert_eq!(parsed.features[0].name, "ENABLE_OPENVASD");
+        assert!(parsed.features[0].compiled_in);
         assert!(parsed.features[0].enabled);
+        assert!(parsed.features[1].compiled_in);
+        assert!(!parsed.features[2].compiled_in);
         assert!(!parsed.features[2].enabled);
     }
 
@@ -83,5 +97,38 @@ mod tests {
         let parsed = GetFeaturesResponse::from_response(&response).expect("parse");
 
         assert!(parsed.features.is_empty());
+    }
+
+    #[test]
+    fn rejects_missing_feature_attributes() {
+        let response = Response::from(
+            r#"<get_features_response status="200" status_text="OK">
+                <feature enabled="1"><name>ENABLE_AGENTS</name></feature>
+            </get_features_response>"#,
+        );
+
+        let error = GetFeaturesResponse::from_response(&response).expect_err("missing compiled_in");
+
+        assert!(matches!(
+            error,
+            ParseError::MissingElement(field) if field == "feature.compiled_in"
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_feature_attributes() {
+        let response = Response::from(
+            r#"<get_features_response status="200" status_text="OK">
+                <feature compiled_in="1" enabled="sometimes"><name>ENABLE_AGENTS</name></feature>
+            </get_features_response>"#,
+        );
+
+        let error = GetFeaturesResponse::from_response(&response).expect_err("invalid enabled");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, value }
+                if field == "feature.enabled" && value == "sometimes"
+        ));
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -218,11 +218,7 @@ impl SessionHandler {
 
         // Route to specific handlers
         match cmd.name.as_str() {
-            "get_features" => {
-                "<get_features_response status=\"200\" status_text=\"OK\"></get_features_response>"
-                    .as_bytes()
-                    .to_vec()
-            }
+            "get_features" => render_features_response(),
             "get_agent_installer_instruction" => render_agent_installer_instruction_response(cmd),
             "get_agent_support_bundle" => render_agent_support_bundle_response(cmd),
             "create_asset" => self.handle_create_asset(cmd, store),
@@ -1458,6 +1454,28 @@ impl SessionHandler {
         )
         .into_bytes()
     }
+}
+
+fn render_features_response() -> Vec<u8> {
+    const FEATURE_NAMES: [&str; 8] = [
+        "ENABLE_OPENVASD",
+        "ENABLE_CONTAINER_SCANNING",
+        "ENABLE_AGENTS",
+        "ENABLE_CREDENTIAL_STORES",
+        "FEED_VT_METADATA",
+        "ENABLE_SECURITY_INTELLIGENCE_EXPORT",
+        "ENABLE_JWT_AUTH",
+        "ENABLE_WEB_APPLICATION_SCANNING",
+    ];
+
+    let mut xml = String::from("<get_features_response status=\"200\" status_text=\"OK\">");
+    for name in FEATURE_NAMES {
+        xml.push_str("<feature compiled_in=\"0\" enabled=\"0\"><name>");
+        xml.push_str(name);
+        xml.push_str("</name></feature>");
+    }
+    xml.push_str("</get_features_response>");
+    xml.into_bytes()
 }
 
 fn render_report_result_xml(result: &Resource) -> String {

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -142,6 +142,11 @@ async fn assert_version_gated_accepted(version: GmpVersion) {
 
     let features_response = send_recv(&mut stream, get_features()).await;
     assert_eq!(features_response.status_code(), Some(200));
+    let features_text = features_response.as_str().expect("valid UTF-8");
+    assert!(features_text.contains(
+        "<feature compiled_in=\"0\" enabled=\"0\"><name>ENABLE_OPENVASD</name></feature>"
+    ));
+    assert!(features_text.contains("<name>ENABLE_WEB_APPLICATION_SCANNING</name>"));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- parse the required `compiled_in` and `enabled` feature attributes emitted by current gvmd instead of a nonexistent `_enabled` child
- expose `compiled_in` and reject missing or invalid feature flags instead of silently reporting them as disabled
- add a compatible `get_features_parsed` client helper while retaining the existing raw versioned-client API
- make the stateful mock emit the canonical eight-feature runtime shape conservatively with every mock feature disabled
- exercise typed feature discovery over the real Unix client transport

## Public compatibility evidence

The wire shape and current eight-entry feature set were verified against the current public gvmd runtime implementation:

- https://github.com/greenbone/gvmd/blob/452969ac33b4f062f574d119d927f3039a7b3aab/src/gmp.c#L13940-L14035
- https://github.com/greenbone/gvmd/blob/452969ac33b4f062f574d119d927f3039a7b3aab/src/schema_formats/XML/GMP.xml.in

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --no-fail-fast`
- `cargo test --workspace --all-features --no-fail-fast`
- strict workspace/all-target/all-feature Clippy and rustdoc
- Rust 1.85 all-feature workspace check and test
- full python-gvm Unix, TLS, and mTLS integration suite via `make test-integration`
- `cargo deny check`, `cargo audit`, `cargo machete`, and `cargo vet`
- workspace unsafe-usage check: all five crates report `used_unsafe=0`
- Semgrep Rust/security/secrets scan with `--disable-nosem --error`: no findings
- staged Gitleaks scan: no findings
- CycloneDX generation/postprocessing and repository SBOM quality tests
- `cargo llvm-cov` plus `diff-cover --compare-branch=upstream/devel --fail-under=100`: 46/46 changed executable lines covered

## Validation boundaries

- No live gvmd instance was available; compatibility was verified against pinned current public gvmd runtime source/schema and exercised through the real client transport against `gvm-mock-server`.
- Fuzzing was not run under the current project restriction; deterministic parser/error and transport regressions cover this changed surface.
- Local `sbomqs` was unavailable; generation/postprocessing and repository quality tests passed, and the repository CI quality job remains authoritative.