### PR TITLE
Correct system report contract fidelity

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -89,6 +89,7 @@ pub use gvm_gmp::commands::oci_image_targets::{
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
+pub use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateOciImageTargetTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateWebApplicationTaskOpts;

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -90,6 +90,7 @@ use gvm_gmp::commands::system::{
     describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
     get_vulns, FilteredGetOpts,
 };
+use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
 use gvm_gmp::commands::tasks::{
@@ -129,9 +130,9 @@ use gvm_gmp::responses::{
     GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
     GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse,
     GetResultsResponse, GetRolesResponse, GetScanConfigsResponse, GetScannersResponse,
-    GetSchedulesResponse, GetSettingsResponse, GetTagsResponse, GetTargetsResponse,
-    GetTasksResponse, GetTicketsResponse, GetTimezonesResponse, GetTlsCertificatesResponse,
-    GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
+    GetSchedulesResponse, GetSettingsResponse, GetSystemReportsResponse, GetTagsResponse,
+    GetTargetsResponse, GetTasksResponse, GetTicketsResponse, GetTimezonesResponse,
+    GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse, GetVulnerabilitiesResponse,
     GetWebApplicationTargetsResponse, HelpResponse, ModifyAssetResponse, ModifyCredentialResponse,
     ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyScanConfigResponse,
     ModifyScannerResponse, ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse,
@@ -1871,6 +1872,18 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn get_settings(&mut self) -> Result<GetSettingsResponse, GvmError> {
         let response = self.send(get_settings(FilteredGetOpts::default())).await?;
         GetSettingsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `get_system_reports` request and return typed report metadata and payloads.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_system_reports(
+        &mut self,
+        opts: GetSystemReportsOpts,
+    ) -> Result<GetSystemReportsResponse, GvmError> {
+        let response = self.send(get_system_reports(opts)).await?;
+        GetSystemReportsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a `help` request and return a typed [`HelpResponse`].

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -6,8 +6,8 @@
 
 use gvm_client::{
     CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts,
-    CredentialStoreCredentialType, GetCredentialStoresOpts, GmpClient, GmpNextCommands,
-    GmpVersioned, GvmError, ImportReportOpts, ModifyCredentialStoreCredentialOpts,
+    CredentialStoreCredentialType, GetCredentialStoresOpts, GetSystemReportsOpts, GmpClient,
+    GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, ModifyCredentialStoreCredentialOpts,
     ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
@@ -642,6 +642,49 @@ async fn get_feed_sends_typed_get_feeds_command() {
     assert_eq!(
         std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
         "<get_feeds type=\"NVT\"/>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_system_reports_preserve_wire_options_and_payload_metadata() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let response = client
+        .get_system_reports(GetSystemReportsOpts {
+            name: Some("load".into()),
+            duration: Some(3600),
+            ..Default::default()
+        })
+        .await
+        .expect("system report should parse");
+
+    assert_eq!(response.reports.len(), 1);
+    let report = &response.reports[0];
+    assert_eq!(report.name, "load");
+    assert_eq!(report.title.as_deref(), Some("System Load"));
+    assert_eq!(report.report_format.as_deref(), Some("png"));
+    assert_eq!(report.report_duration, Some(3600));
+    assert!(report.report.is_some());
+
+    let history = server.command_history();
+    let command = history.last().expect("system-report command recorded");
+    assert_eq!(command.command_name(), "get_system_reports");
+    assert_eq!(
+        std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
+        "<get_system_reports duration=\"3600\" name=\"load\"/>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -9,6 +9,8 @@ use crate::common::add_filter_attrs;
 use crate::enums::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceType, SortOrder};
 use crate::types::EntityId;
 
+pub use super::system_reports::{get_system_reports, GetSystemReportsOpts};
+
 /// Options for `get_aggregates` requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetAggregatesOpts {
@@ -133,18 +135,6 @@ pub fn get_aggregates(opts: GetAggregatesOpts) -> impl Request {
     if let Some(sort_order) = opts.sort_order {
         cmd.set_attribute("sort_order", sort_order.as_gmp_str());
     }
-    cmd
-}
-
-/// Build a `get_system_reports` request.
-#[must_use]
-pub fn get_system_reports(opts: FilteredGetOpts) -> impl Request {
-    let mut cmd = XmlCommand::new("get_system_reports");
-    add_filter_attrs(
-        &mut cmd,
-        opts.filter_string.as_deref(),
-        opts.filter_id.as_ref(),
-    );
     cmd
 }
 
@@ -311,11 +301,11 @@ mod tests {
             ..Default::default()
         }))
         .contains("filt_id=\"f1\""));
-        assert!(xml(get_system_reports(FilteredGetOpts {
-            filter_string: Some("name=foo".into()),
+        assert!(xml(get_system_reports(GetSystemReportsOpts {
+            name: Some("load".into()),
             ..Default::default()
         }))
-        .contains("filter=\"name=foo\""));
+        .contains("name=\"load\""));
         assert!(xml(get_info(GetInfoOpts {
             info_type: Some(InfoType::Nvt),
             info_id: Some(id("i1")),

--- a/crates/gvm-gmp/src/commands/system_reports.rs
+++ b/crates/gvm-gmp/src/commands/system_reports.rs
@@ -5,23 +5,48 @@
 
 use gvm_protocol::XmlCommand;
 
-use crate::common::add_filter_attrs;
+use crate::common::bool_str;
 use crate::types::EntityId;
 
 /// Options for `get_system_reports` requests.
 #[derive(Debug, Clone, Default)]
 pub struct GetSystemReportsOpts {
-    /// Optional inline filter expression.
-    pub filter: Option<String>,
-    /// Optional saved filter identifier.
-    pub filter_id: Option<EntityId>,
+    /// Name of a single system report to retrieve.
+    pub name: Option<String>,
+    /// Number of seconds into the past to include.
+    pub duration: Option<u64>,
+    /// Start of the requested interval as an ISO timestamp.
+    pub start_time: Option<String>,
+    /// End of the requested interval as an ISO timestamp.
+    pub end_time: Option<String>,
+    /// Whether to list report metadata without the report payload.
+    pub brief: Option<bool>,
+    /// Scanner from which to retrieve the report.
+    pub slave_id: Option<EntityId>,
 }
 
 /// Build a `get_system_reports` request.
 #[must_use]
 pub fn get_system_reports(opts: GetSystemReportsOpts) -> XmlCommand {
     let mut cmd = XmlCommand::new("get_system_reports");
-    add_filter_attrs(&mut cmd, opts.filter.as_deref(), opts.filter_id.as_ref());
+    if let Some(name) = opts.name.as_deref() {
+        cmd.set_attribute("name", name);
+    }
+    if let Some(duration) = opts.duration {
+        cmd.set_attribute("duration", &duration.to_string());
+    }
+    if let Some(start_time) = opts.start_time.as_deref() {
+        cmd.set_attribute("start_time", start_time);
+    }
+    if let Some(end_time) = opts.end_time.as_deref() {
+        cmd.set_attribute("end_time", end_time);
+    }
+    if let Some(brief) = opts.brief {
+        cmd.set_attribute("brief", bool_str(brief));
+    }
+    if let Some(slave_id) = opts.slave_id.as_ref() {
+        cmd.set_attribute("slave_id", slave_id.as_str());
+    }
     cmd
 }
 
@@ -35,10 +60,14 @@ mod tests {
     fn get_system_reports_builds_xml() {
         assert_eq!(
             xml(get_system_reports(GetSystemReportsOpts {
-                filter: Some("name=load".into()),
-                filter_id: Some(EntityId::new("f1").expect("valid id")),
+                name: Some("load".into()),
+                duration: Some(3600),
+                start_time: Some("2026-07-23T12:00:00Z".into()),
+                end_time: Some("2026-07-23T13:00:00Z".into()),
+                brief: Some(false),
+                slave_id: Some(EntityId::new("scanner-1").expect("valid id")),
             })),
-            "<get_system_reports filt_id=\"f1\" filter=\"name=load\"/>"
+            "<get_system_reports brief=\"0\" duration=\"3600\" end_time=\"2026-07-23T13:00:00Z\" name=\"load\" slave_id=\"scanner-1\" start_time=\"2026-07-23T12:00:00Z\"/>"
         );
     }
 }

--- a/crates/gvm-gmp/src/responses/system_reports.rs
+++ b/crates/gvm-gmp/src/responses/system_reports.rs
@@ -14,6 +14,10 @@ pub struct SystemReport {
     pub name: String,
     pub title: Option<String>,
     pub report: Option<String>,
+    pub report_format: Option<String>,
+    pub report_duration: Option<u64>,
+    pub report_start_time: Option<String>,
+    pub report_end_time: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,11 +33,39 @@ impl SystemReport {
     fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
         let name = node.required_child_text("name")?;
         let title = node.optional_child_text("title");
-        let report = node.optional_child_text("report");
+        let report_node = node.child("report");
+        let report = report_node
+            .map(|report| report.text.clone())
+            .filter(|content| !content.is_empty());
+        let report_format = report_node
+            .and_then(|report| report.attr("format"))
+            .map(ToString::to_string);
+        let report_duration = report_node
+            .and_then(|report| report.attr("duration"))
+            .filter(|duration| !duration.is_empty())
+            .map(|duration| {
+                duration.parse().map_err(|_| ParseError::InvalidValue {
+                    field: "system_report.report.duration".to_string(),
+                    value: duration.to_string(),
+                })
+            })
+            .transpose()?;
+        let report_start_time = report_node
+            .and_then(|report| report.attr("start_time"))
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+        let report_end_time = report_node
+            .and_then(|report| report.attr("end_time"))
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
         Ok(Self {
             name,
             title,
             report,
+            report_format,
+            report_duration,
+            report_start_time,
+            report_end_time,
         })
     }
 }
@@ -67,7 +99,8 @@ mod tests {
                 <system_report>
                     <name>load</name>
                     <title>System Load</title>
-                    <report>Load: 0.5</report>
+                    <report format="txt" start_time="2026-07-23T12:00:00Z"
+                            end_time="2026-07-23T13:00:00Z" duration="">TG9hZDogMC41</report>
                 </system_report>
                 <system_report>
                     <name>mem</name>
@@ -83,8 +116,22 @@ mod tests {
         assert_eq!(parsed.reports.len(), 2);
         assert_eq!(parsed.reports[0].name, "load");
         assert_eq!(parsed.reports[0].title.as_deref(), Some("System Load"));
-        assert_eq!(parsed.reports[0].report.as_deref(), Some("Load: 0.5"));
+        assert_eq!(parsed.reports[0].report.as_deref(), Some("TG9hZDogMC41"));
+        assert_eq!(parsed.reports[0].report_format.as_deref(), Some("txt"));
+        assert_eq!(parsed.reports[0].report_duration, None);
+        assert_eq!(
+            parsed.reports[0].report_start_time.as_deref(),
+            Some("2026-07-23T12:00:00Z")
+        );
+        assert_eq!(
+            parsed.reports[0].report_end_time.as_deref(),
+            Some("2026-07-23T13:00:00Z")
+        );
         assert!(parsed.reports[1].report.is_none());
+        assert_eq!(parsed.reports[1].report_format, None);
+        assert_eq!(parsed.reports[1].report_duration, None);
+        assert_eq!(parsed.reports[1].report_start_time, None);
+        assert_eq!(parsed.reports[1].report_end_time, None);
     }
 
     #[test]
@@ -95,5 +142,24 @@ mod tests {
         let parsed = GetSystemReportsResponse::from_response(&response).expect("parse");
 
         assert!(parsed.reports.is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_report_duration() {
+        let response = Response::from(
+            r#"<get_system_reports_response status="200" status_text="OK">
+                <system_report>
+                    <name>load</name>
+                    <title>System Load</title>
+                    <report format="png" duration="invalid">cG5n</report>
+                </system_report>
+            </get_system_reports_response>"#,
+        );
+
+        assert!(matches!(
+            GetSystemReportsResponse::from_response(&response),
+            Err(ParseError::InvalidValue { field, value })
+                if field == "system_report.report.duration" && value == "invalid"
+        ));
     }
 }

--- a/crates/gvm-gmp/tests/test_system.rs
+++ b/crates/gvm-gmp/tests/test_system.rs
@@ -25,11 +25,12 @@ fn test_system_help_and_feeds() {
 fn test_system_filtered_getters() {
     assert_eq!(xml(get_settings(Default::default())), "<get_settings/>");
     assert_eq!(
-        xml(get_system_reports(FilteredGetOpts {
-            filter_string: Some("name=foo".into()),
-            filter_id: Some(id("f1"))
+        xml(get_system_reports(GetSystemReportsOpts {
+            name: Some("load".into()),
+            brief: Some(true),
+            ..Default::default()
         })),
-        "<get_system_reports filt_id=\"f1\" filter=\"name=foo\"/>"
+        "<get_system_reports brief=\"1\" name=\"load\"/>"
     );
     assert_eq!(
         xml(get_preferences(FilteredGetOpts {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -20,7 +20,7 @@ use crate::response_gen::{
 };
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 use crate::store::{AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, TaskStatus};
-use crate::util::xml_escape;
+use crate::util::{xml_escape, xml_escape_attr};
 use crate::version::{command_available, GmpVersion};
 use crate::ServerMode;
 
@@ -816,7 +816,7 @@ impl SessionHandler {
         match cmd.name.as_str() {
             "get_feeds" => return render_feeds_response(),
             "get_aggregates" => return render_aggregates_response(cmd),
-            "get_system_reports" => return render_system_reports_response(),
+            "get_system_reports" => return render_system_reports_response(cmd, store),
             "get_info" => return render_secinfo_response(cmd),
             "get_vulns" => return render_vulnerabilities_response(cmd),
             "get_report_hosts"
@@ -1750,18 +1750,75 @@ fn render_aggregates_response(cmd: &ParsedCommand) -> Vec<u8> {
     .into_bytes()
 }
 
-fn render_system_reports_response() -> Vec<u8> {
-    "<get_system_reports_response status=\"200\" status_text=\"OK\">\
-     <system_report id=\"system-report-1\">\
-     <name>GVMD Performance Snapshot</name>\
-     <comment>Mock system report</comment>\
-     <created>2026-03-18T00:00:00Z</created>\
-     <duration>15m</duration>\
-     </system_report>\
-     <system_report_count>1<filtered>1</filtered></system_report_count>\
-     </get_system_reports_response>"
-        .as_bytes()
-        .to_vec()
+fn render_system_reports_response(cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+    const REPORTS: [(&str, &str); 2] = [("proc", "Processes"), ("load", "System Load")];
+    let selected_name = cmd.attr("name");
+    let brief = match cmd.attr("brief") {
+        None | Some("0") | Some("false") => false,
+        Some("1") | Some("true") => true,
+        Some(_) => return error_response("get_system_reports", 400, "Invalid brief value"),
+    };
+    let duration = match cmd.attr("duration") {
+        Some(value) => match value.parse::<u64>() {
+            Ok(duration) => Some(duration),
+            Err(_) => return error_response("get_system_reports", 400, "Invalid duration"),
+        },
+        None => None,
+    };
+    if selected_name.is_some_and(|selected| {
+        !REPORTS
+            .iter()
+            .any(|(name, _)| selected.eq_ignore_ascii_case(name))
+    }) {
+        return error_response("get_system_reports", 404, "System report not found");
+    }
+    if let Some(slave_id) = cmd.attr("slave_id") {
+        let Ok(slave_id) = Uuid::parse_str(slave_id) else {
+            return error_response("get_system_reports", 400, "Invalid slave ID");
+        };
+        if store
+            .get(&slave_id)
+            .is_none_or(|resource| resource.resource_type != "scanner")
+        {
+            return error_response("get_system_reports", 404, "Slave not found");
+        }
+    }
+    let start_time = cmd.attr("start_time").unwrap_or_default();
+    let end_time = cmd.attr("end_time").unwrap_or_default();
+    let duration = duration.map(|value| value.to_string()).unwrap_or_else(|| {
+        if !start_time.is_empty() && !end_time.is_empty() {
+            String::new()
+        } else {
+            "86400".to_string()
+        }
+    });
+    let mut reports = String::new();
+
+    for (name, title) in REPORTS {
+        if selected_name.is_some_and(|selected| !selected.eq_ignore_ascii_case(name)) {
+            continue;
+        }
+        reports.push_str("<system_report><name>");
+        reports.push_str(name);
+        reports.push_str("</name><title>");
+        reports.push_str(title);
+        reports.push_str("</title>");
+        if !brief {
+            reports.push_str("<report format=\"png\" start_time=\"");
+            reports.push_str(&xml_escape_attr(start_time));
+            reports.push_str("\" end_time=\"");
+            reports.push_str(&xml_escape_attr(end_time));
+            reports.push_str("\" duration=\"");
+            reports.push_str(&duration);
+            reports.push_str("\">iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB</report>");
+        }
+        reports.push_str("</system_report>");
+    }
+
+    format!(
+        "<get_system_reports_response status=\"200\" status_text=\"OK\">{reports}</get_system_reports_response>"
+    )
+    .into_bytes()
 }
 
 fn render_secinfo_response(cmd: &ParsedCommand) -> Vec<u8> {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -641,7 +641,7 @@ async fn stateful_user_settings_get_and_modify() {
 }
 
 #[tokio::test]
-async fn stateful_system_reports_return_fixture_response() {
+async fn stateful_system_reports_follow_gvmd_request_and_response_shapes() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -651,8 +651,79 @@ async fn stateful_system_reports_return_fixture_response() {
     let resp = send_recv(&mut stream, b"<get_system_reports/>").await;
     assert_eq!(resp.status_code(), Some(200));
     let text = resp.as_str().expect("utf8");
-    assert!(text.contains("GVMD Performance Snapshot"));
-    assert!(text.contains("<system_report_count>1"));
+    assert!(text.contains("<name>proc</name><title>Processes</title>"));
+    assert!(text.contains("<name>load</name><title>System Load</title>"));
+    assert!(
+        text.contains("<report format=\"png\" start_time=\"\" end_time=\"\" duration=\"86400\">")
+    );
+    assert!(!text.contains("<system_report_count>"));
+
+    let brief = send_recv(
+        &mut stream,
+        b"<get_system_reports name=\"load\" brief=\"true\"/>",
+    )
+    .await;
+    assert_eq!(brief.status_code(), Some(200));
+    let brief_text = brief.as_str().expect("utf8");
+    assert!(!brief_text.contains("<name>proc</name>"));
+    assert!(brief_text.contains("<name>load</name>"));
+    assert!(!brief_text.contains("<report "));
+
+    let not_brief = send_recv(
+        &mut stream,
+        b"<get_system_reports name=\"load\" brief=\"false\"/>",
+    )
+    .await;
+    assert_eq!(not_brief.status_code(), Some(200));
+    assert!(not_brief.as_str().expect("utf8").contains("<report "));
+
+    let invalid_brief = send_recv(&mut stream, b"<get_system_reports brief=\"sometimes\"/>").await;
+    assert_eq!(invalid_brief.status_code(), Some(400));
+
+    let invalid = send_recv(
+        &mut stream,
+        b"<get_system_reports duration=\"not-a-number\"/>",
+    )
+    .await;
+    assert_eq!(invalid.status_code(), Some(400));
+
+    let unknown = send_recv(&mut stream, b"<get_system_reports name=\"unknown\"/>").await;
+    assert_eq!(unknown.status_code(), Some(404));
+
+    let interval = send_recv(
+        &mut stream,
+        b"<get_system_reports name=\"load\" start_time=\"2026-07-23T12:00:00Z\" end_time=\"2026-07-23T13:00:00Z\"/>",
+    )
+    .await;
+    assert_eq!(interval.status_code(), Some(200));
+    assert!(interval.as_str().expect("utf8").contains(
+        "start_time=\"2026-07-23T12:00:00Z\" end_time=\"2026-07-23T13:00:00Z\" duration=\"\""
+    ));
+
+    let unknown_slave = send_recv(
+        &mut stream,
+        b"<get_system_reports slave_id=\"00000000-0000-0000-0000-000000000404\"/>",
+    )
+    .await;
+    assert_eq!(unknown_slave.status_code(), Some(404));
+
+    let invalid_slave = send_recv(&mut stream, b"<get_system_reports slave_id=\"invalid\"/>").await;
+    assert_eq!(invalid_slave.status_code(), Some(400));
+
+    let scanner = send_recv(
+        &mut stream,
+        b"<create_scanner><name>System Report Scanner</name></create_scanner>",
+    )
+    .await;
+    assert_eq!(scanner.status_code(), Some(201));
+    let scanner_id = extract_id(&scanner);
+    let scanner_report = send_recv(
+        &mut stream,
+        format!("<get_system_reports slave_id=\"{scanner_id}\" brief=\"1\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(scanner_report.status_code(), Some(200));
+    assert!(!scanner_report.as_str().expect("utf8").contains("<report "));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Description

Align `get_system_reports` with the current gvmd request and response contract.

- replace the two duplicate generic-filter builders with one canonical builder for `name`, `duration`, `start_time`, `end_time`, `brief`, and `slave_id`
- add a typed client helper
- preserve report format, duration, interval metadata, and encoded payloads
- make the stateful mock model listing, payload, interval, unknown-name, and scanner-validation behavior

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [ ] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated (if applicable)
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable: protocol-fidelity correction)
- [x] Journal entry updated (not applicable: no journal exists for this surface)

## Testing

- workspace tests with default and all features
- strict Clippy and rustdoc
- Rust 1.85 all-feature check and test
- real Unix-socket typed-client path against `gvm-mock-server`
- public `python-gvm` Unix, TLS, and mutual-TLS integration suites
- `cargo deny`, `cargo audit`, `cargo machete`, and `cargo vet`
- fresh-target workspace unsafe-usage audit: zero unsafe use
- strict Semgrep (`--disable-nosem --error`) and staged Gitleaks: no findings
- CycloneDX generation/post-processing and helper tests
- changed-line coverage: 135/135 executable lines (100%)

Fuzzing was not run in this environment. Deterministic builder, parser, error-path, real transport, and full workspace regression tests cover this change.
