### PR TITLE
Remove unmaintained rustls-pemfile dependency

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,9 +7,4 @@ ignore = [
     # Transitive via russh → rsa. No direct exposure; SSH transport
     # doesn't use raw RSA PKCS#1. Tracked upstream.
     "RUSTSEC-2023-0071",
-
-    # rustls-pemfile: unmaintained
-    # Optional TLS dependency, not yet active. Will migrate when
-    # TLS transport is implemented.
-    "RUSTSEC-2025-0134",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,6 @@ dependencies = [
  "russh",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "sha2",
  "tempfile",
  "thiserror",
@@ -1005,7 +1004,6 @@ dependencies = [
  "rstest",
  "russh",
  "rustls",
- "rustls-pemfile",
  "sha2",
  "tempfile",
  "tokio",
@@ -1970,15 +1968,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ sha1 = "0.11"
 # TLS (feature-gated)
 tokio-rustls = "0.26"
 rustls = "0.23"
-rustls-pemfile = "2"
 rustls-native-certs = "0.8"
 x509-cert = { version = "0.3", features = ["builder"] }
 p256 = "=0.14.0-rc.10"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,6 @@ Accepted advisories are documented in [`deny.toml`](deny.toml) with rationale:
 | Advisory | Crate | Reason |
 |----------|-------|--------|
 | RUSTSEC-2023-0071 | `rsa` | Transitive via `russh`; Marvin attack requires RSA key exchange — mitigated by preferring Ed25519/ECDSA keys |
-| RUSTSEC-2025-0134 | `rustls-pemfile` | Unmaintained; will migrate when `rustls` ecosystem provides replacement |
 
 ### Supply Chain
 

--- a/crates/gvm-connection/Cargo.toml
+++ b/crates/gvm-connection/Cargo.toml
@@ -17,7 +17,6 @@ large-response-tests = ["unix-socket-tests"]
 tls = [
     "dep:tokio-rustls",
     "dep:rustls",
-    "dep:rustls-pemfile",
     "dep:rustls-native-certs",
     "gvm-mock-server/tls",
 ]
@@ -33,7 +32,6 @@ gvm-protocol.workspace = true
 # Feature-gated
 tokio-rustls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 russh = { workspace = true, optional = true }
 

--- a/crates/gvm-connection/src/tls.rs
+++ b/crates/gvm-connection/src/tls.rs
@@ -4,12 +4,12 @@
 //! Verified TLS transport for gvmd.
 
 use std::fmt;
-use std::io::Cursor;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rustls::pki_types::ServerName;
+use rustls::pki_types::pem::{Error as PemError, PemObject};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use rustls::{ClientConfig, RootCertStore};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -58,20 +58,9 @@ impl TlsClientIdentity {
         ))
     }
 
-    fn parse(
-        &self,
-    ) -> Result<(
-        Vec<rustls::pki_types::CertificateDer<'static>>,
-        rustls::pki_types::PrivateKeyDer<'static>,
-    )> {
+    fn parse(&self) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
         let certificates = parse_certificates(&self.certificate_chain_pem, "client certificate")?;
-        let private_key = rustls_pemfile::private_key(&mut Cursor::new(&self.private_key_pem))
-            .map_err(|error| invalid_configuration(format!("invalid client private key: {error}")))?
-            .ok_or_else(|| {
-                invalid_configuration(
-                    "client private key is missing, encrypted, or in an unsupported PEM format",
-                )
-            })?;
+        let private_key = parse_private_key(&self.private_key_pem)?;
         Ok((certificates, private_key))
     }
 }
@@ -414,19 +403,50 @@ fn protocol_read_error(error: &gvm_protocol::ProtocolError) -> ConnectionError {
     ))
 }
 
