### PR TITLE
Pin remaining GitHub Actions references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: greenbone/actions/trigger-workflow@v3
+      - uses: greenbone/actions/trigger-workflow@aa49604a7c2a28d7810d23addac6513af7d8e11f # v3.36.12
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           repository: clawosiris/rust-gvm-e2e-tests

--- a/.github/workflows/journal-pr-automation.yml
+++ b/.github/workflows/journal-pr-automation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate changed files are journal entries only
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -38,7 +38,7 @@ jobs:
               return;
             }
       - name: Enable squash auto-merge
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Set up Python and pontos
-        uses: greenbone/actions/setup-pontos@v3
+        uses: greenbone/actions/setup-pontos@aa49604a7c2a28d7810d23addac6513af7d8e11f # v3.36.12
 
       - name: Configure git
         run: |
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Trigger release.yml and wait for completion
-        uses: greenbone/actions/trigger-workflow@v3
+        uses: greenbone/actions/trigger-workflow@aa49604a7c2a28d7810d23addac6513af7d8e11f # v3.36.12
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
## Description

Pin the five remaining mutable GitHub Actions invocations to immutable commit
SHAs:

- `actions/github-script` is pinned to the commit for `v9.0.0`
- `greenbone/actions/setup-pontos` and
  `greenbone/actions/trigger-workflow` are pinned to the commit for `v3.36.12`

The version comments preserve human-readable provenance and allow the existing
weekly GitHub Actions Dependabot configuration to continue proposing updates.
This changes no workflow logic, permissions, triggers, or secret handling.

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [ ] test: Adding/updating tests
- [ ] docs: Documentation
- [x] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo check --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Documentation updated (not applicable; no user-facing behavior changed)
- [x] New tests added for new functionality (not applicable; reference-only change)
- [x] OpenSpec updated (not applicable; no design change)
- [x] Journal entry updated (not applicable; no user-facing behavior change)

## Testing

- Verified all 104 active external `uses:` references under
  `.github/workflows/` are pinned to 40-character commit SHAs.
- Resolved each release tag against its public upstream repository and verified
  that the referenced action metadata exists at the pinned commit.
- Ran the full all-features workspace test suite, strict all-targets Clippy,
  rustdoc with warnings denied, and the formatting check.
- Ran `cargo audit`, `cargo deny`, `cargo machete`, and `cargo vet`.
- Ran strict Semgrep with suppressions disabled and a tracked-source Gitleaks
  scan; both were clean.

This workflow-only change has no executable Rust lines for local differential
coverage. The repository coverage job remains enabled. No fuzzing was run
because the change does not affect a fuzzable runtime surface.
