### PR TITLE
Add structured scan report support

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -48,7 +48,7 @@ use gvm_gmp::commands::report_configs::{
 use gvm_gmp::commands::reports::{
     get_report_applications, get_report_closed_cves, get_report_cves, get_report_errors,
     get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
-    get_report_vulns,
+    get_report_vulns, get_scan_report,
 };
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
@@ -88,7 +88,9 @@ pub use gvm_gmp::commands::oci_image_targets::{
     CreateOciImageTargetOpts, GetOciImageTargetsOpts, ModifyOciImageTargetOpts,
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
-pub use gvm_gmp::commands::reports::{GetReportDetailsOpts, GetReportExportOpts, ImportReportOpts};
+pub use gvm_gmp::commands::reports::{
+    GetReportDetailsOpts, GetReportExportOpts, GetScanReportOpts, ImportReportOpts,
+};
 pub use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateOciImageTargetTaskOpts;
@@ -756,6 +758,19 @@ impl<C: GvmConnection> GmpClient<C> {
         .await
     }
 
+    /// Get one structured vulnerability report.
+    ///
+    /// # Errors
+    /// Returns an error if the server does not support the command, the transport fails,
+    /// parsing fails, or the server returns a non-success status.
+    pub async fn get_scan_report(
+        &mut self,
+        scan_report_id: &EntityId,
+        opts: GetScanReportOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(get_scan_report(scan_report_id, opts)).await
+    }
+
     /// Get host summaries for a report.
     ///
     /// # Errors
@@ -1202,6 +1217,13 @@ pub trait GmpNextCommands {
         &mut self,
         integration_config_id: &EntityId,
         opts: ModifyIntegrationConfigOpts,
+    ) -> Result<Response, GvmError>;
+
+    /// Get one structured vulnerability report.
+    async fn get_scan_report(
+        &mut self,
+        scan_report_id: &EntityId,
+        opts: GetScanReportOpts,
     ) -> Result<Response, GvmError>;
 
     /// Get report host summaries.
@@ -1762,6 +1784,14 @@ impl<C: GvmConnection + Send> GmpNextCommands for GmpNext<C> {
         self.0
             .modify_integration_config(integration_config_id, opts)
             .await
+    }
+
+    async fn get_scan_report(
+        &mut self,
+        scan_report_id: &EntityId,
+        opts: GetScanReportOpts,
+    ) -> Result<Response, GvmError> {
+        self.0.get_scan_report(scan_report_id, opts).await
     }
 
     async fn get_report_hosts(

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -160,6 +160,12 @@ mod tests {
         assert!(command_supported("get_features", GmpVersion(22, 6)));
         assert!(!command_supported("get_report_hosts", GmpVersion(22, 7)));
         assert!(command_supported("get_report_hosts", GmpVersion(22, 8)));
+        assert!(!command_supported("get_scan_report", GmpVersion(22, 7)));
+        assert!(command_supported("get_scan_report", GmpVersion(22, 8)));
+        assert_eq!(
+            minimum_version_for_command("get_scan_report"),
+            Some(GmpVersion(22, 8))
+        );
         assert!(command_supported(
             "unknown_future_command",
             GmpVersion(22, 4)

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -6,9 +6,10 @@
 
 use gvm_client::{
     CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts,
-    CredentialStoreCredentialType, GetCredentialStoresOpts, GetSystemReportsOpts, GmpClient,
-    GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts, ModifyCredentialStoreCredentialOpts,
-    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts, WireTraceDirection, WireTraceEvent,
+    CredentialStoreCredentialType, GetCredentialStoresOpts, GetScanReportOpts,
+    GetSystemReportsOpts, GmpClient, GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts,
+    ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
+    WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
@@ -49,7 +50,9 @@ use gvm_gmp::responses::{
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::FeedType;
-use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, Resource, ServerMode};
+use gvm_mock_server::{
+    GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
+};
 use std::sync::{Arc, Mutex};
 
 async fn stateful_server() -> Option<MockGmpServer> {
@@ -2310,6 +2313,164 @@ async fn typed_report_drilldowns_parse_stateful_mock_responses() {
         .await
         .expect("report cves should parse");
     assert_eq!(cves.items[0].name.as_deref(), Some("CVE-2026-0001"));
+
+    server.shutdown().await;
+}
+
+const SCAN_REPORT_ID: &str = "10000000-0000-4000-8000-000000000001";
+const SCAN_REPORT_TASK_ID: &str = "20000000-0000-4000-8000-000000000001";
+const SCAN_REPORT_TARGET_ID: &str = "30000000-0000-4000-8000-000000000001";
+const SCAN_REPORT_FILTER_ID: &str = "40000000-0000-4000-8000-000000000001";
+
+fn seed_scan_report_fixture(store: &ResourceStore) {
+    let mut target = Resource::with_id(
+        "target",
+        "Scan Report Target",
+        SCAN_REPORT_TARGET_ID.parse().expect("valid target UUID"),
+    );
+    target.comment = "Target comment".into();
+    store.seed(target);
+
+    let mut task = Resource::with_id(
+        "task",
+        "Scan Report Task",
+        SCAN_REPORT_TASK_ID.parse().expect("valid task UUID"),
+    );
+    task.comment = "Task comment".into();
+    task.set_attr("target_id", SCAN_REPORT_TARGET_ID);
+    task.set_attr("status", "Done");
+    store.seed(task);
+
+    let mut report = Resource::with_id(
+        "report",
+        "Structured Scan Report",
+        SCAN_REPORT_ID.parse().expect("valid report UUID"),
+    );
+    report.comment = "Report comment".into();
+    report.set_attr("task_id", SCAN_REPORT_TASK_ID);
+    report.set_attr("status", "Done");
+    report.set_attr("usage_type", "scan");
+    store.seed(report);
+
+    let mut saved_filter = Resource::with_id(
+        "filter",
+        "Saved Result Filter",
+        SCAN_REPORT_FILTER_ID.parse().expect("valid filter UUID"),
+    );
+    saved_filter.set_attr(
+        "term",
+        "bare levels=chm min_qod=70 apply_overrides=0 first=1 rows=10 \
+         sort-reverse=severity result_hosts_only=1 unknown=ignored",
+    );
+    store.seed(saved_filter);
+
+    for (name, severity, qod, host, port, false_positive, threat) in [
+        ("Critical", "9.5", "90", "192.0.2.1", "443/tcp", false, ""),
+        ("High", "8.0", "80", "192.0.2.2", "22/tcp", false, ""),
+        ("Medium", "5.0", "60", "192.0.2.1", "80/tcp", false, ""),
+        ("Low", "2.0", "100", "192.0.2.3", "80/tcp", false, ""),
+        ("Log", "0.0", "100", "192.0.2.4", "0/tcp", false, ""),
+        (
+            "False positive",
+            "9.0",
+            "100",
+            "192.0.2.5",
+            "25/tcp",
+            true,
+            "",
+        ),
+        (
+            "Scanner error",
+            "0.0",
+            "100",
+            "192.0.2.6",
+            "0/tcp",
+            false,
+            "Error",
+        ),
+    ] {
+        let mut result = Resource::new("result", name);
+        result.set_attr("report_id", SCAN_REPORT_ID);
+        result.set_attr("severity", severity);
+        result.set_attr("qod", qod);
+        result.set_attr("host", host);
+        result.set_attr("port", port);
+        if false_positive {
+            result.set_attr("false_positive", "1");
+        }
+        if !threat.is_empty() {
+            result.set_attr("threat", threat);
+        }
+        store.seed(result);
+    }
+}
+
+#[tokio::test]
+async fn next_client_get_scan_report_uses_stateful_mock_transport() {
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(MockVersion::V22_8)
+        .unix_socket_auto()
+        .seed(seed_scan_report_fixture)
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+
+    let mut client = GmpVersioned::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authentication should succeed");
+    let mut client = match client {
+        GmpVersioned::Next(client) => client,
+        other => panic!("expected Next client, got {other:?}"),
+    };
+    server.clear_history();
+
+    let response = client
+        .get_scan_report(
+            &EntityId::new(SCAN_REPORT_ID).expect("valid report ID"),
+            GetScanReportOpts {
+                filter_string: Some("levels=l".into()),
+                filter_id: Some(EntityId::new(SCAN_REPORT_FILTER_ID).expect("valid filter ID")),
+            },
+        )
+        .await
+        .expect("get_scan_report should succeed");
+    let xml = response.as_str().expect("response should be UTF-8");
+
+    assert!(xml.starts_with("<get_scan_report_response status=\"200\""));
+    assert!(xml.contains(&format!("<report id=\"{SCAN_REPORT_ID}\">")));
+    assert!(xml.contains("<scan_run_status>Done</scan_run_status>"));
+    assert!(xml.contains("<hosts><count>6</count></hosts>"));
+    assert!(xml.contains("<vulns><count>7</count></vulns>"));
+    assert!(xml.contains("<errors><count>1</count></errors>"));
+    assert!(xml.contains(&format!("<task id=\"{SCAN_REPORT_TASK_ID}\">")));
+    assert!(xml.contains(&format!("<target id=\"{SCAN_REPORT_TARGET_ID}\">")));
+    assert!(xml.contains("<target_type>target</target_type>"));
+    assert!(xml.contains("<full>7</full><filtered>2</filtered>"));
+    assert!(xml.contains("<severity><full>9.5</full><filtered>9.5</filtered></severity>"));
+    assert!(xml.contains(&format!("<filters id=\"{SCAN_REPORT_FILTER_ID}\">")));
+    assert!(xml.contains("<column>levels</column>"));
+    assert!(xml.contains("<sort><field>severity<order>descending</order></field></sort>"));
+    assert!(xml.contains("<scan_report start=\"1\" max=\"1\"/>"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].command_name(), "get_scan_report");
+    assert_eq!(
+        std::str::from_utf8(history[0].raw_xml()).expect("request should be UTF-8"),
+        format!(
+            "<get_scan_report filt_id=\"{SCAN_REPORT_FILTER_ID}\" filter=\"levels=l\" \
+             scan_report_id=\"{SCAN_REPORT_ID}\"/>"
+        )
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -17,6 +17,7 @@ use gvm_connection::{GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::agents::get_agents;
 use gvm_gmp::commands::credentials::{create_credential, verify_credential_store, CredentialOpts};
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
+use gvm_gmp::commands::reports::{get_scan_report, GetScanReportOpts};
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 
@@ -650,6 +651,39 @@ async fn versioned_client_rejects_agent_commands_before_next() {
             version: GmpVersion(22, 7),
             required: "22.8",
         } if command == "get_agents"
+    ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn versioned_client_rejects_get_scan_report_before_next() {
+    let Some(server) = stateful_server(MockVersion::V22_7).await else {
+        return;
+    };
+    let mut client = GmpVersioned::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+
+    let report_id = EntityId::new("10000000-0000-4000-8000-000000000001").expect("valid report ID");
+    let error = client
+        .call(get_scan_report(&report_id, GetScanReportOpts::default()))
+        .await
+        .expect_err("22.7 should reject get_scan_report");
+
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "get_scan_report"
     ));
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/capabilities.rs
+++ b/crates/gvm-gmp/src/capabilities.rs
@@ -163,6 +163,7 @@ command_capabilities! {
     ("get_resource_names", Stateful, None, PinnedSchema),
     ("get_results", Stateful, None, PinnedSchema),
     ("get_roles", Stateful, None, PinnedSchema),
+    ("get_scan_report", Stateful, Some(GmpVersion(22, 8)), PinnedSchema),
     ("get_scanners", Stateful, None, PinnedSchema),
     ("get_schedules", Stateful, None, PinnedSchema),
     ("get_settings", Stateful, None, PinnedSchema),

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -46,6 +46,15 @@ pub struct GetReportsOpts {
     pub ignore_pagination: Option<bool>,
 }
 
+/// Options for `get_scan_report` requests.
+#[derive(Debug, Clone, Default)]
+pub struct GetScanReportOpts {
+    /// Optional inline result filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved result filter identifier.
+    pub filter_id: Option<EntityId>,
+}
+
 /// Options for `get_reports` report-format export requests.
 #[derive(Debug, Clone)]
 pub struct GetReportExportOpts {
@@ -177,6 +186,19 @@ pub fn get_report(report_id: &EntityId) -> impl Request {
     XmlCommand::new("get_reports")
         .attribute("report_id", report_id.as_str())
         .attribute("details", "1")
+}
+
+/// Build a `get_scan_report` request for a structured vulnerability report.
+#[must_use]
+pub fn get_scan_report(scan_report_id: &EntityId, opts: GetScanReportOpts) -> impl Request {
+    let mut cmd =
+        XmlCommand::new("get_scan_report").attribute("scan_report_id", scan_report_id.as_str());
+    add_filter_attrs(
+        &mut cmd,
+        opts.filter_string.as_deref(),
+        opts.filter_id.as_ref(),
+    );
+    cmd
 }
 
 /// Build a `get_reports` export request for a specific report format.

--- a/crates/gvm-gmp/tests/data/gvmd-gmp-commands-fb21137.txt
+++ b/crates/gvm-gmp/tests/data/gvmd-gmp-commands-fb21137.txt
@@ -1,8 +1,8 @@
 # Extracted top-level GMP commands from public gvmd source.
 # Repository: https://github.com/greenbone/gvmd
-# Commit: aa53bc1057a4d535557d568a85c459bfb7780c81
+# Commit: fb21137097f41e5eb83bb45ee43170b775dbea49
 # Path: src/schema_formats/XML/GMP.xml.in
-# GMP.xml.in SHA-256: 03089cd37735d2c98a56138cdf147311d350e34e8a9522b6e988cc32aee8efa0
+# GMP.xml.in SHA-256: 9bf8435a057da2c56f946a465b55aac439b63a9e8b81849526a04aaa92c3e6fc
 authenticate
 create_agent_group
 create_alert
@@ -98,6 +98,7 @@ get_reports
 get_resource_names
 get_results
 get_roles
+get_scan_report
 get_scanners
 get_schedules
 get_settings

--- a/crates/gvm-gmp/tests/gmp_schema_snapshot.rs
+++ b/crates/gvm-gmp/tests/gmp_schema_snapshot.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use gvm_gmp::capabilities::{GvmdEvidence, MockSupport, COMMAND_CAPABILITIES};
 use gvm_gmp::GmpVersion;
 
-const PINNED_COMMANDS: &str = include_str!("data/gvmd-gmp-commands-aa53bc1.txt");
+const PINNED_COMMANDS: &str = include_str!("data/gvmd-gmp-commands-fb21137.txt");
 
 fn pinned_commands() -> BTreeSet<&'static str> {
     PINNED_COMMANDS
@@ -39,7 +39,7 @@ fn pinned_schema_matches_qualified_registry() {
         registry_only.is_empty(),
         "commands marked PinnedSchema but absent from pinned GMP.xml.in: {registry_only:?}"
     );
-    assert_eq!(pinned.len(), 151);
+    assert_eq!(pinned.len(), 152);
 }
 
 #[test]

--- a/crates/gvm-gmp/tests/test_reports.rs
+++ b/crates/gvm-gmp/tests/test_reports.rs
@@ -119,6 +119,28 @@ fn test_report_get_and_delete() {
 }
 
 #[test]
+fn test_get_scan_report_with_filters() {
+    assert_eq!(
+        xml(get_scan_report(
+            &id("r1"),
+            GetScanReportOpts {
+                filter_string: Some("levels=chml min_qod=70".into()),
+                filter_id: Some(id("f1")),
+            },
+        )),
+        "<get_scan_report filt_id=\"f1\" filter=\"levels=chml min_qod=70\" scan_report_id=\"r1\"/>"
+    );
+}
+
+#[test]
+fn test_get_scan_report_without_filters() {
+    assert_eq!(
+        xml(get_scan_report(&id("r1"), Default::default())),
+        "<get_scan_report scan_report_id=\"r1\"/>"
+    );
+}
+
+#[test]
 fn test_report_export_with_report_config() {
     let mut opts = GetReportExportOpts::new(id("rf1"));
     opts.report_config_id = Some(id("rc1"));

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1435,7 +1435,7 @@ impl SessionHandler {
             .and_then(|task_id| Uuid::parse_str(task_id).ok())
             .and_then(|task_id| store.get_typed(&task_id, "task"));
         let task_xml = task.as_ref().map_or_else(
-            || "<task><name></name><comment></comment><progress>0</progress></task>".to_string(),
+            || "<task/>".to_string(),
             |task| render_scan_report_task(task, store),
         );
         let status = report.attr("status").unwrap_or("Done");
@@ -1838,7 +1838,7 @@ fn render_scan_report_task(task: &Resource, store: &ResourceStore) -> String {
                 )
             })
     })
-    .unwrap_or_default();
+    .unwrap_or_else(|| "<target/>".to_string());
     let progress = if task.attr("status") == Some("Done") {
         100
     } else {
@@ -2581,6 +2581,16 @@ mod tests {
 
         let xml = render_scan_report_task(&task, &store);
         assert!(xml.contains("<target_type>oci_image</target_type>"));
+        assert!(xml.contains("<progress>0</progress>"));
+    }
+
+    #[test]
+    fn scan_report_task_renders_empty_target_when_unlinked() {
+        let store = ResourceStore::new();
+        let task = Resource::new("task", "Import Task");
+
+        let xml = render_scan_report_task(&task, &store);
+        assert!(xml.contains("<target/>"));
         assert!(xml.contains("<progress>0</progress>"));
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -3,6 +3,7 @@
 
 //! GMP session handler — processes commands and generates responses.
 
+use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
@@ -643,6 +644,11 @@ impl SessionHandler {
         if let Some(scheduler_cron_time) = parse_element_text(raw_xml, "scheduler_cron_time") {
             resource.set_attr("scheduler_cron_time", &scheduler_cron_time);
         }
+        if resource_type == "filter" {
+            if let Some(term) = parse_element_text(raw_xml, "term") {
+                resource.set_attr("term", &term);
+            }
+        }
         if resource_type == "oci_image_target" {
             if let Some(image_references) = parse_element_text(raw_xml, "image_references") {
                 resource.set_attr("image_references", &image_references);
@@ -845,6 +851,7 @@ impl SessionHandler {
         match cmd.name.as_str() {
             "get_feeds" => return render_feeds_response(cmd),
             "get_aggregates" => return render_aggregates_response(cmd),
+            "get_scan_report" => return self.render_scan_report_response(cmd, store),
             "get_system_reports" => return render_system_reports_response(cmd, store),
             "get_info" => return render_secinfo_response(cmd),
             "get_vulns" => return render_vulnerabilities_response(cmd),
@@ -1006,6 +1013,7 @@ impl SessionHandler {
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
         let new_value = parse_element_text(raw_xml, "value");
+        let new_term = parse_element_text(raw_xml, "term");
         let new_credential_store_id = parse_element_text(raw_xml, "credential_store_id");
         let new_vault_id = parse_element_text(raw_xml, "vault_id");
         let new_host_identifier = parse_element_text(raw_xml, "host_identifier");
@@ -1144,6 +1152,11 @@ impl SessionHandler {
             }
             if let Some(ref value) = new_value {
                 r.set_attr("value", value);
+            }
+            if resource_type == "filter" {
+                if let Some(ref term) = new_term {
+                    r.set_attr("term", term);
+                }
             }
             if resource_type == "credential" {
                 if let Some(ref credential_store_id) = new_credential_store_id {
@@ -1364,6 +1377,128 @@ impl SessionHandler {
         .into_bytes()
     }
 
+    fn render_scan_report_response(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let Some(report_id) = cmd.attr("scan_report_id") else {
+            return error_response(&cmd.name, 400, "Missing required attribute: scan_report_id");
+        };
+        let Ok(report_id) = Uuid::parse_str(report_id) else {
+            return error_response(&cmd.name, 400, "Invalid UUID");
+        };
+        let Some(report) = store.get_typed(&report_id, "report") else {
+            return error_response(&cmd.name, 404, "Resource not found");
+        };
+        if report.attr("usage_type") == Some("audit") {
+            return error_response(
+                &cmd.name,
+                400,
+                "Audit and compliance reports are not supported",
+            );
+        }
+
+        let (filter_id, filter) = match cmd.attr("filt_id") {
+            Some(filter_id) => {
+                let Ok(filter_id) = Uuid::parse_str(filter_id) else {
+                    return error_response(&cmd.name, 400, "Invalid filter UUID");
+                };
+                let Some(saved_filter) = store.get_typed(&filter_id, "filter") else {
+                    return error_response(&cmd.name, 400, "Saved filter not found");
+                };
+                (
+                    filter_id.to_string(),
+                    saved_filter.attr("term").unwrap_or_default().to_string(),
+                )
+            }
+            None => (
+                String::new(),
+                cmd.attr("filter").unwrap_or_default().to_string(),
+            ),
+        };
+
+        let filter = resolve_scan_report_filter(&filter);
+        let (sort_field, sort_order) = scan_report_sort(&filter);
+        let report_id_text = report_id.to_string();
+        let results: Vec<Resource> = store
+            .list("result")
+            .into_iter()
+            .filter(|result| result.attr("report_id") == Some(report_id_text.as_str()))
+            .collect();
+        let filtered_results: Vec<&Resource> = results
+            .iter()
+            .filter(|result| scan_report_result_matches(result, &filter))
+            .collect();
+        let full_counts = ScanReportResultCounts::from_results(results.iter());
+        let filtered_counts =
+            ScanReportResultCounts::from_results(filtered_results.iter().copied());
+
+        let task = report
+            .attr("task_id")
+            .and_then(|task_id| Uuid::parse_str(task_id).ok())
+            .and_then(|task_id| store.get_typed(&task_id, "task"));
+        let task_xml = task.as_ref().map_or_else(
+            || "<task><name></name><comment></comment><progress>0</progress></task>".to_string(),
+            |task| render_scan_report_task(task, store),
+        );
+        let status = report.attr("status").unwrap_or("Done");
+        let scan_end = if matches!(status, "Done" | "Stopped" | "Interrupted") {
+            report.modification_time.as_str()
+        } else {
+            ""
+        };
+        let filter_keywords = render_scan_report_filter_keywords(&filter);
+
+        format!(
+            "<get_scan_report_response status=\"200\" status_text=\"OK\">\
+             <report id=\"{report_id}\">\
+             <owner><name>admin</name></owner>\
+             <name>{report_name}</name>\
+             <comment>{comment}</comment>\
+             <creation_time>{creation_time}</creation_time>\
+             <modification_time>{modification_time}</modification_time>\
+             <writable>0</writable><in_use>0</in_use>\
+             <scan_run_status>{status}</scan_run_status>\
+             <hosts><count>{hosts}</count></hosts>\
+             <closed_cves><count>0</count></closed_cves>\
+             <cves><count>0</count></cves>\
+             <vulns><count>{vulns}</count></vulns>\
+             <os><count>0</count></os>\
+             <apps><count>0</count></apps>\
+             <ssl_certs><count>0</count></ssl_certs>\
+             <ports><count>{ports}</count></ports>\
+             <errors><count>{errors}</count></errors>\
+             {task_xml}\
+             <timestamp>{creation_time}</timestamp>\
+             <scan_start>{creation_time}</scan_start>\
+             <timezone>UTC</timezone><timezone_abbrev>UTC</timezone_abbrev>\
+             {result_count_xml}\
+             <severity><full>{full_severity:.1}</full><filtered>{filtered_severity:.1}</filtered></severity>\
+             <scan_end>{scan_end}</scan_end>\
+             </report>\
+             <filters id=\"{filter_id}\"><term>{filter}</term><keywords>{filter_keywords}</keywords></filters>\
+             <sort><field>{sort_field}<order>{sort_order}</order></field></sort>\
+             <scan_report start=\"1\" max=\"1\"/>\
+             <scan_report_count>1<filtered>1</filtered><page>0</page></scan_report_count>\
+             </get_scan_report_response>",
+            report_id = report.id,
+            report_name = xml_escape(&report.name),
+            comment = xml_escape(&report.comment),
+            creation_time = xml_escape(&report.creation_time),
+            modification_time = xml_escape(&report.modification_time),
+            status = xml_escape(status),
+            hosts = full_counts.hosts,
+            vulns = full_counts.total,
+            ports = full_counts.ports,
+            errors = full_counts.errors,
+            result_count_xml = render_scan_report_result_counts(&full_counts, &filtered_counts),
+            full_severity = full_counts.max_severity,
+            filtered_severity = filtered_counts.max_severity,
+            filter_id = xml_escape_attr(&filter_id),
+            filter = xml_escape(&filter),
+            scan_end = xml_escape(scan_end),
+            sort_field = xml_escape(&sort_field),
+        )
+        .into_bytes()
+    }
+
     fn render_report_detail_response(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
         let Some(report_id) = cmd.attr("report_id") else {
             return error_response(&cmd.name, 400, "Missing required attribute: report_id");
@@ -1508,6 +1643,228 @@ fn render_report_result_xml(result: &Resource) -> String {
 
     xml.push_str("</result>");
     xml
+}
+
+#[derive(Default)]
+struct ScanReportResultCounts {
+    total: usize,
+    critical: usize,
+    high: usize,
+    medium: usize,
+    low: usize,
+    log: usize,
+    false_positive: usize,
+    errors: usize,
+    hosts: usize,
+    ports: usize,
+    max_severity: f64,
+}
+
+impl ScanReportResultCounts {
+    fn from_results<'a>(results: impl Iterator<Item = &'a Resource>) -> Self {
+        let mut counts = Self::default();
+        let mut hosts = BTreeSet::new();
+        let mut ports = BTreeSet::new();
+        for result in results {
+            counts.total += 1;
+            let severity = scan_report_result_severity(result);
+            counts.max_severity = counts.max_severity.max(severity);
+            if result.attr("false_positive") == Some("1") {
+                counts.false_positive += 1;
+            } else if severity >= 9.0 {
+                counts.critical += 1;
+            } else if severity >= 7.0 {
+                counts.high += 1;
+            } else if severity >= 4.0 {
+                counts.medium += 1;
+            } else if severity > 0.0 {
+                counts.low += 1;
+            } else {
+                counts.log += 1;
+            }
+            if result.attr("threat") == Some("Error") {
+                counts.errors += 1;
+            }
+            if let Some(host) = result.attr("host") {
+                hosts.insert(host);
+            }
+            if let Some(port) = result.attr("port") {
+                ports.insert(port);
+            }
+        }
+        counts.hosts = hosts.len();
+        counts.ports = ports.len();
+        counts
+    }
+}
+
+fn scan_report_result_severity(result: &Resource) -> f64 {
+    result
+        .attr("severity")
+        .and_then(|severity| severity.parse().ok())
+        .unwrap_or_default()
+}
+
+fn scan_report_result_matches(result: &Resource, filter: &str) -> bool {
+    let severity = scan_report_result_severity(result);
+    for predicate in filter.split_whitespace() {
+        let Some((key, value)) = predicate.split_once('=') else {
+            continue;
+        };
+        match key {
+            "levels" => {
+                let level = if result.attr("false_positive") == Some("1") {
+                    'f'
+                } else if severity >= 9.0 {
+                    'c'
+                } else if severity >= 7.0 {
+                    'h'
+                } else if severity >= 4.0 {
+                    'm'
+                } else if severity > 0.0 {
+                    'l'
+                } else {
+                    'g'
+                };
+                if !value.contains(level) {
+                    return false;
+                }
+            }
+            "min_qod" => {
+                let minimum = value.parse::<u32>().unwrap_or_default();
+                let qod = result
+                    .attr("qod")
+                    .and_then(|qod| qod.parse().ok())
+                    .unwrap_or(100);
+                if qod < minimum {
+                    return false;
+                }
+            }
+            "first" | "rows" | "sort" | "sort-reverse" | "apply_overrides"
+            | "result_hosts_only" => {}
+            _ => {}
+        }
+    }
+    true
+}
+
+fn resolve_scan_report_filter(filter: &str) -> String {
+    let mut resolved = filter.trim().to_string();
+    let has_keyword = |filter: &str, expected: &str| {
+        filter.split_whitespace().any(|predicate| {
+            predicate
+                .split_once('=')
+                .is_some_and(|(key, _)| key == expected)
+        })
+    };
+    if !has_keyword(&resolved, "min_qod") {
+        resolved = format!("min_qod=70 {resolved}").trim_end().to_string();
+    }
+    if !has_keyword(&resolved, "apply_overrides") {
+        resolved = format!("apply_overrides=0 {resolved}")
+            .trim_end()
+            .to_string();
+    }
+    resolved
+}
+
+fn scan_report_sort(filter: &str) -> (String, &'static str) {
+    for predicate in filter.split_whitespace() {
+        match predicate.split_once('=') {
+            Some(("sort", field)) => return (field.to_string(), "ascending"),
+            Some(("sort-reverse", field)) => return (field.to_string(), "descending"),
+            _ => {}
+        }
+    }
+    ("name".to_string(), "ascending")
+}
+
+fn render_scan_report_result_counts(
+    full: &ScanReportResultCounts,
+    filtered: &ScanReportResultCounts,
+) -> String {
+    format!(
+        "<result_count>{total}\
+         <full>{total}</full><filtered>{filtered_total}</filtered>\
+         <critical><full>{critical}</full><filtered>{filtered_critical}</filtered></critical>\
+         <hole deprecated=\"1\"><full>{high}</full><filtered>{filtered_high}</filtered></hole>\
+         <high><full>{high}</full><filtered>{filtered_high}</filtered></high>\
+         <info deprecated=\"1\"><full>{low}</full><filtered>{filtered_low}</filtered></info>\
+         <low><full>{low}</full><filtered>{filtered_low}</filtered></low>\
+         <log><full>{log}</full><filtered>{filtered_log}</filtered></log>\
+         <warning deprecated=\"1\"><full>{medium}</full><filtered>{filtered_medium}</filtered></warning>\
+         <medium><full>{medium}</full><filtered>{filtered_medium}</filtered></medium>\
+         <false_positive><full>{false_positive}</full><filtered>{filtered_false_positive}</filtered></false_positive>\
+         </result_count>",
+        total = full.total,
+        filtered_total = filtered.total,
+        critical = full.critical,
+        filtered_critical = filtered.critical,
+        high = full.high,
+        filtered_high = filtered.high,
+        low = full.low,
+        filtered_low = filtered.low,
+        log = full.log,
+        filtered_log = filtered.log,
+        medium = full.medium,
+        filtered_medium = filtered.medium,
+        false_positive = full.false_positive,
+        filtered_false_positive = filtered.false_positive,
+    )
+}
+
+fn render_scan_report_task(task: &Resource, store: &ResourceStore) -> String {
+    let target = [
+        ("target_id", "target"),
+        ("agent_group_id", "agent_group"),
+        ("oci_image_target_id", "oci_image_target"),
+        ("web_application_target_id", "web_application_target"),
+    ]
+    .into_iter()
+    .find_map(|(attribute, resource_type)| {
+        task.attr(attribute)
+            .and_then(|id| Uuid::parse_str(id).ok())
+            .and_then(|id| store.get_typed(&id, resource_type))
+            .map(|target| {
+                let target_type = resource_type
+                    .strip_suffix("_target")
+                    .unwrap_or(resource_type);
+                format!(
+                    "<target id=\"{id}\"><trash>0</trash><name>{name}</name>\
+                     <comment>{comment}</comment><target_type>{target_type}</target_type></target>",
+                    id = target.id,
+                    name = xml_escape(&target.name),
+                    comment = xml_escape(&target.comment),
+                )
+            })
+    })
+    .unwrap_or_default();
+    let progress = if task.attr("status") == Some("Done") {
+        100
+    } else {
+        0
+    };
+    format!(
+        "<task id=\"{id}\"><name>{name}</name><comment>{comment}</comment>\
+         {target}<progress>{progress}</progress></task>",
+        id = task.id,
+        name = xml_escape(&task.name),
+        comment = xml_escape(&task.comment),
+    )
+}
+
+fn render_scan_report_filter_keywords(filter: &str) -> String {
+    filter
+        .split_whitespace()
+        .filter_map(|predicate| predicate.split_once('='))
+        .map(|(column, value)| {
+            format!(
+                "<keyword><column>{}</column><relation>=</relation><value>{}</value></keyword>",
+                xml_escape(column),
+                xml_escape(value),
+            )
+        })
+        .collect()
 }
 
 fn render_agent_installer_instruction_response(cmd: &ParsedCommand) -> Vec<u8> {
@@ -2209,5 +2566,21 @@ mod tests {
         let response = String::from_utf8(response).expect("UTF-8 response");
         assert!(response.contains("status=\"409\""));
         assert!(response.contains("Task graph is inconsistent: task report"));
+    }
+
+    #[test]
+    fn scan_report_task_renders_running_specialized_target() {
+        let store = ResourceStore::new();
+        let target = Resource::new("oci_image_target", "Container Target");
+        let target_id = target.id;
+        store.seed(target);
+
+        let mut task = Resource::new("task", "Container Task");
+        task.set_attr("oci_image_target_id", &target_id.to_string());
+        task.set_attr("status", "Running");
+
+        let xml = render_scan_report_task(&task, &store);
+        assert!(xml.contains("<target_type>oci_image</target_type>"));
+        assert!(xml.contains("<progress>0</progress>"));
     }
 }

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -145,6 +145,8 @@ mod tests {
         assert!(command_available("get_report_hosts", GmpVersion::V22_8));
         assert!(!command_available("get_report_vulns", GmpVersion::V22_7));
         assert!(command_available("get_report_vulns", GmpVersion::V22_8));
+        assert!(!command_available("get_scan_report", GmpVersion::V22_7));
+        assert!(command_available("get_scan_report", GmpVersion::V22_8));
         assert!(command_available(
             "get_credential_stores",
             GmpVersion::V22_8

--- a/crates/gvm-mock-server/tests/stateful_scan_report.rs
+++ b/crates/gvm-mock-server/tests/stateful_scan_report.rs
@@ -14,6 +14,8 @@ use tokio::net::UnixStream;
 const SCAN_REPORT_ID: &str = "10000000-0000-4000-8000-000000000001";
 const AUDIT_REPORT_ID: &str = "10000000-0000-4000-8000-000000000002";
 const ABSENT_REPORT_ID: &str = "10000000-0000-4000-8000-000000000003";
+const IMPORT_TASK_ID: &str = "20000000-0000-4000-8000-000000000001";
+const IMPORT_REPORT_ID: &str = "20000000-0000-4000-8000-000000000002";
 const ABSENT_FILTER_ID: &str = "40000000-0000-4000-8000-000000000001";
 
 async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
@@ -61,6 +63,26 @@ async fn scan_report_server() -> Option<MockGmpServer> {
             audit_report.set_attr("status", "Done");
             audit_report.set_attr("usage_type", "audit");
             store.seed(audit_report);
+
+            let mut import_task = Resource::with_id(
+                "task",
+                "Imported Report Task",
+                IMPORT_TASK_ID.parse().expect("valid import task UUID"),
+            );
+            import_task.set_attr("status", "Done");
+            import_task.set_attr("usage_type", "scan");
+            import_task.set_attr("import_task", "1");
+            store.seed(import_task);
+
+            let mut import_report = Resource::with_id(
+                "report",
+                "Imported Report",
+                IMPORT_REPORT_ID.parse().expect("valid import report UUID"),
+            );
+            import_report.set_attr("status", "Done");
+            import_report.set_attr("usage_type", "scan");
+            import_report.set_attr("task_id", IMPORT_TASK_ID);
+            store.seed(import_report);
         })
         .unix_socket_auto()
         .build()
@@ -120,7 +142,7 @@ async fn assert_scan_report_filter_resolution(stream: &mut UnixStream) {
     let xml = response.as_str().expect("valid UTF-8 response");
     assert!(xml.contains("<writable>0</writable><in_use>0</in_use>"));
     assert!(xml.contains("<scan_run_status>Running</scan_run_status>"));
-    assert!(xml.contains("<task><name></name><comment></comment><progress>0</progress></task>"));
+    assert!(xml.contains("<task/>"));
     assert!(xml.contains("<result_count>0<full>0</full><filtered>0</filtered>"));
     assert!(xml.contains("<scan_end></scan_end>"));
     assert!(xml.contains("<filters id=\"\"><term>apply_overrides=0 min_qod=70</term><keywords>"));
@@ -178,6 +200,17 @@ async fn assert_scan_report_filter_resolution(stream: &mut UnixStream) {
         .as_str()
         .expect("valid UTF-8 response")
         .contains("<term>apply_overrides=0 min_qod=70 levels=hm</term>"));
+
+    let response = send_recv(
+        stream,
+        format!("<get_scan_report scan_report_id=\"{IMPORT_REPORT_ID}\"/>").as_bytes(),
+    )
+    .await;
+    let xml = response.as_str().expect("valid UTF-8 response");
+    assert!(xml.contains(&format!(
+        "<task id=\"{IMPORT_TASK_ID}\"><name>Imported Report Task</name>\
+         <comment></comment><target/><progress>100</progress></task>"
+    )));
 }
 
 #[tokio::test]

--- a/crates/gvm-mock-server/tests/stateful_scan_report.rs
+++ b/crates/gvm-mock-server/tests/stateful_scan_report.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Stateful `get_scan_report` behavior from the current public gvmd contract.
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_protocol::Response;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+const SCAN_REPORT_ID: &str = "10000000-0000-4000-8000-000000000001";
+const AUDIT_REPORT_ID: &str = "10000000-0000-4000-8000-000000000002";
+const ABSENT_REPORT_ID: &str = "10000000-0000-4000-8000-000000000003";
+const ABSENT_FILTER_ID: &str = "40000000-0000-4000-8000-000000000001";
+
+async fn send_recv(stream: &mut UnixStream, xml: &[u8]) -> Response {
+    stream.write_all(xml).await.expect("write failed");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = stream.read(&mut buf).await.expect("read failed");
+    buf.truncate(n);
+    Response::new(buf)
+}
+
+async fn connect_and_auth(server: &MockGmpServer) -> UnixStream {
+    let mut stream = UnixStream::connect(server.socket_path().expect("Unix socket path"))
+        .await
+        .expect("connect failed");
+    let response = send_recv(
+        &mut stream,
+        b"<authenticate><credentials><username>admin</username><password>admin</password></credentials></authenticate>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+    stream
+}
+
+async fn scan_report_server() -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_8)
+        .credentials("admin", "admin")
+        .seed(|store| {
+            let mut scan_report = Resource::with_id(
+                "report",
+                "Running Scan",
+                SCAN_REPORT_ID.parse().expect("valid scan report UUID"),
+            );
+            scan_report.set_attr("status", "Running");
+            scan_report.set_attr("usage_type", "scan");
+            store.seed(scan_report);
+
+            let mut audit_report = Resource::with_id(
+                "report",
+                "Audit Report",
+                AUDIT_REPORT_ID.parse().expect("valid audit report UUID"),
+            );
+            audit_report.set_attr("status", "Done");
+            audit_report.set_attr("usage_type", "audit");
+            store.seed(audit_report);
+        })
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+async fn assert_scan_report_errors(stream: &mut UnixStream) {
+    for (request, status) in [
+        ("<get_scan_report/>".to_string(), 400),
+        (
+            "<get_scan_report scan_report_id=\"not-a-uuid\"/>".to_string(),
+            400,
+        ),
+        (
+            format!("<get_scan_report scan_report_id=\"{ABSENT_REPORT_ID}\"/>"),
+            404,
+        ),
+        (
+            format!(
+                "<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\" filt_id=\"not-a-uuid\"/>"
+            ),
+            400,
+        ),
+        (
+            format!(
+                "<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\" filt_id=\"{ABSENT_FILTER_ID}\"/>"
+            ),
+            400,
+        ),
+        (
+            format!("<get_scan_report scan_report_id=\"{AUDIT_REPORT_ID}\"/>"),
+            400,
+        ),
+    ] {
+        assert_eq!(
+            send_recv(stream, request.as_bytes())
+                .await
+                .status_code(),
+            Some(status),
+            "unexpected status for {request}"
+        );
+    }
+}
+
+async fn assert_scan_report_filter_resolution(stream: &mut UnixStream) {
+    let response = send_recv(
+        stream,
+        format!("<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+    let xml = response.as_str().expect("valid UTF-8 response");
+    assert!(xml.contains("<writable>0</writable><in_use>0</in_use>"));
+    assert!(xml.contains("<scan_run_status>Running</scan_run_status>"));
+    assert!(xml.contains("<task><name></name><comment></comment><progress>0</progress></task>"));
+    assert!(xml.contains("<result_count>0<full>0</full><filtered>0</filtered>"));
+    assert!(xml.contains("<scan_end></scan_end>"));
+    assert!(xml.contains("<filters id=\"\"><term>apply_overrides=0 min_qod=70</term><keywords>"));
+    assert!(xml.contains("<sort><field>name<order>ascending</order></field></sort>"));
+
+    let response = send_recv(
+        stream,
+        format!(
+            "<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\" \
+             filter=\"sort=host min_qod=0 apply_overrides=1\"/>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    let xml = response.as_str().expect("valid UTF-8 response");
+    assert!(xml.contains("<term>sort=host min_qod=0 apply_overrides=1</term>"));
+    assert!(xml.contains("<sort><field>host<order>ascending</order></field></sort>"));
+
+    let created_filter = send_recv(
+        stream,
+        b"<create_filter><name>Scan Results</name><term>levels=l</term></create_filter>",
+    )
+    .await;
+    assert_eq!(created_filter.status_code(), Some(201));
+    let filter_id = created_filter.id().expect("created filter ID");
+    let response = send_recv(
+        stream,
+        format!(
+            "<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\" \
+             filt_id=\"{filter_id}\" filter=\"levels=c\"/>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    let xml = response.as_str().expect("valid UTF-8 response");
+    assert!(xml.contains(&format!(
+        "<filters id=\"{filter_id}\"><term>apply_overrides=0 min_qod=70 levels=l</term>"
+    )));
+    assert!(xml.contains("<sort><field>name<order>ascending</order></field></sort>"));
+
+    let modified_filter = send_recv(
+        stream,
+        format!("<modify_filter filter_id=\"{filter_id}\"><term>levels=hm</term></modify_filter>")
+            .as_bytes(),
+    )
+    .await;
+    assert_eq!(modified_filter.status_code(), Some(200));
+    let response = send_recv(
+        stream,
+        format!("<get_scan_report scan_report_id=\"{SCAN_REPORT_ID}\" filt_id=\"{filter_id}\"/>")
+            .as_bytes(),
+    )
+    .await;
+    assert!(response
+        .as_str()
+        .expect("valid UTF-8 response")
+        .contains("<term>apply_overrides=0 min_qod=70 levels=hm</term>"));
+}
+
+#[tokio::test]
+async fn stateful_get_scan_report_validates_ids_type_and_singular_response() {
+    let Some(server) = scan_report_server().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    assert_scan_report_errors(&mut stream).await;
+    assert_scan_report_filter_resolution(&mut stream).await;
+    server.shutdown().await;
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -191,7 +191,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | Version-specific command rejection | ✅ | Returns 400 for commands unavailable in configured version |
 | `report_config` commands (22.5+) | ✅ | create, get, modify, delete |
 | `features` command (22.6+) | ✅ | get_features |
-| REST-support GMP helpers (22.8+) | ✅ | report drill-downs, get_timezones, get_credential_stores |
+| REST-support GMP helpers (22.8+) | ✅ | raw structured scan report, report drill-downs, get_timezones, get_credential_stores |
 | Version range metadata in responses | ✅ | Status text includes version requirement |
 
 ### CLI (Standalone Binary)

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -11,26 +11,33 @@ not a claim of full conformance with every gvmd deployment or feature build.
 | 22.5 | `Gmp225` | 115 | `V22_5` |
 | 22.6 | `Gmp226` | 120 | `V22_6` |
 | 22.7 | `Gmp227` | 120 | `V22_7` |
-| 22.8 and newer | `GmpNext` | 154 | `V22_8` |
+| 22.8 and newer | `GmpNext` | 155 | `V22_8` |
 
 The command count is derived from
 `gvm_gmp::capabilities::COMMAND_CAPABILITIES`. Five commands require GMP 22.6
-and another 34 require GMP 22.8. It describes typed-client gates and stateful
+and another 35 require GMP 22.8. It describes typed-client gates and stateful
 mock behavior, not the commands enabled in every gvmd build. The client
 deliberately permits unknown raw commands for forward compatibility; standard
 mock responses reject commands absent from the registry. Explicit fixture and
 scenario configuration remains programmable by design.
 
+`get_scan_report` follows the public python-gvm `GMPNext` placement and is
+therefore gated at 22.8. Current gvmd source compiles the command
+unconditionally even in builds that may still advertise 22.7, so applications
+using such a deployment can send the public builder through a lower-level
+connection path, but the versioned high-level client will reject it until the
+server advertises 22.8.
+
 ## Command and mock qualification
 
-The registry contains 154 wire command names:
+The registry contains 155 wire command names:
 
 | Qualification | Count | Meaning |
 |---|---:|---|
-| Stateful mock behavior | 137 | Bespoke behavior or deterministic generic CRUD |
+| Stateful mock behavior | 138 | Bespoke behavior or deterministic generic CRUD |
 | Fixture mock behavior | 10 | Deterministic built-in fixture response |
 | Echo-only mock behavior | 7 | Intentionally limited to a generic success response |
-| Current pinned `GMP.xml.in` | 151 | Present in the public schema snapshot |
+| Current pinned `GMP.xml.in` | 152 | Present in the public schema snapshot |
 | Public gvmd source only | 2 | Implemented publicly but omitted from that schema |
 | Legacy compatibility | 1 | Retained for public legacy-client compatibility |
 
@@ -51,12 +58,12 @@ The three commands outside the pinned schema are explicitly qualified:
 ## Pinned public evidence and drift audit
 
 The deterministic snapshot is extracted from Greenbone's public gvmd commit
-[`aa53bc1057a4d535557d568a85c459bfb7780c81`](https://github.com/greenbone/gvmd/commit/aa53bc1057a4d535557d568a85c459bfb7780c81),
+[`fb21137097f41e5eb83bb45ee43170b775dbea49`](https://github.com/greenbone/gvmd/commit/fb21137097f41e5eb83bb45ee43170b775dbea49),
 file
-[`src/schema_formats/XML/GMP.xml.in`](https://github.com/greenbone/gvmd/blob/aa53bc1057a4d535557d568a85c459bfb7780c81/src/schema_formats/XML/GMP.xml.in).
-The snapshot records the source file SHA-256 and its 151 unique top-level
+[`src/schema_formats/XML/GMP.xml.in`](https://github.com/greenbone/gvmd/blob/fb21137097f41e5eb83bb45ee43170b775dbea49/src/schema_formats/XML/GMP.xml.in).
+The snapshot records the source file SHA-256 and its 152 unique top-level
 commands. The source-only qualification is backed by the same commit's
-[credential-store implementation](https://github.com/greenbone/gvmd/blob/aa53bc1057a4d535557d568a85c459bfb7780c81/src/gmp_credential_stores.c).
+[credential-store implementation](https://github.com/greenbone/gvmd/blob/fb21137097f41e5eb83bb45ee43170b775dbea49/src/gmp_credential_stores.c).
 The legacy qualification is backed by public python-gvm commit
 [`2bb100fd03f02e598f046e2032e12550b5b14751`](https://github.com/greenbone/python-gvm/blob/2bb100fd03f02e598f046e2032e12550b5b14751/gvm/protocols/gmp/requests/v224/_tls_certificates.py).
 


### PR DESCRIPTION
## Summary

- add a `get_scan_report` GMP request builder and raw high-level `GmpNext` client method
- gate the command at GMP 22.8 and refresh the pinned public gvmd schema snapshot
- implement deterministic stateful-mock validation, filtering, summary rendering, and real Unix-transport coverage
- update the support/status documentation and capability counts

The high-level API intentionally returns the raw structured `Response`; this PR does not invent a typed summary model before the response contract has broader runtime evidence.

## Public evidence

- gvmd schema/source pin: `fb21137097f41e5eb83bb45ee43170b775dbea49`
- `GMP.xml.in` SHA-256: `9bf8435a057da2c56f946a465b55aac439b63a9e8b81849526a04aaa92c3e6fc`
- the command is placed in `GMPNext` consistently with current public python-gvm

Current gvmd compiles the command unconditionally in configurations that can still advertise GMP 22.7. The versioned Rust client follows the public `GMPNext` placement and rejects it below 22.8; callers targeting such an advertised-22.7 build can still send the public request builder through a lower-level connection path.

## Validation

- `make ci`
- `cargo +1.85.0 check --workspace --all-features`
- public schema audit: 152/152 qualified commands match
- real versioned Rust client over the stateful Unix mock, including 22.7 rejection and 22.8 success
- python-gvm Unix and TLS integration regression suites
- Cobertura coverage plus `diff-cover --compare-branch=upstream/devel --fail-under=100`: 262/262 changed executable lines
- `cargo audit`, `cargo machete`, `cargo vet --locked`, `cargo deny check`
- workspace unsafe-usage gate
- Semgrep with `p/rust`, `p/security-audit`, and `p/secrets`, using `--disable-nosem --error`
- Gitleaks tracked-worktree scan
- CycloneDX generation and SBOM quality policy: all workspace crates above the 8.3 threshold

## Validation boundaries

- No live gvmd 26.34 runtime exchange was available. The pinned schema example reports `<page>0</page>`, while the executable source path may report a different singular-page count; the mock retains the published schema value.
- The released python-gvm package used by the integration suite does not yet expose `get_scan_report`, so that suite proves regression safety rather than the new command. The new command itself is exercised through the real Rust client/transport path.
- Stateful-mock resource summaries are deterministic approximations over seeded resources, not proof of full gvmd database-level conformance.
- Fuzz tooling was not run for this change; deterministic builder, error-path, filter-resolution, version-gate, and transport regressions were used instead.