-fn parse_certificates(
-    pem: &[u8],
-    description: &str,
-) -> Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
-    let certificates = rustls_pemfile::certs(&mut Cursor::new(pem))
-        .collect::<std::io::Result<Vec<_>>>()
-        .map_err(|error| invalid_configuration(format!("invalid {description}: {error}")))?;
+fn parse_certificates(pem: &[u8], description: &str) -> Result<Vec<CertificateDer<'static>>> {
+    let certificates = CertificateDer::pem_slice_iter(pem)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| {
+            invalid_configuration(format!(
+                "invalid {description}: {}",
+                legacy_pem_error_message(error)
+            ))
+        })?;
     if certificates.is_empty() {
         return Err(invalid_configuration(format!(
             "{description} PEM contains no certificates"
         )));
     }
     Ok(certificates)
+}
+
+fn parse_private_key(pem: &[u8]) -> Result<PrivateKeyDer<'static>> {
+    PrivateKeyDer::from_pem_slice(pem).map_err(|error| match error {
+        PemError::NoItemsFound => invalid_configuration(
+            "client private key is missing, encrypted, or in an unsupported PEM format",
+        ),
+        error => invalid_configuration(format!(
+            "invalid client private key: {}",
+            legacy_pem_error_message(error)
+        )),
+    })
+}
+
+fn legacy_pem_error_message(error: PemError) -> String {
+    match error {
+        PemError::MissingSectionEnd { end_marker } => format!(
+            "section end {:?} missing",
+            String::from_utf8_lossy(&end_marker)
+        ),
+        PemError::IllegalSectionStart { line } => {
+            format!(
+                "illegal section start: {:?}",
+                String::from_utf8_lossy(&line)
+            )
+        }
+        PemError::Base64Decode(error) => error,
+        error => format!("{error:?}"),
+    }
 }
 
 fn invalid_configuration(message: impl Into<String>) -> ConnectionError {
@@ -447,6 +467,10 @@ fn log_native_root_load(error_count: usize, ignored: usize, added: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pem(label: &str, body: &str) -> Vec<u8> {
+        format!("-----BEGIN {label}-----\n{body}\n-----END {label}-----\n").into_bytes()
+    }
 
     #[test]
     fn default_config_is_verified_and_uses_gvmd_port() {
@@ -483,5 +507,95 @@ mod tests {
         TlsConfig::default()
             .client_config()
             .expect("platform trust store should contain usable roots");
+    }
+
+    #[test]
+    fn native_pem_parser_preserves_certificate_chain_order() {
+        let certificates = parse_certificates(
+            b"-----BEGIN CERTIFICATE-----\nAQ==\n-----END CERTIFICATE-----\n\
+              -----BEGIN CERTIFICATE-----\nAg==\n-----END CERTIFICATE-----\n",
+            "test certificate",
+        )
+        .expect("certificate chain");
+
+        assert_eq!(certificates.len(), 2);
+        assert_eq!(certificates[0].as_ref(), &[1]);
+        assert_eq!(certificates[1].as_ref(), &[2]);
+    }
+
+    #[test]
+    fn native_pem_parser_accepts_all_documented_private_key_labels() {
+        let pkcs1 = parse_private_key(&pem("RSA PRIVATE KEY", "AQ==")).expect("PKCS#1 key");
+        let pkcs8 = parse_private_key(&pem("PRIVATE KEY", "Ag==")).expect("PKCS#8 key");
+        let sec1 = parse_private_key(&pem("EC PRIVATE KEY", "Aw==")).expect("SEC1 key");
+
+        assert!(matches!(pkcs1, PrivateKeyDer::Pkcs1(_)));
+        assert!(matches!(pkcs8, PrivateKeyDer::Pkcs8(_)));
+        assert!(matches!(sec1, PrivateKeyDer::Sec1(_)));
+    }
+
+    #[test]
+    fn native_pem_parser_preserves_missing_or_unsupported_key_diagnostic() {
+        let error = parse_private_key(&pem("ENCRYPTED PRIVATE KEY", "AQ=="))
+            .expect_err("encrypted key must be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "invalid connection configuration: client private key is missing, encrypted, or in an unsupported PEM format"
+        );
+    }
+
+    #[test]
+    fn native_pem_parser_reports_malformed_certificate_and_key_data() {
+        let certificate_error = parse_certificates(
+            b"-----BEGIN CERTIFICATE-----\n%%%\n-----END CERTIFICATE-----\n",
+            "test certificate",
+        )
+        .expect_err("malformed certificate");
+        let key_error = parse_private_key(&pem("PRIVATE KEY", "%%%")).expect_err("malformed key");
+
+        assert_eq!(
+            certificate_error.to_string(),
+            "invalid connection configuration: invalid test certificate: InvalidCharacter(37)"
+        );
+        assert_eq!(
+            key_error.to_string(),
+            "invalid connection configuration: invalid client private key: InvalidCharacter(37)"
+        );
+    }
+
+    #[test]
+    fn native_pem_parser_preserves_missing_end_marker_diagnostic() {
+        let error = parse_certificates(b"-----BEGIN CERTIFICATE-----\nAQ==\n", "test certificate")
+            .expect_err("certificate without an end marker");
+
+        assert_eq!(
+            error.to_string(),
+            "invalid connection configuration: invalid test certificate: section end \"CERTIFICATE\" missing"
+        );
+    }
+
+    #[test]
+    fn legacy_pem_error_mapping_covers_all_native_error_classes() {
+        assert_eq!(
+            legacy_pem_error_message(PemError::MissingSectionEnd {
+                end_marker: b"CERTIFICATE".to_vec(),
+            }),
+            "section end \"CERTIFICATE\" missing"
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::IllegalSectionStart {
+                line: b"-----BEGIN".to_vec(),
+            }),
+            "illegal section start: \"-----BEGIN\""
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::Base64Decode("bad data".to_owned())),
+            "bad data"
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::SectionTooLarge),
+            "SectionTooLarge"
+        );
     }
 }

