### PR TITLE
fix(gmp): scope scan config getters

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -2175,7 +2175,7 @@ async fn typed_scan_config_nvt_helpers_use_stateful_mock_server_filters() {
 }
 
 #[tokio::test]
-async fn typed_policy_getters_filter_stateful_mock_resources() {
+async fn typed_config_getters_filter_stateful_mock_resources() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -2189,7 +2189,7 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
         .await
         .expect("authenticate should succeed");
 
-    client
+    let scan_config = client
         .create_scan_config(
             "Scan Config One",
             None,
@@ -2215,6 +2215,23 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
 
     server.clear_history();
 
+    let scan_configs = client
+        .get_scan_configs(GetScanConfigsOpts::default())
+        .await
+        .expect("scan configs should be fetched");
+    assert!(scan_configs
+        .items
+        .iter()
+        .all(|item| item.usage_type.as_deref() == Some("scan")));
+    assert!(scan_configs
+        .items
+        .iter()
+        .any(|item| item.meta.id == scan_config.id));
+    assert!(!scan_configs
+        .items
+        .iter()
+        .any(|item| item.meta.id == policy.id));
+
     let policies = client
         .get_policies(GetScanConfigsOpts::default())
         .await
@@ -2237,7 +2254,7 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
     assert_eq!(fetched.items[0].usage_type.as_deref(), Some("policy"));
 
     let history = server.command_history();
-    assert_eq!(history.len(), 2);
+    assert_eq!(history.len(), 3);
     assert!(history
         .iter()
         .all(|record| record.command_name() == "get_configs"));
@@ -2245,9 +2262,10 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
         .iter()
         .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
         .collect::<Vec<_>>();
-    assert_eq!(commands[0], "<get_configs usage_type=\"policy\"/>");
+    assert_eq!(commands[0], "<get_configs usage_type=\"scan\"/>");
+    assert_eq!(commands[1], "<get_configs usage_type=\"policy\"/>");
     assert_eq!(
-        commands[1],
+        commands[2],
         format!(
             "<get_configs config_id=\"{}\" details=\"1\" tasks=\"1\" usage_type=\"policy\"/>",
             policy.id.as_str()

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -111,6 +111,7 @@ pub fn get_scan_configs(opts: GetScanConfigsOpts) -> impl Request {
         filter_id: opts.filter_id,
         trash: opts.trash,
         details: opts.details,
+        usage_type: Some(ConfigUsageType::from(UsageType::Scan)),
         ..Default::default()
     })
 }
@@ -118,7 +119,13 @@ pub fn get_scan_configs(opts: GetScanConfigsOpts) -> impl Request {
 /// Build a `get_scan_config` request.
 #[must_use]
 pub fn get_scan_config(config_id: &EntityId) -> impl Request {
-    get_config(config_id, GetConfigOpts::default())
+    get_config(
+        config_id,
+        GetConfigOpts {
+            usage_type: Some(ConfigUsageType::from(UsageType::Scan)),
+            ..Default::default()
+        },
+    )
 }
 
 /// Build a `get_preferences` request for scan-config preferences.
@@ -692,11 +699,22 @@ mod tests {
 
     #[test]
     fn scan_config_get_modify_delete_sync_build_xml() {
+        assert_eq!(
+            xml(get_scan_configs(GetScanConfigsOpts::default())),
+            "<get_configs usage_type=\"scan\"/>"
+        );
         let rendered = xml(get_scan_configs(GetScanConfigsOpts {
             filter_string: Some("name=foo".into()),
             ..Default::default()
         }));
-        assert!(rendered.contains("filter=\"name=foo\""));
+        assert_eq!(
+            rendered,
+            "<get_configs filter=\"name=foo\" usage_type=\"scan\"/>"
+        );
+        assert_eq!(
+            xml(get_scan_config(&id("c1"))),
+            "<get_configs config_id=\"c1\" details=\"1\" usage_type=\"scan\"/>"
+        );
         let rendered = xml(modify_scan_config(
             &id("c1"),
             ConfigOpts {

--- a/crates/gvm-gmp/tests/test_configs.rs
+++ b/crates/gvm-gmp/tests/test_configs.rs
@@ -146,20 +146,21 @@ fn test_scan_configs_wrappers_match_generic_xml() {
         }))
     );
     assert_eq!(
+        xml(get_scan_configs(GetScanConfigsOpts::default())),
+        "<get_configs usage_type=\"scan\"/>"
+    );
+    assert_eq!(
         xml(get_scan_configs(GetScanConfigsOpts {
             filter_string: Some("name=foo".into()),
+            filter_id: Some(id("f1")),
+            trash: Some(false),
             details: Some(true),
-            ..Default::default()
         })),
-        xml(get_configs(GetConfigsOpts {
-            filter_string: Some("name=foo".into()),
-            details: Some(true),
-            ..Default::default()
-        }))
+        "<get_configs details=\"1\" filt_id=\"f1\" filter=\"name=foo\" trash=\"0\" usage_type=\"scan\"/>"
     );
     assert_eq!(
         xml(get_scan_config(&id("c1"))),
-        xml(get_config(&id("c1"), GetConfigOpts::default()))
+        "<get_configs config_id=\"c1\" details=\"1\" usage_type=\"scan\"/>"
     );
     assert_eq!(
         xml(modify_scan_config(

--- a/crates/gvm-gmp/tests/test_scan_configs.rs
+++ b/crates/gvm-gmp/tests/test_scan_configs.rs
@@ -175,7 +175,7 @@ fn test_scan_config_get_delete_sync() {
     );
     assert_eq!(
         xml(get_scan_config(&id("c1"))),
-        "<get_configs config_id=\"c1\" details=\"1\"/>"
+        "<get_configs config_id=\"c1\" details=\"1\" usage_type=\"scan\"/>"
     );
     assert_eq!(
         xml(sync_config(&id("c1"))),


### PR DESCRIPTION
## Description

Scope the ergonomic scan-config getters to `usage_type="scan"` so they cannot
mix policy resources into scan-config results. The singular wrapper now carries
the same invariant, matching current python-gvm behavior.

The generic config getters remain unchanged, and the plural wrapper continues
to preserve its filter, filter-ID, trash, and details options.

Closes #404

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [ ] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo +1.85.0 check --workspace --all-features`)
- [x] All tests pass (`cargo test --workspace` and `cargo test --workspace --all-features`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all -- --check`)
- [x] Documentation updated (not applicable; no public API shape changed)
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable; this restores existing typed-wrapper semantics)
- [x] Journal entry updated (not applicable; no release-visible API addition)

## Testing

- Exact XML regressions cover default, filtered, and singular scan-config
  getters.
- The Unix-socket client integration test uses the stateful
  `gvm-mock-server`, creates both a scan config and a policy, and verifies that
  the typed scan-config getter returns the scan config, excludes the policy,
  and sends `<get_configs usage_type="scan"/>` over the transport.
- Full Rust workspace tests, all-features tests, MSRV checks/tests, strict
  Clippy, strict rustdoc, and the repository integration suite pass.
- `cargo llvm-cov` plus `diff-cover --compare-branch upstream/devel
  --fail-under=100` reports 100% coverage of changed executable lines.
- Local security/provenance gates pass: `cargo deny`, `cargo audit`,
  `cargo machete`, `cargo vet`, workspace unsafe-use gate, suppression-disabled
  Semgrep, staged Gitleaks, and SBOM quality (8.46-8.69, threshold 8.3).

The live-gvmd reproduction was not rerun locally; issue #404 contains the
current gvmd 26.34/GMP 22.7 end-to-end evidence. No fuzz campaign was run:
this patch changes request scoping and deterministic regressions rather than a
parser, framing boundary, or fuzz-facing input surface.
