### PR TITLE
Align aggregate request and response fidelity

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -79,6 +79,9 @@ pub use gvm_gmp::commands::agents::{
     AgentRetryConfig, AgentScriptExecutorConfig, GetAgentsOpts, ModifyAgentControlScanConfigOpts,
     ModifyAgentOpts,
 };
+pub use gvm_gmp::commands::aggregates::{
+    AggregateMode, AggregateSort, AggregateSortStatistic, GetAggregatesRequestOpts,
+};
 pub use gvm_gmp::commands::credentials::{
     CredentialStoreCredentialOpts, GetCredentialStoresOpts, ModifyCredentialStoreCredentialOpts,
 };
@@ -97,6 +100,7 @@ pub use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateOciImageTargetTaskOpts;
 pub use gvm_gmp::commands::tasks::CreateWebApplicationTaskOpts;
+pub use gvm_gmp::commands::usage_type::UsageType;
 pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -12,6 +12,7 @@
 //! non-2xx status detection), which is then converted to [`GvmError::Parse`].
 
 use gvm_connection::GvmConnection;
+use gvm_gmp::commands::aggregates::{get_aggregates_request, GetAggregatesRequestOpts};
 use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::assets::{
     create_asset, delete_asset, get_assets, modify_asset, AssetType, CreateAssetOpts,
@@ -129,11 +130,11 @@ use gvm_gmp::responses::{
     CreateWebApplicationTargetResponse, DeleteAssetResponse, DeleteConfigResponse,
     DeleteOciImageTargetResponse, DeleteScanConfigResponse, DeleteScannerResponse,
     DeleteWebApplicationTargetResponse, DescribeAuthResponse, EmptyTrashcanResponse,
-    GetAlertsResponse, GetAssetsResponse, GetCertBundAdvisoriesResponse, GetConfigsResponse,
-    GetCpesResponse, GetCredentialStoresResponse, GetCredentialsResponse, GetCvesResponse,
-    GetDfnCertAdvisoriesResponse, GetFeaturesResponse, GetFeedsResponse, GetFiltersResponse,
-    GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse, GetNotesResponse,
-    GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
+    GetAggregatesResponse, GetAlertsResponse, GetAssetsResponse, GetCertBundAdvisoriesResponse,
+    GetConfigsResponse, GetCpesResponse, GetCredentialStoresResponse, GetCredentialsResponse,
+    GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeaturesResponse, GetFeedsResponse,
+    GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse,
+    GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
     GetOperatingSystemAssetsResponse, GetOverridesResponse, GetPermissionsResponse,
     GetPortListsResponse, GetReportApplicationsResponse, GetReportClosedCvesResponse,
     GetReportConfigsResponse, GetReportCvesResponse, GetReportErrorsResponse,
@@ -1996,6 +1997,21 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     }
 
     // ── System ────────────────────────────────────────────────────────────────
+
+    /// Send a current gvmd `get_aggregates` request and return its typed result.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_aggregates(
+        &mut self,
+        resource_type: &str,
+        opts: GetAggregatesRequestOpts,
+    ) -> Result<GetAggregatesResponse, GvmError> {
+        let response = self
+            .send(get_aggregates_request(resource_type, opts))
+            .await?;
+        GetAggregatesResponse::from_response(&response).map_err(GvmError::Parse)
+    }
 
     /// Send a `get_features` request and return a typed
     /// [`GetFeaturesResponse`].

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -5,11 +5,12 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts,
-    CredentialStoreCredentialType, GetCredentialStoresOpts, GetScanReportOpts,
-    GetSystemReportsOpts, GmpClient, GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts,
+    AggregateMode, AggregateSort, AggregateSortStatistic, CreateOciImageTargetOpts,
+    CreateWebApplicationTargetOpts, CredentialStoreCredentialOpts, CredentialStoreCredentialType,
+    GetAggregatesRequestOpts, GetCredentialStoresOpts, GetScanReportOpts, GetSystemReportsOpts,
+    GmpClient, GmpNextCommands, GmpVersioned, GvmError, ImportReportOpts,
     ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
-    WireTraceDirection, WireTraceEvent,
+    UsageType, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
@@ -51,7 +52,7 @@ use gvm_gmp::responses::{
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
-use gvm_gmp::FeedType;
+use gvm_gmp::{FeedType, SortOrder};
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
 };
@@ -215,6 +216,130 @@ async fn typed_feature_discovery_parses_current_gvmd_shape_over_unix_transport()
     assert_eq!(response.features[1].name, "ENABLE_JWT_AUTH");
     assert!(response.features[1].compiled_in);
     assert!(!response.features[1].enabled);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_aggregates_round_trip_current_shape_over_stateful_unix_transport() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate");