--- a/crates/gvm-mock-server/Cargo.toml
+++ b/crates/gvm-mock-server/Cargo.toml
@@ -19,7 +19,6 @@ unix-socket-tests = []
 tls = [
     "dep:tokio-rustls",
     "dep:rustls",
-    "dep:rustls-pemfile",
     "dep:x509-cert",
     "dep:p256",
     "dep:sha2",
@@ -40,7 +39,6 @@ clap.workspace = true
 # Feature-gated
 tokio-rustls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
 x509-cert = { workspace = true, optional = true }
 p256 = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }

--- a/crates/gvm-mock-server/src/tls_listener.rs
+++ b/crates/gvm-mock-server/src/tls_listener.rs
@@ -4,7 +4,6 @@
 //! TLS listener support for the mock GMP server.
 
 use std::future::Future;
-use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 use std::str::FromStr;
@@ -14,6 +13,7 @@ use std::time::Duration;
 use p256::ecdsa::{DerSignature, SigningKey};
 use p256::elliptic_curve::Generate;
 use p256::pkcs8::{EncodePrivateKey, EncodePublicKey};
+use rustls::pki_types::pem::{Error as PemError, PemObject};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::server::WebPkiClientVerifier;
 use rustls::{RootCertStore, ServerConfig};
@@ -159,8 +159,9 @@ async fn handle_tls_stream(
 }
 
 fn parse_certificates(pem: &[u8]) -> std::io::Result<Vec<CertificateDer<'static>>> {
-    let certificates =
-        rustls_pemfile::certs(&mut Cursor::new(pem)).collect::<std::io::Result<Vec<_>>>()?;
+    let certificates = CertificateDer::pem_slice_iter(pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| invalid_data(legacy_pem_error_message(error)))?;
     if certificates.is_empty() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -172,6 +173,27 @@ fn parse_certificates(pem: &[u8]) -> std::io::Result<Vec<CertificateDer<'static>
 
 fn invalid_input(error: impl std::fmt::Display) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+}
