### PR TITLE
fix(gmp): serialize alert data maps and renames

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -13,7 +13,7 @@
 
 use gvm_connection::GvmConnection;
 use gvm_gmp::commands::aggregates::{get_aggregates_request, GetAggregatesRequestOpts};
-use gvm_gmp::commands::alerts::{create_alert, get_alerts, AlertOpts, GetAlertsOpts};
+use gvm_gmp::commands::alerts::{create_alert, get_alerts, modify_alert, AlertOpts, GetAlertsOpts};
 use gvm_gmp::commands::assets::{
     create_asset, delete_asset, get_assets, modify_asset, AssetType, CreateAssetOpts,
     DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
@@ -150,7 +150,7 @@ use gvm_gmp::responses::{
     GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
     GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
-    ModifyAssetResponse, ModifyConfigResponse, ModifyCredentialResponse,
+    ModifyAlertResponse, ModifyAssetResponse, ModifyConfigResponse, ModifyCredentialResponse,
     ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyPortListResponse,
     ModifyScanConfigResponse, ModifyScannerResponse, ModifyUserResponse,
     ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
@@ -1350,6 +1350,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<CreateAlertResponse, GvmError> {
         let response = self.send(create_alert(name, opts)).await?;
         CreateAlertResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_alert` request and return a typed [`ModifyAlertResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_alert(
+        &mut self,
+        alert_id: &EntityId,
+        opts: AlertOpts,
+    ) -> Result<ModifyAlertResponse, GvmError> {
+        let response = self.send(modify_alert(alert_id, opts)).await?;
+        ModifyAlertResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Credentials ───────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -14,7 +14,9 @@ use gvm_client::{
 };
 use gvm_connection::{ConnectionError, GvmConnection, UnixSocketConnection};
 use gvm_gmp::commands::aggregates::{get_aggregates as get_aggregates_legacy, GetAggregatesOpts};
-use gvm_gmp::commands::alerts::{trigger_alert, TriggerAlertOpts};
+use gvm_gmp::commands::alerts::{
+    trigger_alert, AlertData, AlertOpts, GetAlertsOpts, TriggerAlertOpts,
+};
 use gvm_gmp::commands::assets::{
     AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
 };
@@ -58,7 +60,9 @@ use gvm_gmp::responses::{
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
-use gvm_gmp::{FeedType, PermissionSubjectType, SortOrder};
+use gvm_gmp::{
+    AlertCondition, AlertEvent, AlertMethod, FeedType, PermissionSubjectType, SortOrder,
+};
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
 };
@@ -689,6 +693,115 @@ async fn trigger_alert_sends_get_reports_command() {
         std::str::from_utf8(command.raw_xml()).expect("valid UTF-8 command"),
         "<get_reports alert_id=\"alert-1\" delta_report_id=\"delta-1\" filt_id=\"filter-1\" filter=\"severity&gt;5\" format_id=\"format-1\" report_id=\"report-1\"/>"
     );
+
+    server.shutdown().await;
+}
+
+fn only_alert(response: &gvm_gmp::responses::GetAlertsResponse) -> &gvm_gmp::responses::Alert {
+    assert_eq!(response.items.len(), 1);
+    &response.items[0]
+}
+
+fn assert_alert_data(
+    alert: &gvm_gmp::responses::Alert,
+    name: &str,
+    event_status: Option<&str>,
+    severity: &str,
+    to_address: &str,
+) {
+    assert_eq!(alert.meta.name, name);
+    assert_eq!(
+        alert.event_data.get("status").map(String::as_str),
+        event_status
+    );
+    assert_eq!(
+        alert.condition_data.get("severity").map(String::as_str),
+        Some(severity)
+    );
+    assert_eq!(
+        alert.method_data.get("to_address").map(String::as_str),
+        Some(to_address)
+    );
+}
+
+#[tokio::test]
+async fn typed_alert_data_maps_and_rename_round_trip() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created = client
+        .create_alert(
+            "Typed Alert",
+            AlertOpts {
+                event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: vec![AlertData::new("status", "Done")],
+                condition: Some(AlertCondition::SeverityAtLeast),
+                condition_data: vec![AlertData::new("severity", "5.5")],
+                method: Some(AlertMethod::Email),
+                method_data: vec![AlertData::new("to_address", "ops@example.com")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_alert should succeed");
+
+    let fetched = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts should succeed");
+    let alert = only_alert(&fetched);
+    assert_eq!(alert.meta.id, created.id);
+    assert_alert_data(alert, "Typed Alert", Some("Done"), "5.5", "ops@example.com");
+
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                name: Some("Renamed Alert".into()),
+                event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: vec![],
+                condition: Some(AlertCondition::SeverityAtLeast),
+                condition_data: vec![AlertData::new("severity", "7.0")],
+                method: Some(AlertMethod::Email),
+                method_data: vec![AlertData::new("to_address", "soc@example.com")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_alert should succeed");
+
+    let modified = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after modify should succeed");
+    let alert = only_alert(&modified);
+    assert_alert_data(alert, "Renamed Alert", None, "7.0", "soc@example.com");
+
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                comment: Some("data omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("partial modify_alert should succeed");
+    let partially_modified = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after partial modify should succeed");
+    let alert = only_alert(&partially_modified);
+    assert_alert_data(alert, "Renamed Alert", None, "7.0", "soc@example.com");
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -803,6 +803,30 @@ async fn typed_alert_data_maps_and_rename_round_trip() {
     let alert = only_alert(&partially_modified);
     assert_alert_data(alert, "Renamed Alert", None, "7.0", "soc@example.com");
 
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                method: Some(AlertMethod::Email),
+                method_data: vec![AlertData::new("to_address", "nested-name@example.com")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("data-only modify_alert should succeed");
+    let data_only_modified = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after data-only modify should succeed");
+    let alert = only_alert(&data_only_modified);
+    assert_alert_data(
+        alert,
+        "Renamed Alert",
+        None,
+        "7.0",
+        "nested-name@example.com",
+    );
+
     server.shutdown().await;
 }
 

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -94,6 +94,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "get_vulnerability",
     "get_alerts",
     "create_alert",
+    "modify_alert",
     "get_credentials",
     "create_credential",
     "create_credential_store_credential",

--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -9,17 +9,44 @@ use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_b
 use crate::enums::{AlertCondition, AlertEvent, AlertMethod};
 use crate::types::EntityId;
 
+/// A name/value entry nested below an alert event, condition, or method.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlertData {
+    /// Protocol-defined data name.
+    pub name: String,
+    /// Data value.
+    pub value: String,
+}
+
+impl AlertData {
+    /// Create an alert data entry.
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
 /// Optional fields for alert create and modify requests.
 #[derive(Debug, Clone, Default)]
 pub struct AlertOpts {
+    /// Optional replacement name used by modify requests.
+    pub name: Option<String>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
     /// Optional alert event value.
     pub event: Option<AlertEvent>,
+    /// Data entries applied when `event` is present.
+    pub event_data: Vec<AlertData>,
     /// Optional alert condition value.
     pub condition: Option<AlertCondition>,
+    /// Data entries applied when `condition` is present.
+    pub condition_data: Vec<AlertData>,
     /// Optional alert delivery method.
     pub method: Option<AlertMethod>,
+    /// Data entries applied when `method` is present.
+    pub method_data: Vec<AlertData>,
     /// Optional saved filter identifier.
     pub filter_id: Option<EntityId>,
 }
@@ -91,6 +118,7 @@ pub fn get_alert(alert_id: &EntityId) -> impl Request {
 #[must_use]
 pub fn modify_alert(alert_id: &EntityId, opts: AlertOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_alert").attribute("alert_id", alert_id.as_str());
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_alert_body(&mut cmd, &opts);
     cmd
 }
@@ -135,18 +163,45 @@ pub fn trigger_alert(
 
 fn add_alert_body(cmd: &mut XmlCommand, opts: &AlertOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
-    if let Some(event) = opts.event {
-        cmd.add_element_with_text("event", event.as_alert_name());
-    }
-    if let Some(condition) = opts.condition {
-        cmd.add_element_with_text("condition", condition.as_alert_name());
-    }
-    if let Some(method) = opts.method {
-        cmd.add_element_with_text("method", method.as_alert_name());
-    }
+    add_alert_field(
+        cmd,
+        "event",
+        opts.event.map(AlertEvent::as_alert_name),
+        &opts.event_data,
+    );
+    add_alert_field(
+        cmd,
+        "condition",
+        opts.condition.map(AlertCondition::as_alert_name),
+        &opts.condition_data,
+    );
+    add_alert_field(
+        cmd,
+        "method",
+        opts.method.map(AlertMethod::as_alert_name),
+        &opts.method_data,
+    );
     if let Some(filter_id) = opts.filter_id.as_ref() {
         cmd.add_element("filter")
             .set_attribute("id", filter_id.as_str());
+    }
+}
+
+fn add_alert_field(
+    cmd: &mut XmlCommand,
+    field_name: &str,
+    field_value: Option<&str>,
+    data: &[AlertData],
+) {
+    let Some(field_value) = field_value else {
+        return;
+    };
+    let field = cmd.add_element(field_name);
+    field.set_text(field_value);
+    for entry in data {
+        let data_element = field.add_child("data");
+        data_element.set_text(&entry.value);
+        data_element.add_child_with_text("name", &entry.name);
     }
 }
 
@@ -165,16 +220,18 @@ mod tests {
             "alert",
             AlertOpts {
                 event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: vec![AlertData::new("status", "Done")],
                 condition: Some(AlertCondition::Always),
                 method: Some(AlertMethod::Email),
+                method_data: vec![AlertData::new("to_address", "ops@example.com")],
                 filter_id: Some(id("f1")),
                 ..Default::default()
             },
         ));
-        assert!(rendered.contains("<event>Task run status changed</event>"));
-        assert!(rendered.contains("<condition>Always</condition>"));
-        assert!(rendered.contains("<method>Email</method>"));
-        assert!(rendered.contains("<filter id=\"f1\"/>"));
+        assert_eq!(
+            rendered,
+            "<create_alert><name>alert</name><event>Task run status changed<data>Done<name>status</name></data></event><condition>Always</condition><method>Email<data>ops@example.com<name>to_address</name></data></method><filter id=\"f1\"/></create_alert>"
+        );
         assert_eq!(
             xml(clone_alert(&id("a1"))),
             "<create_alert><copy>a1</copy></create_alert>"
@@ -195,14 +252,21 @@ mod tests {
         let rendered = xml(modify_alert(
             &id("a1"),
             AlertOpts {
+                name: Some("Renamed & Escaped".into()),
                 comment: Some("updated".into()),
+                event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: vec![AlertData::new("key&name", "value <&>")],
                 method: Some(AlertMethod::SysLog),
                 ..Default::default()
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_alert alert_id=\"a1\"><comment>updated</comment><method>Syslog</method></modify_alert>"
+            "<modify_alert alert_id=\"a1\"><name>Renamed &amp; Escaped</name><comment>updated</comment><event>Task run status changed<data>value &lt;&amp;&gt;<name>key&amp;name</name></data></event><method>Syslog</method></modify_alert>"
+        );
+        assert_eq!(
+            xml(modify_alert(&id("a1"), AlertOpts::default())),
+            "<modify_alert alert_id=\"a1\"/>"
         );
         assert_eq!(
             xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -25,12 +25,16 @@ fn test_create_alert_with_all_optionals() {
             AlertOpts {
                 comment: Some("c".into()),
                 event: Some(AlertEvent::TaskRunStatusChanged),
-                condition: Some(AlertCondition::Always),
+                event_data: vec![AlertData::new("status", "Done")],
+                condition: Some(AlertCondition::SeverityAtLeast),
+                condition_data: vec![AlertData::new("severity", "5.5")],
                 method: Some(AlertMethod::Email),
+                method_data: vec![AlertData::new("to_address", "ops@example.com")],
                 filter_id: Some(id("f1")),
+                ..Default::default()
             }
         )),
-        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed</event><condition>Always</condition><method>Email</method><filter id=\"f1\"/></create_alert>"
+        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed<data>Done<name>status</name></data></event><condition>Severity at least<data>5.5<name>severity</name></data></condition><method>Email<data>ops@example.com<name>to_address</name></data></method><filter id=\"f1\"/></create_alert>"
     );
 }
 
@@ -48,13 +52,15 @@ fn test_alert_get_modify_delete_and_test() {
         xml(modify_alert(
             &id("a1"),
             AlertOpts {
+                name: Some("renamed".into()),
                 event: Some(AlertEvent::TaskRunStatusChanged),
+                event_data: vec![AlertData::new("status", "Done")],
                 condition: Some(AlertCondition::Always),
                 method: Some(AlertMethod::SysLog),
                 ..Default::default()
             }
         )),
-        "<modify_alert alert_id=\"a1\"><event>Task run status changed</event><condition>Always</condition><method>Syslog</method></modify_alert>"
+        "<modify_alert alert_id=\"a1\"><name>renamed</name><event>Task run status changed<data>Done<name>status</name></data></event><condition>Always</condition><method>Syslog</method></modify_alert>"
     );
     assert_eq!(
         xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -679,6 +679,9 @@ impl SessionHandler {
                 resource.set_attr("credential_id", credential_id);
             }
         }
+        if resource_type == "alert" {
+            set_alert_fields(&mut resource, cmd);
+        }
 
         if matches!(resource_type, "config" | "task") {
             let usage_type = if has_config_import_payload {
@@ -1206,6 +1209,9 @@ impl SessionHandler {
                 if let Some(ref term) = new_term {
                     r.set_attr("term", term);
                 }
+            }
+            if resource_type == "alert" {
+                set_alert_fields(r, cmd);
             }
             if resource_type == "credential" {
                 if let Some(ref credential_store_id) = new_credential_store_id {
@@ -3501,6 +3507,31 @@ fn nested_child_text(cmd: &ParsedCommand, path: &[&str]) -> Option<String> {
         element = element.children.iter().find(|child| child.name == **name)?;
     }
     Some(element.text.clone().unwrap_or_default())
+}
+
+fn set_alert_fields(resource: &mut Resource, cmd: &ParsedCommand) {
+    for field in ["event", "condition", "method"] {
+        let Some(element) = cmd.children.iter().find(|child| child.name == field) else {
+            continue;
+        };
+        resource.set_attr(field, element.text.as_deref().unwrap_or_default());
+        let data_prefix = format!("{field}_data:");
+        resource
+            .attrs
+            .retain(|key, _| !key.starts_with(&data_prefix));
+        for data in element.children.iter().filter(|child| child.name == "data") {
+            let Some(name) = element_child_text(data, "name") else {
+                continue;
+            };
+            resource.set_attr(
+                &format!("{data_prefix}{name}"),
+                data.text.as_deref().unwrap_or_default(),
+            );
+        }
+    }
+    if let Some(filter_id) = cmd.child_attr("filter", "id") {
+        resource.set_attr("filter_id", filter_id);
+    }
 }
 
 fn set_permission_references(resource: &mut Resource, cmd: &ParsedCommand) {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1014,6 +1014,8 @@ impl SessionHandler {
 
         let new_name = if resource_type == "user" {
             parse_element_text(raw_xml, "new_name")
+        } else if resource_type == "alert" {
+            cmd.child_text("name").map(str::to_string)
         } else {
             parse_element_text(raw_xml, "name")
         };

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -353,12 +353,44 @@ impl Resource {
             }
         }
         // Add type-specific attributes
+        if self.resource_type == "alert" {
+            for field in ["event", "condition", "method"] {
+                if let Some(value) = self.attr(field) {
+                    xml.push_str(&format!("<{field}>{}", xml_escape(value)));
+                    let data_prefix = format!("{field}_data:");
+                    for (key, data_value) in self.attrs.iter().filter_map(|(key, value)| {
+                        key.strip_prefix(&data_prefix).map(|name| (name, value))
+                    }) {
+                        xml.push_str(&format!(
+                            "<data>{}<name>{}</name></data>",
+                            xml_escape(data_value),
+                            xml_escape(key),
+                        ));
+                    }
+                    xml.push_str(&format!("</{field}>"));
+                }
+            }
+            if let Some(filter_id) = self.attr("filter_id") {
+                xml.push_str(&format!(
+                    "<filter id=\"{}\"><name></name></filter>",
+                    xml_escape_attr(filter_id),
+                ));
+            }
+        }
         for (k, v) in &self.attrs {
             if self.resource_type == "scanner" && k == "credential_id" {
                 xml.push_str(&format!(
                     "<credential id=\"{}\"><name></name></credential>",
                     xml_escape_attr(v),
                 ));
+                continue;
+            }
+            if self.resource_type == "alert"
+                && (matches!(k.as_str(), "event" | "condition" | "method" | "filter_id")
+                    || k.starts_with("event_data:")
+                    || k.starts_with("condition_data:")
+                    || k.starts_with("method_data:"))
+            {
                 continue;
             }
             if self.resource_type == "permission"


### PR DESCRIPTION
## What problem does this solve?

Typed alert responses already exposed event, condition, and method data maps, but the command builders could not write those maps or rename an alert. This forced downstream clients to fall back to raw XML for a normal alert round trip.

## What changed?

- add ordered typed alert data entries with current-gvmd mixed-content XML
- serialize data below event, condition, and method fields
- add the optional modify-name field
- expose `modify_alert` through `GmpClient`
- teach the stateful mock to persist and render alert maps and rename changes
- preserve omitted parent fields while allowing an explicitly supplied field with no entries to clear its map
- cover exact XML, escaping, typed create/read/modify, and omission behavior

## User impact

Rust clients can now map complete typed alert inputs and outputs without constructing raw GMP XML.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --all-features`
- `cargo test -p gvm-client --test client_integration --all-features`
- `cargo test -p gvm-client --test typed_facade_inventory --all-features`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`

Fixes #422

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high