+    server.clear_history();
+
+    let response = client
+        .get_aggregates(
+            "task&<",
+            GetAggregatesRequestOpts {
+                filter_string: Some("owner=me & rows=-1".into()),
+                data_columns: vec!["qod&<".into()],
+                group_column: Some("status&<".into()),
+                sorts: vec![AggregateSort {
+                    field: "qod&<".into(),
+                    statistic: Some(AggregateSortStatistic::Maximum),
+                    order: Some(SortOrder::Descending),
+                }],
+                text_columns: vec!["name&<".into()],
+                first_group: Some(1),
+                max_groups: Some(-1),
+                usage_type: Some(UsageType::Audit),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("typed aggregate response should parse");
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    let request = String::from_utf8(history[0].raw_xml().to_vec()).expect("request is UTF-8");
+    assert_eq!(response.aggregates.len(), 1);
+    let aggregate = &response.aggregates[0];
+    assert_eq!(
+        aggregate.data_type, "task&<",
+        "unexpected response for request {request}"
+    );
+    assert_eq!(aggregate.data_columns, vec!["qod&<".to_string()]);
+    assert_eq!(aggregate.group_column.as_deref(), Some("status&<"));
+    assert_eq!(aggregate.groups.len(), 2);
+    assert_eq!(aggregate.groups[0].count, 3);
+    assert_eq!(aggregate.groups[1].c_count, Some(8));
+    assert_eq!(aggregate.groups[0].statistics[0].column, "qod&<");
+    assert_eq!(aggregate.groups[0].texts[0].column, "name&<");
+    assert_eq!(
+        response.filter.as_ref().expect("filter metadata").term,
+        "owner=me & rows=-1"
+    );
+
+    assert_eq!(
+        request,
+        "<get_aggregates filter=\"owner=me &amp; rows=-1\" first_group=\"1\" \
+         group_column=\"status&amp;&lt;\" max_groups=\"-1\" type=\"task&amp;&lt;\" \
+         usage_type=\"audit\"><sort field=\"qod&amp;&lt;\" \
+         order=\"descending\" stat=\"max\"/><data_column>qod&amp;&lt;</data_column>\
+         <text_column>name&amp;&lt;</text_column></get_aggregates>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_word_count_aggregates_parse_current_gvmd_shape_over_unix_transport() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate");
+    server.clear_history();
+
+    let response = client
+        .get_aggregates(
+            "task",
+            GetAggregatesRequestOpts {
+                group_column: Some("comment".into()),
+                mode: Some(AggregateMode::WordCounts),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("current gvmd word-count response should parse");
+
+    let aggregate = &response.aggregates[0];
+    assert_eq!(aggregate.data_type, "task");
+    assert_eq!(aggregate.group_column.as_deref(), Some("comment"));
+    assert_eq!(aggregate.groups.len(), 2);
+    assert_eq!(aggregate.groups[0].value, "security");
+    assert_eq!(aggregate.groups[0].c_count, None);
+    assert!(aggregate.groups[0].statistics.is_empty());
+    assert!(aggregate.groups[0].texts.is_empty());
+    assert_eq!(
+        aggregate
+            .column_info
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["value", "count"]
+    );
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0].raw_xml(),
+        br#"<get_aggregates group_column="comment" mode="word_counts" type="task"/>"#
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -13,6 +13,7 @@ use gvm_client::{
     UsageType, WireTraceDirection, WireTraceEvent,
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
+use gvm_gmp::commands::aggregates::{get_aggregates as get_aggregates_legacy, GetAggregatesOpts};
 use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
 use gvm_gmp::commands::assets::{
     AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
@@ -285,6 +286,50 @@ async fn typed_aggregates_round_trip_current_shape_over_stateful_unix_transport(
          usage_type=\"audit\"><sort field=\"qod&amp;&lt;\" \
          order=\"descending\" stat=\"max\"/><data_column>qod&amp;&lt;</data_column>\
          <text_column>name&amp;&lt;</text_column></get_aggregates>"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn legacy_aggregates_round_trip_comma_separated_columns_over_stateful_unix_transport() {
+    let Some(server) = stateful_server_with_version(MockVersion::V22_8).await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate");
+    server.clear_history();
+
+    let response = client
+        .call(get_aggregates_legacy(
+            "task",
+            GetAggregatesOpts {
+                data_columns: Some("qod, severity".into()),
+                text_columns: Some("name, comment".into()),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("legacy aggregate request should succeed");
+
+    let xml = response.as_str().expect("response should be UTF-8");
+    for column in ["qod", "severity"] {
+        assert!(xml.contains(&format!("<data_column>{column}</data_column>")));
+        assert!(xml.contains(&format!("<stats column=\"{column}\">")));
+    }
+    for column in ["name", "comment"] {
+        assert!(xml.contains(&format!("<text_column>{column}</text_column>")));
+        assert!(xml.contains(&format!("<text column=\"{column}\">All</text>")));
+    }
+    assert_eq!(
+        server.command_history()[0].raw_xml(),
+        br#"<get_aggregates data_columns="qod, severity" text_columns="name, comment" type="task"/>"#
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/aggregates.rs
+++ b/crates/gvm-gmp/src/commands/aggregates.rs
@@ -5,9 +5,15 @@
 
 use gvm_protocol::XmlCommand;
 
+use crate::commands::usage_type::UsageType;
+use crate::enums::SortOrder;
 use crate::types::EntityId;
 
-/// Options for `get_aggregates` requests.
+/// Legacy options for `get_aggregates` requests.
+///
+/// This type preserves the original rust-gvm wire shape. New code should use
+/// [`GetAggregatesRequestOpts`] with [`get_aggregates_request`] so repeated
+/// columns and sort criteria use the current gvmd child-element form.
 #[derive(Debug, Clone, Default)]
 pub struct GetAggregatesOpts {
     /// Optional group-by column.
@@ -30,7 +36,142 @@ pub struct GetAggregatesOpts {
     pub mode: Option<String>,
 }
 
-/// Build a `get_aggregates` request.
+/// A statistic accepted by current gvmd aggregate sort criteria.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AggregateSortStatistic {
+    /// Sort by the minimum value.
+    Minimum,
+    /// Sort by the maximum value.
+    Maximum,
+    /// Sort by the arithmetic mean.
+    Mean,
+    /// Sort by the sum.
+    Sum,
+    /// Sort by the resource count.
+    Count,
+    /// Sort by the group value.
+    Value,
+}
+
+impl AggregateSortStatistic {
+    /// Return the current gvmd wire value.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::Minimum => "min",
+            Self::Maximum => "max",
+            Self::Mean => "mean",
+            Self::Sum => "sum",
+            Self::Count => "count",
+            Self::Value => "value",
+        }
+    }
+}
+
+/// One current gvmd aggregate sort criterion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateSort {
+    /// Aggregate field to sort by.
+    pub field: String,
+    /// Optional statistic for the selected field.
+    pub statistic: Option<AggregateSortStatistic>,
+    /// Optional sort direction.
+    pub order: Option<SortOrder>,
+}
+
+/// Special aggregate processing modes supported by current gvmd.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AggregateMode {
+    /// Count words in the selected group column.
+    WordCounts,
+}
+
+impl AggregateMode {
+    /// Return the current gvmd wire value.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::WordCounts => "word_counts",
+        }
+    }
+}
+
+/// Current gvmd options for [`get_aggregates_request`].
+#[derive(Debug, Clone, Default)]
+pub struct GetAggregatesRequestOpts {
+    /// Optional inline filter expression.
+    pub filter_string: Option<String>,
+    /// Optional saved filter identifier.
+    pub filter_id: Option<EntityId>,
+    /// Columns whose numeric statistics should be returned.
+    pub data_columns: Vec<String>,
+    /// Optional group-by column.
+    pub group_column: Option<String>,
+    /// Optional subgroup column. Current gvmd requires `group_column` with it.
+    pub subgroup_column: Option<String>,
+    /// Ordered sort criteria.
+    pub sorts: Vec<AggregateSort>,
+    /// Columns returned as text without calculated statistics.
+    pub text_columns: Vec<String>,
+    /// One-based index of the first aggregate group to return.
+    pub first_group: Option<u32>,
+    /// Maximum groups to return. Use `-1` for all groups.
+    pub max_groups: Option<i32>,
+    /// Optional special processing mode.
+    pub mode: Option<AggregateMode>,
+    /// Optional task or config usage type.
+    pub usage_type: Option<UsageType>,
+}
+
+/// Build a current gvmd `get_aggregates` request.
+#[must_use]
+pub fn get_aggregates_request(resource_type: &str, opts: GetAggregatesRequestOpts) -> XmlCommand {
+    let mut cmd = XmlCommand::new("get_aggregates");
+    cmd.set_attribute("type", resource_type);
+    if let Some(filter) = opts.filter_string.as_deref() {
+        cmd.set_attribute("filter", filter);
+    }
+    if let Some(filter_id) = opts.filter_id.as_ref() {
+        cmd.set_attribute("filt_id", filter_id.as_str());
+    }
+    if let Some(group_column) = opts.group_column.as_deref() {
+        cmd.set_attribute("group_column", group_column);
+    }
+    if let Some(subgroup_column) = opts.subgroup_column.as_deref() {
+        cmd.set_attribute("subgroup_column", subgroup_column);
+    }
+    if let Some(first_group) = opts.first_group {
+        cmd.set_attribute("first_group", &first_group.to_string());
+    }
+    if let Some(max_groups) = opts.max_groups {
+        cmd.set_attribute("max_groups", &max_groups.to_string());
+    }
+    if let Some(mode) = opts.mode {
+        cmd.set_attribute("mode", mode.as_gmp_str());
+    }
+    if let Some(usage_type) = opts.usage_type {
+        cmd.set_attribute("usage_type", usage_type.as_gmp_str());
+    }
+    for sort in opts.sorts {
+        let sort_element = cmd.add_element("sort");
+        sort_element.set_attribute("field", &sort.field);
+        if let Some(statistic) = sort.statistic {
+            sort_element.set_attribute("stat", statistic.as_gmp_str());
+        }
+        if let Some(order) = sort.order {
+            sort_element.set_attribute("order", order.as_gmp_str());
+        }
+    }
+    for data_column in opts.data_columns {
+        cmd.add_element("data_column").set_text(&data_column);
+    }
+    for text_column in opts.text_columns {
+        cmd.add_element("text_column").set_text(&text_column);
+    }
+    cmd
+}
+
+/// Build a legacy rust-gvm `get_aggregates` request.
 #[must_use]
 pub fn get_aggregates(resource_type: &str, opts: GetAggregatesOpts) -> XmlCommand {
     let mut cmd = XmlCommand::new("get_aggregates");
@@ -67,8 +208,13 @@ pub fn get_aggregates(resource_type: &str, opts: GetAggregatesOpts) -> XmlComman
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::aggregates::{get_aggregates, GetAggregatesOpts};
+    use crate::commands::aggregates::{
+        get_aggregates, get_aggregates_request, AggregateMode, AggregateSort,
+        AggregateSortStatistic, GetAggregatesOpts, GetAggregatesRequestOpts,
+    };
+    use crate::commands::usage_type::UsageType;
     use crate::common::xml;
+    use crate::enums::SortOrder;
     use crate::types::EntityId;
 
     #[test]
@@ -90,5 +236,49 @@ mod tests {
             )),
             "<get_aggregates data_columns=\"value,count\" filt_id=\"f1\" filter=\"rows=10\" first_group=\"2\" group_column=\"severity\" max_groups=\"5\" mode=\"dynamic\" sort_criteria=\"value desc\" text_columns=\"name\" type=\"task\"/>"
         );
+    }
+
+    #[test]
+    fn current_get_aggregates_builds_schema_faithful_xml() {
+        assert_eq!(
+            xml(get_aggregates_request(
+                "task",
+                GetAggregatesRequestOpts {
+                    filter_string: Some("rows=10 & owner=me".into()),
+                    filter_id: Some(EntityId::new("f1").expect("valid id")),
+                    data_columns: vec!["severity".into(), "qod".into()],
+                    group_column: Some("name".into()),
+                    subgroup_column: Some("status".into()),
+                    sorts: vec![
+                        AggregateSort {
+                            field: "severity".into(),
+                            statistic: Some(AggregateSortStatistic::Maximum),
+                            order: Some(SortOrder::Descending),
+                        },
+                        AggregateSort {
+                            field: "name".into(),
+                            statistic: Some(AggregateSortStatistic::Value),
+                            order: Some(SortOrder::Ascending),
+                        },
+                    ],
+                    text_columns: vec!["comment".into()],
+                    first_group: Some(2),
+                    max_groups: Some(-1),
+                    mode: Some(AggregateMode::WordCounts),
+                    usage_type: Some(UsageType::Audit),
+                }
+            )),
+            "<get_aggregates filt_id=\"f1\" filter=\"rows=10 &amp; owner=me\" first_group=\"2\" group_column=\"name\" max_groups=\"-1\" mode=\"word_counts\" subgroup_column=\"status\" type=\"task\" usage_type=\"audit\"><sort field=\"severity\" order=\"descending\" stat=\"max\"/><sort field=\"name\" order=\"ascending\" stat=\"value\"/><data_column>severity</data_column><data_column>qod</data_column><text_column>comment</text_column></get_aggregates>"
+        );
+    }
+
+    #[test]
+    fn aggregate_sort_statistics_use_current_gvmd_wire_values() {
+        assert_eq!(AggregateSortStatistic::Minimum.as_gmp_str(), "min");
+        assert_eq!(AggregateSortStatistic::Maximum.as_gmp_str(), "max");
+        assert_eq!(AggregateSortStatistic::Mean.as_gmp_str(), "mean");
+        assert_eq!(AggregateSortStatistic::Sum.as_gmp_str(), "sum");
+        assert_eq!(AggregateSortStatistic::Count.as_gmp_str(), "count");
+        assert_eq!(AggregateSortStatistic::Value.as_gmp_str(), "value");
     }
 }

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -11,7 +11,11 @@ use crate::types::EntityId;
 
 pub use super::system_reports::{get_system_reports, GetSystemReportsOpts};
 
-/// Options for `get_aggregates` requests.
+/// Legacy system-module options for `get_aggregates` requests.
+///
+/// This type and [`get_aggregates`] are retained for source compatibility.
+/// They predate current gvmd's required aggregate resource type. New code
+/// should use [`crate::commands::aggregates::get_aggregates_request`].
 #[derive(Debug, Clone, Default)]
 pub struct GetAggregatesOpts {
     /// Optional aggregate data column.
@@ -111,7 +115,11 @@ pub fn get_timezones() -> impl Request {
     XmlCommand::new("get_timezones")
 }
 
-/// Build a `get_aggregates` request.
+/// Build a legacy system-module `get_aggregates` request.
+///
+/// New code should use
+/// [`crate::commands::aggregates::get_aggregates_request`], which includes the
+/// required resource type and models repeated sort and column elements.
 #[must_use]
 pub fn get_aggregates(opts: GetAggregatesOpts) -> impl Request {
     let mut cmd = XmlCommand::new("get_aggregates");

--- a/crates/gvm-gmp/src/responses/aggregates.rs
+++ b/crates/gvm-gmp/src/responses/aggregates.rs
@@ -5,9 +5,61 @@
 
 use gvm_protocol::Response;
 
-use crate::responses::common::{parse_document, status_from_response, ParseError, XmlNode};
+use crate::responses::common::{
+    parse_document, parse_u32, status_from_response, ParseError, XmlNode,
+};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateText {
+    pub column: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateStatisticValues {
+    pub column: String,
+    pub min: String,
+    pub max: String,
+    pub mean: String,
+    pub sum: String,
+    pub c_sum: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateColumnInfo {
+    pub name: String,
+    pub statistic: String,
+    pub resource_type: String,
+    pub column: String,
+    pub data_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateFilterKeyword {
+    pub column: String,
+    pub relation: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateFilter {
+    pub id: String,
+    pub term: String,
+    pub name: Option<String>,
+    pub keywords: Vec<AggregateFilterKeyword>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AggregateGroup {
@@ -16,14 +68,21 @@ pub struct AggregateGroup {
     pub c_count: Option<u32>,
     pub text: Option<String>,
     pub subgroups: Vec<AggregateSubgroup>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub statistics: Vec<AggregateStatisticValues>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub texts: Vec<AggregateText>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AggregateSubgroup {
     pub value: String,
     pub count: u32,
+    pub c_count: Option<u32>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub statistics: Vec<AggregateStatisticValues>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +94,32 @@ pub struct AggregateStats {
     pub max: Option<f64>,
     pub mean: Option<f64>,
     pub sum: Option<f64>,
+    pub c_sum: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateOverall {
+    pub count: u32,
+    pub c_count: u32,
+    pub statistics: Vec<AggregateStatisticValues>,
+    pub texts: Vec<AggregateText>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AggregateResult {
+    pub data_type: String,
+    pub data_columns: Vec<String>,
+    pub group_column: Option<String>,
+    pub subgroup_column: Option<String>,
+    pub text_columns: Vec<String>,
+    pub groups: Vec<AggregateGroup>,
+    pub overall: Option<AggregateOverall>,
+    pub subgroup_values: Vec<String>,
+    pub column_info: Vec<AggregateColumnInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -43,37 +128,82 @@ pub struct AggregateStats {
 pub struct GetAggregatesResponse {
     pub status: u16,
     pub status_text: String,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub aggregates: Vec<AggregateResult>,
+    pub filter: Option<AggregateFilter>,
+    /// Groups from the first aggregate, retained for API compatibility.
     pub groups: Vec<AggregateGroup>,
+    /// Column names from the first aggregate, retained for API compatibility.
     pub column_info: Vec<String>,
+    /// First numeric overall statistic, retained for API compatibility.
     pub overall: Option<AggregateStats>,
+}
+
+fn required_u32(node: &XmlNode, element: &str, field: &str) -> Result<u32, ParseError> {
+    let value = node.required_child_text(element)?;
+    parse_u32(&value, field)
+}
+
+fn statistic_values_from_node(node: &XmlNode) -> Result<AggregateStatisticValues, ParseError> {
+    Ok(AggregateStatisticValues {
+        column: node.attr("column").unwrap_or_default().to_string(),
+        min: node.required_child_text("min")?,
+        max: node.required_child_text("max")?,
+        mean: node.required_child_text("mean")?,
+        sum: node.required_child_text("sum")?,
+        c_sum: node.required_child_text("c_sum")?,
+    })
+}
+
+fn statistics_from_node(node: &XmlNode) -> Result<Vec<AggregateStatisticValues>, ParseError> {
+    node.children_named("stats")
+        .map(statistic_values_from_node)
+        .collect()
+}
+
+fn texts_from_node(node: &XmlNode) -> Vec<AggregateText> {
+    node.children_named("text")
+        .map(|text| AggregateText {
+            // Current gvmd emits `column`; the GMP schema historically named
+            // this attribute `name`, so accept either spelling.
+            column: text
+                .attr("column")
+                .or_else(|| text.attr("name"))
+                .unwrap_or_default()
+                .to_string(),
+            value: text.text.clone(),
+        })
+        .collect()
 }
 
 impl AggregateGroup {
     fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
-        let value = node.child_text("value").unwrap_or_default();
-        let count = node
-            .child_text("count")
-            .and_then(|text| text.parse().ok())
-            .unwrap_or(0);
+        let value = node.required_child_text("value")?;
+        let count = required_u32(node, "count", "aggregate.group.count")?;
+        // Standard aggregates include c_count. gvmd's word_counts mode omits
+        // it, despite the general response schema marking it as required.
         let c_count = node
-            .child_text("c_count")
-            .and_then(|text| text.parse().ok());
-        let text = node.optional_child_text("text");
+            .optional_child_text("c_count")
+            .map(|value| parse_u32(&value, "aggregate.group.c_count"))
+            .transpose()?;
+        let texts = texts_from_node(node);
+        let text = texts.first().map(|text| text.value.clone());
 
         let subgroups = node
             .children_named("subgroup")
-            .filter_map(|subgroup| {
-                let sub_value = subgroup.child_text("value")?;
-                let sub_count = subgroup
-                    .child_text("count")
-                    .and_then(|text| text.parse().ok())
-                    .unwrap_or(0);
-                Some(AggregateSubgroup {
-                    value: sub_value,
-                    count: sub_count,
+            .map(|subgroup| {
+                Ok(AggregateSubgroup {
+                    value: subgroup.required_child_text("value")?,
+                    count: required_u32(subgroup, "count", "aggregate.group.subgroup.count")?,
+                    c_count: Some(required_u32(
+                        subgroup,
+                        "c_count",
+                        "aggregate.group.subgroup.c_count",
+                    )?),
+                    statistics: statistics_from_node(subgroup)?,
                 })
             })
-            .collect();
+            .collect::<Result<Vec<_>, ParseError>>()?;
 
         Ok(Self {
             value,
@@ -81,7 +211,107 @@ impl AggregateGroup {
             c_count,
             text,
             subgroups,
+            statistics: statistics_from_node(node)?,
+            texts,
         })
+    }
+}
+
+impl AggregateResult {
+    fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
+        let groups = node
+            .children_named("group")
+            .map(AggregateGroup::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        let overall = node
+            .child("overall")
+            .map(|overall| {
+                Ok::<AggregateOverall, ParseError>(AggregateOverall {
+                    count: required_u32(overall, "count", "aggregate.overall.count")?,
+                    c_count: required_u32(overall, "c_count", "aggregate.overall.c_count")?,
+                    statistics: statistics_from_node(overall)?,
+                    texts: texts_from_node(overall),
+                })
+            })
+            .transpose()?;
+        let column_info_node = node
+            .child("column_info")
+            .ok_or_else(|| ParseError::MissingElement("column_info".to_string()))?;
+        let column_info = column_info_node
+            .children_named("aggregate_column")
+            .map(|column| {
+                Ok(AggregateColumnInfo {
+                    name: column.required_child_text("name")?,
+                    statistic: column.required_child_text("stat")?,
+                    resource_type: column.required_child_text("type")?,
+                    column: column.required_child_text("column")?,
+                    data_type: column.required_child_text("data_type")?,
+                })
+            })
+            .collect::<Result<Vec<_>, ParseError>>()?;
+
+        Ok(Self {
+            data_type: node.required_child_text("data_type")?,
+            data_columns: node
+                .children_named("data_column")
+                .map(|column| column.text.clone())
+                .collect(),
+            group_column: node.optional_child_text("group_column"),
+            subgroup_column: node.optional_child_text("subgroup_column"),
+            text_columns: node
+                .children_named("text_column")
+                .map(|column| column.text.clone())
+                .collect(),
+            groups,
+            overall,
+            subgroup_values: node
+                .child("subgroups")
+                .map(|subgroups| {
+                    subgroups
+                        .children_named("value")
+                        .map(|value| value.text.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            column_info,
+        })
+    }
+}
+
+fn filter_from_node(node: &XmlNode) -> Result<AggregateFilter, ParseError> {
+    let keywords = node
+        .child("keywords")
+        .map(|keywords| {
+            keywords
+                .children_named("keyword")
+                .map(|keyword| {
+                    Ok(AggregateFilterKeyword {
+                        column: keyword.required_child_text("column")?,
+                        relation: keyword.required_child_text("relation")?,
+                        value: keyword.required_child_text("value")?,
+                    })
+                })
+                .collect::<Result<Vec<_>, ParseError>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(AggregateFilter {
+        id: node.attr("id").unwrap_or_default().to_string(),
+        term: node.required_child_text("term")?,
+        name: node.optional_child_text("name"),
+        keywords,
+    })
+}
+
+fn legacy_stats(statistic: &AggregateStatisticValues) -> AggregateStats {
+    AggregateStats {
+        column: statistic.column.clone(),
+        min: statistic.min.parse().ok(),
+        max: statistic.max.parse().ok(),
+        mean: statistic.mean.parse().ok(),
+        sum: statistic.sum.parse().ok(),
+        c_sum: statistic.c_sum.parse().ok(),
     }
 }
 
@@ -89,40 +319,36 @@ impl GetAggregatesResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
         let root = parse_document(response.data())?;
-
-        let aggregate = root.child("aggregate");
-        let groups = aggregate
-            .map(|agg| {
-                agg.children_named("group")
-                    .map(AggregateGroup::from_node)
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .transpose()?
+        let aggregates = root
+            .children_named("aggregate")
+            .map(AggregateResult::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        let groups = aggregates
+            .first()
+            .map(|aggregate| aggregate.groups.clone())
             .unwrap_or_default();
-
-        let column_info = aggregate
-            .and_then(|agg| agg.child("column_info"))
-            .map(|col_info| {
-                col_info
-                    .children_named("aggregate_column")
-                    .filter_map(|col| col.child_text("name"))
+        let column_info = aggregates
+            .first()
+            .map(|aggregate| {
+                aggregate
+                    .column_info
+                    .iter()
+                    .map(|column| column.name.clone())
                     .collect()
             })
             .unwrap_or_default();
-
-        let overall = aggregate
-            .and_then(|agg| agg.child("overall"))
-            .map(|o| AggregateStats {
-                column: o.child_text("column").unwrap_or_default(),
-                min: o.child_text("min").and_then(|t| t.parse().ok()),
-                max: o.child_text("max").and_then(|t| t.parse().ok()),
-                mean: o.child_text("mean").and_then(|t| t.parse().ok()),
-                sum: o.child_text("sum").and_then(|t| t.parse().ok()),
-            });
+        let overall = aggregates
+            .first()
+            .and_then(|aggregate| aggregate.overall.as_ref())
+            .and_then(|overall| overall.statistics.first())
+            .map(legacy_stats);
+        let filter = root.child("filters").map(filter_from_node).transpose()?;
 
         Ok(Self {
             status,
             status_text,
+            aggregates,
+            filter,
             groups,
             column_info,
             overall,
@@ -141,13 +367,24 @@ mod tests {
         let response = Response::from(
             r#"<get_aggregates_response status="200" status_text="OK">
                 <aggregate>
+                    <data_type>task</data_type>
+                    <data_column>severity</data_column>
+                    <group_column>status</group_column>
                     <column_info>
-                        <aggregate_column><name>severity</name></aggregate_column>
+                        <aggregate_column>
+                            <name>value</name><stat>value</stat><type>task</type>
+                            <column>status</column><data_type>text</data_type>
+                        </aggregate_column>
                     </column_info>
                     <group>
                         <value>High</value>
                         <count>5</count>
                         <c_count>5</c_count>
+                        <stats column="severity">
+                            <min>7.0</min><max>10.0</max><mean>8.5</mean>
+                            <sum>42.5</sum><c_sum>42.5</c_sum>
+                        </stats>
+                        <text column="comment">urgent</text>
                     </group>
                     <group>
                         <value>Medium</value>
@@ -155,6 +392,14 @@ mod tests {
                         <c_count>15</c_count>
                     </group>
                 </aggregate>
+                <filters id="">
+                    <term>rows=-1</term>
+                    <keywords>
+                        <keyword>
+                            <column>rows</column><relation>=</relation><value>-1</value>
+                        </keyword>
+                    </keywords>
+                </filters>
             </get_aggregates_response>"#,
         );
 
@@ -165,19 +410,159 @@ mod tests {
         assert_eq!(parsed.groups[0].value, "High");
         assert_eq!(parsed.groups[0].count, 5);
         assert_eq!(parsed.groups[1].c_count, Some(15));
-        assert_eq!(parsed.column_info, vec!["severity".to_string()]);
+        assert_eq!(parsed.groups[0].statistics[0].sum, "42.5");
+        assert_eq!(parsed.groups[0].texts[0].column, "comment");
+        assert_eq!(parsed.column_info, vec!["value".to_string()]);
+        assert_eq!(parsed.aggregates[0].data_type, "task");
+        assert_eq!(
+            parsed.filter.as_ref().expect("filter metadata").keywords[0].value,
+            "-1"
+        );
     }
 
     #[test]
-    fn parses_empty_aggregates() {
+    fn parses_overall_and_multiple_aggregates() {
         let response = Response::from(
             r#"<get_aggregates_response status="200" status_text="OK">
-                <aggregate/>
+                <aggregate>
+                    <data_type>task</data_type>
+                    <overall>
+                        <count>3</count><c_count>3</c_count>
+                        <stats column="severity">
+                            <min>4</min><max>9</max><mean>6.5</mean>
+                            <sum>19.5</sum><c_sum>19.5</c_sum>
+                        </stats>
+                    </overall>
+                    <column_info/>
+                </aggregate>
+                <aggregate>
+                    <data_type>result</data_type>
+                    <column_info/>
+                </aggregate>
             </get_aggregates_response>"#,
         );
 
         let parsed = GetAggregatesResponse::from_response(&response).expect("parse");
 
         assert!(parsed.groups.is_empty());
+        assert_eq!(parsed.aggregates.len(), 2);
+        assert_eq!(
+            parsed.aggregates[0]
+                .overall
+                .as_ref()
+                .expect("overall")
+                .count,
+            3
+        );
+        assert_eq!(
+            parsed.overall.as_ref().expect("legacy overall").mean,
+            Some(6.5)
+        );
+    }
+
+    #[test]
+    fn parses_subgroups_and_timestamp_statistics_without_numeric_loss() {
+        let response = Response::from(
+            r#"<get_aggregates_response status="200" status_text="OK">
+                <aggregate>
+                    <data_type>task</data_type>
+                    <group_column>status</group_column>
+                    <subgroup_column>creation_time</subgroup_column>
+                    <group>
+                        <value>Running</value>
+                        <subgroup>
+                            <value>2026-07-24T10:00:00Z</value>
+                            <count>2</count><c_count>2</c_count>
+                            <stats column="creation_time">
+                                <min>2026-07-24T10:00:00Z</min>
+                                <max>2026-07-24T11:00:00Z</max>
+                                <mean>2026-07-24T10:30:00Z</mean>
+                                <sum></sum><c_sum></c_sum>
+                            </stats>
+                        </subgroup>
+                        <count>2</count><c_count>2</c_count>
+                    </group>
+                    <subgroups><value>2026-07-24T10:00:00Z</value></subgroups>
+                    <column_info/>
+                </aggregate>
+            </get_aggregates_response>"#,
+        );
+
+        let parsed = GetAggregatesResponse::from_response(&response).expect("parse");
+        let subgroup = &parsed.groups[0].subgroups[0];
+        assert_eq!(subgroup.c_count, Some(2));
+        assert_eq!(subgroup.statistics[0].min, "2026-07-24T10:00:00Z");
+        assert_eq!(
+            parsed.aggregates[0].subgroup_values,
+            vec!["2026-07-24T10:00:00Z".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_required_counts() {
+        let response = Response::from(
+            r#"<get_aggregates_response status="200" status_text="OK">
+                <aggregate>
+                    <data_type>task</data_type>
+                    <group><value>Running</value><count>three</count><c_count>3</c_count></group>
+                    <column_info/>
+                </aggregate>
+            </get_aggregates_response>"#,
+        );
+
+        let error = GetAggregatesResponse::from_response(&response).expect_err("invalid count");
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { ref field, ref value }
+                if field == "aggregate.group.count" && value == "three"
+        ));
+
+        let invalid_subgroup = Response::from(
+            r#"<get_aggregates_response status="200" status_text="OK">
+                <aggregate>
+                    <data_type>task</data_type>
+                    <group>
+                        <value>Running</value>
+                        <subgroup>
+                            <value>Primary</value><count>3</count><c_count>three</c_count>
+                        </subgroup>
+                        <count>3</count><c_count>3</c_count>
+                    </group>
+                    <column_info/>
+                </aggregate>
+            </get_aggregates_response>"#,
+        );
+
+        let error = GetAggregatesResponse::from_response(&invalid_subgroup)
+            .expect_err("invalid subgroup count");
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { ref field, ref value }
+                if field == "aggregate.group.subgroup.c_count" && value == "three"
+        ));
+    }
+
+    #[test]
+    fn parses_word_counts_without_cumulative_counts() {
+        let response = Response::from(
+            r#"<get_aggregates_response status="200" status_text="OK">
+                <aggregate>
+                    <data_type>task</data_type>
+                    <group_column>comment</group_column>
+                    <group><value>security</value><count>4</count></group>
+                    <column_info>
+                        <aggregate_column>
+                            <name>value</name><stat>value</stat><type>task</type>
+                            <column>comment</column><data_type>text</data_type>
+                        </aggregate_column>
+                    </column_info>
+                </aggregate>
+            </get_aggregates_response>"#,
+        );
+
+        let parsed = GetAggregatesResponse::from_response(&response).expect("word counts parse");
+        assert_eq!(parsed.groups[0].value, "security");
+        assert_eq!(parsed.groups[0].count, 4);
+        assert_eq!(parsed.groups[0].c_count, None);
     }
 }

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -141,7 +141,9 @@ pub(crate) fn status_from_response(response: &Response) -> Result<(u16, String),
 pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
     let text = str::from_utf8(data)?;
     let mut reader = Reader::from_str(text);
-    reader.config_mut().trim_text(true);
+    // Trimming each event loses significant whitespace when quick-xml splits
+    // text around a character reference (for example `left &amp; right`).
+    reader.config_mut().trim_text(false);
     let mut stack: Vec<XmlNode> = Vec::new();
 
     loop {
@@ -181,10 +183,28 @@ pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
                     node.text.push_str(str::from_utf8(event.as_ref())?);
                 }
             }
+            Event::GeneralRef(event) => {
+                let node = stack.last_mut().ok_or_else(|| {
+                    ParseError::MissingElement("root for entity reference".to_string())
+                })?;
+                if let Some(character) = event.resolve_char_ref()? {
+                    node.text.push(character);
+                } else {
+                    let entity = event.decode().map_err(quick_xml::Error::from)?;
+                    let Some(value) = quick_xml::escape::resolve_xml_entity(&entity) else {
+                        return Err(ParseError::InvalidValue {
+                            field: "entity reference".to_string(),
+                            value: entity.into_owned(),
+                        });
+                    };
+                    node.text.push_str(value);
+                }
+            }
             Event::End(_) => {
-                let Some(node) = stack.pop() else {
+                let Some(mut node) = stack.pop() else {
                     return Err(ParseError::MissingElement("root".to_string()));
                 };
+                node.text = node.text.trim().to_string();
                 if let Some(parent) = stack.last_mut() {
                     parent.children.push(node);
                 } else {
@@ -192,11 +212,7 @@ pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
                 }
             }
             Event::Eof => return Err(ParseError::MissingElement("root".to_string())),
-            Event::Decl(_)
-            | Event::PI(_)
-            | Event::DocType(_)
-            | Event::Comment(_)
-            | Event::GeneralRef(_) => {}
+            Event::Decl(_) | Event::PI(_) | Event::DocType(_) | Event::Comment(_) => {}
         }
     }
 }
@@ -454,5 +470,34 @@ mod tests {
         assert_eq!(parse_score("NaN"), None);
         assert_eq!(parse_score("inf"), None);
         assert_eq!(parse_score("-inf"), None);
+    }
+
+    #[test]
+    fn parse_document_preserves_predefined_and_character_references() {
+        let root = parse_document(
+            br#"<?xml version="1.0"?><!-- metadata --><?test instruction?><!DOCTYPE root><root attr="A &amp; B"><value>A &amp; B &lt; &#x21;&#33;</value></root>"#,
+        )
+        .expect("valid references should parse");
+
+        assert_eq!(root.attr("attr"), Some("A & B"));
+        assert_eq!(root.child_text("value").as_deref(), Some("A & B < !!"));
+    }
+
+    #[test]
+    fn parse_document_rejects_unknown_entity_references() {
+        let error =
+            parse_document(b"<root>&unknown;</root>").expect_err("unknown entity should fail");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, value }
+                if field == "entity reference" && value == "unknown"
+        ));
+
+        assert!(matches!(
+            parse_document(b"&amp;<root/>"),
+            Err(ParseError::MissingElement(element))
+                if element == "root for entity reference"
+        ));
     }
 }

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -60,7 +60,11 @@ pub use agent_group::{
     AgentGroup, CloneAgentGroupResponse, CreateAgentGroupResponse, DeleteAgentGroupResponse,
     GetAgentGroupsResponse, ModifyAgentGroupResponse,
 };
-pub use aggregates::{AggregateGroup, AggregateStats, AggregateSubgroup, GetAggregatesResponse};
+pub use aggregates::{
+    AggregateColumnInfo, AggregateFilter, AggregateFilterKeyword, AggregateGroup, AggregateOverall,
+    AggregateResult, AggregateStatisticValues, AggregateStats, AggregateSubgroup, AggregateText,
+    GetAggregatesResponse,
+};
 pub use alert::{
     Alert, CreateAlertResponse, DeleteAlertResponse, GetAlertsResponse, ModifyAlertResponse,
 };

--- a/crates/gvm-mock-server/src/command_parser.rs
+++ b/crates/gvm-mock-server/src/command_parser.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use quick_xml::events::Event;
+use quick_xml::events::{BytesRef, Event};
 use quick_xml::{Reader, XmlVersion};
 
 /// A parsed GMP command extracted from incoming XML.
@@ -73,12 +73,12 @@ pub fn parse_command(xml: &[u8]) -> Option<ParsedCommand> {
         match reader.read_event() {
             Ok(Event::Start(ref e)) => {
                 let name = std::str::from_utf8(e.name().as_ref()).ok()?.to_string();
-                let attributes = extract_attributes(e);
+                let attributes = extract_attributes(e)?;
                 break (name, attributes);
             }
             Ok(Event::Empty(ref e)) => {
                 let name = std::str::from_utf8(e.name().as_ref()).ok()?.to_string();
-                let attributes = extract_attributes(e);
+                let attributes = extract_attributes(e)?;
                 return Some(ParsedCommand {
                     name,
                     attributes,
@@ -93,7 +93,7 @@ pub fn parse_command(xml: &[u8]) -> Option<ParsedCommand> {
     };
 
     // Parse children
-    let (children, _root_text) = parse_children(&mut reader, &name);
+    let (children, _root_text) = parse_children(&mut reader)?;
 
     Some(ParsedCommand {
         name,
@@ -103,10 +103,7 @@ pub fn parse_command(xml: &[u8]) -> Option<ParsedCommand> {
     })
 }
 
-fn parse_children(
-    reader: &mut Reader<&[u8]>,
-    parent_name: &str,
-) -> (Vec<ParsedElement>, Option<String>) {
+fn parse_children(reader: &mut Reader<&[u8]>) -> Option<(Vec<ParsedElement>, Option<String>)> {
     let mut children = Vec::new();
     let mut current_text = String::new();
 
@@ -115,8 +112,8 @@ fn parse_children(
             Ok(Event::Start(ref e)) => {
                 let qn = e.name();
                 let child_name = std::str::from_utf8(qn.as_ref()).unwrap_or("").to_string();
-                let attrs = extract_attributes(e);
-                let (grandchildren, child_text) = parse_children(reader, &child_name);
+                let attrs = extract_attributes(e)?;
+                let (grandchildren, child_text) = parse_children(reader)?;
                 children.push(ParsedElement {
                     name: child_name,
                     attributes: attrs,
@@ -127,7 +124,7 @@ fn parse_children(
             Ok(Event::Empty(ref e)) => {
                 let qn = e.name();
                 let child_name = std::str::from_utf8(qn.as_ref()).unwrap_or("").to_string();
-                let attrs = extract_attributes(e);
+                let attrs = extract_attributes(e)?;
                 children.push(ParsedElement {
                     name: child_name,
                     attributes: attrs,
@@ -140,21 +137,19 @@ fn parse_children(
                     current_text.push_str(&unescaped);
                 }
             }
-            Ok(Event::End(ref e)) => {
-                let qn = e.name();
-                let end_name = std::str::from_utf8(qn.as_ref()).unwrap_or("");
-                if end_name == parent_name {
-                    break;
-                }
+            Ok(Event::GeneralRef(ref reference)) => {
+                current_text.push_str(&resolve_reference(reference)?);
             }
-            Ok(Event::Eof) => break,
-            Err(_) => break,
+            Ok(Event::End(_)) => {
+                // quick-xml checks matching end names before yielding this
+                // event, so this closes the element for this recursion level.
+                let text = (!current_text.is_empty()).then_some(current_text);
+                return Some((children, text));
+            }
+            Ok(Event::Eof) | Err(_) => return None,
             _ => continue,
         }
     }
-
-    let text = (!current_text.is_empty()).then_some(current_text);
-    (children, text)
 }
 
 /// Helper: re-parse children to associate text with the correct element.
@@ -183,6 +178,9 @@ pub fn parse_element_text(xml: &[u8], element_name: &str) -> Option<String> {
                     result.push_str(&unescaped);
                 }
             }
+            Ok(Event::GeneralRef(ref reference)) if inside => {
+                result.push_str(&resolve_reference(reference)?);
+            }
             Ok(Event::End(ref e)) if inside => {
                 let qn = e.name();
                 let name = std::str::from_utf8(qn.as_ref()).ok()?;
@@ -197,18 +195,26 @@ pub fn parse_element_text(xml: &[u8], element_name: &str) -> Option<String> {
     }
 }
 
-fn extract_attributes(e: &quick_xml::events::BytesStart<'_>) -> HashMap<String, String> {
-    let mut map = HashMap::new();
-    for attr in e.attributes().flatten() {
-        if let (Ok(key), Ok(val)) = (
-            std::str::from_utf8(attr.key.as_ref()),
-            attr.normalized_value(XmlVersion::Implicit1_0)
-                .map(|v| v.into_owned()),
-        ) {
-            map.insert(key.to_string(), val);
-        }
+fn resolve_reference(reference: &BytesRef<'_>) -> Option<String> {
+    if let Some(character) = reference.resolve_char_ref().ok()? {
+        return Some(character.to_string());
     }
-    map
+    let entity = reference.decode().ok()?;
+    quick_xml::escape::resolve_xml_entity(&entity).map(ToString::to_string)
+}
+
+fn extract_attributes(e: &quick_xml::events::BytesStart<'_>) -> Option<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for attr in e.attributes() {
+        let attr = attr.ok()?;
+        let key = std::str::from_utf8(attr.key.as_ref()).ok()?;
+        let value = attr
+            .normalized_value(XmlVersion::Implicit1_0)
+            .ok()?
+            .into_owned();
+        map.insert(key.to_string(), value);
+    }
+    Some(map)
 }
 
 #[cfg(test)]
@@ -257,6 +263,31 @@ mod tests {
         assert_eq!(cmd.child_text("name"), Some("My Task"));
         assert_eq!(cmd.child_text("comment"), Some("A comment"));
         assert_eq!(cmd.child_text("missing"), None);
+    }
+
+    #[test]
+    fn test_parse_command_preserves_xml_references() {
+        let xml = br#"<get_aggregates type="task&amp;&lt;"><data_column>qod&amp;&lt;&#33;</data_column></get_aggregates>"#;
+        let cmd = parse_command(xml).expect("should parse");
+
+        assert_eq!(cmd.attr("type"), Some("task&<"));
+        assert_eq!(cmd.child_text("data_column"), Some("qod&<!"));
+        assert_eq!(
+            parse_element_text(xml, "data_column").as_deref(),
+            Some("qod&<!")
+        );
+    }
+
+    #[test]
+    fn test_parse_command_rejects_unknown_entity_references() {
+        assert!(parse_command(b"<create_task><name>a&unknown;b</name></create_task>").is_none());
+        assert!(parse_command(br#"<get_aggregates type="task" filter="a&unknown;b"/>"#).is_none());
+    }
+
+    #[test]
+    fn test_parse_command_rejects_mismatched_and_truncated_children() {
+        assert!(parse_command(b"<create_task><name>task</comment></create_task>").is_none());
+        assert!(parse_command(b"<create_task><name>task").is_none());
     }
 
     // XML-006

--- a/crates/gvm-mock-server/src/command_parser.rs
+++ b/crates/gvm-mock-server/src/command_parser.rs
@@ -66,7 +66,7 @@ impl ParsedCommand {
 pub fn parse_command(xml: &[u8]) -> Option<ParsedCommand> {
     let text = std::str::from_utf8(xml).ok()?;
     let mut reader = Reader::from_str(text);
-    reader.config_mut().trim_text(true);
+    reader.config_mut().trim_text(false);
 
     // Find the root element
     let (name, attributes) = loop {
@@ -143,7 +143,8 @@ fn parse_children(reader: &mut Reader<&[u8]>) -> Option<(Vec<ParsedElement>, Opt
             Ok(Event::End(_)) => {
                 // quick-xml checks matching end names before yielding this
                 // event, so this closes the element for this recursion level.
-                let text = (!current_text.is_empty()).then_some(current_text);
+                let text = current_text.trim();
+                let text = (!text.is_empty()).then(|| text.to_string());
                 return Some((children, text));
             }
             Ok(Event::Eof) | Err(_) => return None,
@@ -158,7 +159,7 @@ fn parse_children(reader: &mut Reader<&[u8]>) -> Option<(Vec<ParsedElement>, Opt
 pub fn parse_element_text(xml: &[u8], element_name: &str) -> Option<String> {
     let text = std::str::from_utf8(xml).ok()?;
     let mut reader = Reader::from_str(text);
-    reader.config_mut().trim_text(true);
+    reader.config_mut().trim_text(false);
 
     let mut inside = false;
     let mut result = String::new();
@@ -185,7 +186,7 @@ pub fn parse_element_text(xml: &[u8], element_name: &str) -> Option<String> {
                 let qn = e.name();
                 let name = std::str::from_utf8(qn.as_ref()).ok()?;
                 if name == element_name {
-                    return Some(result);
+                    return Some(result.trim().to_string());
                 }
             }
             Ok(Event::Eof) => return None,
@@ -275,6 +276,18 @@ mod tests {
         assert_eq!(
             parse_element_text(xml, "data_column").as_deref(),
             Some("qod&<!")
+        );
+    }
+
+    #[test]
+    fn test_parse_command_preserves_whitespace_around_xml_references() {
+        let xml = b"<create_task><name>left &amp; right &#33; done</name></create_task>";
+        let cmd = parse_command(xml).expect("should parse");
+
+        assert_eq!(cmd.child_text("name"), Some("left & right ! done"));
+        assert_eq!(
+            parse_element_text(xml, "name").as_deref(),
+            Some("left & right ! done")
         );
     }
 

--- a/crates/gvm-mock-server/src/fixtures.rs
+++ b/crates/gvm-mock-server/src/fixtures.rs
@@ -186,8 +186,13 @@ impl FixtureStore {
         self.fixtures.insert(
             "get_aggregates".to_string(),
             "<get_aggregates_response status=\"200\" status_text=\"OK\">\
-             <aggregate><text>High</text><value>3</value></aggregate>\
-             <aggregate><text>Medium</text><value>5</value></aggregate>\
+             <aggregate><data_type>task</data_type><group_column>severity</group_column>\
+             <group><value>High</value><count>3</count><c_count>3</c_count></group>\
+             <group><value>Medium</value><count>5</count><c_count>8</c_count></group>\
+             <column_info><aggregate_column><name>value</name><stat>value</stat>\
+             <type>task</type><column>severity</column><data_type>text</data_type>\
+             </aggregate_column></column_info></aggregate>\
+             <filters id=\"\"><term></term><keywords/></filters>\
              </get_aggregates_response>"
                 .to_string(),
         );

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -2270,15 +2270,211 @@ fn render_feeds_response(cmd: &ParsedCommand) -> Vec<u8> {
 }
 
 fn render_aggregates_response(cmd: &ParsedCommand) -> Vec<u8> {
-    let resource_type = cmd.attr("type").unwrap_or("task");
-    let group_column = cmd.attr("group_column").unwrap_or("severity");
+    let Some(resource_type) = cmd.attr("type") else {
+        return error_response("get_aggregates", 400, "A 'type' attribute is required");
+    };
+    let group_column = cmd.attr("group_column");
+    let subgroup_column = cmd.attr("subgroup_column");
+    if subgroup_column.is_some() && group_column.is_none() {
+        return error_response(
+            "get_aggregates",
+            400,
+            "A 'group_column' attribute is required when 'subgroup_column' is given",
+        );
+    }
+    if cmd
+        .attr("mode")
+        .is_some_and(|mode| mode.eq_ignore_ascii_case("word_counts"))
+    {
+        let Some(group_column) = group_column else {
+            return error_response(
+                "get_aggregates",
+                400,
+                "A 'group_column' attribute is required for word_counts mode",
+            );
+        };
+        let filter_id = cmd.attr("filt_id").unwrap_or_default();
+        let filter_term = cmd.attr("filter").unwrap_or_default();
+        return format!(
+            "<get_aggregates_response status=\"200\" status_text=\"OK\">\
+             <aggregate><data_type>{}</data_type><group_column>{}</group_column>\
+             <group><value>security</value><count>3</count></group>\
+             <group><value>update</value><count>5</count></group>\
+             <column_info><aggregate_column><name>value</name><stat>value</stat>\
+             <type>{}</type><column>{}</column><data_type>text</data_type>\
+             </aggregate_column><aggregate_column><name>count</name><stat>count</stat>\
+             <type>{}</type><column></column><data_type>integer</data_type>\
+             </aggregate_column></column_info></aggregate>\
+             <filters id=\"{}\"><term>{}</term><keywords/></filters>\
+             </get_aggregates_response>",
+            xml_escape(resource_type),
+            xml_escape(group_column),
+            xml_escape(resource_type),
+            xml_escape(group_column),
+            xml_escape(resource_type),
+            xml_escape_attr(filter_id),
+            xml_escape(filter_term)
+        )
+        .into_bytes();
+    }
+
+    let mut data_columns: Vec<&str> = cmd
+        .children
+        .iter()
+        .filter(|child| child.name == "data_column")
+        .filter_map(|child| child.text.as_deref())
+        .collect();
+    if data_columns.is_empty() {
+        if let Some(data_column) = cmd.attr("data_column") {
+            if !data_column.is_empty() {
+                data_columns.push(data_column);
+            }
+        }
+    }
+    let text_columns: Vec<&str> = cmd
+        .children
+        .iter()
+        .filter(|child| child.name == "text_column")
+        .filter_map(|child| child.text.as_deref())
+        .collect();
+
+    let mut aggregate = format!(
+        "<aggregate><data_type>{}</data_type>",
+        xml_escape(resource_type)
+    );
+    for data_column in &data_columns {
+        aggregate.push_str(&format!(
+            "<data_column>{}</data_column>",
+            xml_escape(data_column)
+        ));
+    }
+    for text_column in &text_columns {
+        aggregate.push_str(&format!(
+            "<text_column>{}</text_column>",
+            xml_escape(text_column)
+        ));
+    }
+    if let Some(group_column) = group_column {
+        aggregate.push_str(&format!(
+            "<group_column>{}</group_column>",
+            xml_escape(group_column)
+        ));
+    }
+    if let Some(subgroup_column) = subgroup_column {
+        aggregate.push_str(&format!(
+            "<subgroup_column>{}</subgroup_column>",
+            xml_escape(subgroup_column)
+        ));
+    }
+
+    let append_statistics = |xml: &mut String, count: u32, cumulative: u32| {
+        for data_column in &data_columns {
+            xml.push_str(&format!(
+                "<stats column=\"{}\"><min>1</min><max>{count}</max>\
+                 <mean>2</mean><sum>{count}</sum><c_sum>{cumulative}</c_sum></stats>",
+                xml_escape_attr(data_column)
+            ));
+        }
+    };
+    let append_text = |xml: &mut String, value: &str| {
+        for text_column in &text_columns {
+            xml.push_str(&format!(
+                "<text column=\"{}\">{}</text>",
+                xml_escape_attr(text_column),
+                xml_escape(value)
+            ));
+        }
+    };
+
+    if group_column.is_none() {
+        aggregate.push_str("<overall><count>8</count><c_count>8</c_count>");
+        append_statistics(&mut aggregate, 8, 8);
+        append_text(&mut aggregate, "All");
+        aggregate.push_str("</overall>");
+    } else if subgroup_column.is_some() {
+        aggregate.push_str("<group><value>High</value>");
+        aggregate.push_str("<subgroup><value>Primary</value><count>3</count><c_count>3</c_count>");
+        append_statistics(&mut aggregate, 3, 3);
+        aggregate.push_str("</subgroup><count>3</count><c_count>3</c_count>");
+        append_statistics(&mut aggregate, 3, 3);
+        append_text(&mut aggregate, "High");
+        aggregate.push_str("</group><group><value>Medium</value>");
+        aggregate
+            .push_str("<subgroup><value>Secondary</value><count>5</count><c_count>5</c_count>");
+        append_statistics(&mut aggregate, 5, 5);
+        aggregate.push_str("</subgroup><count>5</count><c_count>8</c_count>");
+        append_statistics(&mut aggregate, 5, 8);
+        append_text(&mut aggregate, "Medium");
+        aggregate.push_str(
+            "</group><subgroups><value>Primary</value><value>Secondary</value></subgroups>",
+        );
+    } else {
+        aggregate.push_str("<group><value>High</value><count>3</count><c_count>3</c_count>");
+        append_statistics(&mut aggregate, 3, 3);
+        append_text(&mut aggregate, "High");
+        aggregate
+            .push_str("</group><group><value>Medium</value><count>5</count><c_count>8</c_count>");
+        append_statistics(&mut aggregate, 5, 8);
+        append_text(&mut aggregate, "Medium");
+        aggregate.push_str("</group>");
+    }
+
+    aggregate.push_str("<column_info>");
+    if let Some(group_column) = group_column {
+        aggregate.push_str(&format!(
+            "<aggregate_column><name>value</name><stat>value</stat>\
+             <type>{}</type><column>{}</column><data_type>text</data_type></aggregate_column>",
+            xml_escape(resource_type),
+            xml_escape(group_column)
+        ));
+    }
+    if let Some(subgroup_column) = subgroup_column {
+        aggregate.push_str(&format!(
+            "<aggregate_column><name>subgroup_value</name><stat>value</stat>\
+             <type>{}</type><column>{}</column><data_type>text</data_type></aggregate_column>",
+            xml_escape(resource_type),
+            xml_escape(subgroup_column)
+        ));
+    }
+    aggregate.push_str(&format!(
+        "<aggregate_column><name>count</name><stat>count</stat>\
+         <type>{}</type><column></column><data_type>integer</data_type></aggregate_column>\
+         <aggregate_column><name>c_count</name><stat>c_count</stat>\
+         <type>{}</type><column></column><data_type>integer</data_type></aggregate_column>",
+        xml_escape(resource_type),
+        xml_escape(resource_type)
+    ));
+    for data_column in &data_columns {
+        for statistic in ["min", "max", "mean", "sum", "c_sum"] {
+            aggregate.push_str(&format!(
+                "<aggregate_column><name>{}_{statistic}</name><stat>{statistic}</stat>\
+                 <type>{}</type><column>{}</column><data_type>number</data_type>\
+                 </aggregate_column>",
+                xml_escape(data_column),
+                xml_escape(resource_type),
+                xml_escape(data_column)
+            ));
+        }
+    }
+    for text_column in &text_columns {
+        aggregate.push_str(&format!(
+            "<aggregate_column><name>{}</name><stat>text</stat>\
+             <type>{}</type><column>{}</column><data_type>text</data_type></aggregate_column>",
+            xml_escape(text_column),
+            xml_escape(resource_type),
+            xml_escape(text_column)
+        ));
+    }
+    aggregate.push_str("</column_info></aggregate>");
+
+    let filter_id = cmd.attr("filt_id").unwrap_or_default();
+    let filter_term = cmd.attr("filter").unwrap_or_default();
     format!(
-        "<get_aggregates_response status=\"200\" status_text=\"OK\">\
-         <type>{resource_type}</type>\
-         <group_column>{group_column}</group_column>\
-         <aggregate><text>High</text><value>3</value></aggregate>\
-         <aggregate><text>Medium</text><value>5</value></aggregate>\
-         </get_aggregates_response>"
+        "<get_aggregates_response status=\"200\" status_text=\"OK\">{aggregate}\
+         <filters id=\"{}\"><term>{}</term><keywords/></filters>\
+         </get_aggregates_response>",
+        xml_escape_attr(filter_id),
+        xml_escape(filter_term)
     )
     .into_bytes()
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -2329,14 +2329,31 @@ fn render_aggregates_response(cmd: &ParsedCommand) -> Vec<u8> {
             if !data_column.is_empty() {
                 data_columns.push(data_column);
             }
+        } else if let Some(legacy_columns) = cmd.attr("data_columns") {
+            data_columns.extend(
+                legacy_columns
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|column| !column.is_empty()),
+            );
         }
     }
-    let text_columns: Vec<&str> = cmd
+    let mut text_columns: Vec<&str> = cmd
         .children
         .iter()
         .filter(|child| child.name == "text_column")
         .filter_map(|child| child.text.as_deref())
         .collect();
+    if text_columns.is_empty() {
+        if let Some(legacy_columns) = cmd.attr("text_columns") {
+            text_columns.extend(
+                legacy_columns
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|column| !column.is_empty()),
+            );
+        }
+    }
 
     let mut aggregate = format!(
         "<aggregate><data_type>{}</data_type>",

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -615,14 +615,87 @@ async fn stateful_aggregates_returns_fixture_response() {
 
     let resp = send_recv(
         &mut stream,
-        br#"<get_aggregates type="task" group_column="severity"/>"#,
+        br#"<get_aggregates type="task&amp;&lt;" group_column="severity&lt;&amp;"><data_column>qod&amp;&lt;</data_column><text_column>name&amp;&lt;</text_column></get_aggregates>"#,
     )
     .await;
     assert_eq!(resp.status_code(), Some(200));
     let text = resp.as_str().expect("utf8");
-    assert!(text.contains("<type>task</type>"));
-    assert!(text.contains("<group_column>severity</group_column>"));
-    assert!(text.contains("<aggregate><text>High</text><value>3</value></aggregate>"));
+    assert!(text.contains("<data_type>task&amp;&lt;</data_type>"));
+    assert!(text.contains("<group_column>severity&lt;&amp;</group_column>"));
+    assert!(text.contains("<data_column>qod&amp;&lt;</data_column>"));
+    assert!(text.contains("<group><value>High</value><count>3</count><c_count>3</c_count>"));
+    assert!(text.contains("<stats column=\"qod&amp;&lt;\">"));
+    assert!(text.contains("<text column=\"name&amp;&lt;\">High</text>"));
+    assert!(!text.contains("task&<"));
+
+    let no_columns = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" group_column="severity"/>"#,
+    )
+    .await;
+    assert_eq!(no_columns.status_code(), Some(200));
+    assert!(no_columns
+        .as_str()
+        .expect("utf8")
+        .contains("<group><value>High</value><count>3</count><c_count>3</c_count></group>"));
+
+    let missing_type = send_recv(&mut stream, br#"<get_aggregates/>"#).await;
+    assert_eq!(missing_type.status_code(), Some(400));
+
+    let missing_group = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" subgroup_column="status"/>"#,
+    )
+    .await;
+    assert_eq!(missing_group.status_code(), Some(400));
+
+    let subgroup = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" group_column="status" subgroup_column="owner"><data_column>qod</data_column></get_aggregates>"#,
+    )
+    .await;
+    assert_eq!(subgroup.status_code(), Some(200));
+    let subgroup_text = subgroup.as_str().expect("utf8");
+    assert!(subgroup_text
+        .contains("<subgroup><value>Primary</value><count>3</count><c_count>3</c_count>"));
+    assert!(subgroup_text.contains(
+        "<subgroup><value>Secondary</value><count>5</count><c_count>5</c_count>\
+         <stats column=\"qod\"><min>1</min><max>5</max><mean>2</mean><sum>5</sum>\
+         <c_sum>5</c_sum></stats></subgroup>"
+    ));
+    assert!(subgroup_text.contains(
+        "<aggregate_column><name>subgroup_value</name><stat>value</stat>\
+         <type>task</type><column>owner</column><data_type>text</data_type>"
+    ));
+
+    let overall = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" data_column="severity" filt_id="filter-1" filter="owner=me"/>"#,
+    )
+    .await;
+    assert_eq!(overall.status_code(), Some(200));
+    let overall_text = overall.as_str().expect("utf8");
+    assert!(overall_text
+        .contains("<overall><count>8</count><c_count>8</c_count><stats column=\"severity\">"));
+    assert!(overall_text
+        .contains("<filters id=\"filter-1\"><term>owner=me</term><keywords/></filters>"));
+
+    let word_counts = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" group_column="comment" mode="word_counts"/>"#,
+    )
+    .await;
+    assert_eq!(word_counts.status_code(), Some(200));
+    let word_counts_text = word_counts.as_str().expect("utf8");
+    assert!(word_counts_text.contains("<group><value>security</value><count>3</count></group>"));
+    assert!(!word_counts_text.contains("<c_count>"));
+
+    let word_counts_without_group = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" mode="word_counts"/>"#,
+    )
+    .await;
+    assert_eq!(word_counts_without_group.status_code(), Some(400));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -605,6 +605,29 @@ async fn stateful_help_returns_command_listing() {
     server.shutdown().await;
 }
 
+async fn assert_aggregate_column_precedence(stream: &mut UnixStream) {
+    let conflicting_columns = send_recv(
+        stream,
+        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data" text_columns="legacy-text"><data_column>current-data</data_column><text_column>current-text</text_column></get_aggregates>"#,
+    )
+    .await;
+    let conflicting_text = conflicting_columns.as_str().expect("utf8");
+    assert!(conflicting_text.contains("<data_column>current-data</data_column>"));
+    assert!(conflicting_text.contains("<text_column>current-text</text_column>"));
+    assert!(!conflicting_text.contains("singular"));
+    assert!(!conflicting_text.contains("legacy-data"));
+    assert!(!conflicting_text.contains("legacy-text"));
+
+    let singular_precedence = send_recv(
+        stream,
+        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data"/>"#,
+    )
+    .await;
+    let singular_text = singular_precedence.as_str().expect("utf8");
+    assert!(singular_text.contains("<data_column>singular</data_column>"));
+    assert!(!singular_text.contains("legacy-data"));
+}
+
 #[tokio::test]
 async fn stateful_aggregates_returns_fixture_response() {
     let Some(server) = stateful_server().await else {
@@ -628,26 +651,7 @@ async fn stateful_aggregates_returns_fixture_response() {
     assert!(text.contains("<text column=\"name&amp;&lt;\">High</text>"));
     assert!(!text.contains("task&<"));
 
-    let conflicting_columns = send_recv(
-        &mut stream,
-        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data" text_columns="legacy-text"><data_column>current-data</data_column><text_column>current-text</text_column></get_aggregates>"#,
-    )
-    .await;
-    let conflicting_text = conflicting_columns.as_str().expect("utf8");
-    assert!(conflicting_text.contains("<data_column>current-data</data_column>"));
-    assert!(conflicting_text.contains("<text_column>current-text</text_column>"));
-    assert!(!conflicting_text.contains("singular"));
-    assert!(!conflicting_text.contains("legacy-data"));
-    assert!(!conflicting_text.contains("legacy-text"));
-
-    let singular_precedence = send_recv(
-        &mut stream,
-        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data"/>"#,
-    )
-    .await;
-    let singular_text = singular_precedence.as_str().expect("utf8");
-    assert!(singular_text.contains("<data_column>singular</data_column>"));
-    assert!(!singular_text.contains("legacy-data"));
+    assert_aggregate_column_precedence(&mut stream).await;
 
     let no_columns = send_recv(
         &mut stream,

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -628,6 +628,27 @@ async fn stateful_aggregates_returns_fixture_response() {
     assert!(text.contains("<text column=\"name&amp;&lt;\">High</text>"));
     assert!(!text.contains("task&<"));
 
+    let conflicting_columns = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data" text_columns="legacy-text"><data_column>current-data</data_column><text_column>current-text</text_column></get_aggregates>"#,
+    )
+    .await;
+    let conflicting_text = conflicting_columns.as_str().expect("utf8");
+    assert!(conflicting_text.contains("<data_column>current-data</data_column>"));
+    assert!(conflicting_text.contains("<text_column>current-text</text_column>"));
+    assert!(!conflicting_text.contains("singular"));
+    assert!(!conflicting_text.contains("legacy-data"));
+    assert!(!conflicting_text.contains("legacy-text"));
+
+    let singular_precedence = send_recv(
+        &mut stream,
+        br#"<get_aggregates type="task" data_column="singular" data_columns="legacy-data"/>"#,
+    )
+    .await;
+    let singular_text = singular_precedence.as_str().expect("utf8");
+    assert!(singular_text.contains("<data_column>singular</data_column>"));
+    assert!(!singular_text.contains("legacy-data"));
+
     let no_columns = send_recv(
         &mut stream,
         br#"<get_aggregates type="task" group_column="severity"/>"#,


### PR DESCRIPTION
## Summary

- add a schema-faithful aggregate request builder and typed client helper while retaining both legacy builders for source compatibility
- parse the full current aggregate response shape, including multiple aggregates, group/subgroup/overall statistics, text columns, filter metadata, and the reduced `word_counts` shape emitted by gvmd
- align the stateful mock server and fixture with current gvmd behavior, including strict request validation, XML escaping, and reference handling

## Compatibility

The existing `commands::aggregates::get_aggregates`, `commands::system::get_aggregates`, and their option structs remain available unchanged. The new API uses `get_aggregates_request` and `GetAggregatesRequestOpts` because current gvmd represents repeated sort/data/text columns as child elements rather than the legacy comma-separated attributes.

The response keeps the existing flattened `groups`, name-only `column_info`, and numeric-first `overall` views while adding complete typed aggregate results. New fields use serde defaults where required for backward deserialization.

The wire contract was checked against the current public gvmd schema and implementation, including the supported aggregate sort statistics and gvmd's special word-count response:

- https://github.com/greenbone/gvmd/blob/f8cedbda62ea8e8499f1d130b403a7356c5a9a5c/src/manage_sql.c#L1294-L1340
- https://github.com/greenbone/gvmd/blob/f8cedbda62ea8e8499f1d130b403a7356c5a9a5c/src/gmp.c#L10905-L11060

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- Rust 1.85 workspace check and tests
- real Rust client / Unix stateful-mock round trips for standard and word-count aggregates
- public `python-gvm` Unix, TLS, and mutual-TLS integration suites
- Cobertura diff coverage: 566/566 changed executable lines
- cargo-audit, cargo-deny, cargo-machete, cargo-vet, zero-unsafe, strict Semgrep, tracked-source Gitleaks, and SBOM quality gates

No live gvmd exchange was available. Fuzzing was not run; deterministic malformed/reference/parser regressions and the full transport suites cover the changed XML paths.
