### PR TITLE
Make transport timeouts terminal

### DIFF
--- a/crates/gvm-connection/src/connection.rs
+++ b/crates/gvm-connection/src/connection.rs
@@ -3,7 +3,12 @@
 
 //! Shared connection trait for GVM transports.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+use crate::error::ConnectionError;
 
 /// Abstraction over async transports that communicate with gvmd.
 #[async_trait]
@@ -22,13 +27,19 @@ pub trait GvmConnection: Send + Sync {
 
     /// Send data to the server.
     ///
+    /// A send error leaves the outcome of the request ambiguous. Implementations
+    /// therefore invalidate an active transport before returning the error.
+    ///
     /// # Errors
-    /// Returns an error if the transport is disconnected or the write fails.
+    /// Returns an error if the transport is disconnected, the write times out,
+    /// or the write or flush fails.
     async fn send(&mut self, data: &[u8]) -> crate::Result<()>;
 
     /// Read a complete GMP response from the server.
     ///
     /// Uses `XmlReader` to detect complete XML elements.
+    /// A read error invalidates an active transport so a late response cannot
+    /// be mistaken for the response to a later request.
     ///
     /// # Errors
     /// Returns an error if the transport is disconnected, the read times out,
@@ -37,4 +48,81 @@ pub trait GvmConnection: Send + Sync {
 
     /// Check if currently connected.
     fn is_connected(&self) -> bool;
+}
+
+pub(crate) async fn write_all_and_flush_with_timeout<W>(
+    writer: &mut W,
+    data: &[u8],
+    operation_timeout: Duration,
+) -> crate::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::time::timeout(operation_timeout, async {
+        writer.write_all(data).await?;
+        writer.flush().await
+    })
+    .await
+    .map_err(|_| ConnectionError::Timeout(operation_timeout))?
+    .map_err(ConnectionError::SendFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+    use super::*;
+
+    struct PendingFlushWriter;
+
+    impl AsyncWrite for PendingFlushWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+            buffer: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(buffer.len()))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Pending
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn outbound_deadline_covers_write_backpressure() {
+        let (mut writer, _reader) = tokio::io::duplex(1);
+        let result =
+            write_all_and_flush_with_timeout(&mut writer, &[0_u8; 1024], Duration::from_millis(10))
+                .await;
+
+        assert!(matches!(result, Err(ConnectionError::Timeout(_))));
+    }
+
+    #[tokio::test]
+    async fn outbound_deadline_covers_flush() {
+        let mut writer = PendingFlushWriter;
+        let result = write_all_and_flush_with_timeout(
+            &mut writer,
+            b"<get_version/>",
+            Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ConnectionError::Timeout(_))));
+        writer.shutdown().await.expect("shutdown");
+    }
 }

--- a/crates/gvm-connection/src/ssh.rs
+++ b/crates/gvm-connection/src/ssh.rs
@@ -7,15 +7,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::connection::{write_all_and_flush_with_timeout, GvmConnection};
+use crate::error::{ConnectionError, Result};
 use russh::client;
 use russh::keys::agent::client::AgentClient;
 use russh::keys::ssh_key::{HashAlg, PublicKey};
 use russh::keys::{self, PrivateKeyWithHashAlg};
 use russh::{AgentAuthError, Channel, ChannelMsg, Disconnect};
-use tokio::io::AsyncWriteExt;
-
-use crate::connection::GvmConnection;
-use crate::error::{ConnectionError, Result};
 
 /// Configuration for SSH tunnel connections.
 #[derive(Clone)]
