### PR TITLE
Correct help command and response fidelity

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -80,6 +80,7 @@ pub use gvm_gmp::commands::agents::{
 pub use gvm_gmp::commands::credentials::{
     CredentialStoreCredentialOpts, GetCredentialStoresOpts, ModifyCredentialStoreCredentialOpts,
 };
+pub use gvm_gmp::commands::help::HelpMode;
 pub use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
 };

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -28,7 +28,7 @@ use gvm_gmp::commands::credentials::{
 use gvm_gmp::commands::feed::get_feeds;
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{create_group, get_groups, GetGroupsOpts, GroupOpts};
-use gvm_gmp::commands::help::help;
+use gvm_gmp::commands::help::{help, help_with_mode, HelpMode};
 use gvm_gmp::commands::hosts::{create_host, get_hosts, GetHostsOpts, HostOpts};
 use gvm_gmp::commands::notes::{create_note, get_notes, GetNotesOpts, NoteOpts};
 use gvm_gmp::commands::nvts::{
@@ -1807,6 +1807,15 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_help(&mut self) -> Result<HelpResponse, GvmError> {
         let response = self.send(help(None)).await?;
+        HelpResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `help` request for an explicit response mode.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_help_with_mode(&mut self, mode: HelpMode) -> Result<HelpResponse, GvmError> {
+        let response = self.send(help_with_mode(mode)).await?;
         HelpResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -21,6 +21,7 @@ use gvm_gmp::commands::credentials::{
     ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::feed::get_feed;
+use gvm_gmp::commands::help::HelpMode;
 use gvm_gmp::commands::nvts::{
     get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,
 };
@@ -238,6 +239,37 @@ async fn live_wire_trace_observes_typed_helper_with_redaction() {
                 && event_text(event).contains("<authenticate_response")
         }));
     }
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_help_preserves_brief_xml_over_unix_transport() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authentication should succeed");
+
+    let response = client
+        .get_help_with_mode(HelpMode::BriefXml)
+        .await
+        .expect("brief XML help should parse");
+    let schema = response.schema.expect("brief help schema");
+
+    assert!(response.help_text.is_empty());
+    assert_eq!(schema.format.as_deref(), Some("XML"));
+    assert_eq!(schema.commands.len(), 6);
+    assert!(schema
+        .commands
+        .iter()
+        .any(|command| command.name == "get_tasks"));
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-gmp/src/commands/help.rs
+++ b/crates/gvm-gmp/src/commands/help.rs
@@ -5,7 +5,12 @@
 
 use gvm_protocol::XmlCommand;
 
+use crate::enums::HelpFormat as SchemaFormat;
+
 /// Supported help output formats.
+///
+/// This compatibility enum selects the XML command-listing variants. Use
+/// [`HelpMode`] for new code that also needs text or another schema format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HelpFormat {
     /// Abbreviated command listing.
@@ -15,7 +20,10 @@ pub enum HelpFormat {
 }
 
 impl HelpFormat {
-    /// Returns the GMP wire-format string for this value.
+    /// Return the legacy symbolic value.
+    ///
+    /// These values describe the compatibility variants; [`help`] maps them
+    /// to gvmd's valid `format` and `type` attribute combination.
     #[must_use]
     pub const fn as_gmp_str(self) -> &'static str {
         match self {
@@ -25,34 +33,77 @@ impl HelpFormat {
     }
 }
 
+/// Valid help response modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum HelpMode {
+    /// Plain-text command summary.
+    #[default]
+    Text,
+    /// Abbreviated XML command listing.
+    BriefXml,
+    /// Complete schema in the selected format.
+    Schema(SchemaFormat),
+}
+
 /// Build a `help` request.
+///
+/// `Brief` and `Full` are retained for source compatibility and now map to
+/// gvmd's valid XML help attributes. Older releases incorrectly placed these
+/// values in the `format` attribute.
 #[must_use]
 pub fn help(format: Option<HelpFormat>) -> XmlCommand {
+    match format {
+        Some(HelpFormat::Brief) => help_with_mode(HelpMode::BriefXml),
+        Some(HelpFormat::Full) => help_with_mode(HelpMode::Schema(SchemaFormat::Xml)),
+        None => help_with_mode(HelpMode::Text),
+    }
+}
+
+/// Build a `help` request for an explicit response mode.
+#[must_use]
+pub fn help_with_mode(mode: HelpMode) -> XmlCommand {
     let mut cmd = XmlCommand::new("help");
-    if let Some(format) = format {
-        cmd.set_attribute("format", format.as_gmp_str());
+    match mode {
+        HelpMode::Text => {}
+        HelpMode::BriefXml => {
+            cmd.set_attribute("format", SchemaFormat::Xml.as_gmp_str());
+            cmd.set_attribute("type", "brief");
+        }
+        HelpMode::Schema(format) => {
+            cmd.set_attribute("format", format.as_gmp_str());
+        }
     }
     cmd
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::help::{help, HelpFormat};
+    use crate::commands::help::{help, help_with_mode, HelpFormat, HelpMode};
     use crate::common::xml;
+    use crate::enums::HelpFormat as SchemaFormat;
 
     #[test]
-    fn help_format_variants_map_to_wire_values() {
+    fn compatibility_help_builds_valid_xml_modes() {
         assert_eq!(HelpFormat::Brief.as_gmp_str(), "brief");
         assert_eq!(HelpFormat::Full.as_gmp_str(), "full");
-    }
-
-    #[test]
-    fn help_builds_xml() {
         assert_eq!(xml(help(None)), "<help/>");
         assert_eq!(
             xml(help(Some(HelpFormat::Brief))),
-            "<help format=\"brief\"/>"
+            "<help format=\"xml\" type=\"brief\"/>"
         );
-        assert_eq!(xml(help(Some(HelpFormat::Full))), "<help format=\"full\"/>");
+        assert_eq!(xml(help(Some(HelpFormat::Full))), "<help format=\"xml\"/>");
+    }
+
+    #[test]
+    fn explicit_help_modes_build_valid_wire_shapes() {
+        assert_eq!(xml(help_with_mode(HelpMode::Text)), "<help/>");
+        assert_eq!(
+            xml(help_with_mode(HelpMode::BriefXml)),
+            "<help format=\"xml\" type=\"brief\"/>"
+        );
+        assert_eq!(
+            xml(help_with_mode(HelpMode::Schema(SchemaFormat::Html))),
+            "<help format=\"html\"/>"
+        );
     }
 }

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -73,11 +73,12 @@ pub struct FilteredGetOpts {
 /// Build a `help` request.
 #[must_use]
 pub fn help(format: Option<HelpFormat>) -> impl Request {
-    let mut cmd = XmlCommand::new("help");
-    if let Some(format) = format {
-        cmd.set_attribute("format", format.as_gmp_str());
+    match format {
+        Some(format) => {
+            crate::commands::help::help_with_mode(crate::commands::help::HelpMode::Schema(format))
+        }
+        None => crate::commands::help::help_with_mode(crate::commands::help::HelpMode::Text),
     }
-    cmd
 }
 
 /// Build a `get_feeds` request.

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -143,7 +143,7 @@ pub use secinfo::{
 };
 pub use system::{
     AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, GetTimezonesResponse,
-    HelpResponse, Setting, Timezone,
+    HelpCommand, HelpResponse, HelpSchema, Setting, Timezone,
 };
 pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -51,6 +51,26 @@ pub struct HelpResponse {
     pub status: u16,
     pub status_text: String,
     pub help_text: String,
+    pub schema: Option<HelpSchema>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HelpSchema {
+    pub format: Option<String>,
+    pub extension: Option<String>,
+    pub content_type: Option<String>,
+    pub content: Option<String>,
+    pub commands: Vec<HelpCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct HelpCommand {
+    pub name: String,
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -146,11 +166,44 @@ impl HelpResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
         let root = parse_document(response.data())?;
+        let schema = root.child("schema").map(|schema| {
+            let mut commands = Vec::new();
+            collect_help_commands(schema, &mut commands);
+            HelpSchema {
+                format: schema.attr("format").map(ToString::to_string),
+                extension: schema.attr("extension").map(ToString::to_string),
+                content_type: schema.attr("content_type").map(ToString::to_string),
+                content: (!schema.text.is_empty()).then(|| schema.text.clone()),
+                commands,
+            }
+        });
         Ok(Self {
             status,
             status_text,
             help_text: root.text.clone(),
+            schema,
         })
+    }
+}
+
+fn collect_help_commands(
+    node: &crate::responses::common::XmlNode,
+    commands: &mut Vec<HelpCommand>,
+) {
+    for child in &node.children {
+        if child.name == "command" {
+            if let Some(name) = child
+                .optional_child_text("name")
+                .or_else(|| (!child.text.is_empty()).then(|| child.text.clone()))
+            {
+                commands.push(HelpCommand {
+                    name,
+                    summary: child.optional_child_text("summary"),
+                });
+            }
+        } else {
+            collect_help_commands(child, commands);
+        }
     }
 }
 
@@ -253,6 +306,54 @@ mod tests {
             parsed.help_text,
             "Available commands: get_tasks, get_alerts"
         );
+        assert!(parsed.schema.is_none());
+    }
+
+    #[test]
+    fn parses_brief_xml_help_response() {
+        let response = Response::from(
+            r#"<help_response status="200" status_text="OK">
+                <schema format="XML" extension="xml" content_type="text/xml">
+                    <command><name>get_tasks</name><summary>Get tasks</summary></command>
+                    <command><name>get_alerts</name><summary>Get alerts</summary></command>
+                </schema>
+            </help_response>"#,
+        );
+
+        let parsed = HelpResponse::from_response(&response).expect("brief XML help parse");
+        let schema = parsed.schema.expect("schema");
+
+        assert!(parsed.help_text.is_empty());
+        assert_eq!(schema.format.as_deref(), Some("XML"));
+        assert_eq!(schema.extension.as_deref(), Some("xml"));
+        assert_eq!(schema.content_type.as_deref(), Some("text/xml"));
+        assert_eq!(schema.commands.len(), 2);
+        assert_eq!(schema.commands[0].name, "get_tasks");
+        assert_eq!(schema.commands[0].summary.as_deref(), Some("Get tasks"));
+    }
+
+    #[test]
+    fn parses_encoded_schema_content_and_nested_commands() {
+        let encoded = Response::from(
+            r#"<help_response status="200" status_text="OK">
+                <schema format="html" extension="html" content_type="text/html">PGh0bWw+PC9odG1sPg==</schema>
+            </help_response>"#,
+        );
+        let parsed = HelpResponse::from_response(&encoded).expect("encoded help parse");
+        assert_eq!(
+            parsed.schema.expect("schema").content.as_deref(),
+            Some("PGh0bWw+PC9odG1sPg==")
+        );
+
+        let xml = Response::from(
+            r#"<help_response status="200" status_text="OK">
+                <schema format="XML" extension="xml" content_type="text/xml">
+                    <protocol><command><name>get_tasks</name></command></protocol>
+                </schema>
+            </help_response>"#,
+        );
+        let parsed = HelpResponse::from_response(&xml).expect("nested XML help parse");
+        assert_eq!(parsed.schema.expect("schema").commands[0].name, "get_tasks");
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1596,6 +1596,9 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
     if !matches!(help_type, "" | "brief") {
         return error_response("help", 400, "Help type must be blank or 'brief'");
     }
+    if help_type == "brief" && format.as_deref() != Some("xml") {
+        return error_response("help", 400, "Brief help requires XML format");
+    }
 
     if format.as_deref().is_none_or(|value| value == "text") {
         let mut body = String::new();
@@ -1610,9 +1613,6 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
     }
 
     if help_type == "brief" {
-        if format.as_deref() != Some("xml") {
-            return error_response("help", 400, "Brief help requires XML format");
-        }
         let mut body = String::new();
         for (name, summary) in COMMANDS {
             body.push_str("<command><name>");

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -255,7 +255,7 @@ impl SessionHandler {
             }
             "restore" => self.handle_restore(cmd, store),
             // Help
-            "help" => render_help_response(cmd.attr("format")),
+            "help" => render_help_response(cmd),
             "sync_agents" => b"<sync_agents_response status=\"200\" status_text=\"OK\"/>".to_vec(),
             // Everything else
             _ => echo_response(&cmd.name, self.version.as_str()),
@@ -1581,12 +1581,71 @@ fn usage_type_matches(resource: &Resource, requested_usage_type: Option<&str>) -
     }
 }
 
-fn render_help_response(format: Option<&str>) -> Vec<u8> {
-    let body = match format {
-        Some("brief") => "<commands><command>get_feeds</command><command>get_tasks</command><command>get_configs</command></commands>",
-        _ => "<commands><command>get_feeds</command><command>get_tasks</command><command>get_configs</command><command>get_reports</command><command>get_info</command><command>get_settings</command></commands>",
-    };
-    format!("<help_response status=\"200\" status_text=\"OK\">{body}</help_response>").into_bytes()
+fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
+    const COMMANDS: [(&str, &str); 6] = [
+        ("get_configs", "Get scan configurations"),
+        ("get_feeds", "Get feed information"),
+        ("get_info", "Get security information"),
+        ("get_reports", "Get reports"),
+        ("get_settings", "Get settings"),
+        ("get_tasks", "Get tasks"),
+    ];
+
+    let format = cmd.attr("format").map(str::to_ascii_lowercase);
+    let help_type = cmd.attr("type").unwrap_or_default();
+    if !matches!(help_type, "" | "brief") {
+        return error_response("help", 400, "Help type must be blank or 'brief'");
+    }
+
+    if format.as_deref().is_none_or(|value| value == "text") {
+        let mut body = String::new();
+        for (name, summary) in COMMANDS {
+            body.push_str(name);
+            body.push_str(" - ");
+            body.push_str(summary);
+            body.push('\n');
+        }
+        return format!("<help_response status=\"200\" status_text=\"OK\">{body}</help_response>")
+            .into_bytes();
+    }
+
+    if help_type == "brief" {
+        if format.as_deref() != Some("xml") {
+            return error_response("help", 400, "Brief help requires XML format");
+        }
+        let mut body = String::new();
+        for (name, summary) in COMMANDS {
+            body.push_str("<command><name>");
+            body.push_str(name);
+            body.push_str("</name><summary>");
+            body.push_str(summary);
+            body.push_str("</summary></command>");
+        }
+        return format!(
+            "<help_response status=\"200\" status_text=\"OK\"><schema format=\"XML\" extension=\"xml\" content_type=\"text/xml\">{body}</schema></help_response>"
+        )
+        .into_bytes();
+    }
+
+    match format.as_deref().unwrap_or_default() {
+        "xml" => {
+            let mut commands = String::new();
+            for (name, summary) in COMMANDS {
+                commands.push_str("<command><name>");
+                commands.push_str(name);
+                commands.push_str("</name><summary>");
+                commands.push_str(summary);
+                commands.push_str("</summary></command>");
+            }
+            format!(
+                "<help_response status=\"200\" status_text=\"OK\"><schema format=\"xml\" extension=\"xml\" content_type=\"text/xml\"><protocol><name>Greenbone Management Protocol</name>{commands}</protocol></schema></help_response>"
+            )
+            .into_bytes()
+        }
+        "html" => b"<help_response status=\"200\" status_text=\"OK\"><schema format=\"html\" extension=\"html\" content_type=\"text/html\">PGh0bWw+PGJvZHk+R01QPC9ib2R5PjwvaHRtbD4=</schema></help_response>".to_vec(),
+        "rnc" => b"<help_response status=\"200\" status_text=\"OK\"><schema format=\"rnc\" extension=\"rnc\" content_type=\"application/relax-ng-compact-syntax\">c3RhcnQgPSBlbGVtZW50IGhlbHAgeyB0ZXh0IH0=</schema></help_response>".to_vec(),
+        other => error_response("help", 404, &format!("Unknown help format '{other}'")),
+    }
 }
 
 fn render_feeds_response() -> Vec<u8> {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -532,11 +532,49 @@ async fn stateful_help_returns_command_listing() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let resp = send_recv(&mut stream, br#"<help format="brief"/>"#).await;
+    let resp = send_recv(&mut stream, br#"<help format="xml" type="brief"/>"#).await;
     assert_eq!(resp.status_code(), Some(200));
     let text = resp.as_str().expect("utf8");
-    assert!(text.contains("<command>get_feeds</command>"));
-    assert!(text.contains("<command>get_tasks</command>"));
+    assert!(text.contains("<schema format=\"XML\""));
+    assert!(text.contains("<command><name>get_feeds</name>"));
+    assert!(text.contains("<command><name>get_tasks</name>"));
+
+    let plain = send_recv(&mut stream, br#"<help/>"#).await;
+    assert_eq!(plain.status_code(), Some(200));
+    assert!(plain
+        .as_str()
+        .expect("utf8")
+        .contains("get_tasks - Get tasks"));
+
+    let invalid = send_recv(&mut stream, br#"<help format="brief"/>"#).await;
+    assert_eq!(invalid.status_code(), Some(404));
+
+    let invalid_type = send_recv(&mut stream, br#"<help type="full"/>"#).await;
+    assert_eq!(invalid_type.status_code(), Some(400));
+
+    let invalid_brief_format =
+        send_recv(&mut stream, br#"<help format="html" type="brief"/>"#).await;
+    assert_eq!(invalid_brief_format.status_code(), Some(400));
+
+    let full_xml = send_recv(&mut stream, br#"<help format="xml"/>"#).await;
+    assert_eq!(full_xml.status_code(), Some(200));
+    let full_xml_text = full_xml.as_str().expect("utf8");
+    assert!(full_xml_text.contains("<protocol>"));
+    assert!(full_xml_text.contains("<command><name>get_tasks</name>"));
+
+    let html = send_recv(&mut stream, br#"<help format="html"/>"#).await;
+    assert_eq!(html.status_code(), Some(200));
+    assert!(html
+        .as_str()
+        .expect("utf8")
+        .contains("<schema format=\"html\""));
+
+    let rnc = send_recv(&mut stream, br#"<help format="rnc"/>"#).await;
+    assert_eq!(rnc.status_code(), Some(200));
+    assert!(rnc
+        .as_str()
+        .expect("utf8")
+        .contains("<schema format=\"rnc\""));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -556,6 +556,9 @@ async fn stateful_help_returns_command_listing() {
         send_recv(&mut stream, br#"<help format="html" type="brief"/>"#).await;
     assert_eq!(invalid_brief_format.status_code(), Some(400));
 
+    let missing_brief_format = send_recv(&mut stream, br#"<help type="brief"/>"#).await;
+    assert_eq!(missing_brief_format.status_code(), Some(400));
+
     let full_xml = send_recv(&mut stream, br#"<help format="xml"/>"#).await;
     assert_eq!(full_xml.status_code(), Some(200));
     let full_xml_text = full_xml.as_str().expect("utf8");


### PR DESCRIPTION
## Description

Align the GMP `help` request and response surface with the current gvmd contract.

- send `format="xml" type="brief"` for brief help instead of the invalid `format="brief"`
- retain the existing public `HelpFormat` API while adding explicit text, brief XML, and full-schema modes
- preserve plain-text help and parse structured schema metadata, embedded content, and command summaries
- make the stateful mock return representative text, XML, HTML, and RNC response shapes with gvmd-compatible status handling

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [ ] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated (if applicable)
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable: protocol-fidelity correction)
- [x] Journal entry updated (not applicable: no journal exists for this surface)

## Testing

- workspace tests with default and all features
- strict Clippy and rustdoc
- Rust 1.85 all-feature check and test
- real Unix-socket typed-client path against `gvm-mock-server`
- public `python-gvm` Unix, TLS, and mutual-TLS integration suites
- `cargo deny`, `cargo audit`, `cargo machete`, and `cargo vet`
- fresh-target workspace unsafe-usage audit: zero unsafe use
- strict Semgrep (`--disable-nosem --error`) and staged Gitleaks: no findings
- CycloneDX generation/post-processing and helper tests
- changed-line coverage: 132/132 executable lines (100%)

Fuzzing was not run in this environment. Deterministic parser, request-shape, mock transport, and full workspace regression tests cover this change.
