### PR TITLE
Verify SSH host keys by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ let mut client = GmpClient::connect(conn).await?;
 // Same API as Unix socket — connect/call/disconnect
 ```
 
+SSH verifies the server key against `~/.ssh/known_hosts` by default, including
+the configured port. Use `SshHostKeyPolicy::KnownHostsFile` for a nonstandard
+file or `SshHostKeyPolicy::Fingerprint` for an explicitly pinned SHA-256
+fingerprint. `SshHostKeyPolicy::AcceptAll` disables verification and is only
+appropriate for tests or an independently authenticated transport.
+This secure default is a behavior change for callers that previously relied on
+implicit host-key acceptance; choose one of the explicit trust policies when
+migrating existing deployments.
+
 #### TLS transport
 
 TLS verifies the server certificate and DNS/IP subject name by default. Add a

--- a/crates/gvm-connection/src/ssh.rs
+++ b/crates/gvm-connection/src/ssh.rs
@@ -67,7 +67,7 @@ impl Default for SshConfig {
             timeout: Duration::from_secs(60),
             read_buffer_size: 64 * 1024,
             max_response_bytes: Some(64 * 1024 * 1024),
-            host_key_policy: SshHostKeyPolicy::AcceptAll,
+            host_key_policy: SshHostKeyPolicy::KnownHosts,
         }
     }
 }
@@ -158,6 +158,10 @@ impl std::fmt::Debug for SshAuth {
 /// SSH host key verification policy.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SshHostKeyPolicy {
+    /// Require the server key to match the user's `~/.ssh/known_hosts` file.
+    KnownHosts,
+    /// Require the server key to match a specific OpenSSH `known_hosts` file.
+    KnownHostsFile(PathBuf),
     /// Accept any server key.
     ///
     /// This is insecure and vulnerable to man-in-the-middle attacks. Use only in tests or when
@@ -169,18 +173,40 @@ pub enum SshHostKeyPolicy {
 
 #[derive(Debug, Clone)]
 struct SshServerKeyVerifier {
+    hostname: String,
+    port: u16,
     policy: SshHostKeyPolicy,
 }
 
 impl SshServerKeyVerifier {
-    fn new(policy: SshHostKeyPolicy) -> Self {
-        Self { policy }
+    fn new(hostname: impl Into<String>, port: u16, policy: SshHostKeyPolicy) -> Self {
+        Self {
+            hostname: hostname.into(),
+            port,
+            policy,
+        }
     }
-}
 
-impl Default for SshServerKeyVerifier {
-    fn default() -> Self {
-        Self::new(SshHostKeyPolicy::AcceptAll)
+    fn check_server_key_with<F>(
+        &self,
+        server_public_key: &PublicKey,
+        check_default_known_hosts: F,
+    ) -> std::result::Result<bool, russh::Error>
+    where
+        F: FnOnce(&str, u16, &PublicKey) -> std::result::Result<bool, keys::Error>,
+    {
+        Ok(match &self.policy {
+            SshHostKeyPolicy::KnownHosts => {
+                check_default_known_hosts(&self.hostname, self.port, server_public_key)?
+            }
+            SshHostKeyPolicy::KnownHostsFile(path) => {
+                keys::check_known_hosts_path(&self.hostname, self.port, server_public_key, path)?
+            }
+            SshHostKeyPolicy::AcceptAll => true,
+            SshHostKeyPolicy::Fingerprint(expected) => {
+                host_key_fingerprint(server_public_key) == normalize_fingerprint(expected)
+            }
+        })
     }
 }
 
@@ -191,12 +217,7 @@ impl client::Handler for SshServerKeyVerifier {
         &mut self,
         server_public_key: &PublicKey,
     ) -> std::result::Result<bool, Self::Error> {
-        Ok(match &self.policy {
-            SshHostKeyPolicy::AcceptAll => true,
-            SshHostKeyPolicy::Fingerprint(expected) => {
-                host_key_fingerprint(server_public_key) == normalize_fingerprint(expected)
-            }
-        })
+        self.check_server_key_with(server_public_key, keys::check_known_hosts)
     }
 }
 
@@ -385,7 +406,11 @@ impl GvmConnection for SshConnection {
             client::connect(
                 ssh_config,
                 (self.config.hostname.as_str(), self.config.port),
-                SshServerKeyVerifier::new(self.config.host_key_policy.clone()),
+                SshServerKeyVerifier::new(
+                    &self.config.hostname,
+                    self.config.port,
+                    self.config.host_key_policy.clone(),
+                ),
             ),
         )
         .await
@@ -570,7 +595,7 @@ mod tests {
         assert_eq!(config.remote_socket, "/run/gvmd/gvmd.sock");
         assert_eq!(config.timeout, Duration::from_secs(60));
         assert_eq!(config.max_response_bytes, Some(64 * 1024 * 1024));
-        assert_eq!(config.host_key_policy, SshHostKeyPolicy::AcceptAll);
+        assert_eq!(config.host_key_policy, SshHostKeyPolicy::KnownHosts);
     }
 
     #[test]
@@ -629,9 +654,32 @@ mod tests {
             .expect("host key")
             .public_key()
             .clone();
-        let mut verifier = SshServerKeyVerifier::default();
+        let mut verifier =
+            SshServerKeyVerifier::new("scanner.example", 22, SshHostKeyPolicy::AcceptAll);
 
         let accepted = tokio_test::block_on(verifier.check_server_key(&public_key)).expect("ok");
+
+        assert!(accepted);
+    }
+
+    #[test]
+    fn test_default_known_hosts_policy() {
+        let mut rng = UnwrapErr(SystemRng);
+        let public_key = keys::PrivateKey::random(&mut rng, keys::Algorithm::Ed25519)
+            .expect("host key")
+            .public_key()
+            .clone();
+        let verifier =
+            SshServerKeyVerifier::new("scanner.example", 2222, SshHostKeyPolicy::KnownHosts);
+
+        let accepted = verifier
+            .check_server_key_with(&public_key, |hostname, port, received_key| {
+                assert_eq!(hostname, "scanner.example");
+                assert_eq!(port, 2222);
+                assert_eq!(received_key, &public_key);
+                Ok(true)
+            })
+            .expect("known host check");
 
         assert!(accepted);
     }
@@ -643,13 +691,20 @@ mod tests {
             keys::PrivateKey::random(&mut rng, keys::Algorithm::Ed25519).expect("host key");
         let public_key = private_key.public_key().clone();
         let fingerprint = host_key_fingerprint(&public_key);
-        let mut verifier =
-            SshServerKeyVerifier::new(SshHostKeyPolicy::Fingerprint(fingerprint.clone()));
+        let mut verifier = SshServerKeyVerifier::new(
+            "scanner.example",
+            22,
+            SshHostKeyPolicy::Fingerprint(fingerprint.clone()),
+        );
 
         let accepted = tokio_test::block_on(verifier.check_server_key(&public_key)).expect("ok");
         let rejected = tokio_test::block_on(
-            SshServerKeyVerifier::new(SshHostKeyPolicy::Fingerprint("invalid".into()))
-                .check_server_key(&public_key),
+            SshServerKeyVerifier::new(
+                "scanner.example",
+                22,
+                SshHostKeyPolicy::Fingerprint("invalid".into()),
+            )
+            .check_server_key(&public_key),
         )
         .expect("ok");
 
@@ -658,6 +713,42 @@ mod tests {
             normalize_fingerprint(&format!("SHA256:{fingerprint}")),
             fingerprint
         );
+        assert!(!rejected);
+    }
+
+    #[test]
+    fn test_known_hosts_file_policy() {
+        let mut rng = UnwrapErr(SystemRng);
+        let private_key =
+            keys::PrivateKey::random(&mut rng, keys::Algorithm::Ed25519).expect("host key");
+        let public_key = private_key.public_key().clone();
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("known_hosts");
+        std::fs::write(
+            &path,
+            format!(
+                "[scanner.example]:2222 {}\n",
+                public_key.to_openssh().expect("OpenSSH public key")
+            ),
+        )
+        .expect("write known_hosts");
+
+        let mut matching = SshServerKeyVerifier::new(
+            "scanner.example",
+            2222,
+            SshHostKeyPolicy::KnownHostsFile(path.clone()),
+        );
+        let accepted =
+            tokio_test::block_on(matching.check_server_key(&public_key)).expect("known host check");
+        let mut unknown = SshServerKeyVerifier::new(
+            "other.example",
+            2222,
+            SshHostKeyPolicy::KnownHostsFile(path),
+        );
+        let rejected = tokio_test::block_on(unknown.check_server_key(&public_key))
+            .expect("unknown host check");
+
+        assert!(accepted);
         assert!(!rejected);
     }
 }

--- a/crates/gvm-connection/tests/ssh_connection.rs
+++ b/crates/gvm-connection/tests/ssh_connection.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use gvm_connection::{GvmConnection, SshAuth, SshConfig, SshConnection};
+use gvm_connection::{GvmConnection, SshAuth, SshConfig, SshConnection, SshHostKeyPolicy};
 
 #[test]
 fn test_default_config() {
@@ -15,6 +15,7 @@ fn test_default_config() {
     assert_eq!(config.port, 22);
     assert_eq!(config.remote_socket, "/run/gvmd/gvmd.sock");
     assert_eq!(config.timeout, Duration::from_secs(60));
+    assert_eq!(config.host_key_policy, SshHostKeyPolicy::KnownHosts);
 }
 
 #[test]
@@ -29,6 +30,28 @@ fn test_custom_config() {
     assert_eq!(config.port, 2200);
     assert_eq!(config.remote_socket, "/srv/gvmd.sock");
     assert_eq!(config.timeout, Duration::from_secs(5));
+    assert_eq!(config.host_key_policy, SshHostKeyPolicy::KnownHosts);
+}
+
+#[test]
+fn test_custom_host_key_policies() {
+    let known_hosts = SshConfig::default().with_host_key_policy(SshHostKeyPolicy::KnownHostsFile(
+        PathBuf::from("/etc/gvm/known_hosts"),
+    ));
+    assert_eq!(
+        known_hosts.host_key_policy,
+        SshHostKeyPolicy::KnownHostsFile(PathBuf::from("/etc/gvm/known_hosts"))
+    );
+
+    let fingerprint = SshConfig::default()
+        .with_host_key_policy(SshHostKeyPolicy::Fingerprint("sha256".to_string()));
+    assert_eq!(
+        fingerprint.host_key_policy,
+        SshHostKeyPolicy::Fingerprint("sha256".to_string())
+    );
+
+    let insecure = SshConfig::default().with_host_key_policy(SshHostKeyPolicy::AcceptAll);
+    assert_eq!(insecure.host_key_policy, SshHostKeyPolicy::AcceptAll);
 }
 
 #[test]

--- a/crates/gvm-connection/tests/ssh_e2e.rs
+++ b/crates/gvm-connection/tests/ssh_e2e.rs
@@ -31,6 +31,12 @@ fn config_for(server: &MockGmpServer) -> SshConfig {
     SshConfig::new("127.0.0.1", "admin", SshAuth::Password("admin".to_string()))
         .with_port(server.ssh_port().expect("ssh port"))
         .with_remote_socket("/run/gvmd/gvmd.sock")
+        .with_host_key_policy(SshHostKeyPolicy::Fingerprint(
+            server
+                .ssh_host_key_fingerprint()
+                .expect("SSH host key fingerprint")
+                .to_string(),
+        ))
 }
 
 #[tokio::test]
@@ -166,6 +172,102 @@ async fn ssh_connect_with_pinned_fingerprint() {
 
     conn.connect().await.expect("connect failed");
     conn.disconnect().await.expect("disconnect failed");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_connect_with_known_hosts_file() {
+    let server = start_mock().await;
+    let Some(server) = server else {
+        return;
+    };
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("known_hosts");
+    std::fs::write(
+        &path,
+        format!(
+            "[127.0.0.1]:{} {}\n",
+            server.ssh_port().expect("ssh port"),
+            server.ssh_host_public_key().expect("SSH host public key")
+        ),
+    )
+    .expect("write known_hosts");
+    let config = config_for(&server).with_host_key_policy(SshHostKeyPolicy::KnownHostsFile(path));
+    let mut connection = SshConnection::new(config);
+
+    connection.connect().await.expect("connect failed");
+    connection
+        .send(b"<get_version/>")
+        .await
+        .expect("send failed");
+    let response = Response::new(connection.read().await.expect("read failed"));
+    assert_eq!(response.status_code(), Some(200));
+    connection.disconnect().await.expect("disconnect failed");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_rejects_unknown_host_in_known_hosts_file() {
+    let server = start_mock().await;
+    let Some(server) = server else {
+        return;
+    };
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("known_hosts");
+    std::fs::write(&path, "").expect("write known_hosts");
+    let config = config_for(&server).with_host_key_policy(SshHostKeyPolicy::KnownHostsFile(path));
+    let mut connection = SshConnection::new(config);
+
+    let error = connection.connect().await.expect_err("connect should fail");
+    assert!(matches!(error, ConnectionError::ConnectFailed(_)));
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_rejects_changed_key_in_known_hosts_file() {
+    let trusted_server = start_mock().await;
+    let Some(trusted_server) = trusted_server else {
+        return;
+    };
+    let server = start_mock().await;
+    let Some(server) = server else {
+        trusted_server.shutdown().await;
+        return;
+    };
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("known_hosts");
+    std::fs::write(
+        &path,
+        format!(
+            "[127.0.0.1]:{} {}\n",
+            server.ssh_port().expect("ssh port"),
+            trusted_server
+                .ssh_host_public_key()
+                .expect("trusted SSH host public key")
+        ),
+    )
+    .expect("write known_hosts");
+    let config = config_for(&server).with_host_key_policy(SshHostKeyPolicy::KnownHostsFile(path));
+    let mut connection = SshConnection::new(config);
+
+    let error = connection.connect().await.expect_err("connect should fail");
+    assert!(matches!(error, ConnectionError::ConnectFailed(_)));
+    assert!(error.to_string().to_ascii_lowercase().contains("changed"));
+    server.shutdown().await;
+    trusted_server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_connect_with_explicit_accept_all() {
+    let server = start_mock().await;
+    let Some(server) = server else {
+        return;
+    };
+    let config = config_for(&server).with_host_key_policy(SshHostKeyPolicy::AcceptAll);
+    let mut connection = SshConnection::new(config);
+
+    connection.connect().await.expect("connect failed");
+    connection.disconnect().await.expect("disconnect failed");
     server.shutdown().await;
 }
 

--- a/crates/gvm-mock-server/src/server.rs
+++ b/crates/gvm-mock-server/src/server.rs
@@ -57,6 +57,9 @@ pub struct MockGmpServer {
     /// The SSH host key fingerprint without the `SHA256:` prefix.
     #[cfg(feature = "ssh")]
     ssh_host_key_fingerprint: Option<String>,
+    /// The SSH host public key in OpenSSH format.
+    #[cfg(feature = "ssh")]
+    ssh_host_public_key: Option<String>,
     /// Command history shared with all sessions.
     history: CommandHistory,
     /// Shutdown signal.
@@ -130,6 +133,8 @@ impl MockGmpServer {
             ssh_addr: None,
             #[cfg(feature = "ssh")]
             ssh_host_key_fingerprint: None,
+            #[cfg(feature = "ssh")]
+            ssh_host_public_key: None,
             history,
             shutdown,
             listener_handle: handle,
@@ -186,6 +191,8 @@ impl MockGmpServer {
             ssh_addr: None,
             #[cfg(feature = "ssh")]
             ssh_host_key_fingerprint: None,
+            #[cfg(feature = "ssh")]
+            ssh_host_public_key: None,
             history,
             shutdown,
             listener_handle: handle,
@@ -244,6 +251,8 @@ impl MockGmpServer {
             ssh_addr: None,
             #[cfg(feature = "ssh")]
             ssh_host_key_fingerprint: None,
+            #[cfg(feature = "ssh")]
+            ssh_host_public_key: None,
             history,
             shutdown,
             listener_handle: handle,
@@ -270,6 +279,10 @@ impl MockGmpServer {
         let local_addr = listener.local_addr()?;
         let host_key = generate_host_key()?;
         let fingerprint = host_key_fingerprint(&host_key);
+        let public_key = host_key
+            .public_key()
+            .to_openssh()
+            .map_err(std::io::Error::other)?;
         let history = CommandHistory::new();
         let shutdown = Arc::new(Notify::new());
 
@@ -303,6 +316,7 @@ impl MockGmpServer {
             tls_certificate_pem: None,
             ssh_addr: Some(local_addr),
             ssh_host_key_fingerprint: Some(fingerprint),
+            ssh_host_public_key: Some(public_key),
             history,
             shutdown,
             listener_handle: handle,
@@ -358,6 +372,12 @@ impl MockGmpServer {
     #[cfg(feature = "ssh")]
     pub fn ssh_host_key_fingerprint(&self) -> Option<&str> {
         self.ssh_host_key_fingerprint.as_deref()
+    }
+
+    /// Get the generated SSH host public key in OpenSSH format.
+    #[cfg(feature = "ssh")]
+    pub fn ssh_host_public_key(&self) -> Option<&str> {
+        self.ssh_host_public_key.as_deref()
     }
 
     /// Get the command history.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -251,6 +251,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | `remote_socket` | `/run/gvmd/gvmd.sock` | Path to gvmd socket on remote host |
 | `timeout` | 60s | Connect + read timeout |
 | `read_buffer_size` | 64 KB | Per-read allocation |
+| `host_key_policy` | `KnownHosts` | Standard or custom `known_hosts`, pinned SHA-256 fingerprint, or explicit insecure opt-out |
 
 ### TlsConfig
 

--- a/docs/proxy-access-control-analysis.md
+++ b/docs/proxy-access-control-analysis.md
@@ -501,7 +501,7 @@ Strict tenant isolation through policy engine. Customer A cannot see Customer B'
 | Version negotiation | ✅ Complete | `GmpClient` auto-negotiates |
 | Connection trait | ✅ Complete | Polymorphic over transport |
 | Buffer limits | ✅ PR #36 | `max_buffer_bytes` on XmlReader |
-| Host key verification | ✅ PR #36 | `SshHostKeyPolicy::Fingerprint` |
+| Host key verification | ✅ PR #36 | `KnownHosts` by default, custom known-hosts file, or `Fingerprint` pinning |
 
 ### 9.2 What the Gateway Would Add
 


### PR DESCRIPTION
## Description

Make SSH host-key verification fail closed by default.

- verify server keys against the user's OpenSSH `known_hosts` file by default
- support an explicit custom `known_hosts` file for hermetic and service deployments
- retain SHA-256 fingerprint pinning
- keep `AcceptAll` only as a documented explicit insecure opt-out
- expose the mock SSH server's public host key so real transport tests can build deterministic trust stores

### Compatibility

This intentionally changes the runtime behavior of `SshConfig::default()` and
`SshConfig::new()`: callers that previously relied on implicit host-key
acceptance must provide a trusted host entry, a custom known-hosts file, a
pinned fingerprint, or explicitly select `AcceptAll`.

The public `SshHostKeyPolicy` enum also gains variants, so downstream exhaustive
matches may need updating. The maintainer may therefore want to coordinate this
security correction with the project's release/versioning policy.

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [x] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable: transport security default)
- [x] Journal entry updated (not applicable: no journal exists for this surface)

## Testing

- workspace tests with default and all features
- strict Clippy and rustdoc
- Rust 1.85 all-feature check and workspace test
- real `SshConnection` paths against `gvm-mock-server`: matching known-hosts entry, unknown host, changed key, fingerprint pinning, and explicit `AcceptAll`
- public `python-gvm` Unix, TLS, and mutual-TLS integration suites
- `cargo audit`, `cargo deny`, `cargo machete`, and `cargo vet`
- fresh-target workspace unsafe-usage audit: zero workspace unsafe use
- strict Semgrep (`--disable-nosem --error`) and tracked-source Gitleaks: no findings
- changed executable-line coverage: 88/88 (100%)

Fuzzing was not run in this environment. The changed surface is covered by
deterministic unit tests, real SSH transport tests, and full workspace
regression tests.
