### PR TITLE
Correct feed discovery response fidelity

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -95,7 +95,7 @@ pub use gvm_gmp::commands::tasks::CreateWebApplicationTaskOpts;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
-pub use gvm_gmp::enums::CredentialStoreCredentialType;
+pub use gvm_gmp::enums::{CredentialStoreCredentialType, FeedType};
 pub use version::{
     command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
     required_version_label,

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -26,7 +26,7 @@ use gvm_gmp::commands::credentials::{
     ModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::features::get_features;
-use gvm_gmp::commands::feed::get_feeds;
+use gvm_gmp::commands::feed::{get_feed, get_feeds};
 use gvm_gmp::commands::filters::{create_filter, get_filters, FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{create_group, get_groups, GetGroupsOpts, GroupOpts};
 use gvm_gmp::commands::help::{help, help_with_mode, HelpMode};
@@ -139,7 +139,7 @@ use gvm_gmp::responses::{
     VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
-use gvm_gmp::CredentialStoreCredentialType;
+use gvm_gmp::{CredentialStoreCredentialType, FeedType};
 
 use crate::{GmpClient, GvmError};
 
@@ -1019,6 +1019,15 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_feeds(&mut self) -> Result<GetFeedsResponse, GvmError> {
         let response = self.send(get_feeds()).await?;
+        GetFeedsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a type-filtered `get_feeds` request and return a typed response.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_feed(&mut self, feed_type: FeedType) -> Result<GetFeedsResponse, GvmError> {
+        let response = self.send(get_feed(feed_type)).await?;
         GetFeedsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -20,7 +20,6 @@ use gvm_gmp::commands::credentials::{
     create_credential_store_credential, get_credential, modify_credential_store_credential,
     ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
 };
-use gvm_gmp::commands::feed::get_feed;
 use gvm_gmp::commands::help::HelpMode;
 use gvm_gmp::commands::nvts::{
     get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -630,11 +630,18 @@ async fn get_feed_sends_typed_get_feeds_command() {
         .expect("authenticate should succeed");
 
     let response = client
-        .call(get_feed(FeedType::Nvt))
+        .get_feed(FeedType::Nvt)
         .await
-        .expect("get_feed should send get_feeds command");
+        .expect("get_feed should return typed feed data");
 
-    assert_eq!(response.status_code(), Some(200));
+    assert_eq!(response.status, 200);
+    assert!(response.feed_owner_set);
+    assert!(response.feed_roles_set);
+    assert!(response.feed_resources_access);
+    assert_eq!(response.items.len(), 1);
+    assert_eq!(response.items[0].type_, "NVT");
+    assert_eq!(response.items[0].status, None);
+    assert_eq!(response.counts, Default::default());
 
     let history = server.command_history();
     let command = history.last().expect("feed command recorded");
@@ -642,6 +649,30 @@ async fn get_feed_sends_typed_get_feeds_command() {
     assert_eq!(
         std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
         "<get_feeds type=\"NVT\"/>"
+    );
+
+    let all = client
+        .get_feeds()
+        .await
+        .expect("all feeds should return typed data");
+    assert_eq!(all.items.len(), 4);
+    let scap = all
+        .items
+        .iter()
+        .find(|feed| feed.type_ == "SCAP")
+        .expect("SCAP feed");
+    assert_eq!(
+        scap.currently_syncing.as_deref(),
+        Some("2026-03-18T00:00:00Z")
+    );
+    let cert = all
+        .items
+        .iter()
+        .find(|feed| feed.type_ == "CERT")
+        .expect("CERT feed");
+    assert_eq!(
+        cert.sync_not_available.as_deref(),
+        Some("Feed synchronization is unavailable")
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/responses/feed.rs
+++ b/crates/gvm-gmp/src/responses/feed.rs
@@ -57,11 +57,9 @@ impl Feed {
     }
 }
 
-fn required_bool_child(root: &XmlNode, name: &str) -> Result<bool, ParseError> {
-    let value = root
-        .child_text(name)
-        .ok_or_else(|| ParseError::MissingElement(name.to_string()))?;
-    parse_bool(&value, name)
+fn optional_bool_child(root: &XmlNode, name: &str) -> Result<bool, ParseError> {
+    root.child_text(name)
+        .map_or(Ok(false), |value| parse_bool(&value, name))
 }
 
 impl GetFeedsResponse {
@@ -77,9 +75,9 @@ impl GetFeedsResponse {
             status_text,
             items,
             counts: count_info(&root, "feed_count")?,
-            feed_owner_set: required_bool_child(&root, "feed_owner_set")?,
-            feed_roles_set: required_bool_child(&root, "feed_roles_set")?,
-            feed_resources_access: required_bool_child(&root, "feed_resources_access")?,
+            feed_owner_set: optional_bool_child(&root, "feed_owner_set")?,
+            feed_roles_set: optional_bool_child(&root, "feed_roles_set")?,
+            feed_resources_access: optional_bool_child(&root, "feed_resources_access")?,
         })
     }
 }
@@ -238,10 +236,10 @@ mod tests {
                 <feed_roles_set>1</feed_roles_set>
             </get_feeds_response>"#,
         );
-        assert!(matches!(
-            GetFeedsResponse::from_response(&missing_flag),
-            Err(ParseError::MissingElement(field)) if field == "feed_resources_access"
-        ));
+        let parsed = GetFeedsResponse::from_response(&missing_flag).expect("missing flag defaults");
+        assert!(parsed.feed_owner_set);
+        assert!(parsed.feed_roles_set);
+        assert!(!parsed.feed_resources_access);
 
         let missing_timestamp = Response::from(
             r#"<get_feeds_response status="200" status_text="OK">

--- a/crates/gvm-gmp/src/responses/feed.rs
+++ b/crates/gvm-gmp/src/responses/feed.rs
@@ -43,7 +43,11 @@ impl Feed {
             .transpose()?;
         let currently_syncing = node
             .child("currently_syncing")
-            .map(|sync| sync.required_child_text("timestamp"))
+            .map(|sync| {
+                sync.optional_child_text("timestamp")
+                    .or_else(|| (!sync.text.is_empty()).then(|| sync.text.clone()))
+                    .ok_or_else(|| ParseError::MissingElement("timestamp".to_string()))
+            })
             .transpose()?;
         Ok(Self {
             type_: node.required_child_text("type")?,
@@ -183,6 +187,27 @@ mod tests {
         assert_eq!(feed.description, None);
         assert_eq!(feed.sync_not_available, None);
         assert_eq!(feed.currently_syncing, None);
+    }
+
+    #[test]
+    fn preserves_legacy_direct_sync_value() {
+        let response = Response::from(
+            r#"<get_feeds_response status="200" status_text="OK">
+                <feed>
+                    <type>NVT</type>
+                    <name>NVT Feed</name>
+                    <version>202603260800</version>
+                    <currently_syncing>0</currently_syncing>
+                </feed>
+            </get_feeds_response>"#,
+        );
+
+        let parsed = GetFeedsResponse::from_response(&response).expect("legacy sync value parses");
+
+        assert_eq!(parsed.items[0].currently_syncing.as_deref(), Some("0"));
+        assert!(!parsed.feed_owner_set);
+        assert!(!parsed.feed_roles_set);
+        assert!(!parsed.feed_resources_access);
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/feed.rs
+++ b/crates/gvm-gmp/src/responses/feed.rs
@@ -44,9 +44,13 @@ impl Feed {
         let currently_syncing = node
             .child("currently_syncing")
             .map(|sync| {
-                sync.optional_child_text("timestamp")
-                    .or_else(|| (!sync.text.is_empty()).then(|| sync.text.clone()))
-                    .ok_or_else(|| ParseError::MissingElement("timestamp".to_string()))
+                if sync.child("timestamp").is_some() {
+                    sync.required_child_text("timestamp")
+                } else if !sync.text.is_empty() {
+                    Ok(sync.text.clone())
+                } else {
+                    Err(ParseError::MissingElement("timestamp".to_string()))
+                }
             })
             .transpose()?;
         Ok(Self {

--- a/crates/gvm-gmp/src/responses/feed.rs
+++ b/crates/gvm-gmp/src/responses/feed.rs
@@ -6,7 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, status_from_response, CountInfo, ParseError,
+    count_info, parse_bool, parse_document, status_from_response, CountInfo, ParseError, XmlNode,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +18,7 @@ pub struct Feed {
     pub version: String,
     pub status: Option<String>,
     pub description: Option<String>,
+    pub sync_not_available: Option<String>,
     pub currently_syncing: Option<String>,
 }
 
@@ -29,19 +30,38 @@ pub struct GetFeedsResponse {
     pub status_text: String,
     pub items: Vec<Feed>,
     pub counts: CountInfo,
+    pub feed_owner_set: bool,
+    pub feed_roles_set: bool,
+    pub feed_resources_access: bool,
 }
 
 impl Feed {
-    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let sync_not_available = node
+            .child("sync_not_available")
+            .map(|sync| sync.required_child_text("error"))
+            .transpose()?;
+        let currently_syncing = node
+            .child("currently_syncing")
+            .map(|sync| sync.required_child_text("timestamp"))
+            .transpose()?;
         Ok(Self {
             type_: node.required_child_text("type")?,
             name: node.required_child_text("name")?,
             version: node.required_child_text("version")?,
             status: node.optional_child_text("status"),
             description: node.optional_child_text("description"),
-            currently_syncing: node.optional_child_text("currently_syncing"),
+            sync_not_available,
+            currently_syncing,
         })
     }
+}
+
+fn required_bool_child(root: &XmlNode, name: &str) -> Result<bool, ParseError> {
+    let value = root
+        .child_text(name)
+        .ok_or_else(|| ParseError::MissingElement(name.to_string()))?;
+    parse_bool(&value, name)
 }
 
 impl GetFeedsResponse {
@@ -57,6 +77,9 @@ impl GetFeedsResponse {
             status_text,
             items,
             counts: count_info(&root, "feed_count")?,
+            feed_owner_set: required_bool_child(&root, "feed_owner_set")?,
+            feed_roles_set: required_bool_child(&root, "feed_roles_set")?,
+            feed_resources_access: required_bool_child(&root, "feed_resources_access")?,
         })
     }
 }
@@ -71,40 +94,50 @@ mod tests {
     fn parses_multiple_feeds() {
         let response = Response::from(
             r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>1</feed_owner_set>
+                <feed_roles_set>0</feed_roles_set>
+                <feed_resources_access>true</feed_resources_access>
                 <feed>
                     <type>NVT</type>
                     <name>NVT Feed</name>
                     <version>202603260800</version>
-                    <status>Current</status>
                     <description>Network vulnerability tests</description>
-                    <currently_syncing>0</currently_syncing>
+                    <currently_syncing><timestamp></timestamp></currently_syncing>
                 </feed>
                 <feed>
                     <type>SCAP</type>
                     <name>SCAP Feed</name>
                     <version>202603250700</version>
-                    <status>Updating</status>
                     <description>Security content automation data</description>
-                    <currently_syncing>1</currently_syncing>
+                    <sync_not_available><error>Feed lock unavailable</error></sync_not_available>
                 </feed>
-                <feed_count>2<filtered>2</filtered><page>1</page></feed_count>
             </get_feeds_response>"#,
         );
 
         let parsed = GetFeedsResponse::from_response(&response).expect("feeds parse");
 
         assert_eq!(parsed.items.len(), 2);
-        assert_eq!(parsed.counts.total, Some(2));
-        assert_eq!(parsed.counts.filtered, Some(2));
-        assert_eq!(parsed.counts.page, Some(1));
+        assert_eq!(parsed.counts, CountInfo::default());
+        assert!(parsed.feed_owner_set);
+        assert!(!parsed.feed_roles_set);
+        assert!(parsed.feed_resources_access);
         assert_eq!(parsed.items[0].type_, "NVT");
-        assert_eq!(parsed.items[1].currently_syncing.as_deref(), Some("1"));
+        assert_eq!(parsed.items[0].currently_syncing.as_deref(), Some(""));
+        assert_eq!(
+            parsed.items[1].sync_not_available.as_deref(),
+            Some("Feed lock unavailable")
+        );
     }
 
     #[test]
     fn parses_empty_feeds() {
         let response = Response::from(
-            r#"<get_feeds_response status="200" status_text="OK"><feed_count>0<filtered>0</filtered></feed_count></get_feeds_response>"#,
+            r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>0</feed_owner_set>
+                <feed_roles_set>0</feed_roles_set>
+                <feed_resources_access>0</feed_resources_access>
+                <feed_count>0<filtered>0</filtered></feed_count>
+            </get_feeds_response>"#,
         );
 
         let parsed = GetFeedsResponse::from_response(&response).expect("feeds parse");
@@ -133,6 +166,9 @@ mod tests {
     fn parses_missing_optional_non_version_feed_fields() {
         let response = Response::from(
             r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>1</feed_owner_set>
+                <feed_roles_set>1</feed_roles_set>
+                <feed_resources_access>1</feed_resources_access>
                 <feed>
                     <type>CERT</type>
                     <name>CERT Feed</name>
@@ -147,6 +183,7 @@ mod tests {
         assert_eq!(feed.version, "202603260800");
         assert_eq!(feed.status, None);
         assert_eq!(feed.description, None);
+        assert_eq!(feed.sync_not_available, None);
         assert_eq!(feed.currently_syncing, None);
     }
 
@@ -179,6 +216,47 @@ mod tests {
         assert!(matches!(
             GetFeedsResponse::from_response(&missing_version),
             Err(ParseError::MissingElement(field)) if field == "version"
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_access_flag_and_incomplete_sync_state() {
+        let invalid_flag = Response::from(
+            r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>sometimes</feed_owner_set>
+            </get_feeds_response>"#,
+        );
+        assert!(matches!(
+            GetFeedsResponse::from_response(&invalid_flag),
+            Err(ParseError::InvalidValue { field, value })
+                if field == "feed_owner_set" && value == "sometimes"
+        ));
+
+        let missing_flag = Response::from(
+            r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>1</feed_owner_set>
+                <feed_roles_set>1</feed_roles_set>
+            </get_feeds_response>"#,
+        );
+        assert!(matches!(
+            GetFeedsResponse::from_response(&missing_flag),
+            Err(ParseError::MissingElement(field)) if field == "feed_resources_access"
+        ));
+
+        let missing_timestamp = Response::from(
+            r#"<get_feeds_response status="200" status_text="OK">
+                <feed_owner_set>1</feed_owner_set>
+                <feed_roles_set>1</feed_roles_set>
+                <feed_resources_access>1</feed_resources_access>
+                <feed>
+                    <type>NVT</type><name>NVT Feed</name><version>1</version>
+                    <currently_syncing/>
+                </feed>
+            </get_feeds_response>"#,
+        );
+        assert!(matches!(
+            GetFeedsResponse::from_response(&missing_timestamp),
+            Err(ParseError::MissingElement(field)) if field == "timestamp"
         ));
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -814,7 +814,7 @@ impl SessionHandler {
 
     fn handle_get(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
         match cmd.name.as_str() {
-            "get_feeds" => return render_feeds_response(),
+            "get_feeds" => return render_feeds_response(cmd),
             "get_aggregates" => return render_aggregates_response(cmd),
             "get_system_reports" => return render_system_reports_response(),
             "get_info" => return render_secinfo_response(cmd),
@@ -1725,15 +1725,67 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
     }
 }
 
-fn render_feeds_response() -> Vec<u8> {
-    "<get_feeds_response status=\"200\" status_text=\"OK\">\
-     <feed><type>NVT</type><name>Network Vulnerability Tests</name><version>2026031801</version><status>current</status></feed>\
-     <feed><type>SCAP</type><name>SCAP Data</name><version>2026031701</version><status>current</status></feed>\
-     <feed><type>CERT</type><name>CERT Advisories</name><version>2026031601</version><status>current</status></feed>\
-     <feed_count>3<filtered>3</filtered></feed_count>\
-     </get_feeds_response>"
-        .as_bytes()
-        .to_vec()
+fn render_feeds_response(cmd: &ParsedCommand) -> Vec<u8> {
+    const FEEDS: [(&str, &str, &str, &str); 4] = [
+        (
+            "NVT",
+            "Greenbone Security Feed",
+            "2026031801",
+            "Network vulnerability tests",
+        ),
+        (
+            "SCAP",
+            "Greenbone SCAP Feed",
+            "2026031701",
+            "Security content automation data",
+        ),
+        (
+            "CERT",
+            "Greenbone CERT Feed",
+            "2026031601",
+            "CERT advisories",
+        ),
+        (
+            "GVMD_DATA",
+            "Greenbone Data Objects Feed",
+            "2026031501",
+            "Manager data objects",
+        ),
+    ];
+    let selected_type = cmd.attr("type");
+    let mut feeds = String::new();
+    for (feed_type, name, version, description) in FEEDS {
+        if selected_type.is_some_and(|selected| !selected.eq_ignore_ascii_case(feed_type)) {
+            continue;
+        }
+        feeds.push_str("<feed><type>");
+        feeds.push_str(feed_type);
+        feeds.push_str("</type><name>");
+        feeds.push_str(name);
+        feeds.push_str("</name><version>");
+        feeds.push_str(version);
+        feeds.push_str("</version><description>");
+        feeds.push_str(description);
+        feeds.push_str("</description>");
+        if feed_type == "SCAP" {
+            feeds.push_str(
+                "<currently_syncing><timestamp>2026-03-18T00:00:00Z</timestamp></currently_syncing>",
+            );
+        } else if feed_type == "CERT" {
+            feeds.push_str(
+                "<sync_not_available><error>Feed synchronization is unavailable</error></sync_not_available>",
+            );
+        }
+        feeds.push_str("</feed>");
+    }
+    format!(
+        "<get_feeds_response status=\"200\" status_text=\"OK\">\
+         <feed_owner_set>1</feed_owner_set>\
+         <feed_roles_set>1</feed_roles_set>\
+         <feed_resources_access>1</feed_resources_access>\
+         {feeds}</get_feeds_response>"
+    )
+    .into_bytes()
 }
 
 fn render_aggregates_response(cmd: &ParsedCommand) -> Vec<u8> {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -406,7 +406,7 @@ async fn stateful_auth_and_license_modifiers_use_gmp_builder_shape() {
 }
 
 #[tokio::test]
-async fn stateful_get_feeds_returns_static_entries() {
+async fn stateful_get_feeds_returns_canonical_entries() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -416,9 +416,13 @@ async fn stateful_get_feeds_returns_static_entries() {
     let resp = send_recv(&mut stream, b"<get_feeds/>").await;
     assert_eq!(resp.status_code(), Some(200));
     let text = resp.as_str().expect("utf8");
-    assert!(text.contains("Network Vulnerability Tests"));
+    assert!(text.contains("<feed_owner_set>1</feed_owner_set>"));
+    assert!(text.contains("<name>Greenbone Security Feed</name>"));
     assert!(text.contains("<type>SCAP</type>"));
-    assert!(text.contains("<feed_count>3"));
+    assert!(text.contains("<type>GVMD_DATA</type>"));
+    assert!(text.contains("<currently_syncing><timestamp>"));
+    assert!(text.contains("<sync_not_available><error>"));
+    assert!(!text.contains("<feed_count>"));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Description

Align typed feed discovery and the stateful mock with the current gvmd contract.

- expose the required feed-owner, feed-role, and feed-resource-access flags
- preserve nested synchronization timestamps and synchronization-unavailable errors
- add a type-filtered typed client helper
- make the mock honor case-insensitive feed type filters and return all four current feed families
- remove invented mock `status` and count fields while retaining parser compatibility for older responses

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [ ] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated (if applicable)
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable: protocol-fidelity correction)
- [x] Journal entry updated (not applicable: no journal exists for this surface)

## Testing

- workspace tests with default and all features
- strict Clippy and rustdoc
- Rust 1.85 all-feature check and test
- real Unix-socket typed-client path against `gvm-mock-server`
- public `python-gvm` Unix, TLS, and mutual-TLS integration suites
- `cargo deny`, `cargo audit`, `cargo machete`, and `cargo vet`
- fresh-target workspace unsafe-usage audit: zero unsafe use
- strict Semgrep (`--disable-nosem --error`) and staged Gitleaks: no findings
- CycloneDX generation/post-processing and helper tests
- changed-line coverage: 76/76 executable lines (100%)

Fuzzing was not run in this environment. Deterministic parser, filtering, error-path, real transport, and full workspace regression tests cover this change.