@@ -30,7 +28,7 @@ pub struct SshConfig {
     pub auth: SshAuth,
     /// Remote gvmd Unix socket path.
     pub remote_socket: String,
-    /// Connection timeout.
+    /// Connect, authentication, channel, request-write/flush, and response-read timeout.
     pub timeout: Duration,
     /// Read buffer size in bytes.
     pub read_buffer_size: usize,
@@ -458,19 +456,15 @@ impl GvmConnection for SshConnection {
     }
 
     async fn send(&mut self, data: &[u8]) -> Result<()> {
-        let channel = self.channel.as_ref().ok_or(ConnectionError::NotConnected)?;
-        let mut writer = channel.make_writer();
-
-        tokio::time::timeout(self.config.timeout, writer.write_all(data))
-            .await
-            .map_err(|_| ConnectionError::Timeout(self.config.timeout))?
-            .map_err(ConnectionError::SendFailed)?;
-        tokio::time::timeout(self.config.timeout, writer.flush())
-            .await
-            .map_err(|_| ConnectionError::Timeout(self.config.timeout))?
-            .map_err(ConnectionError::SendFailed)?;
-
-        Ok(())
+        let result = {
+            let channel = self.channel.as_ref().ok_or(ConnectionError::NotConnected)?;
+            let mut writer = channel.make_writer();
+            write_all_and_flush_with_timeout(&mut writer, data, self.config.timeout).await
+        };
+        if result.is_err() {
+            self.invalidate_connection();
+        }
+        result
     }
 
     async fn read(&mut self) -> Result<Vec<u8>> {
@@ -495,10 +489,17 @@ impl GvmConnection for SshConnection {
         }
 
         loop {
-            let channel = self.channel.as_mut().ok_or(ConnectionError::NotConnected)?;
-            let message = tokio::time::timeout(self.config.timeout, channel.wait())
-                .await
-                .map_err(|_| ConnectionError::Timeout(self.config.timeout))?;
+            let wait_result = {
+                let channel = self.channel.as_mut().ok_or(ConnectionError::NotConnected)?;
+                tokio::time::timeout(self.config.timeout, channel.wait()).await
+            };
+            let message = match wait_result {
+                Ok(message) => message,
+                Err(_) => {
+                    self.invalidate_connection();
+                    return Err(ConnectionError::Timeout(self.config.timeout));
+                }
+            };
 
             match message {
                 Some(ChannelMsg::Data { data }) | Some(ChannelMsg::ExtendedData { data, .. }) => {
@@ -526,15 +527,18 @@ impl GvmConnection for SshConnection {
                     )));
                 }
                 Some(ChannelMsg::OpenFailure(error)) => {
-                    return Err(Self::read_error(format!("{error:?}")));
+                    let error = Self::read_error(format!("{error:?}"));
+                    self.invalidate_connection();
+                    return Err(error);
                 }
                 Some(
                     ChannelMsg::WindowAdjusted { .. } | ChannelMsg::Success | ChannelMsg::Failure,
                 ) => {}
                 Some(other) => {
-                    return Err(Self::read_error(format!(
-                        "unexpected ssh channel message: {other:?}"
-                    )));
+                    let error =
+                        Self::read_error(format!("unexpected ssh channel message: {other:?}"));
+                    self.invalidate_connection();
+                    return Err(error);
                 }
             }
         }

--- a/crates/gvm-connection/src/tls.rs
+++ b/crates/gvm-connection/src/tls.rs
@@ -16,7 +16,7 @@ use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
 use tokio_rustls::TlsConnector;
 
-use crate::connection::GvmConnection;
+use crate::connection::{write_all_and_flush_with_timeout, GvmConnection};
 use crate::error::{ConnectionError, Result};
 
 const DEFAULT_GVM_PORT: u16 = 9390;
