### PR TITLE
fix(gmp): complete scanner round-trip fields

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3335,9 +3335,71 @@ async fn typed_scan_config_lifecycle(client: &mut GmpClient<UnixSocketConnection
         .expect("delete original config should succeed");
 }
 
+fn assert_scanner_connection_fields(
+    scanner: &gvm_gmp::responses::Scanner,
+    name: &str,
+    host: &str,
+    port: u16,
+    scanner_type: &str,
+    ca_pub: &str,
+    credential_id: &str,
+) {
+    assert_eq!(scanner.meta.name, name);
+    assert_eq!(scanner.host.as_deref(), Some(host));
+    assert_eq!(scanner.port, Some(port));
+    assert_eq!(scanner.scanner_type.as_deref(), Some(scanner_type));
+    assert_eq!(scanner.ca_pub.as_deref(), Some(ca_pub));
+    assert_eq!(
+        scanner
+            .credential
+            .as_ref()
+            .map(|credential| credential.id.as_str()),
+        Some(credential_id)
+    );
+}
+
+async fn assert_partial_scanner_modify_preserves_fields(
+    client: &mut GmpClient<UnixSocketConnection>,
+    scanner_id: &EntityId,
+) {
+    client
+        .modify_scanner(
+            scanner_id,
+            ScannerOpts {
+                comment: Some("omitted fields stay unchanged".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("partial modify_scanner should succeed");
+    let scanner = client
+        .get_scanner(scanner_id)
+        .await
+        .expect("get_scanner after partial modify should succeed");
+    assert_eq!(scanner.items[0].port, Some(9391));
+    assert_eq!(scanner.items[0].ca_pub.as_deref(), Some("Replacement CA"));
+    assert_eq!(
+        scanner.items[0]
+            .credential
+            .as_ref()
+            .map(|credential| credential.id.as_str()),
+        Some("credential-2")
+    );
+}
+
 async fn typed_scanner_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
     let created_scanner = client
-        .create_scanner("Typed Scanner", ScannerOpts::default())
+        .create_scanner(
+            "Typed Scanner",
+            ScannerOpts {
+                host: Some("scanner.example".into()),
+                port: Some(9390),
+                scanner_type: Some(gvm_gmp::ScannerType::OpenVasScanner),
+                ca_pub: Some("Initial CA".into()),
+                credential_id: Some(EntityId::new("credential-1").expect("valid id")),
+                ..Default::default()
+            },
+        )
         .await
         .expect("create_scanner should succeed");
     let scanner_id = created_scanner.id;
@@ -3348,16 +3410,27 @@ async fn typed_scanner_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
         .expect("get_scanner should succeed");
     assert_eq!(fetched_scanner.items.len(), 1);
     assert_eq!(fetched_scanner.items[0].meta.id, scanner_id);
-    assert_eq!(fetched_scanner.items[0].meta.name, "Typed Scanner");
+    assert_scanner_connection_fields(
+        &fetched_scanner.items[0],
+        "Typed Scanner",
+        "scanner.example",
+        9390,
+        "2",
+        "Initial CA",
+        "credential-1",
+    );
 
     client
         .modify_scanner(
             &scanner_id,
             ScannerOpts {
+                name: Some("Renamed Scanner".into()),
                 comment: Some("updated".into()),
                 host: Some("127.0.0.1".into()),
-                port: Some(9390),
-                ..Default::default()
+                port: Some(9391),
+                scanner_type: Some(gvm_gmp::ScannerType::GreenBoneSensorType),
+                ca_pub: Some("Replacement CA".into()),
+                credential_id: Some(EntityId::new("credential-2").expect("valid id")),
             },
         )
         .await
@@ -3371,8 +3444,17 @@ async fn typed_scanner_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
         updated_scanner.items[0].meta.comment.as_deref(),
         Some("updated")
     );
-    assert_eq!(updated_scanner.items[0].host.as_deref(), Some("127.0.0.1"));
-    assert_eq!(updated_scanner.items[0].port, Some(9390));
+    assert_scanner_connection_fields(
+        &updated_scanner.items[0],
+        "Renamed Scanner",
+        "127.0.0.1",
+        9391,
+        "5",
+        "Replacement CA",
+        "credential-2",
+    );
+
+    assert_partial_scanner_modify_preserves_fields(client, &scanner_id).await;
 
     client
         .verify_scanner(&scanner_id)
@@ -3388,7 +3470,10 @@ async fn typed_scanner_lifecycle(client: &mut GmpClient<UnixSocketConnection>) {
         .get_scanner(&cloned_scanner_id)
         .await
         .expect("get cloned scanner should succeed");
-    assert_eq!(cloned_scanner_response.items[0].meta.name, "Typed Scanner");
+    assert_eq!(
+        cloned_scanner_response.items[0].meta.name,
+        "Renamed Scanner"
+    );
 
     client
         .delete_scanner(&cloned_scanner_id, true)

--- a/crates/gvm-gmp/src/commands/scanners.rs
+++ b/crates/gvm-gmp/src/commands/scanners.rs
@@ -9,10 +9,13 @@ use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_b
 use crate::enums::ScannerType;
 use crate::types::EntityId;
 
-/// Optional fields for scanner create and modify requests.
+/// Optional fields shared by scanner create and modify requests.
+///
+/// [`create_scanner`] takes its name as a separate required argument and does
+/// not read [`Self::name`]. All other fields apply to both request types.
 #[derive(Debug, Clone, Default)]
 pub struct ScannerOpts {
-    /// Optional replacement name used by modify requests.
+    /// Optional replacement name emitted only by [`modify_scanner`].
     pub name: Option<String>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,

--- a/crates/gvm-gmp/src/commands/scanners.rs
+++ b/crates/gvm-gmp/src/commands/scanners.rs
@@ -12,6 +12,8 @@ use crate::types::EntityId;
 /// Optional fields for scanner create and modify requests.
 #[derive(Debug, Clone, Default)]
 pub struct ScannerOpts {
+    /// Optional replacement name used by modify requests.
+    pub name: Option<String>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
     /// Optional host name or address.
@@ -20,6 +22,8 @@ pub struct ScannerOpts {
     pub port: Option<u16>,
     /// Optional scanner type.
     pub scanner_type: Option<ScannerType>,
+    /// Optional CA certificate in PEM format.
+    pub ca_pub: Option<String>,
     /// Optional credential identifier.
     pub credential_id: Option<EntityId>,
 }
@@ -56,6 +60,7 @@ pub fn create_scanner(name: &str, opts: ScannerOpts) -> impl Request {
     if let Some(scanner_type) = opts.scanner_type {
         cmd.add_element_with_text("type", scanner_type.as_scanner_type());
     }
+    add_text_element(&mut cmd, "ca_pub", opts.ca_pub.as_deref());
     if let Some(credential_id) = opts.credential_id.as_ref() {
         cmd.add_element("credential")
             .set_attribute("id", credential_id.as_str());
@@ -89,11 +94,19 @@ pub fn get_scanner(scanner_id: &EntityId) -> impl Request {
 #[must_use]
 pub fn modify_scanner(scanner_id: &EntityId, opts: ScannerOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_scanner").attribute("scanner_id", scanner_id.as_str());
-    add_text_element(&mut cmd, "name", Some(""));
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
     add_text_element(&mut cmd, "host", opts.host.as_deref());
     if let Some(port) = opts.port {
         cmd.add_element_with_text("port", &port.to_string());
+    }
+    if let Some(scanner_type) = opts.scanner_type {
+        cmd.add_element_with_text("type", scanner_type.as_scanner_type());
+    }
+    add_text_element(&mut cmd, "ca_pub", opts.ca_pub.as_deref());
+    if let Some(credential_id) = opts.credential_id.as_ref() {
+        cmd.add_element("credential")
+            .set_attribute("id", credential_id.as_str());
     }
     cmd
 }
@@ -129,12 +142,15 @@ mod tests {
                 host: Some("127.0.0.1".into()),
                 port: Some(9390),
                 scanner_type: Some(ScannerType::OpenVasScanner),
+                ca_pub: Some("CA certificate".into()),
                 credential_id: Some(id("cred1")),
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<type>2</type>"));
-        assert!(rendered.contains("<credential id=\"cred1\"/>"));
+        assert_eq!(
+            rendered,
+            "<create_scanner><name>scanner</name><host>127.0.0.1</host><port>9390</port><type>2</type><ca_pub>CA certificate</ca_pub><credential id=\"cred1\"/></create_scanner>"
+        );
         assert_eq!(
             xml(clone_scanner(&id("s1"))),
             "<create_scanner><copy>s1</copy></create_scanner>"
@@ -155,13 +171,22 @@ mod tests {
         let rendered = xml(modify_scanner(
             &id("s1"),
             ScannerOpts {
+                name: Some("Renamed scanner".into()),
+                comment: Some("updated".into()),
                 host: Some("localhost".into()),
-                ..Default::default()
+                port: Some(9390),
+                scanner_type: Some(ScannerType::OpenVasScanner),
+                ca_pub: Some("Replacement CA".into()),
+                credential_id: Some(id("cred2")),
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_scanner scanner_id=\"s1\"><host>localhost</host></modify_scanner>"
+            "<modify_scanner scanner_id=\"s1\"><name>Renamed scanner</name><comment>updated</comment><host>localhost</host><port>9390</port><type>2</type><ca_pub>Replacement CA</ca_pub><credential id=\"cred2\"/></modify_scanner>"
+        );
+        assert_eq!(
+            xml(modify_scanner(&id("s1"), ScannerOpts::default())),
+            "<modify_scanner scanner_id=\"s1\"/>"
         );
         assert_eq!(
             xml(delete_scanner(&id("s1"), true)),

--- a/crates/gvm-gmp/src/responses/scanner.rs
+++ b/crates/gvm-gmp/src/responses/scanner.rs
@@ -19,6 +19,7 @@ pub struct Scanner {
     pub scanner_type: Option<String>,
     pub host: Option<String>,
     pub port: Option<u16>,
+    pub ca_pub: Option<String>,
     pub credential: Option<NamedEntity>,
 }
 
@@ -48,6 +49,7 @@ impl Scanner {
             scanner_type: node.optional_child_text("type"),
             host: node.optional_child_text("host"),
             port: optional_u16(node, "port", "port")?,
+            ca_pub: node.optional_child_text("ca_pub"),
             credential: parse_named_entity(node, "credential")?,
         })
     }
@@ -112,6 +114,7 @@ mod tests {
                     <type>OpenVAS</type>
                     <host>127.0.0.1</host>
                     <port>9390</port>
+                    <ca_pub>CA certificate</ca_pub>
                     <credential id="cred-1"><name>OSP Credential</name></credential>
                 </scanner>
                 <scanner id="scanner-2">
@@ -126,6 +129,17 @@ mod tests {
         assert_eq!(parsed.items.len(), 2);
         assert_eq!(parsed.items[0].scanner_type.as_deref(), Some("OpenVAS"));
         assert_eq!(parsed.items[0].port, Some(9390));
+        assert_eq!(parsed.items[0].ca_pub.as_deref(), Some("CA certificate"));
+        assert!(parsed.items[0].meta.writable);
+        assert!(!parsed.items[0].meta.in_use);
+        assert_eq!(
+            parsed.items[0]
+                .meta
+                .owner
+                .as_ref()
+                .map(|owner| owner.name.as_str()),
+            Some("admin")
+        );
         assert_eq!(
             parsed.items[0]
                 .credential
@@ -189,6 +203,7 @@ mod tests {
 
         assert_eq!(scanner.host, None);
         assert_eq!(scanner.port, None);
+        assert_eq!(scanner.ca_pub, None);
         assert_eq!(scanner.credential, None);
     }
 }

--- a/crates/gvm-gmp/tests/test_scanners.rs
+++ b/crates/gvm-gmp/tests/test_scanners.rs
@@ -27,10 +27,31 @@ fn test_create_scanner_with_optionals() {
                 host: Some("127.0.0.1".into()),
                 port: Some(9390),
                 scanner_type: Some(ScannerType::OpenVasScanner),
+                ca_pub: Some("CA certificate".into()),
                 credential_id: Some(id("cred1")),
+                ..Default::default()
             }
         )),
-        "<create_scanner><name>scanner</name><comment>c</comment><host>127.0.0.1</host><port>9390</port><type>2</type><credential id=\"cred1\"/></create_scanner>"
+        "<create_scanner><name>scanner</name><comment>c</comment><host>127.0.0.1</host><port>9390</port><type>2</type><ca_pub>CA certificate</ca_pub><credential id=\"cred1\"/></create_scanner>"
+    );
+}
+
+#[test]
+fn test_modify_scanner_with_optionals() {
+    assert_eq!(
+        xml(modify_scanner(
+            &id("s1"),
+            ScannerOpts {
+                name: Some("renamed".into()),
+                comment: Some("updated".into()),
+                host: Some("scanner.example".into()),
+                port: Some(9390),
+                scanner_type: Some(ScannerType::OpenVasScanner),
+                ca_pub: Some("Replacement CA".into()),
+                credential_id: Some(id("cred2")),
+            }
+        )),
+        "<modify_scanner scanner_id=\"s1\"><name>renamed</name><comment>updated</comment><host>scanner.example</host><port>9390</port><type>2</type><ca_pub>Replacement CA</ca_pub><credential id=\"cred2\"/></modify_scanner>"
     );
 }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -668,6 +668,16 @@ impl SessionHandler {
                 resource.set_attr("credential_id", credential_id);
             }
         }
+        if resource_type == "scanner" {
+            for field in ["host", "port", "type", "ca_pub"] {
+                if let Some(value) = parse_element_text(raw_xml, field) {
+                    resource.set_attr(field, &value);
+                }
+            }
+            if let Some(credential_id) = cmd.child_attr("credential", "id") {
+                resource.set_attr("credential_id", credential_id);
+            }
+        }
 
         if matches!(resource_type, "config" | "task") {
             let usage_type = if has_config_import_payload {
@@ -1015,6 +1025,8 @@ impl SessionHandler {
         let new_task_id = cmd.child_attr("task", "id").map(str::to_string);
         let new_credential_id = cmd.child_attr("credential", "id").map(str::to_string);
         let new_port = parse_element_text(raw_xml, "port");
+        let new_type = parse_element_text(raw_xml, "type");
+        let new_ca_pub = parse_element_text(raw_xml, "ca_pub");
         let new_severity = parse_element_text(raw_xml, "severity");
         let new_new_severity = parse_element_text(raw_xml, "new_severity");
         let new_active = parse_element_text(raw_xml, "active");
@@ -1132,18 +1144,24 @@ impl SessionHandler {
             if let Some(ref task_id) = new_task_id {
                 r.set_attr("task_id", task_id);
             }
-            if resource_type == "oci_image_target" {
-                if let Some(ref credential_id) = new_credential_id {
-                    r.set_attr("credential_id", credential_id);
-                }
-            }
-            if resource_type == "web_application_target" {
+            if matches!(
+                resource_type,
+                "oci_image_target" | "web_application_target" | "scanner"
+            ) {
                 if let Some(ref credential_id) = new_credential_id {
                     r.set_attr("credential_id", credential_id);
                 }
             }
             if let Some(ref port) = new_port {
                 r.set_attr("port", port);
+            }
+            if resource_type == "scanner" {
+                if let Some(ref scanner_type) = new_type {
+                    r.set_attr("type", scanner_type);
+                }
+                if let Some(ref ca_pub) = new_ca_pub {
+                    r.set_attr("ca_pub", ca_pub);
+                }
             }
             if let Some(ref severity) = new_severity {
                 r.set_attr("severity", severity);

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -333,6 +333,13 @@ impl Resource {
         }
         // Add type-specific attributes
         for (k, v) in &self.attrs {
+            if self.resource_type == "scanner" && k == "credential_id" {
+                xml.push_str(&format!(
+                    "<credential id=\"{}\"><name></name></credential>",
+                    xml_escape_attr(v),
+                ));
+                continue;
+            }
             if self.resource_type == "permission"
                 && matches!(
                     k.as_str(),


### PR DESCRIPTION
## What problem does this solve?

The typed scanner surface could create some connection fields but could not rename scanners, send type or credential changes, handle CA certificates, or parse CA certificates from scanner responses. `modify_scanner` also emitted an empty name and silently ignored type and credential options.

## What changed?

- extend scanner options with modify-name and CA-certificate fields
- serialize name, type, CA certificate, and credential on modification
- serialize CA certificates on creation
- parse `ca_pub` while preserving credential and entity metadata parsing
- make the stateful mock persist and render the canonical scanner fields
- cover exact XML, response metadata, complete typed lifecycle, and omission-preserves-state behavior

## User impact

Typed Rust clients can now create, read, rename, and fully update scanner connection settings without raw XML.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --all-features`
- `cargo test -p gvm-client --test client_integration --all-features`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`

Fixes #426

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high