### PR TITLE
Harden GMP wire trace redaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,7 @@ dependencies = [
  "gvm-mock-server",
  "gvm-protocol",
  "pretty_assertions",
+ "quick-xml",
  "rstest",
  "tempfile",
  "thiserror",

--- a/crates/gvm-client/Cargo.toml
+++ b/crates/gvm-client/Cargo.toml
@@ -21,6 +21,7 @@ async-trait.workspace = true
 gvm-connection.workspace = true
 gvm-protocol.workspace = true
 gvm-gmp.workspace = true
+quick-xml.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
 

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -16,6 +16,7 @@
 mod error;
 mod typed;
 mod version;
+mod wire_trace;
 
 use std::fmt;
 use std::sync::Arc;
@@ -67,6 +68,7 @@ use gvm_gmp::responses::{
 };
 use gvm_gmp::types::{EntityId, GmpVersion};
 use gvm_protocol::{Request, Response};
+use wire_trace::redact_wire_bytes;
 
 pub use error::GvmError;
 pub use gvm_gmp::commands::agent_groups::{
@@ -139,8 +141,16 @@ pub struct WireTraceEvent {
 
 /// Sink for opt-in GMP wire trace events.
 ///
-/// Events are redacted by default before this callback is invoked. The tracing
-/// hook is disabled unless configured explicitly on [`GmpClient`].
+/// Events are structurally parsed and redacted before this callback is invoked.
+/// Known GMP secret fields, generic `value`, `default_value`, and `param`
+/// payloads, sensitive attributes, comments, and processing instructions are
+/// removed. Malformed or non-UTF-8 payloads are replaced entirely with a fixed
+/// marker.
+///
+/// This policy is not a general secret detector for arbitrary custom XML field
+/// names. Applications sending raw custom requests should still restrict trace
+/// access as they would other diagnostic data. The tracing hook is disabled
+/// unless configured explicitly on [`GmpClient`].
 pub trait WireTrace: Send + Sync + 'static {
     /// Receive a redacted GMP wire trace event.
     fn trace(&self, event: WireTraceEvent);
@@ -847,80 +857,6 @@ fn emit_wire_trace(
             bytes: redact_wire_bytes(bytes),
         });
     }
-}
-
-fn redact_wire_bytes(bytes: &[u8]) -> Vec<u8> {
-    let Ok(text) = std::str::from_utf8(bytes) else {
-        return b"<non-utf8-redacted/>".to_vec();
-    };
-
-    let mut text = text.to_string();
-    for tag in [
-        "password",
-        "private",
-        "private_key",
-        "passphrase",
-        "secret",
-        "auth_password",
-        "privacy_password",
-        "key",
-    ] {
-        text = redact_xml_element_text(&text, tag);
-    }
-    text.into_bytes()
-}
-
-fn redact_xml_element_text(input: &str, tag: &str) -> String {
-    let mut redacted = String::with_capacity(input.len());
-    let close = format!("</{tag}>");
-    let mut rest = input;
-
-    while let Some(open_start) = find_open_element(rest, tag) {
-        let (before, after_before) = rest.split_at(open_start);
-        redacted.push_str(before);
-
-        let Some(open_end) = after_before.find('>') else {
-            redacted.push_str(after_before);
-            return redacted;
-        };
-        let (open_tag, after_open) = after_before.split_at(open_end + 1);
-        redacted.push_str(open_tag);
-
-        if open_tag.trim_end().ends_with("/>") {
-            rest = after_open;
-            continue;
-        }
-
-        let Some(close_start) = after_open.find(&close) else {
-            redacted.push_str(after_open);
-            return redacted;
-        };
-        redacted.push_str("<redacted>");
-        redacted.push_str(&close);
-        rest = &after_open[close_start + close.len()..];
-    }
-
-    redacted.push_str(rest);
-    redacted
-}
-
-fn find_open_element(input: &str, tag: &str) -> Option<usize> {
-    let open_prefix = format!("<{tag}");
-    let mut search_start = 0;
-
-    while let Some(relative_start) = input[search_start..].find(&open_prefix) {
-        let start = search_start + relative_start;
-        let after_tag = start + open_prefix.len();
-        let next = input[after_tag..].chars().next();
-
-        if next.is_some_and(|ch| ch == '>' || ch == '/' || ch.is_whitespace()) {
-            return Some(start);
-        }
-
-        search_start = after_tag;
-    }
-
-    None
 }
 
 /// GMP 22.4 client wrapper.