@@ -98,7 +98,7 @@ pub struct TlsConfig {
     pub port: u16,
     /// DNS name or IP address required in the server certificate SAN.
     pub server_name: String,
-    /// TCP connect, TLS handshake, and response-read timeout.
+    /// TCP connect, TLS handshake, request-write/flush, and response-read timeout.
     pub timeout: Duration,
     /// Read buffer size in bytes.
     pub read_buffer_size: usize,
@@ -186,7 +186,7 @@ impl TlsConfig {
         self
     }
 
-    /// Set the timeout.
+    /// Set the transport operation timeout.
     #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
@@ -339,11 +339,14 @@ impl GvmConnection for TlsConnection {
     }
 
     async fn send(&mut self, data: &[u8]) -> Result<()> {
-        let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
-        stream
-            .write_all(data)
-            .await
-            .map_err(ConnectionError::SendFailed)
+        let result = {
+            let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
+            write_all_and_flush_with_timeout(stream, data, self.config.timeout).await
+        };
+        if result.is_err() {
+            self.invalidate_connection();
+        }
+        result
     }
 
     async fn read(&mut self) -> Result<Vec<u8>> {
@@ -370,11 +373,21 @@ impl GvmConnection for TlsConnection {
         let mut buffer = vec![0_u8; self.config.read_buffer_size];
 
         loop {
-            let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
-            let read = tokio::time::timeout(self.config.timeout, stream.read(&mut buffer))
-                .await
-                .map_err(|_| ConnectionError::Timeout(self.config.timeout))?
-                .map_err(ConnectionError::ReadFailed)?;
+            let read_result = {
+                let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
+                tokio::time::timeout(self.config.timeout, stream.read(&mut buffer)).await
+            };
+            let read = match read_result {
+                Ok(Ok(read)) => read,
+                Ok(Err(error)) => {
+                    self.invalidate_connection();
+                    return Err(ConnectionError::ReadFailed(error));
+                }
+                Err(_) => {
+                    self.invalidate_connection();
+                    return Err(ConnectionError::Timeout(self.config.timeout));
+                }
+            };
 
             if read == 0 {
                 self.invalidate_connection();

--- a/crates/gvm-connection/src/unix.rs
+++ b/crates/gvm-connection/src/unix.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
-use crate::connection::GvmConnection;
+use crate::connection::{write_all_and_flush_with_timeout, GvmConnection};
 use crate::error::{ConnectionError, Result};
 
 /// Configuration for Unix socket connections.
@@ -17,7 +17,7 @@ use crate::error::{ConnectionError, Result};
 pub struct UnixSocketConfig {
     /// Path to the Unix socket.
     pub path: PathBuf,
-    /// Connection timeout.
+    /// Connect, request-write/flush, and response-read timeout.
     pub timeout: Duration,
     /// Read buffer size in bytes.
     pub read_buffer_size: usize,
@@ -46,7 +46,7 @@ impl UnixSocketConfig {
         }
     }
 
-    /// Set the timeout.
+    /// Set the transport operation timeout.
     #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
@@ -149,12 +149,14 @@ impl GvmConnection for UnixSocketConnection {
     }
 
     async fn send(&mut self, data: &[u8]) -> Result<()> {
-        let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
-        stream
-            .write_all(data)
-            .await
-            .map_err(ConnectionError::SendFailed)?;
-        Ok(())
+        let result = {
+            let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
+            write_all_and_flush_with_timeout(stream, data, self.config.timeout).await
+        };
+        if result.is_err() {
+            self.invalidate_connection();
+        }
+        result
     }
 
     async fn read(&mut self) -> Result<Vec<u8>> {
@@ -181,11 +183,21 @@ impl GvmConnection for UnixSocketConnection {
         let mut buf = vec![0_u8; self.config.read_buffer_size];
 
         loop {
-            let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
-            let n = tokio::time::timeout(self.config.timeout, stream.read(&mut buf))
-                .await
-                .map_err(|_| ConnectionError::Timeout(self.config.timeout))?
-                .map_err(ConnectionError::ReadFailed)?;
+            let read_result = {
+                let stream = self.stream.as_mut().ok_or(ConnectionError::NotConnected)?;
+                tokio::time::timeout(self.config.timeout, stream.read(&mut buf)).await
+            };
+            let n = match read_result {
+                Ok(Ok(n)) => n,
+                Ok(Err(error)) => {
+                    self.invalidate_connection();
+                    return Err(ConnectionError::ReadFailed(error));
+                }
+                Err(_) => {
+                    self.invalidate_connection();
+                    return Err(ConnectionError::Timeout(self.config.timeout));
+                }
+            };
 
             if n == 0 {
                 self.invalidate_connection();

--- a/crates/gvm-connection/tests/ssh_e2e.rs
+++ b/crates/gvm-connection/tests/ssh_e2e.rs
@@ -5,6 +5,7 @@
 #![cfg(all(feature = "ssh", feature = "unix-socket-tests"))]
 
 use std::io::ErrorKind;
+use std::time::Duration;
 
 use gvm_connection::{
     ConnectionError, GvmConnection, SshAuth, SshConfig, SshConnection, SshHostKeyPolicy,
@@ -140,6 +141,45 @@ async fn ssh_reconnect_flow() {
     );
 
     conn2.disconnect().await.expect("disconnect 2 failed");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn ssh_response_timeout_invalidates_connection() {
+    let server = start_mock().await;
+    let Some(server) = server else {
+        return;
+    };
+    let mut connection =
+        SshConnection::new(config_for(&server).with_timeout(Duration::from_millis(50)));
+    connection.connect().await.expect("connect");
+    connection.send(b"<incomplete").await.expect("send request");
+
+    assert!(matches!(
+        connection.read().await,
+        Err(ConnectionError::Timeout(_))
+    ));
+    assert!(!connection.is_connected());
+    assert!(matches!(
+        connection.send(b"<get_version/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+    assert!(matches!(
+        connection.read().await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    connection.connect().await.expect("reconnect");
+    connection
+        .send(b"<get_version/>")
+        .await
+        .expect("send fresh request");
+    assert_eq!(
+        Response::new(connection.read().await.expect("fresh response")).status_code(),
+        Some(200)
+    );
+    connection.disconnect().await.expect("disconnect");
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-connection/tests/tls_connection.rs
+++ b/crates/gvm-connection/tests/tls_connection.rs
@@ -253,10 +253,8 @@ async fn mutual_tls_requires_and_accepts_trusted_client_identity() {
         rejection,
         ConnectionError::SendFailed(_) | ConnectionError::ReadFailed(_)
     ));
-    assert!(matches!(
-        anonymous.disconnect().await,
-        Err(ConnectionError::DisconnectFailed(_))
-    ));
+    assert!(!anonymous.is_connected());
+    anonymous.disconnect().await.expect("already invalidated");
 
     let identity = TlsClientIdentity::from_pem(
         material.certificate_pem.into_bytes(),
@@ -468,6 +466,18 @@ async fn response_timeout_and_size_limit_are_reported() {
         timed_out.read().await,
         Err(ConnectionError::Timeout(_))
     ));
+    assert!(!timed_out.is_connected());
+    assert!(matches!(
+        timed_out.send(b"<get_version/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+    assert!(matches!(
+        timed_out.read().await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    timed_out.connect().await.expect("reconnect");
+    assert_eq!(get_version(&mut timed_out).await.status_code(), Some(200));
     timed_out.disconnect().await.expect("disconnect");
 
     let mut size_limited = TlsConnection::new(config_for(&server).with_max_response_bytes(Some(8)));
@@ -480,6 +490,7 @@ async fn response_timeout_and_size_limit_are_reported() {
         size_limited.read().await,
         Err(ConnectionError::ReadFailed(_))
     ));
+    assert!(!size_limited.is_connected());
     size_limited.disconnect().await.expect("disconnect");
 
     server.shutdown().await;

--- a/crates/gvm-connection/tests/unix_connection.rs
+++ b/crates/gvm-connection/tests/unix_connection.rs
@@ -4,8 +4,10 @@
 #![allow(clippy::print_stdout, clippy::unwrap_used, missing_docs)]
 #![cfg(feature = "unix-socket-tests")]
 
+use std::time::Duration;
+
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConfig, UnixSocketConnection};
-use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
+use gvm_mock_server::{Fault, FaultKind, GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response, XmlCommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixListener;
@@ -128,6 +130,90 @@ async fn reconnect_flow() {
 }
 
 #[tokio::test]
+async fn response_timeout_invalidates_connection() {
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .inject_fault(Fault::once(FaultKind::Delay(Duration::from_millis(250))))
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("mock server start failed: {error}"),
+    };
+    let config = UnixSocketConfig::new(server.socket_path().expect("socket path"))
+        .with_timeout(Duration::from_millis(50));
+    let mut connection = UnixSocketConnection::new(config);
+    connection.connect().await.expect("connect");
+    connection
+        .send(b"<get_version/>")
+        .await
+        .expect("send request");
+
+    assert!(matches!(
+        connection.read().await,
+        Err(ConnectionError::Timeout(_))
+    ));
+    assert!(!connection.is_connected());
+    assert!(matches!(
+        connection.send(b"<get_version/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+    assert!(matches!(
+        connection.read().await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn outbound_timeout_invalidates_connection_and_allows_clean_reconnect() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("outbound-timeout.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (first, _) = listener.accept().await.expect("first connection");
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        drop(first);
+
+        let (mut second, _) = listener.accept().await.expect("second connection");
+        let mut request = [0_u8; 64];
+        let _ = second.read(&mut request).await.expect("second request");
+        second
+            .write_all(b"<fresh_response/>")
+            .await
+            .expect("fresh response");
+    });
+
+    let config = UnixSocketConfig::new(&socket_path).with_timeout(Duration::from_millis(50));
+    let mut connection = UnixSocketConnection::new(config);
+    connection.connect().await.expect("first connect");
+
+    let request = vec![0_u8; 16 * 1024 * 1024];
+    assert!(matches!(
+        connection.send(&request).await,
+        Err(ConnectionError::Timeout(_))
+    ));
+    assert!(!connection.is_connected());
+    assert!(matches!(
+        connection.send(b"<request/>").await,
+        Err(ConnectionError::NotConnected)
+    ));
+
+    connection.connect().await.expect("second connect");
+    connection.send(b"<request/>").await.expect("second send");
+    assert_eq!(
+        connection.read().await.expect("fresh response"),
+        b"<fresh_response/>"
+    );
+
+    server.await.expect("server task");
+}
+
+#[tokio::test]
 async fn connect_not_connected_errors() {
     let mut conn = UnixSocketConnection::with_path("/nonexistent/socket.sock");
     assert!(!conn.is_connected());
@@ -223,6 +309,50 @@ async fn reconnect_discards_a_pending_response_tail() {
         b"<current_response/>"
     );
     connection.disconnect().await.expect("disconnect");
+
+    connection.connect().await.expect("second connect");
+    connection.send(b"<request/>").await.expect("second send");
+    assert_eq!(
+        connection.read().await.expect("fresh response"),
+        b"<fresh_response/>"
+    );
+
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn reconnect_after_partial_response_timeout_discards_parser_state() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let socket_path = directory.path().join("timeout-reconnect.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind socket");
+    let server = tokio::spawn(async move {
+        let (mut first, _) = listener.accept().await.expect("first connection");
+        let mut request = [0_u8; 64];
+        let _ = first.read(&mut request).await.expect("first request");
+        first
+            .write_all(b"<stale_response>")
+            .await
+            .expect("partial response");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        drop(first);
+
+        let (mut second, _) = listener.accept().await.expect("second connection");
+        let _ = second.read(&mut request).await.expect("second request");
+        second
+            .write_all(b"<fresh_response/>")
+            .await
+            .expect("fresh response");
+    });
+
+    let config = UnixSocketConfig::new(&socket_path).with_timeout(Duration::from_millis(200));
+    let mut connection = UnixSocketConnection::new(config);
+    connection.connect().await.expect("first connect");
+    connection.send(b"<request/>").await.expect("first send");
+    assert!(matches!(
+        connection.read().await,
+        Err(ConnectionError::Timeout(_))
+    ));
+    assert!(!connection.is_connected());
 
     connection.connect().await.expect("second connect");
     connection.send(b"<request/>").await.expect("second send");

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -237,7 +237,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | Field | Default | Notes |
 |-------|---------|-------|
 | `path` | `/run/gvmd/gvmd.sock` | Configurable |
-| `timeout` | 60s | Connect + read timeout |
+| `timeout` | 60s | Connect, request write/flush, and response-read timeout |
 | `read_buffer_size` | 64 KB | Per-read allocation |
 
 ### SshConfig
@@ -249,7 +249,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | `username` | `root` | SSH user |
 | `auth` | `Agent` | `Password`, `PrivateKey { key_path, passphrase }`, or `Agent` |
 | `remote_socket` | `/run/gvmd/gvmd.sock` | Path to gvmd socket on remote host |
-| `timeout` | 60s | Connect + read timeout |
+| `timeout` | 60s | Connect/auth/channel, request write/flush, and response-read timeout |
 | `read_buffer_size` | 64 KB | Per-read allocation |
 | `host_key_policy` | `KnownHosts` | Standard or custom `known_hosts`, pinned SHA-256 fingerprint, or explicit insecure opt-out |
 
@@ -263,7 +263,7 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | `use_native_roots` | `true` | Platform trust store; disabling does not disable verification |
 | custom roots | None | PEM roots can be supplied in memory or from a file |
 | client identity | None | Optional PEM certificate chain plus unencrypted private key for mTLS |
-| `timeout` | 60s | TCP connect, TLS handshake, and response-read timeout |
+| `timeout` | 60s | TCP connect, TLS handshake, request write/flush, and response-read timeout |
 | `max_response_bytes` | 64 MiB | Bounded XML response size |
 
 ### Error Types
@@ -286,8 +286,13 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 | Connect + get_version | ✅ |
 | Auth + create_target | ✅ |
 | Reconnect flow (python-gvm pattern) | ✅ |
+| Timeout invalidation and clean reconnect | ✅ |
 | Not-connected error paths | ✅ |
 | Double-connect error | ✅ |
+
+Once an active transport returns a send or read error, it is invalidated. Callers
+must reconnect before issuing another request; this prevents partial writes or
+late responses from being associated with a later GMP command.
 
 ## gvm-gmp
 


### PR DESCRIPTION
## Description

GMP transports have no request identifiers that could safely re-synchronize a connection after a partial write or late response. This change:

- applies one operation deadline to the complete request write and flush on Unix, TLS, and SSH transports
- invalidates the transport plus XML parser state after send failures, read failures, and timeouts
- requires a fresh connection before another command can be issued
- documents the expanded timeout and terminal-error contract
- adds real Unix, TLS, and SSH transport regressions, including outbound backpressure and clean reconnects after partial responses

## Type

- [x] fix: Bug fix
- [x] test: Adding/updating tests
- [x] docs: Documentation

## Checklist

- [x] Code compiles without warnings
- [x] All workspace tests pass with all features
- [x] Strict workspace Clippy and rustdoc pass
- [x] Code is formatted
- [x] Documentation updated
- [x] New tests added for the changed behavior
- [x] MSRV 1.85 check passes

## Testing

- cargo test --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
- cargo +1.85.0 check --workspace --all-features
- real Rust Unix, TLS, and SSH mock-server transport paths
- python-gvm Unix, TLS, and mutual-TLS integration flows
- cargo llvm-cov plus diff-cover: 100% changed-line coverage
- cargo audit, cargo deny, cargo machete, cargo vet, and workspace unsafe-usage gate
- Semgrep with p/rust, p/security-audit, and p/secrets using --disable-nosem --error
- staged/current-tree secret scans
- CycloneDX SBOM quality: every workspace SBOM passed the 8.3 threshold

No live gvmd instance was available for this validation. Fuzzing was not run; deterministic timeout, backpressure, partial-response, and reconnect regressions cover the changed behavior.