### PR TITLE
fix(gmp): emit parameterless sync_config

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -599,16 +599,31 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
-    /// Send a `sync_config` request and return a typed [`SyncConfigResponse`].
+    /// Send the global `sync_config` request and return a typed
+    /// [`SyncConfigResponse`].
     ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
+    pub async fn sync_config(&mut self) -> Result<SyncConfigResponse, GvmError> {
+        let response = self.send(sync_config()).await?;
+        SyncConfigResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send the global `sync_config` request and return a typed
+    /// [`SyncConfigResponse`].
+    ///
+    /// The GMP command synchronizes all configs and does not accept a config
+    /// identifier. The argument is retained temporarily for source
+    /// compatibility and is ignored.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    #[deprecated(note = "use sync_config(), which has global semantics")]
     pub async fn sync_scan_config(
         &mut self,
-        config_id: &EntityId,
+        _config_id: &EntityId,
     ) -> Result<SyncConfigResponse, GvmError> {
-        let response = self.send(sync_config(config_id)).await?;
-        SyncConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.sync_config().await
     }
 
     // ── Scanners ──────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3310,9 +3310,14 @@ async fn typed_scan_config_lifecycle(client: &mut GmpClient<UnixSocketConnection
     );
 
     client
+        .sync_config()
+        .await
+        .expect("sync_config should succeed");
+    #[allow(deprecated)]
+    client
         .sync_scan_config(&config_id)
         .await
-        .expect("sync_scan_config should succeed");
+        .expect("deprecated sync_scan_config compatibility shim should succeed");
 
     let cloned_config = client
         .clone_scan_config(&config_id)

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -37,6 +37,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "delete_scan_config",
     "clone_scan_config",
     "sync_scan_config",
+    "sync_config",
     "get_scanners",
     "create_scanner",
     "get_scanner",

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -325,10 +325,10 @@ pub fn delete_scan_config(config_id: &EntityId, ultimate: bool) -> impl Request 
     )
 }
 
-/// Build a `sync_config` request.
+/// Build the global, parameterless `sync_config` request.
 #[must_use]
-pub fn sync_config(config_id: &EntityId) -> impl Request {
-    XmlCommand::new("sync_config").attribute("config_id", config_id.as_str())
+pub fn sync_config() -> impl Request {
+    XmlCommand::new("sync_config")
 }
 
 /// Build a clone request for an existing policy.
@@ -742,10 +742,7 @@ mod tests {
             xml(delete_scan_config(&id("c1"), false)),
             "<delete_config config_id=\"c1\" ultimate=\"0\"/>"
         );
-        assert_eq!(
-            xml(sync_config(&id("c1"))),
-            "<sync_config config_id=\"c1\"/>"
-        );
+        assert_eq!(xml(sync_config()), "<sync_config/>");
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_scan_configs.rs
+++ b/crates/gvm-gmp/tests/test_scan_configs.rs
@@ -177,10 +177,7 @@ fn test_scan_config_get_delete_sync() {
         xml(get_scan_config(&id("c1"))),
         "<get_configs config_id=\"c1\" details=\"1\" usage_type=\"scan\"/>"
     );
-    assert_eq!(
-        xml(sync_config(&id("c1"))),
-        "<sync_config config_id=\"c1\"/>"
-    );
+    assert_eq!(xml(sync_config()), "<sync_config/>");
 }
 
 #[test]

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -189,11 +189,7 @@ async fn matrix_configs_full_lifecycle_helpers() {
     assert!(get_text.contains("<comment>updated</comment>"));
     assert!(get_text.contains("<usage_type>scan</usage_type>"));
 
-    let sync_resp = send_recv(
-        &mut stream,
-        format!("<sync_config config_id=\"{config_id}\"/>").as_bytes(),
-    )
-    .await;
+    let sync_resp = send_recv(&mut stream, b"<sync_config/>").await;
     assert_eq!(sync_resp.status_code(), Some(200));
 
     let cloned_config_id = create_and_get_id(

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -373,7 +373,7 @@ Convenience methods on `GmpClient<C>` that combine `send()` + `XxxResponse::from
 | version | ✅ | — | `get_version()` |
 | auth | — | — | `authenticate()` |
 | target | ✅ | ✅ | |
-| scan_config | ✅ | ✅ | Also: `get_scan_config()`, `modify_scan_config()`, `delete_scan_config()`, `clone_scan_config()`, `sync_scan_config()` |
+| scan_config | ✅ | ✅ | Also: `get_scan_config()`, `modify_scan_config()`, `delete_scan_config()`, `clone_scan_config()`, global `sync_config()`; deprecated `sync_scan_config(id)` remains source-compatible |
 | scanner | ✅ | ✅ | Also: `get_scanner()`, `modify_scanner()`, `delete_scanner()`, `verify_scanner()`, `clone_scanner()` |
 | port_list | ✅ | ✅ | |
 | task | ✅ | ✅ | Also: `start_task()` |


### PR DESCRIPTION
## What Problem This Solves

The typed scan-config sync helper emitted `<sync_config config_id="…"/>`, but current gvmd defines `sync_config` as a global, parameterless command. Stable Community gvmd advertises the command and rejects the attributed request as a bogus command.

## Why This Change Was Made

- Change the low-level builder to emit exactly `<sync_config/>`.
- Add canonical `GmpClient::sync_config()` with global semantics.
- Retain `GmpClient::sync_scan_config(id)` as a deprecated source-compatible shim; its obsolete ID argument is deliberately ignored.
- Update typed facade inventory, exact wire tests, stateful transport coverage, and public status documentation.

## User Impact

Typed callers can synchronize configs using the schema-valid request. Existing callers of `sync_scan_config(id)` continue to compile while receiving a deprecation path to the correct global API.

## Evidence

- `cargo test -p gvm-gmp --all-features` — 394 unit tests plus integration suites passed.
- `cargo test -p gvm-client --test client_integration --all-features` — 52 passed.
- `cargo test -p gvm-client --test typed_facade_inventory --all-features` — 2 passed.
- `cargo test -p gvm-mock-server --test stateful_resource_matrix --all-features` — 9 passed.
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Fixes #414

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
