### PR TITLE
chore(vet): temporarily exempt wnaf 0.14.0

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1064,6 +1064,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wnaf]]
 version = "0.14.0"
+criteria = "safe-to-deploy"
 
 [[exemptions.x509-cert]]
 version = "0.3.0"


### PR DESCRIPTION
## Summary

- add the missing `safe-to-deploy` criterion to the existing `wnaf 0.14.0` Cargo Vet exemption;
- treat it as a temporary, call-graph-scoped risk acceptance rather than a crate-wide audit certification;
- track upstream fixes, dependency replacement, and exemption removal in #417.

## Rationale

The dual-model review confirmed correctness defects in public `wnaf` APIs. The current `rust-gvm`/`russh` path does not exercise those paths: it uses fresh `primeorder` values, fixed `U5`, canonical big-endian NIST encodings, and no raw-byte API.

This PR unblocks the inherited Security failure while #417 preserves the findings and explicit removal criteria. It intentionally changes `config.toml` rather than adding an audit to `audits.toml`.

## Validation

- `cargo vet` — passed: 22 fully audited, 3 partially audited, 267 exempted
- `git diff --check` — passed
- commit rebased onto current `origin/devel`
- commit SSH signature verified for `clawosiris@gmail.com`

Refs #417

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
