### PR TITLE
fix(gmp): nest permission references

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -34,9 +34,11 @@ use gvm_gmp::commands::nvts::{
     get_nvt_preference, get_nvt_preferences, GetNvtPreferencesOpts, GetNvtsOpts,
 };
 use gvm_gmp::commands::operating_systems::{get_operating_systems, GetOperatingSystemsOpts};
+use gvm_gmp::commands::permissions::{modify_permission, GetPermissionsOpts, PermissionOpts};
 use gvm_gmp::commands::reports::{
     get_report_export, get_report_hosts, get_report_vulnerabilities, get_reports, GetReportsOpts,
 };
+use gvm_gmp::commands::roles::RoleOpts;
 use gvm_gmp::commands::scan_configs::{
     create_policy, get_policies, get_scan_config_preference, get_scan_config_preferences,
     ConfigOpts, GetPolicyOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
@@ -49,11 +51,12 @@ use gvm_gmp::commands::targets::{
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
 use gvm_gmp::responses::{
-    Asset, ConfigUsageKind, CreateScanConfigResponse, GetConfigsResponse, GetScanConfigsResponse,
+    Asset, ConfigUsageKind, CreateScanConfigResponse, GetConfigsResponse, GetPermissionsResponse,
+    GetScanConfigsResponse, Permission,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
-use gvm_gmp::{FeedType, SortOrder};
+use gvm_gmp::{FeedType, PermissionSubjectType, SortOrder};
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
 };
@@ -130,6 +133,17 @@ fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
 
 fn event_text(event: &WireTraceEvent) -> String {
     String::from_utf8(event.bytes.clone()).expect("trace event should be UTF-8")
+}
+
+fn permission_by_id<'a>(
+    permissions: &'a GetPermissionsResponse,
+    permission_id: &EntityId,
+) -> &'a Permission {
+    permissions
+        .items
+        .iter()
+        .find(|item| item.meta.id == *permission_id)
+        .expect("permission should be listed")
 }
 
 #[tokio::test]
