### PR TITLE
docs(journal): 2026-07-29 update

### DIFF
--- a/journal/2026-07-29.md
+++ b/journal/2026-07-29.md
@@ -1,0 +1,9 @@
+# 2026-07-29 — Security Risk Was Bounded While GMP Fixes Recovered
+
+## Temporary Supply-Chain Risk Acceptance
+- PR [#418](https://github.com/greenbone-hive/rust-gvm/pull/418) merged a narrowly scoped `wnaf 0.14.0` Cargo Vet exemption into `devel`, restoring the security gate after review found correctness defects in public `wnaf` APIs but no reachable exposure through the current `rust-gvm`/`russh` call graph.
+- Issue [#417](https://github.com/greenbone-hive/rust-gvm/issues/417) now tracks upstream reporting and fixes, regression coverage, dependency replacement, and removal of the temporary exemption; the risk acceptance must be revisited if the bounded call-graph assumptions change.
+
+## GMP Pull Requests Reconciled
+- PR [#413](https://github.com/greenbone-hive/rust-gvm/pull/413) was replayed onto the rewritten protected `devel` history, reducing a stale 174-file conflict to its intended five-file permission-nesting patch; the full protected matrix is green and the mergeable PR awaits independent review.
+- PR [#412](https://github.com/greenbone-hive/rust-gvm/pull/412) was likewise reconciled with current `devel`; it remains mergeable and review-required while its refreshed security matrix completes.


### PR DESCRIPTION
Documents the temporary wnaf risk acceptance and tracker, plus reconciliation of the two active GMP fixes with the rewritten devel history.