### PR TITLE
fix(gmp): encode modify_setting values

### DIFF
--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -5,6 +5,7 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
+use crate::commands::user_settings::{modify_user_setting, ModifyUserSettingOpts};
 use crate::common::add_filter_attrs;
 use crate::enums::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceType, SortOrder};
 use crate::types::EntityId;
@@ -251,12 +252,15 @@ pub fn modify_license(key: &str) -> impl Request {
     XmlCommand::new("modify_license").child_with_text("key", key)
 }
 
-/// Build a `modify_setting` request.
+/// Build a `modify_setting` request, Base64-encoding the UTF-8 value for GMP.
 #[must_use]
 pub fn modify_setting(setting_id: &EntityId, value: &str) -> impl Request {
-    XmlCommand::new("modify_setting")
-        .attribute("setting_id", setting_id.as_str())
-        .child_with_text("value", value)
+    modify_user_setting(
+        setting_id,
+        ModifyUserSettingOpts {
+            value: value.to_string(),
+        },
+    )
 }
 
 /// Build a `run_wizard` request.
@@ -344,8 +348,8 @@ mod tests {
             "<modify_license><key>abc</key></modify_license>"
         );
         assert_eq!(
-            xml(modify_setting(&id("s1"), "v")),
-            "<modify_setting setting_id=\"s1\"><value>v</value></modify_setting>"
+            xml(modify_setting(&id("s1"), "Europe/Berlin")),
+            "<modify_setting setting_id=\"s1\"><value>RXVyb3BlL0Jlcmxpbg==</value></modify_setting>"
         );
         let rendered = xml(run_wizard("quick", &[("target".into(), "10.0.0.1".into())]));
         assert!(rendered.contains("<param name=\"target\">10.0.0.1</param>"));

--- a/crates/gvm-gmp/src/commands/user_settings.rs
+++ b/crates/gvm-gmp/src/commands/user_settings.rs
@@ -3,6 +3,7 @@
 
 //! User-setting command builders.
 
+use base64::Engine as _;
 use gvm_protocol::XmlCommand;
 
 use crate::common::add_filter_attrs;
@@ -20,7 +21,7 @@ pub struct GetUserSettingsOpts {
 /// Options for `modify_setting` requests.
 #[derive(Debug, Clone)]
 pub struct ModifyUserSettingOpts {
-    /// Setting value to apply.
+    /// UTF-8 setting value to apply; the builder Base64-encodes it for GMP.
     pub value: String,
 }
 
@@ -38,12 +39,13 @@ pub fn get_user_setting(id: &EntityId) -> XmlCommand {
     XmlCommand::new("get_settings").attribute("setting_id", id.as_str())
 }
 
-/// Build a `modify_setting` request.
+/// Build a `modify_setting` request, Base64-encoding the UTF-8 value for GMP.
 #[must_use]
 pub fn modify_user_setting(id: &EntityId, opts: ModifyUserSettingOpts) -> XmlCommand {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(opts.value.as_bytes());
     XmlCommand::new("modify_setting")
         .attribute("setting_id", id.as_str())
-        .child_with_text("value", &opts.value)
+        .child_with_text("value", &encoded)
 }
 
 #[cfg(test)]
@@ -79,7 +81,7 @@ mod tests {
                     value: "UTC".into(),
                 }
             )),
-            "<modify_setting setting_id=\"s1\"><value>UTC</value></modify_setting>"
+            "<modify_setting setting_id=\"s1\"><value>VVRD</value></modify_setting>"
         );
     }
 }

--- a/crates/gvm-gmp/tests/test_system.rs
+++ b/crates/gvm-gmp/tests/test_system.rs
@@ -88,8 +88,8 @@ fn test_system_aggregates_info_resource_names_and_mutations() {
         "<modify_license><key>abc</key></modify_license>"
     );
     assert_eq!(
-        xml(modify_setting(&id("s1"), "v")),
-        "<modify_setting setting_id=\"s1\"><value>v</value></modify_setting>"
+        xml(modify_setting(&id("s1"), "Europe/Berlin")),
+        "<modify_setting setting_id=\"s1\"><value>RXVyb3BlL0Jlcmxpbg==</value></modify_setting>"
     );
     assert_eq!(xml(run_wizard("quick", &[("target".into(), "10.0.0.1".into()), ("ports".into(), "T:1-5".into())])), "<run_wizard name=\"quick\"><param name=\"target\">10.0.0.1</param><param name=\"ports\">T:1-5</param></run_wizard>");
 }