@@ -2109,7 +2045,7 @@ mod tests {
 
         let auth_request = event_text(&events[2]);
         assert!(auth_request.contains("<authenticate>"));
-        assert!(auth_request.contains("<password><redacted></password>"));
+        assert!(auth_request.contains("<password><redacted/></password>"));
         assert!(!auth_request.contains("secret-password"));
 
         assert_eq!(events[3].direction, WireTraceDirection::Response);
@@ -2369,15 +2305,16 @@ mod tests {
 
     #[test]
     fn redacts_known_credential_elements() {
-        let bytes = br#"<root><password>pw</password><private>key</private><private_key>key2</private_key><passphrase>phrase</passphrase><secret>oidc-secret</secret><auth_password>auth</auth_password><privacy_password>privacy</privacy_password><password algorithm="x">again</password></root>"#;
+        let bytes = br#"<root><password>pw</password><community>snmp</community><private>key</private><private_key>key2</private_key><passphrase>phrase</passphrase><secret>oidc-secret</secret><auth_password>auth</auth_password><privacy_password>privacy</privacy_password><password algorithm="x">again</password></root>"#;
 
         let redacted = String::from_utf8(redact_wire_bytes(bytes)).expect("utf-8");
 
         assert_eq!(
             redacted,
-            r#"<root><password><redacted></password><private><redacted></private><private_key><redacted></private_key><passphrase><redacted></passphrase><secret><redacted></secret><auth_password><redacted></auth_password><privacy_password><redacted></privacy_password><password algorithm="x"><redacted></password></root>"#
+            r#"<root><password><redacted/></password><community><redacted/></community><private><redacted/></private><private_key><redacted/></private_key><passphrase><redacted/></passphrase><secret><redacted/></secret><auth_password><redacted/></auth_password><privacy_password><redacted/></privacy_password><password algorithm="x"><redacted/></password></root>"#
         );
         assert!(!redacted.contains(">pw<"));
+        assert!(!redacted.contains(">snmp<"));
         assert!(!redacted.contains(">key<"));
         assert!(!redacted.contains(">key2<"));
         assert!(!redacted.contains(">phrase<"));
@@ -2395,7 +2332,7 @@ mod tests {
 
         assert_eq!(
             redacted,
-            "<modify_license><key><redacted></key></modify_license>"
+            "<modify_license><key><redacted/></key></modify_license>"
         );
         assert!(!redacted.contains("license-secret"));
     }
@@ -2408,8 +2345,34 @@ mod tests {
 
         assert_eq!(
             redacted,
-            r#"<root><password_hash>keep</password_hash><secret_name>keep-secret-name</secret_name><password/><secret/><password><redacted></password><secret><redacted></secret></root>"#
+            r#"<root><password_hash>keep</password_hash><secret_name>keep-secret-name</secret_name><password/><secret/><password><redacted/></password><secret><redacted/></secret></root>"#
         );
+    }
+
+    #[test]
+    fn redacts_credential_store_preference_builder_values() {
+        use gvm_gmp::commands::credentials::{
+            modify_credential_store, CredentialStorePreference, ModifyCredentialStoreOpts,
+        };
+
+        let request = modify_credential_store(
+            &EntityId::new("credential-store-1").expect("valid ID"),
+            ModifyCredentialStoreOpts {
+                host: Some("store.example".into()),
+                preferences: vec![CredentialStorePreference {
+                    name: "token".into(),
+                    value: "preference-sentinel".into(),
+                }],
+                ..Default::default()
+            },
+        )
+        .to_bytes();
+        let redacted = String::from_utf8(redact_wire_bytes(&request)).expect("UTF-8 trace");
+
+        assert!(redacted.contains("<host>store.example</host>"));
+        assert!(redacted.contains("<name>token</name>"));
+        assert!(redacted.contains("<value><redacted/></value>"));
+        assert!(!redacted.contains("preference-sentinel"));
     }
 
     #[test]

--- a/crates/gvm-client/src/wire_trace.rs
+++ b/crates/gvm-client/src/wire_trace.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Structure-aware redaction for opt-in GMP wire traces.
+
+use quick_xml::events::{BytesRef, BytesStart, Event};
+use quick_xml::{Reader, Writer};
+
+const NON_UTF8_REDACTED: &[u8] = b"<non-utf8-redacted/>";
+const MALFORMED_XML_REDACTED: &[u8] = b"<malformed-xml-redacted/>";
+const REDACTED: &[u8] = b"redacted";
+
+pub(super) fn redact_wire_bytes(bytes: &[u8]) -> Vec<u8> {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return NON_UTF8_REDACTED.to_vec();
+    };
+    redact_xml(text).unwrap_or_else(|| MALFORMED_XML_REDACTED.to_vec())
+}
+
+fn redact_xml(xml: &str) -> Option<Vec<u8>> {
+    let mut reader = Reader::from_str(xml);
+    let mut writer = Writer::new(Vec::with_capacity(xml.len()));
+    let mut stack = Vec::new();
+    let mut sensitive_depth = 0_usize;
+    let mut saw_root = false;
+    let mut completed_root = false;
+    let mut saw_declaration = false;
+
+    loop {
+        let event = reader.read_event().ok()?;
+        match event {
+            Event::Start(start) => {
+                if stack.is_empty() {
+                    if saw_root || completed_root {
+                        return None;
+                    }
+                    saw_root = true;
+                }
+                let local_name = local_name(start.name().local_name().as_ref())?;
+                let redacted_start = redact_attributes(&start, &stack, &local_name)?;
+                let redact_contents = sensitive_depth == 0 && is_sensitive_element(&local_name);
+                stack.push(local_name);
+
+                if sensitive_depth > 0 {
+                    sensitive_depth += 1;
+                } else {
+                    writer.write_event(Event::Start(redacted_start)).ok()?;
+                    if redact_contents {
+                        writer
+                            .write_event(Event::Empty(BytesStart::new("redacted")))
+                            .ok()?;
+                        sensitive_depth = 1;
+                    }
+                }
+            }
+            Event::Empty(start) => {
+                if stack.is_empty() {
+                    if saw_root || completed_root {
+                        return None;
+                    }
+                    saw_root = true;
+                    completed_root = true;
+                }
+                let local_name = local_name(start.name().local_name().as_ref())?;
+                let redacted_start = redact_attributes(&start, &stack, &local_name)?;
+                if sensitive_depth == 0 {
+                    writer.write_event(Event::Empty(redacted_start)).ok()?;
+                }
+            }
+            Event::End(end) => {
+                stack.pop()?;
+                if sensitive_depth > 0 {
+                    sensitive_depth -= 1;
+                    if sensitive_depth == 0 {
+                        writer.write_event(Event::End(end)).ok()?;
+                    }
+                } else {
+                    writer.write_event(Event::End(end)).ok()?;
+                }
+                if stack.is_empty() {
+                    completed_root = true;
+                }
+            }
+            Event::Text(text) => {
+                if stack.is_empty() && !text.as_ref().iter().all(u8::is_ascii_whitespace) {
+                    return None;
+                }
+                if sensitive_depth == 0 {
+                    writer.write_event(Event::Text(text)).ok()?;
+                }
+            }
+            Event::CData(data) => {
+                if stack.is_empty() {
+                    return None;
+                }
+                if sensitive_depth == 0 {
+                    writer.write_event(Event::CData(data)).ok()?;
+                }
+            }
+            Event::GeneralRef(reference) => write_general_reference(
+                &mut writer,
+                reference,
+                !stack.is_empty(),
+                sensitive_depth == 0,
+            )?,
+            Event::Decl(declaration) => {
+                if saw_declaration || saw_root {
+                    return None;
+                }
+                saw_declaration = true;
+                writer.write_event(Event::Decl(declaration)).ok()?;
+            }
+            Event::DocType(_) => return None,
+            Event::PI(_) | Event::Comment(_) => {}
+            Event::Eof => {
+                return (saw_root && completed_root && stack.is_empty())
+                    .then(|| writer.into_inner());
+            }
+        }
+    }
+}
+
+fn write_general_reference(
+    writer: &mut Writer<Vec<u8>>,
+    reference: BytesRef<'_>,
+    in_element: bool,
+    visible: bool,
+) -> Option<()> {
+    if !in_element || !valid_general_reference(&reference) {
+        return None;
+    }
+    if visible {
+        writer.write_event(Event::GeneralRef(reference)).ok()?;
+    }
+    Some(())
+}
+
+fn valid_general_reference(reference: &BytesRef<'_>) -> bool {
+    match reference.resolve_char_ref() {
+        Ok(Some(character)) => matches!(
+            character,
+            '\u{9}' | '\u{A}' | '\u{D}' | '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{FFFD}' | '\u{10000}'..='\u{10FFFF}'
+        ),
+        Ok(None) => matches!(
+            reference.as_ref(),
+            b"lt" | b"gt" | b"amp" | b"apos" | b"quot"
+        ),
+        Err(_) => false,
+    }
+}
+
+fn redact_attributes(
+    start: &BytesStart<'_>,
+    stack: &[String],
+    element_name: &str,
+) -> Option<BytesStart<'static>> {
+    let mut redacted = start.clone().into_owned();
+    redacted.clear_attributes();
+    let credential_store_preference = is_credential_store_preference(stack, element_name);
+
+    for attribute in start.attributes() {
+        let attribute = attribute.ok()?;
+        let key = attribute.key.as_ref();
+        let key_name = local_name(attribute.key.local_name().as_ref())?;
+        let sensitive = is_sensitive_name(&key_name)
+            || (key_name == "value"
+                && (credential_store_preference || is_sensitive_name(element_name)));
+        redacted.push_attribute((
+            key,
+            if sensitive {
+                REDACTED
+            } else {
+                attribute.value.as_ref()
+            },
+        ));
+    }
+    Some(redacted)
+}
+
+fn is_sensitive_element(element_name: &str) -> bool {
+    is_sensitive_name(element_name) || matches!(element_name, "value" | "param" | "default_value")
+}
+
+fn is_credential_store_preference(stack: &[String], element_name: &str) -> bool {
+    let in_credential_store = stack
+        .first()
+        .is_some_and(|root| root.contains("credential_store"));
+    let in_preferences = stack.iter().any(|name| name == "preferences");
+    let in_preference =
+        element_name == "preference" || stack.iter().any(|name| name == "preference");
+    in_credential_store && in_preferences && in_preference
+}
+
+fn is_sensitive_name(name: &str) -> bool {
+    matches!(
+        name,
+        "password"
+            | "community"
+            | "private"
+            | "private_key"
+            | "private-key"
+            | "passphrase"
+            | "secret"
+            | "client_secret"
+            | "client-secret"
+            | "auth_password"
+            | "auth-password"
+            | "privacy_password"
+            | "privacy-password"
+            | "key"
+            | "token"
+            | "api_key"
+            | "api-key"
+            | "access_token"
+            | "access-token"
+            | "refresh_token"
+            | "refresh-token"
+    )
+}
+
+fn local_name(name: &[u8]) -> Option<String> {
+    std::str::from_utf8(name).ok().map(str::to_ascii_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_namespaced_case_insensitive_elements_and_sensitive_attributes() {
+        let xml = br#"<g:modify_credential_store xmlns:g="urn:gmp" TOKEN="attribute-secret" visible="keep"><g:preferences><g:preference value="attribute-value"><g:name>token</g:name><g:value>preference-secret</g:value><g:default_value>server-default-secret</g:default_value></g:preference></g:preferences><g:Password algorithm="plain" value="password-attribute">nested<child>hidden</child></g:Password><Secret>&amp;<![CDATA[cdata-secret]]></Secret><COMMUNITY>snmp-secret</COMMUNITY><param name="timeout">generic-secret-capable</param><status>visible-value</status></g:modify_credential_store>"#;
+
+        let redacted = String::from_utf8(redact_wire_bytes(xml)).expect("valid UTF-8");
+
+        assert_eq!(
+            redacted,
+            r#"<g:modify_credential_store xmlns:g="urn:gmp" TOKEN="redacted" visible="keep"><g:preferences><g:preference value="redacted"><g:name>token</g:name><g:value><redacted/></g:value><g:default_value><redacted/></g:default_value></g:preference></g:preferences><g:Password algorithm="plain" value="redacted"><redacted/></g:Password><Secret><redacted/></Secret><COMMUNITY><redacted/></COMMUNITY><param name="timeout"><redacted/></param><status>visible-value</status></g:modify_credential_store>"#
+        );
+        for secret in [
+            "attribute-secret",
+            "attribute-value",
+            "preference-secret",
+            "server-default-secret",
+            "password-attribute",
+            "nested",
+            "hidden",
+            "cdata-secret",
+            "snmp-secret",
+            "generic-secret-capable",
+        ] {
+            assert!(!redacted.contains(secret));
+        }
+        assert!(redacted.contains("visible-value"));
+        assert!(redacted.contains("algorithm=\"plain\""));
+    }
+
+    #[test]
+    fn malformed_or_unsafe_xml_fails_closed() {
+        for xml in [
+            "<root><password>secret",
+            "<root><password>secret</root>",
+            "<root duplicate=\"1\" duplicate=\"2\"/>",
+            "<!DOCTYPE root><root/>",
+            "<root/><second/>",
+            "<root/><second></second>",
+            "<root/>not-whitespace",
+            "<![CDATA[outside-root]]><root/>",
+            "&amp;<root/>",
+            "<root>&custom;</root>",
+            "<root>&#0;</root>",
+            "<root>&#1;</root>",
+            "<?xml version=\"1.0\"?><?xml version=\"1.0\"?><root/>",
+        ] {
+            assert_eq!(
+                redact_wire_bytes(xml.as_bytes()),
+                MALFORMED_XML_REDACTED,
+                "unexpected redaction for {xml}"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_valid_declaration_and_non_secret_structure() {
+        let xml = br#"<?xml version="1.0"?><root visible="a&amp;b"><status><![CDATA[keep<&>]]>&amp;&#65;</status><!--omitted--><?trace omitted?></root>"#;
+
+        assert_eq!(
+            redact_wire_bytes(xml),
+            br#"<?xml version="1.0"?><root visible="a&amp;b"><status><![CDATA[keep<&>]]>&amp;&#65;</status></root>"#
+        );
+    }
+
+    #[test]
+    fn suppresses_empty_elements_nested_inside_sensitive_content() {
+        assert_eq!(
+            redact_wire_bytes(b"<root><password><empty/></password></root>"),
+            b"<root><password><redacted/></password></root>"
+        );
+    }
+}

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -21,8 +21,10 @@ use gvm_gmp::commands::configs::{
     GetConfigsOpts, ModifyConfigOpts,
 };
 use gvm_gmp::commands::credentials::{
-    create_credential_store_credential, get_credential, modify_credential_store_credential,
+    create_credential_store_credential, get_credential, modify_credential_store,
+    modify_credential_store_credential, CredentialStorePreference,
     ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
+    ModifyCredentialStoreOpts,
 };
 use gvm_gmp::commands::help::HelpMode;
 use gvm_gmp::commands::nvts::{
@@ -277,7 +279,7 @@ async fn live_wire_trace_observes_typed_helper_with_redaction() {
             })
             .map(event_text)
             .expect("authenticate request trace event");
-        assert!(auth_request.contains("<password><redacted></password>"));
+        assert!(auth_request.contains("<password><redacted/></password>"));
         assert!(!auth_request.contains("<password>admin</password>"));
 
         assert!(events.iter().any(|event| {
@@ -285,6 +287,80 @@ async fn live_wire_trace_observes_typed_helper_with_redaction() {
                 && event_text(event).contains("<authenticate_response")
         }));
     }
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn live_wire_trace_redacts_credential_store_preference_values() {
+    const CREDENTIAL_STORE_ID: &str = "40000000-0000-4000-8000-000000000001";
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(MockVersion::V22_8)
+        .unix_socket_auto()
+        .seed(|store| {
+            store.seed(Resource::with_id(
+                "credential_store",
+                "Trace Store",
+                CREDENTIAL_STORE_ID.parse().expect("valid UUID"),
+            ));
+        })
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let trace_events = Arc::clone(&events);
+    let mut client = GmpClient::connect_with_wire_trace(unix_connection(&server), move |event| {
+        trace_events.lock().expect("trace lock").push(event);
+    })
+    .await
+    .expect("client should connect");
+    client
+        .call(authenticate("admin", "admin"))
+        .await
+        .expect("authentication should succeed");
+    server.clear_history();
+    events.lock().expect("trace lock").clear();
+
+    client
+        .call(modify_credential_store(
+            &EntityId::new(CREDENTIAL_STORE_ID).expect("valid ID"),
+            ModifyCredentialStoreOpts {
+                host: Some("store.example".into()),
+                preferences: vec![CredentialStorePreference {
+                    name: "token".into(),
+                    value: "transport-preference-sentinel".into(),
+                }],
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("credential store modification should succeed");
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let raw = std::str::from_utf8(history[0].raw_xml()).expect("UTF-8 request");
+    assert!(raw.contains("<value>transport-preference-sentinel</value>"));
+
+    let request = {
+        let events = events.lock().expect("trace lock");
+        events
+            .iter()
+            .find(|event| {
+                event.direction == WireTraceDirection::Request
+                    && event_text(event).contains("<modify_credential_store")
+            })
+            .map(event_text)
+            .expect("credential-store request trace")
+    };
+    assert!(request.contains("<host>store.example</host>"));
+    assert!(request.contains("<name>token</name>"));
+    assert!(request.contains("<value><redacted/></value>"));
+    assert!(!request.contains("transport-preference-sentinel"));
+
     server.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary

- replace exact lowercase string replacement with structure-aware XML redaction
- redact known GMP secret elements and attributes case-insensitively by local name, including SNMP communities, credential-store preferences, and generic `value`, `default_value`, and `param` payloads
- omit comments and processing instructions, preserve non-secret XML structure, and replace malformed, non-UTF-8, DOCTYPE-bearing, or invalid-reference payloads with fixed fail-closed markers
- verify credential-store preference redaction through a real `GmpClient`/Unix transport path against the stateful GMP 22.8 mock server

Wire tracing remains opt-in. The public API documentation explicitly notes that this is not a universal secret detector for arbitrary custom raw XML field names, so trace output should still be handled as sensitive diagnostic data.

`quick-xml` was already present in the workspace dependency graph; this makes it a direct `gvm-client` dependency without adding a new package.

## Validation

- `make ci`
- `cargo +1.85.0 check --workspace --all-features`
- `PATH="$PWD/.venv/bin:$PATH" make test-integration` (Python Unix and TLS paths)
- `cargo llvm-cov --workspace --all-features --cobertura ...` plus `diff-cover --compare-branch=upstream/devel --fail-under=100` (247/247 changed executable lines)
- `cargo audit`
- `cargo deny check`
- `cargo machete`
- `cargo vet --locked`
- `python3 -B scripts/check_workspace_unsafe.py`
- `semgrep scan --config p/rust --config p/security-audit --config p/secrets --disable-nosem --error .`
- Gitleaks tracked-worktree scan
- pinned CycloneDX/SBOM quality gate (all five crate SBOMs at 8.46–8.69, threshold 8.3)

## Validation boundary

Validation used the public stateful mock server and real client/transport paths, not a live gvmd instance. Fuzzing was not run; deterministic regressions cover malformed XML, invalid references, nested sensitive content, namespaces/case variants, attributes, CDATA, non-UTF-8 input, and fail-closed behavior.
