### PR TITLE
docs(journal): 2026-07-26 update

### DIFF
--- a/journal/2026-07-26.md
+++ b/journal/2026-07-26.md
@@ -1,0 +1,10 @@
+# 2026-07-26 — Community E2E Exposed Two GMP Request Defects
+
+## Scan-Config Scoping
+- Issue [#404](https://github.com/clawosiris/rust-gvm/issues/404) opened after live differential coverage showed that `get_scan_configs` emits an unscoped `<get_configs/>` request instead of forcing `usage_type="scan"`.
+- Against Community gvmd 26.34.0, the wrapper returned policies and omitted scan configs from the default first page; the fix needs exact serialization and typed-client regression coverage.
+
+## Permission Serialization
+- Issue [#405](https://github.com/clawosiris/rust-gvm/issues/405) opened after a typed `create_permission` call failed against Community Edition with `400 Error in SUBJECT`.
+- The current request flattens subject and resource fields, while gvmd requires nested `<subject>` and `<resource>` elements for create and modify operations.
+- Both defects are actionable blockers discovered by the expanded standalone Community E2E work.


### PR DESCRIPTION
## Summary

- records two GMP request defects discovered by Community E2E coverage
- captures the required scan-config scoping and permission serialization fixes