--- a/crates/gvm-mock-server/Cargo.toml
+++ b/crates/gvm-mock-server/Cargo.toml
@@ -26,6 +26,7 @@ tls = [
 ssh = ["dep:russh"]
 
 [dependencies]
+base64.workspace = true
 gvm-gmp.workspace = true
 gvm-protocol.workspace = true
 tokio.workspace = true
@@ -46,7 +47,6 @@ russh = { workspace = true, optional = true }
 getrandom.workspace = true
 
 [dev-dependencies]
-base64.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 tokio-test.workspace = true

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
+use base64::Engine as _;
 use uuid::Uuid;
 
 use crate::command_parser::{parse_command, parse_element_text, ParsedCommand, ParsedElement};
@@ -1020,6 +1021,25 @@ impl SessionHandler {
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
         let new_value = parse_element_text(raw_xml, "value");
+        let new_value = if resource_type == "setting" {
+            let Some(value) = new_value else {
+                return error_response(&cmd.name, 400, "Missing required element: value");
+            };
+            let decoded = match base64::engine::general_purpose::STANDARD.decode(value.as_bytes()) {
+                Ok(decoded) => decoded,
+                Err(_) => {
+                    return error_response(&cmd.name, 400, "Value cannot be decoded to valid UTF-8")
+                }
+            };
+            match String::from_utf8(decoded) {
+                Ok(value) => Some(value),
+                Err(_) => {
+                    return error_response(&cmd.name, 400, "Value cannot be decoded to valid UTF-8")
+                }
+            }
+        } else {
+            new_value
+        };
         let new_term = parse_element_text(raw_xml, "term");
         let new_credential_store_id = parse_element_text(raw_xml, "credential_store_id");
         let new_vault_id = parse_element_text(raw_xml, "vault_id");

--- a/crates/gvm-mock-server/tests/stateful_audit_report.rs
+++ b/crates/gvm-mock-server/tests/stateful_audit_report.rs
@@ -310,7 +310,7 @@ async fn audit_host_rows_follow_gvmd_sentinel_and_setting_semantics() {
         &mut stream,
         format!(
             "<modify_setting setting_id=\"{ROWS_PER_PAGE_SETTING_ID}\">\
-             <value>2</value></modify_setting>"
+             <value>Mg==</value></modify_setting>"
         )
         .as_bytes(),
     )

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -743,7 +743,7 @@ async fn stateful_user_settings_get_and_modify() {
     let modify = send_recv(
         &mut stream,
         format!(
-            "<modify_setting setting_id=\"{setting_id}\"><value>Europe/Berlin</value></modify_setting>"
+            "<modify_setting setting_id=\"{setting_id}\"><value>RXVyb3BlL0Jlcmxpbg==</value></modify_setting>"
         )
         .as_bytes(),
     )
@@ -757,6 +757,32 @@ async fn stateful_user_settings_get_and_modify() {
     .await;
     let get_one_text = get_one.as_str().expect("utf8");
     assert!(get_one_text.contains("<value>Europe/Berlin</value>"));
+
+    for invalid_value in ["not-valid-base64!", "//8="] {
+        let invalid = send_recv(
+            &mut stream,
+            format!(
+                "<modify_setting setting_id=\"{setting_id}\"><value>{invalid_value}</value></modify_setting>"
+            )
+            .as_bytes(),
+        )
+        .await;
+        assert_eq!(invalid.status_code(), Some(400));
+        assert!(invalid
+            .as_str()
+            .expect("utf8")
+            .contains("Value cannot be decoded to valid UTF-8"));
+    }
+
+    let unchanged = send_recv(
+        &mut stream,
+        format!("<get_settings setting_id=\"{setting_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(unchanged
+        .as_str()
+        .expect("utf8")
+        .contains("<value>Europe/Berlin</value>"));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## What Problem This Solves

Both public `modify_setting` builders emitted plaintext inside `<value>`, but GMP requires that UTF-8 setting values be Base64-encoded. Current Community gvmd rejects plaintext values with `400 Value cannot be decoded to valid UTF-8`.

## Why This Change Was Made

- Make the legacy system builder delegate to the canonical user-setting builder.
- Base64-encode UTF-8 values in the canonical builder.
- Teach the stateful mock to decode and validate setting values before persistence.
- Return a gvmd-compatible 400 response for malformed Base64 and decoded non-UTF-8 values.
- Update exact wire regressions and stateful setting-dependent audit-report coverage.

## User Impact

Callers continue supplying ordinary UTF-8 strings, but rust-gvm now emits GMP-valid wire values. The mock stores and returns the decoded setting value, preserving realistic round-trip semantics.

## Evidence

- `cargo test -p gvm-gmp --all-features` — 394 unit tests plus all GMP integration suites passed.
- `cargo test -p gvm-mock-server --all-features` — full mock-server unit, transport, fixture, stateful, TLS, version, and doc-test suite passed.
- Focused user-setting lifecycle covers successful decode/persistence, invalid Base64, invalid UTF-8, and non-mutation after rejection.
- `cargo clippy -p gvm-gmp -p gvm-mock-server --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Fixes #416

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