@@ -2253,6 +2267,112 @@ async fn typed_policy_getters_filter_stateful_mock_resources() {
             policy.id.as_str()
         )
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_permission_lifecycle_uses_nested_references() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let role = client
+        .create_role("Permission Role", RoleOpts::default())
+        .await
+        .expect("role should be created");
+    let target = client
+        .create_target(
+            "Permission Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created");
+    server.clear_history();
+    let permission = client
+        .create_permission(PermissionOpts {
+            comment: Some("permission comment".into()),
+            name: Some("get_targets".into()),
+            resource_id: Some(target.id.clone()),
+            resource_type: Some("target".into()),
+            subject_type: Some(PermissionSubjectType::Role),
+            subject_id: Some(role.id.clone()),
+        })
+        .await
+        .expect("permission should be created");
+
+    let permissions = client
+        .get_permissions(GetPermissionsOpts::default())
+        .await
+        .expect("permission should be retrieved");
+    let fetched = permission_by_id(&permissions, &permission.id);
+    assert_eq!(fetched.meta.name, "get_targets");
+    assert_eq!(fetched.subject_type.as_deref(), Some("role"));
+    assert_eq!(fetched.subject.as_ref().expect("subject").id, role.id);
+    assert_eq!(fetched.resource_type.as_deref(), Some("target"));
+    assert_eq!(fetched.resource.as_ref().expect("resource").id, target.id);
+
+    client
+        .call(modify_permission(
+            &permission.id,
+            PermissionOpts {
+                comment: Some("updated".into()),
+                resource_id: Some(target.id.clone()),
+                resource_type: Some("target".into()),
+                subject_type: Some(PermissionSubjectType::Role),
+                subject_id: Some(role.id.clone()),
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("permission should be modified");
+
+    let permissions = client
+        .get_permissions(GetPermissionsOpts::default())
+        .await
+        .expect("modified permission should be retrieved");
+    let fetched = permission_by_id(&permissions, &permission.id);
+    assert_eq!(fetched.meta.comment.as_deref(), Some("updated"));
+    assert_eq!(fetched.subject_type.as_deref(), Some("role"));
+    assert_eq!(fetched.resource_type.as_deref(), Some("target"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 4);
+    let commands = history
+        .iter()
+        .map(|record| String::from_utf8(record.raw_xml().to_vec()).expect("xml is utf-8"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands[0],
+        format!(
+            "<create_permission><comment>permission comment</comment><name>get_targets</name><resource id=\"{}\"><type>target</type></resource><subject id=\"{}\"><type>role</type></subject></create_permission>",
+            target.id.as_str(),
+            role.id.as_str(),
+        )
+    );
+    assert_eq!(commands[1], "<get_permissions/>");
+    assert_eq!(
+        commands[2],
+        format!(
+            "<modify_permission permission_id=\"{}\"><comment>updated</comment><resource id=\"{}\"><type>target</type></resource><subject id=\"{}\"><type>role</type></subject></modify_permission>",
+            permission.id.as_str(),
+            target.id.as_str(),
+            role.id.as_str(),
+        )
+    );
+    assert_eq!(commands[3], "<get_permissions/>");
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/permissions.rs
+++ b/crates/gvm-gmp/src/commands/permissions.rs
@@ -14,15 +14,15 @@ use crate::types::EntityId;
 pub struct PermissionOpts {
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Optional resource name.
+    /// Optional permission name.
     pub name: Option<String>,
-    /// Optional related resource identifier.
+    /// Optional resource identifier; pair with `resource_type` for a valid request.
     pub resource_id: Option<EntityId>,
-    /// Optional related resource type.
+    /// Optional resource type; pair with `resource_id` for a valid request.
     pub resource_type: Option<String>,
-    /// Optional permission subject type.
+    /// Optional permission subject type; pair with `subject_id` for a valid request.
     pub subject_type: Option<PermissionSubjectType>,
-    /// Optional permission subject identifier.
+    /// Optional permission subject identifier; pair with `subject_type` for a valid request.
     pub subject_id: Option<EntityId>,
 }
 
@@ -95,15 +95,36 @@ pub fn delete_permission(permission_id: &EntityId, ultimate: bool) -> impl Reque
 fn add_permission_body(cmd: &mut XmlCommand, opts: &PermissionOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     add_text_element(cmd, "name", opts.name.as_deref());
-    add_text_element(cmd, "resource_type", opts.resource_type.as_deref());
-    if let Some(resource_id) = opts.resource_id.as_ref() {
-        cmd.add_element_with_text("resource_id", resource_id.as_str());
+    add_permission_reference(
+        cmd,
+        "resource",
+        opts.resource_id.as_ref(),
+        opts.resource_type.as_deref(),
+    );
+    add_permission_reference(
+        cmd,
+        "subject",
+        opts.subject_id.as_ref(),
+        opts.subject_type.map(PermissionSubjectType::as_gmp_str),
+    );
+}
+
+fn add_permission_reference(
+    cmd: &mut XmlCommand,
+    element_name: &str,
+    id: Option<&EntityId>,
+    reference_type: Option<&str>,
+) {
+    if id.is_none() && reference_type.is_none() {
+        return;
     }
-    if let Some(subject_type) = opts.subject_type {
-        cmd.add_element_with_text("subject_type", subject_type.as_gmp_str());
+
+    let reference = cmd.add_element(element_name);
+    if let Some(id) = id {
+        reference.set_attribute("id", id.as_str());
     }
-    if let Some(subject_id) = opts.subject_id.as_ref() {
-        cmd.add_element_with_text("subject_id", subject_id.as_str());
+    if let Some(reference_type) = reference_type {
+        reference.add_child_with_text("type", reference_type);
     }
 }
 
@@ -124,7 +145,10 @@ mod tests {
             subject_id: Some(id("r1")),
             ..Default::default()
         }));
-        assert!(rendered.contains("<subject_type>role</subject_type>"));
+        assert_eq!(
+            rendered,
+            "<create_permission><name>get_tasks</name><subject id=\"r1\"><type>role</type></subject></create_permission>"
+        );
         assert_eq!(
             xml(clone_permission(&id("p1"))),
             "<create_permission><copy>p1</copy></create_permission>"

--- a/crates/gvm-gmp/tests/test_permissions.rs
+++ b/crates/gvm-gmp/tests/test_permissions.rs
@@ -18,7 +18,33 @@ fn test_create_permission_basic() {
 }
 
 #[test]
-fn test_create_permission_with_optionals() {
+fn test_create_permission_with_nested_subject() {
+    assert_eq!(
+        xml(create_permission(PermissionOpts {
+            name: Some("get_tasks".into()),
+            subject_type: Some(PermissionSubjectType::Role),
+            subject_id: Some(id("s1")),
+            ..Default::default()
+        })),
+        "<create_permission><name>get_tasks</name><subject id=\"s1\"><type>role</type></subject></create_permission>"
+    );
+}
+
+#[test]
+fn test_create_permission_with_nested_resource() {
+    assert_eq!(
+        xml(create_permission(PermissionOpts {
+            name: Some("get_tasks".into()),
+            resource_id: Some(id("r1")),
+            resource_type: Some("task".into()),
+            ..Default::default()
+        })),
+        "<create_permission><name>get_tasks</name><resource id=\"r1\"><type>task</type></resource></create_permission>"
+    );
+}
+
+#[test]
+fn test_create_permission_with_nested_subject_and_resource() {
     assert_eq!(
         xml(create_permission(PermissionOpts {
             comment: Some("c".into()),
@@ -28,7 +54,36 @@ fn test_create_permission_with_optionals() {
             subject_type: Some(PermissionSubjectType::Role),
             subject_id: Some(id("s1")),
         })),
-        "<create_permission><comment>c</comment><name>get_tasks</name><resource_type>task</resource_type><resource_id>r1</resource_id><subject_type>role</subject_type><subject_id>s1</subject_id></create_permission>"
+        "<create_permission><comment>c</comment><name>get_tasks</name><resource id=\"r1\"><type>task</type></resource><subject id=\"s1\"><type>role</type></subject></create_permission>"
+    );
+}
+
+#[test]
+fn test_modify_permission_with_nested_subject_and_resource() {
+    assert_eq!(
+        xml(modify_permission(
+            &id("p1"),
+            PermissionOpts {
+                resource_id: Some(id("r1")),
+                resource_type: Some("task".into()),
+                subject_type: Some(PermissionSubjectType::Role),
+                subject_id: Some(id("s1")),
+                ..Default::default()
+            }
+        )),
+        "<modify_permission permission_id=\"p1\"><resource id=\"r1\"><type>task</type></resource><subject id=\"s1\"><type>role</type></subject></modify_permission>"
+    );
+}
+
+#[test]
+fn test_permission_partial_references_remain_nested() {
+    assert_eq!(
+        xml(create_permission(PermissionOpts {
+            resource_id: Some(id("r1")),
+            subject_type: Some(PermissionSubjectType::Role),
+            ..Default::default()
+        })),
+        "<create_permission><resource id=\"r1\"/><subject><type>role</type></subject></create_permission>"
     );
 }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -2685,10 +2685,15 @@ fn set_permission_references(resource: &mut Resource, cmd: &ParsedCommand) {
         ("subject", "subject_id", "subject_type"),
         ("resource", "resource_id", "resource_type"),
     ] {
-        if let Some(id) = cmd.child_attr(element, "id") {
+        if let Some(id) = cmd
+            .child_attr(element, "id")
+            .filter(|value| !value.is_empty())
+        {
             resource.set_attr(id_key, id);
         }
-        if let Some(reference_type) = nested_child_text(cmd, &[element, "type"]) {
+        if let Some(reference_type) =
+            nested_child_text(cmd, &[element, "type"]).filter(|value| !value.is_empty())
+        {
             resource.set_attr(type_key, &reference_type);
         }
     }
@@ -2708,6 +2713,29 @@ fn singularize_resource_type(plural: &str) -> &str {
 mod tests {
     use super::*;
     use crate::command_parser::parse_command;
+
+    #[test]
+    fn permission_references_ignore_empty_ids_and_types() {
+        let command = parse_command(
+            br#"<create_permission>
+                <subject id=""><type>role</type></subject>
+                <resource id="target-1"><type/></resource>
+            </create_permission>"#,
+        )
+        .expect("parse permission command");
+        let mut permission = Resource::new("permission", "get_targets");
+
+        set_permission_references(&mut permission, &command);
+
+        assert_eq!(permission.attr("subject_id"), None);
+        assert_eq!(permission.attr("subject_type"), Some("role"));
+        assert_eq!(permission.attr("resource_id"), Some("target-1"));
+        assert_eq!(permission.attr("resource_type"), None);
+        let xml = permission.to_xml();
+        assert!(!xml.contains("<subject"));
+        assert!(xml.contains(r#"<resource id="target-1"><name></name></resource>"#));
+        assert!(!xml.contains("<type>"));
+    }
 
     #[test]
     fn optional_child_uuid_reports_specific_missing_and_invalid_ids() {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -695,6 +695,9 @@ impl SessionHandler {
                 resource.set_attr("host_identifier", &host_identifier);
             }
         }
+        if resource_type == "permission" {
+            set_permission_references(&mut resource, cmd);
+        }
 
         // Task-specific: extract references
         if resource_type == "task" {
@@ -1168,6 +1171,9 @@ impl SessionHandler {
                 if let Some(ref host_identifier) = new_host_identifier {
                     r.set_attr("host_identifier", host_identifier);
                 }
+            }
+            if resource_type == "permission" {
+                set_permission_references(r, cmd);
             }
             if let Some(ref service_url) = new_service_url {
                 r.set_attr("service_url", service_url);
@@ -2672,6 +2678,20 @@ fn nested_child_text(cmd: &ParsedCommand, path: &[&str]) -> Option<String> {
         element = element.children.iter().find(|child| child.name == **name)?;
     }
     Some(element.text.clone().unwrap_or_default())
+}
+
+fn set_permission_references(resource: &mut Resource, cmd: &ParsedCommand) {
+    for (element, id_key, type_key) in [
+        ("subject", "subject_id", "subject_type"),
+        ("resource", "resource_id", "resource_type"),
+    ] {
+        if let Some(id) = cmd.child_attr(element, "id") {
+            resource.set_attr(id_key, id);
+        }
+        if let Some(reference_type) = nested_child_text(cmd, &[element, "type"]) {
+            resource.set_attr(type_key, &reference_type);
+        }
+    }
 }
 
 fn singularize_resource_type(plural: &str) -> &str {

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -317,12 +317,17 @@ impl Resource {
                 ("subject", "subject_id", "subject_type"),
                 ("resource", "resource_id", "resource_type"),
             ] {
-                if let Some(id) = self.attr(id_key) {
+                if let Some(id) = self.attr(id_key).filter(|value| !value.is_empty()) {
                     xml.push_str(&format!(
-                        "<{element} id=\"{}\"><name></name><type>{}</type></{element}>",
+                        "<{element} id=\"{}\"><name></name>",
                         xml_escape_attr(id),
-                        xml_escape(self.attr(type_key).unwrap_or_default()),
                     ));
+                    if let Some(reference_type) =
+                        self.attr(type_key).filter(|value| !value.is_empty())
+                    {
+                        xml.push_str(&format!("<type>{}</type>", xml_escape(reference_type)));
+                    }
+                    xml.push_str(&format!("</{element}>"));
                 }
             }
         }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -312,8 +312,30 @@ impl Resource {
             ct = self.creation_time,
             mt = self.modification_time,
         );
+        if self.resource_type == "permission" {
+            for (element, id_key, type_key) in [
+                ("subject", "subject_id", "subject_type"),
+                ("resource", "resource_id", "resource_type"),
+            ] {
+                if let Some(id) = self.attr(id_key) {
+                    xml.push_str(&format!(
+                        "<{element} id=\"{}\"><name></name><type>{}</type></{element}>",
+                        xml_escape_attr(id),
+                        xml_escape(self.attr(type_key).unwrap_or_default()),
+                    ));
+                }
+            }
+        }
         // Add type-specific attributes
         for (k, v) in &self.attrs {
+            if self.resource_type == "permission"
+                && matches!(
+                    k.as_str(),
+                    "subject_id" | "subject_type" | "resource_id" | "resource_type"
+                )
+            {
+                continue;
+            }
             if self.resource_type == "nvt"
                 && matches!(
                     k.as_str(),


### PR DESCRIPTION
## Description

Serialize permission subjects and resources using gvmd's nested reference
shape for both create and modify requests:

```xml
<subject id="..."><type>role</type></subject>
<resource id="..."><type>target</type></resource>
```

`PermissionOpts` remains source-compatible. Its existing optional fields are
retained, and half-specified legacy combinations remain representable in the
nested form rather than being silently discarded.

The stateful mock now preserves and renders nested permission references, which
allows a real typed client/Unix transport regression to cover create, retrieve,
modify, and retrieve behavior.

Closes #405

## Type

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] test: Adding/updating tests
- [ ] docs: Documentation
- [ ] ci: CI/CD changes
- [ ] chore: Maintenance

## Checklist

- [x] Code compiles without warnings (`cargo +1.85.0 check --workspace --all-features`)
- [x] All tests pass (`cargo test --workspace` and `cargo test --workspace --all-features`)
- [x] Clippy passes (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all -- --check`)
- [x] Documentation updated (public field documentation now describes the required ID/type pairing)
- [x] New tests added for new functionality
- [x] OpenSpec updated (not applicable; this restores current gvmd wire semantics)
- [x] Journal entry updated (not applicable; no new public API)

## Testing

- Exact XML regressions cover subject-only, resource-only, combined create,
  combined modify, and half-specified compatibility shapes.
- A typed `GmpClient` test uses the stateful `gvm-mock-server` over a real Unix
  transport to create a role and target, create and retrieve their permission,
  modify it, retrieve it again, and assert the exact create/modify wire XML.
- Full Rust workspace/all-feature tests, MSRV checks/tests, strict
  Clippy/rustdoc, and the public python-gvm Unix/TLS/mTLS integration suite
  pass.
- `cargo llvm-cov` plus `diff-cover --compare-branch upstream/devel
  --fail-under=100` reports 62/62 changed executable lines covered.
- Local security/provenance gates pass: `cargo deny`, `cargo audit`,
  `cargo machete`, `cargo vet`, the workspace unsafe-use gate,
  suppression-disabled Semgrep, staged Gitleaks, and SBOM quality
  (8.46-8.69, threshold 8.3).

The live gvmd reproduction was not rerun locally; issue #405 contains the
current gvmd 26.34/GMP 22.7 end-to-end failure. No fuzz campaign was run:
this patch changes deterministic request construction and stateful mock
fidelity rather than an XML parser, transport framing boundary, or other
fuzz-facing input surface.