+
+fn invalid_data(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn legacy_pem_error_message(error: PemError) -> String {
+    match error {
+        PemError::MissingSectionEnd { end_marker } => format!(
+            "section end {:?} missing",
+            String::from_utf8_lossy(&end_marker)
+        ),
+        PemError::IllegalSectionStart { line } => {
+            format!(
+                "illegal section start: {:?}",
+                String::from_utf8_lossy(&line)
+            )
+        }
+        PemError::Base64Decode(error) => error,
+        error => format!("{error:?}"),
+    }
 }
 
 fn log_accept_error(error: &std::io::Error) {
@@ -225,6 +247,42 @@ mod tests {
         .await;
 
         drop(client);
+    }
+
+    #[test]
+    fn client_ca_parser_preserves_empty_and_malformed_error_kinds() {
+        let empty = parse_certificates(b"").expect_err("empty client CA");
+        let malformed =
+            parse_certificates(b"-----BEGIN CERTIFICATE-----\n%%%\n-----END CERTIFICATE-----\n")
+                .expect_err("malformed client CA");
+
+        assert_eq!(empty.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(malformed.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(malformed.to_string(), "InvalidCharacter(37)");
+    }
+
+    #[test]
+    fn legacy_pem_error_mapping_covers_all_native_error_classes() {
+        assert_eq!(
+            legacy_pem_error_message(PemError::MissingSectionEnd {
+                end_marker: b"CERTIFICATE".to_vec(),
+            }),
+            "section end \"CERTIFICATE\" missing"
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::IllegalSectionStart {
+                line: b"-----BEGIN".to_vec(),
+            }),
+            "illegal section start: \"-----BEGIN\""
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::Base64Decode("bad data".to_owned())),
+            "bad data"
+        );
+        assert_eq!(
+            legacy_pem_error_message(PemError::SectionTooLarge),
+            "SectionTooLarge"
+        );
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -5,8 +5,6 @@
 ignore = [
     # rsa crate Marvin Attack — transitive via russh; no fix available yet in russh dependency tree
     "RUSTSEC-2023-0071",
-    # rustls-pemfile unmaintained — workspace dep for TLS feature; will migrate when rustls ecosystem settles
-    "RUSTSEC-2025-0134",
 ]
 
 [licenses]

--- a/spec/openspec.md
+++ b/spec/openspec.md
@@ -640,7 +640,7 @@ Generated in release and nightly workflows using `cargo-cyclonedx`:
   - GitHub Actions: weekly, grouped
   - pip: monthly
 - **cargo-deny** (`deny.toml`): license allowlist, advisory database, v2 schema
-  - Ignored advisories: RUSTSEC-2023-0071 (rsa Marvin Attack, transitive via russh), RUSTSEC-2025-0134 (rustls-pemfile unmaintained)
+  - Ignored advisory: RUSTSEC-2023-0071 (rsa Marvin Attack, transitive via russh)
 
 ### Makefile
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -682,10 +682,6 @@ criteria = "safe-to-deploy"
 version = "0.8.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls-pemfile]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustls-pki-types]]
 version = "1.14.1"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

- replace `rustls-pemfile` with the PEM APIs already re-exported by `rustls::pki_types`
- preserve certificate-chain ordering, PKCS#1/PKCS#8/SEC1 key support, and existing malformed-PEM diagnostics
- remove the obsolete dependency, lock entry, advisory exceptions, cargo-vet exemption, and active security documentation entry

## Validation

- `cargo test --workspace --all-features`
- warnings-as-errors workspace Clippy and rustdoc
- Rust 1.85 workspace all-feature check
- real Unix, TLS, and mutual-TLS flows with python-gvm and gvm-mock-server
- `cargo audit`, `cargo deny check`, `cargo machete`, `cargo vet`, and zero-unsafe workspace gate
- Semgrep with `--disable-nosem --error`: 0 findings
- Gitleaks staged diff and exact staged tree: 0 findings
- changed-line coverage: 100% (123/123)
- SBOM quality: 8.46-8.69/10

## Validation gaps

- No live gvmd instance was available; transport behavior was exercised through the real Rust and python-gvm client paths against gvm-mock-server.
- Fuzzing was not run for this dependency substitution; deterministic parser regressions cover every legacy PEM error-mapping class.