### PR TITLE
fix(gmp): accept nested empty elements in embedded XML

### DIFF
--- a/crates/gvm-gmp/src/common.rs
+++ b/crates/gvm-gmp/src/common.rs
@@ -105,7 +105,7 @@ pub(crate) fn validate_single_xml_document(
                     validate_root_name(event.name().as_ref(), field, expected_root)?;
                 }
                 saw_root = true;
-                completed_root = true;
+                completed_root = depth == 0;
             }
             Event::End(_) => {
                 if depth == 0 {
@@ -177,4 +177,40 @@ fn validate_root_name(
 #[cfg(test)]
 pub(crate) fn xml(request: impl gvm_protocol::Request) -> String {
     String::from_utf8(request.to_bytes()).expect("request XML should be valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_xml_document_allows_nested_empty_element_before_sibling() {
+        validate_single_xml_document(
+            "<report><summary/><results/></report>",
+            "report_xml",
+            Some("report"),
+        )
+        .expect("nested empty elements must not complete the root document");
+    }
+
+    #[test]
+    fn single_xml_document_allows_self_closing_root() {
+        validate_single_xml_document("<report/>", "report_xml", Some("report"))
+            .expect("a self-closing root is a complete document");
+    }
+
+    #[test]
+    fn single_xml_document_rejects_second_root_after_self_closing_root() {
+        let error =
+            validate_single_xml_document("<report/><report/>", "report_xml", Some("report"))
+                .expect_err("a second top-level root must be rejected");
+
+        match error {
+            ParseError::InvalidValue { field, value } => {
+                assert_eq!(field, "report_xml");
+                assert_eq!(value, "multiple root elements");
+            }
+            error => panic!("expected invalid-value error, got {error:?}"),
+        }
+    }
 }

--- a/crates/gvm-gmp/tests/test_report_formats.rs
+++ b/crates/gvm-gmp/tests/test_report_formats.rs
@@ -33,6 +33,16 @@ fn test_create_report_format_with_optionals() {
 }
 
 #[test]
+fn test_import_report_format_with_nested_empty_element_before_sibling() {
+    let report_format_xml = r#"<get_report_formats_response status="200" status_text="OK"><report_format id="rf-1"><name>HTML</name><comment/><content_type>text/html</content_type></report_format></get_report_formats_response>"#;
+
+    assert_eq!(
+        xml(import_report_format(report_format_xml).expect("valid report format XML")),
+        r#"<create_report_format><get_report_formats_response status="200" status_text="OK"><report_format id="rf-1"><name>HTML</name><comment/><content_type>text/html</content_type></report_format></get_report_formats_response></create_report_format>"#
+    );
+}
+
+#[test]
 fn test_report_format_get_delete_verify() {
     assert_eq!(
         xml(get_report_format(&id("rf1"))),


### PR DESCRIPTION
## Summary

- complete embedded XML documents only when an empty element is the top-level root
- preserve valid nested self-closing elements followed by sibling elements
- add direct validator and public `import_report_format` regression coverage

## Validation

- `cargo fmt --all --check`
- `cargo test -p gvm-gmp --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

The full all-feature workspace suite compiled successfully, but this sandbox prohibits loopback listener creation, so SSH/TLS integration tests stopped at `TcpListener::bind` with `Operation not permitted` before product assertions. The affected `gvm-gmp` all-feature suite passed completely.

Closes #407

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
