### PR TITLE
fix(gmp): enforce typed ticket assignees

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -109,7 +109,9 @@ use gvm_gmp::commands::tasks::{
     create_import_task, create_task, get_tasks, resume_task, start_task, CreateTaskOpts,
     GetTasksOpts,
 };
-use gvm_gmp::commands::tickets::{create_ticket, get_tickets, GetTicketsOpts, TicketOpts};
+use gvm_gmp::commands::tickets::{
+    create_ticket, get_tickets, modify_ticket, CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts,
+};
 use gvm_gmp::commands::tls_certificates::{
     create_tls_certificate, get_tls_certificates, GetTlsCertificatesOpts, TlsCertificateOpts,
 };
@@ -152,7 +154,7 @@ use gvm_gmp::responses::{
     GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
     ModifyAlertResponse, ModifyAssetResponse, ModifyConfigResponse, ModifyCredentialResponse,
     ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyPortListResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ModifyUserResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ModifyTicketResponse, ModifyUserResponse,
     ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
     StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
@@ -1584,10 +1586,23 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn create_ticket(
         &mut self,
         result_id: &EntityId,
-        opts: TicketOpts,
+        opts: CreateTicketOpts,
     ) -> Result<CreateTicketResponse, GvmError> {
         let response = self.send(create_ticket(result_id, opts)).await?;
         CreateTicketResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_ticket` request and return a typed [`ModifyTicketResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_ticket(
+        &mut self,
+        ticket_id: &EntityId,
+        opts: ModifyTicketOpts,
+    ) -> Result<ModifyTicketResponse, GvmError> {
+        let response = self.send(modify_ticket(ticket_id, opts)).await?;
+        ModifyTicketResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     // ── Users ─────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -53,6 +53,7 @@ use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
+use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts};
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{
     Asset, ConfigUsageKind, CreateScanConfigResponse, GetConfigsResponse, GetPermissionsResponse,
@@ -62,6 +63,7 @@ use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
     AlertCondition, AlertEvent, AlertMethod, FeedType, PermissionSubjectType, SortOrder,
+    TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
@@ -825,6 +827,86 @@ async fn typed_alert_data_maps_and_rename_round_trip() {
         None,
         "7.0",
         "nested-name@example.com",
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_ticket_create_read_and_reassign_round_trip() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let result_id = EntityId::new("result-1").expect("valid id");
+    let first_assignee = EntityId::new("user-1").expect("valid id");
+    let created = client
+        .create_ticket(
+            &result_id,
+            CreateTicketOpts {
+                assigned_to: first_assignee.clone(),
+                open_note: "Please investigate".into(),
+                comment: Some("Typed ticket".into()),
+            },
+        )
+        .await
+        .expect("create_ticket should succeed");
+
+    let fetched = client
+        .get_tickets(GetTicketsOpts::default())
+        .await
+        .expect("get_tickets should succeed");
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(
+        fetched.items[0].assigned_to.as_ref().map(|user| &user.id),
+        Some(&first_assignee)
+    );
+    assert_eq!(
+        fetched.items[0].result.as_ref().map(|result| &result.id),
+        Some(&result_id)
+    );
+    assert_eq!(
+        fetched.items[0].open_note.as_deref(),
+        Some("Please investigate")
+    );
+
+    let second_assignee = EntityId::new("user-2").expect("valid id");
+    client
+        .modify_ticket(
+            &created.id,
+            ModifyTicketOpts {
+                assigned_to: Some(second_assignee.clone()),
+                status: Some(TicketStatus::Fixed),
+                fixed_note: Some("Fixed in update".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("modify_ticket should succeed");
+
+    let reassigned = client
+        .get_tickets(GetTicketsOpts::default())
+        .await
+        .expect("get_tickets after reassign should succeed");
+    assert_eq!(
+        reassigned.items[0]
+            .assigned_to
+            .as_ref()
+            .map(|user| &user.id),
+        Some(&second_assignee)
+    );
+    assert_eq!(reassigned.items[0].status.as_deref(), Some("Fixed"));
+    assert_eq!(
+        reassigned.items[0].fixed_note.as_deref(),
+        Some("Fixed in update")
     );
 
     server.shutdown().await;

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -53,7 +53,9 @@ use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
-use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts};
+use gvm_gmp::commands::tickets::{
+    CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts, TicketOpenNote,
+};
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{
     Asset, ConfigUsageKind, CreateScanConfigResponse, GetConfigsResponse, GetPermissionsResponse,
@@ -853,7 +855,7 @@ async fn typed_ticket_create_read_and_reassign_round_trip() {
             &result_id,
             CreateTicketOpts {
                 assigned_to: first_assignee.clone(),
-                open_note: "Please investigate".into(),
+                open_note: TicketOpenNote::new("Please investigate").expect("non-empty note"),
                 comment: Some("Typed ticket".into()),
             },
         )

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -29,7 +29,7 @@ use gvm_gmp::commands::secinfo::GetSecInfoOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::GetTargetsOpts;
 use gvm_gmp::commands::tasks::GetTasksOpts;
-use gvm_gmp::commands::tickets::{GetTicketsOpts, TicketOpts};
+use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts};
 use gvm_gmp::commands::tls_certificates::{GetTlsCertificatesOpts, TlsCertificateOpts};
 use gvm_gmp::commands::users::{GetUsersOpts, UserOpts};
 use gvm_gmp::responses::ParseError;
@@ -346,7 +346,14 @@ async fn create_families_parse_typed_ids_from_table_driven_fixture_responses() {
         }
     ));
     assert_create_success!(client.create_tag("tag", TagOpts::default()));
-    assert_create_success!(client.create_ticket(&related_id, TicketOpts::default()));
+    assert_create_success!(client.create_ticket(
+        &related_id,
+        CreateTicketOpts {
+            assigned_to: related_id.clone(),
+            open_note: "Please investigate".into(),
+            comment: None,
+        }
+    ));
     assert_create_success!(client.create_user("user", UserOpts::default()));
     assert_create_success!(client.create_group("group", GroupOpts::default()));
     assert_create_success!(client.create_role("role", RoleOpts::default()));

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -29,7 +29,7 @@ use gvm_gmp::commands::secinfo::GetSecInfoOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::GetTargetsOpts;
 use gvm_gmp::commands::tasks::GetTasksOpts;
-use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts};
+use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, TicketOpenNote};
 use gvm_gmp::commands::tls_certificates::{GetTlsCertificatesOpts, TlsCertificateOpts};
 use gvm_gmp::commands::users::{GetUsersOpts, UserOpts};
 use gvm_gmp::responses::ParseError;
@@ -350,7 +350,7 @@ async fn create_families_parse_typed_ids_from_table_driven_fixture_responses() {
         &related_id,
         CreateTicketOpts {
             assigned_to: related_id.clone(),
-            open_note: "Please investigate".into(),
+            open_note: TicketOpenNote::new("Please investigate").expect("non-empty note"),
             comment: None,
         }
     ));

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -111,6 +111,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "create_tag",
     "get_tickets",
     "create_ticket",
+    "modify_ticket",
     "get_users",
     "create_user",
     "modify_user",

--- a/crates/gvm-gmp/src/commands/tickets.rs
+++ b/crates/gvm-gmp/src/commands/tickets.rs
@@ -9,11 +9,22 @@ use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_b
 use crate::enums::TicketStatus;
 use crate::types::EntityId;
 
-/// Optional fields for ticket create and modify requests.
+/// Fields for ticket create requests.
+#[derive(Debug, Clone)]
+pub struct CreateTicketOpts {
+    /// User who will own the ticket.
+    pub assigned_to: EntityId,
+    /// Required note explaining why the ticket is being opened.
+    pub open_note: String,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+}
+
+/// Optional fields for ticket modify requests.
 #[derive(Debug, Clone, Default)]
-pub struct TicketOpts {
-    /// Optional assignee name.
-    pub assigned_to: Option<String>,
+pub struct ModifyTicketOpts {
+    /// Optional replacement assignee.
+    pub assigned_to: Option<EntityId>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
     /// Optional ticket status.
@@ -47,11 +58,13 @@ pub fn clone_ticket(ticket_id: &EntityId) -> impl Request {
 
 /// Build a `create_ticket` request.
 #[must_use]
-pub fn create_ticket(result_id: &EntityId, opts: TicketOpts) -> impl Request {
+pub fn create_ticket(result_id: &EntityId, opts: CreateTicketOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_ticket");
     cmd.add_element("result")
         .set_attribute("id", result_id.as_str());
-    add_ticket_body(&mut cmd, &opts);
+    add_assignee(&mut cmd, &opts.assigned_to);
+    cmd.add_element_with_text("open_note", &opts.open_note);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
     cmd
 }
 
@@ -79,9 +92,9 @@ pub fn get_ticket(ticket_id: &EntityId) -> impl Request {
 
 /// Build a `modify_ticket` request.
 #[must_use]
-pub fn modify_ticket(ticket_id: &EntityId, opts: TicketOpts) -> impl Request {
+pub fn modify_ticket(ticket_id: &EntityId, opts: ModifyTicketOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_ticket").attribute("ticket_id", ticket_id.as_str());
-    add_ticket_body(&mut cmd, &opts);
+    add_modify_ticket_body(&mut cmd, &opts);
     cmd
 }
 
@@ -93,8 +106,7 @@ pub fn delete_ticket(ticket_id: &EntityId, ultimate: bool) -> impl Request {
         .attribute("ultimate", bool_str(ultimate))
 }
 
-fn add_ticket_body(cmd: &mut XmlCommand, opts: &TicketOpts) {
-    add_text_element(cmd, "assigned_to", opts.assigned_to.as_deref());
+fn add_modify_ticket_body(cmd: &mut XmlCommand, opts: &ModifyTicketOpts) {
     add_text_element(cmd, "comment", opts.comment.as_deref());
     if let Some(status) = opts.status {
         cmd.add_element_with_text("status", status.as_ticket_status());
@@ -102,6 +114,15 @@ fn add_ticket_body(cmd: &mut XmlCommand, opts: &TicketOpts) {
     add_text_element(cmd, "open_note", opts.open_note.as_deref());
     add_text_element(cmd, "fixed_note", opts.fixed_note.as_deref());
     add_text_element(cmd, "closed_note", opts.closed_note.as_deref());
+    if let Some(assigned_to) = opts.assigned_to.as_ref() {
+        add_assignee(cmd, assigned_to);
+    }
+}
+
+fn add_assignee(cmd: &mut XmlCommand, assigned_to: &EntityId) {
+    cmd.add_element("assigned_to")
+        .add_child("user")
+        .set_attribute("id", assigned_to.as_str());
 }
 
 #[cfg(test)]
@@ -117,14 +138,16 @@ mod tests {
     fn ticket_commands_build_xml() {
         let rendered = xml(create_ticket(
             &id("r1"),
-            TicketOpts {
+            CreateTicketOpts {
+                assigned_to: id("u1"),
+                open_note: "Please fix <today>".into(),
                 comment: Some("c".into()),
-                status: Some(TicketStatus::Open),
-                ..Default::default()
             },
         ));
-        assert!(rendered.contains("<result id=\"r1\"/>"));
-        assert!(rendered.contains("<status>Open</status>"));
+        assert_eq!(
+            rendered,
+            "<create_ticket><result id=\"r1\"/><assigned_to><user id=\"u1\"/></assigned_to><open_note>Please fix &lt;today&gt;</open_note><comment>c</comment></create_ticket>"
+        );
         assert_eq!(
             xml(clone_ticket(&id("tick1"))),
             "<create_ticket><copy>tick1</copy></create_ticket>"
@@ -144,14 +167,19 @@ mod tests {
         assert!(rendered.contains("filter=\"status=open\""));
         let rendered = xml(modify_ticket(
             &id("tick1"),
-            TicketOpts {
+            ModifyTicketOpts {
+                assigned_to: Some(id("u2")),
                 comment: Some("updated".into()),
                 ..Default::default()
             },
         ));
         assert_eq!(
             rendered,
-            "<modify_ticket ticket_id=\"tick1\"><comment>updated</comment></modify_ticket>"
+            "<modify_ticket ticket_id=\"tick1\"><comment>updated</comment><assigned_to><user id=\"u2\"/></assigned_to></modify_ticket>"
+        );
+        assert_eq!(
+            xml(modify_ticket(&id("tick1"), ModifyTicketOpts::default())),
+            "<modify_ticket ticket_id=\"tick1\"/>"
         );
         assert_eq!(
             xml(delete_ticket(&id("tick1"), true)),

--- a/crates/gvm-gmp/src/commands/tickets.rs
+++ b/crates/gvm-gmp/src/commands/tickets.rs
@@ -9,13 +9,62 @@ use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_b
 use crate::enums::TicketStatus;
 use crate::types::EntityId;
 
+/// A validated, non-empty note required when opening a ticket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TicketOpenNote(String);
+
+impl TicketOpenNote {
+    /// Validate a ticket opening note.
+    ///
+    /// # Errors
+    /// Returns [`TicketOpenNoteError::Empty`] when the note is empty or
+    /// contains only whitespace.
+    pub fn new(note: impl Into<String>) -> Result<Self, TicketOpenNoteError> {
+        let note = note.into();
+        if note.trim().is_empty() {
+            return Err(TicketOpenNoteError::Empty);
+        }
+        Ok(Self(note))
+    }
+
+    /// Borrow the validated note.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for TicketOpenNote {
+    type Error = TicketOpenNoteError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for TicketOpenNote {
+    type Error = TicketOpenNoteError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Errors raised while validating a required ticket opening note.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TicketOpenNoteError {
+    /// The note was empty or contained only whitespace.
+    #[error("ticket open note cannot be empty")]
+    Empty,
+}
+
 /// Fields for ticket create requests.
 #[derive(Debug, Clone)]
 pub struct CreateTicketOpts {
     /// User who will own the ticket.
     pub assigned_to: EntityId,
     /// Required note explaining why the ticket is being opened.
-    pub open_note: String,
+    pub open_note: TicketOpenNote,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
 }
@@ -63,7 +112,7 @@ pub fn create_ticket(result_id: &EntityId, opts: CreateTicketOpts) -> impl Reque
     cmd.add_element("result")
         .set_attribute("id", result_id.as_str());
     add_assignee(&mut cmd, &opts.assigned_to);
-    cmd.add_element_with_text("open_note", &opts.open_note);
+    cmd.add_element_with_text("open_note", opts.open_note.as_str());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
     cmd
 }
@@ -140,7 +189,7 @@ mod tests {
             &id("r1"),
             CreateTicketOpts {
                 assigned_to: id("u1"),
-                open_note: "Please fix <today>".into(),
+                open_note: TicketOpenNote::new("Please fix <today>").expect("non-empty note"),
                 comment: Some("c".into()),
             },
         ));
@@ -155,6 +204,22 @@ mod tests {
         assert_eq!(
             xml(get_ticket(&id("tick1"))),
             "<get_tickets details=\"1\" ticket_id=\"tick1\"/>"
+        );
+    }
+
+    #[test]
+    fn ticket_open_note_rejects_empty_text() {
+        assert_eq!(
+            TicketOpenNote::new("").expect_err("empty note must fail"),
+            TicketOpenNoteError::Empty
+        );
+        assert_eq!(
+            TicketOpenNote::new(" \n\t").expect_err("blank note must fail"),
+            TicketOpenNoteError::Empty
+        );
+        assert_eq!(
+            TicketOpenNote::new(" investigate ").expect("non-empty note"),
+            TicketOpenNote(" investigate ".into())
         );
     }
 

--- a/crates/gvm-gmp/tests/test_tickets.rs
+++ b/crates/gvm-gmp/tests/test_tickets.rs
@@ -16,7 +16,7 @@ fn test_create_ticket_basic() {
             &id("r1"),
             CreateTicketOpts {
                 assigned_to: id("u1"),
-                open_note: "Investigate".into(),
+                open_note: TicketOpenNote::new("Investigate").expect("non-empty note"),
                 comment: None,
             }
         )),
@@ -31,7 +31,7 @@ fn test_create_ticket_with_optionals() {
             &id("r1"),
             CreateTicketOpts {
                 assigned_to: id("u1"),
-                open_note: "o".into(),
+                open_note: TicketOpenNote::new("o").expect("non-empty note"),
                 comment: Some("c".into()),
             }
         )),

--- a/crates/gvm-gmp/tests/test_tickets.rs
+++ b/crates/gvm-gmp/tests/test_tickets.rs
@@ -12,8 +12,15 @@ use gvm_gmp::TicketStatus;
 #[test]
 fn test_create_ticket_basic() {
     assert_eq!(
-        xml(create_ticket(&id("r1"), Default::default())),
-        "<create_ticket><result id=\"r1\"/></create_ticket>"
+        xml(create_ticket(
+            &id("r1"),
+            CreateTicketOpts {
+                assigned_to: id("u1"),
+                open_note: "Investigate".into(),
+                comment: None,
+            }
+        )),
+        "<create_ticket><result id=\"r1\"/><assigned_to><user id=\"u1\"/></assigned_to><open_note>Investigate</open_note></create_ticket>"
     );
 }
 
@@ -22,16 +29,13 @@ fn test_create_ticket_with_optionals() {
     assert_eq!(
         xml(create_ticket(
             &id("r1"),
-            TicketOpts {
-                assigned_to: Some("alice".into()),
+            CreateTicketOpts {
+                assigned_to: id("u1"),
+                open_note: "o".into(),
                 comment: Some("c".into()),
-                status: Some(TicketStatus::Open),
-                open_note: Some("o".into()),
-                fixed_note: Some("f".into()),
-                closed_note: Some("cl".into()),
             }
         )),
-        "<create_ticket><result id=\"r1\"/><assigned_to>alice</assigned_to><comment>c</comment><status>Open</status><open_note>o</open_note><fixed_note>f</fixed_note><closed_note>cl</closed_note></create_ticket>"
+        "<create_ticket><result id=\"r1\"/><assigned_to><user id=\"u1\"/></assigned_to><open_note>o</open_note><comment>c</comment></create_ticket>"
     );
 }
 
@@ -44,6 +48,18 @@ fn test_ticket_get_modify_delete() {
     assert_eq!(
         xml(get_ticket(&id("tick1"))),
         "<get_tickets details=\"1\" ticket_id=\"tick1\"/>"
+    );
+    assert_eq!(
+        xml(modify_ticket(
+            &id("tick1"),
+            ModifyTicketOpts {
+                assigned_to: Some(id("u2")),
+                status: Some(TicketStatus::Closed),
+                closed_note: Some("done".into()),
+                ..Default::default()
+            }
+        )),
+        "<modify_ticket ticket_id=\"tick1\"><status>Closed</status><closed_note>done</closed_note><assigned_to><user id=\"u2\"/></assigned_to></modify_ticket>"
     );
     assert_eq!(
         xml(delete_ticket(&id("tick1"), true)),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -629,6 +629,31 @@ impl SessionHandler {
         {
             return error_response(&cmd.name, 400, "Missing required element: host_identifier");
         }
+        let (ticket_result_id, ticket_assignee_id, ticket_open_note) = if resource_type == "ticket"
+        {
+            let Some(result_id) = cmd.child_attr("result", "id") else {
+                return error_response(&cmd.name, 400, "Missing required element: result");
+            };
+            let Some(assignee_id) = nested_child_attr(cmd, &["assigned_to", "user"], "id") else {
+                return error_response(
+                    &cmd.name,
+                    400,
+                    "Missing required element: assigned_to/user",
+                );
+            };
+            let Some(open_note) =
+                parse_element_text(raw_xml, "open_note").filter(|note| !note.trim().is_empty())
+            else {
+                return error_response(&cmd.name, 400, "Missing required element: open_note");
+            };
+            (
+                Some(result_id.to_string()),
+                Some(assignee_id),
+                Some(open_note),
+            )
+        } else {
+            (None, None, None)
+        };
 
         let mut resource = Resource::new(resource_type, &name);
 
@@ -648,6 +673,17 @@ impl SessionHandler {
         if resource_type == "filter" {
             if let Some(term) = parse_element_text(raw_xml, "term") {
                 resource.set_attr("term", &term);
+            }
+        }
+        if resource_type == "ticket" {
+            if let Some(result_id) = ticket_result_id {
+                resource.set_attr("result_id", &result_id);
+            }
+            if let Some(assignee_id) = ticket_assignee_id {
+                resource.set_attr("assigned_to_id", &assignee_id);
+            }
+            if let Some(open_note) = ticket_open_note {
+                resource.set_attr("open_note", &open_note);
             }
         }
         if resource_type == "oci_image_target" {
@@ -1027,6 +1063,9 @@ impl SessionHandler {
         let new_urls = parse_element_text(raw_xml, "urls");
         let new_exclude_urls = parse_element_text(raw_xml, "exclude_urls");
         let new_status = parse_element_text(raw_xml, "status");
+        let new_open_note = parse_element_text(raw_xml, "open_note");
+        let new_fixed_note = parse_element_text(raw_xml, "fixed_note");
+        let new_closed_note = parse_element_text(raw_xml, "closed_note");
         let new_scheduler_cron_time = parse_element_text(raw_xml, "scheduler_cron_time");
         let new_nvt_oid = parse_element_text(raw_xml, "nvt_oid")
             .or_else(|| cmd.child_attr("nvt", "oid").map(str::to_string));
@@ -1034,6 +1073,7 @@ impl SessionHandler {
             .or_else(|| cmd.child_attr("result", "id").map(str::to_string));
         let new_task_id = cmd.child_attr("task", "id").map(str::to_string);
         let new_credential_id = cmd.child_attr("credential", "id").map(str::to_string);
+        let new_assignee_id = nested_child_attr(cmd, &["assigned_to", "user"], "id");
         let new_port = parse_element_text(raw_xml, "port");
         let new_type = parse_element_text(raw_xml, "type");
         let new_ca_pub = parse_element_text(raw_xml, "ca_pub");
@@ -1250,6 +1290,18 @@ impl SessionHandler {
             if resource_type == "ticket" {
                 if let Some(ref status) = new_status {
                     r.set_attr("status", status);
+                }
+                if let Some(ref assignee_id) = new_assignee_id {
+                    r.set_attr("assigned_to_id", assignee_id);
+                }
+                for (value, field) in [
+                    (&new_open_note, "open_note"),
+                    (&new_fixed_note, "fixed_note"),
+                    (&new_closed_note, "closed_note"),
+                ] {
+                    if let Some(value) = value {
+                        r.set_attr(field, value);
+                    }
                 }
             }
         };
@@ -3534,6 +3586,15 @@ fn set_alert_fields(resource: &mut Resource, cmd: &ParsedCommand) {
     if let Some(filter_id) = cmd.child_attr("filter", "id") {
         resource.set_attr("filter_id", filter_id);
     }
+}
+
+fn nested_child_attr(cmd: &ParsedCommand, path: &[&str], attr: &str) -> Option<String> {
+    let (first, rest) = path.split_first()?;
+    let mut element = cmd.children.iter().find(|child| child.name == *first)?;
+    for name in rest {
+        element = element.children.iter().find(|child| child.name == **name)?;
+    }
+    element.attributes.get(attr).cloned()
 }
 
 fn set_permission_references(resource: &mut Resource, cmd: &ParsedCommand) {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -631,10 +631,15 @@ impl SessionHandler {
         }
         let (ticket_result_id, ticket_assignee_id, ticket_open_note) = if resource_type == "ticket"
         {
-            let Some(result_id) = cmd.child_attr("result", "id") else {
+            let Some(result_id) = cmd
+                .child_attr("result", "id")
+                .filter(|id| !id.trim().is_empty())
+            else {
                 return error_response(&cmd.name, 400, "Missing required element: result");
             };
-            let Some(assignee_id) = nested_child_attr(cmd, &["assigned_to", "user"], "id") else {
+            let Some(assignee_id) = nested_child_attr(cmd, &["assigned_to", "user"], "id")
+                .filter(|id| !id.trim().is_empty())
+            else {
                 return error_response(
                     &cmd.name,
                     400,

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -377,6 +377,20 @@ impl Resource {
                 ));
             }
         }
+        if self.resource_type == "ticket" {
+            for (field, element) in [
+                ("assigned_to_id", "assigned_to"),
+                ("result_id", "result"),
+                ("task_id", "task"),
+            ] {
+                if let Some(id) = self.attr(field) {
+                    xml.push_str(&format!(
+                        "<{element} id=\"{}\"><name></name></{element}>",
+                        xml_escape_attr(id),
+                    ));
+                }
+            }
+        }
         for (k, v) in &self.attrs {
             if self.resource_type == "scanner" && k == "credential_id" {
                 xml.push_str(&format!(
@@ -390,6 +404,11 @@ impl Resource {
                     || k.starts_with("event_data:")
                     || k.starts_with("condition_data:")
                     || k.starts_with("method_data:"))
+            {
+                continue;
+            }
+            if self.resource_type == "ticket"
+                && matches!(k.as_str(), "assigned_to_id" | "result_id" | "task_id")
             {
                 continue;
             }

--- a/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
+++ b/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
@@ -190,7 +190,7 @@ async fn create_and_modify_ticket_handles_comment_and_status() {
 
     let create_resp = send_recv(
         &mut stream,
-        b"<create_ticket><result id=\"11111111-1111-1111-1111-111111111111\"/><comment>Investigating</comment></create_ticket>",
+        b"<create_ticket><result id=\"11111111-1111-1111-1111-111111111111\"/><assigned_to><user id=\"22222222-2222-2222-2222-222222222222\"/></assigned_to><open_note>Please investigate</open_note><comment>Investigating</comment></create_ticket>",
     )
     .await;
     assert_eq!(create_resp.status_code(), Some(201));
@@ -199,7 +199,7 @@ async fn create_and_modify_ticket_handles_comment_and_status() {
     let modify_resp = send_recv(
         &mut stream,
         format!(
-            "<modify_ticket ticket_id=\"{ticket_id}\"><comment>Resolved</comment><status>closed</status></modify_ticket>"
+            "<modify_ticket ticket_id=\"{ticket_id}\"><comment>Resolved</comment><status>closed</status><assigned_to><user id=\"33333333-3333-3333-3333-333333333333\"/></assigned_to></modify_ticket>"
         )
         .as_bytes(),
     )
@@ -215,7 +215,8 @@ async fn create_and_modify_ticket_handles_comment_and_status() {
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("<comment>Resolved</comment>"));
     assert!(text.contains("<status>closed</status>"));
-    assert!(text.contains("<result_id>11111111-1111-1111-1111-111111111111</result_id>"));
+    assert!(text.contains("<result id=\"11111111-1111-1111-1111-111111111111\">"));
+    assert!(text.contains("<assigned_to id=\"33333333-3333-3333-3333-333333333333\">"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
+++ b/crates/gvm-mock-server/tests/stateful_mcp_compat.rs
@@ -222,6 +222,29 @@ async fn create_and_modify_ticket_handles_comment_and_status() {
 }
 
 #[tokio::test]
+async fn create_ticket_rejects_empty_required_values() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    for request in [
+        br#"<create_ticket><result id=""/><assigned_to><user id="user-1"/></assigned_to><open_note>Investigate</open_note></create_ticket>"#
+            .as_slice(),
+        br#"<create_ticket><result id="result-1"/><assigned_to><user id=""/></assigned_to><open_note>Investigate</open_note></create_ticket>"#
+            .as_slice(),
+        br#"<create_ticket><result id="result-1"/><assigned_to><user id="user-1"/></assigned_to><open_note> </open_note></create_ticket>"#
+            .as_slice(),
+    ] {
+        let response = send_recv(&mut stream, request).await;
+        assert_eq!(response.status_code(), Some(400));
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn get_report_by_id_returns_nested_results() {
     let report_id = Uuid::new_v4();
     let result_id = Uuid::new_v4();

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix_more.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix_more.rs
@@ -203,7 +203,7 @@ async fn matrix_tickets_create_delete_ultimate() {
 
     let ticket_id = create_and_get_id(
         &mut stream,
-        b"<create_ticket><name>Matrix Ticket</name><comment>ticket</comment></create_ticket>",
+        b"<create_ticket><result id=\"11111111-1111-1111-1111-111111111111\"/><assigned_to><user id=\"22222222-2222-2222-2222-222222222222\"/></assigned_to><open_note>Matrix ticket</open_note><comment>ticket</comment></create_ticket>",
         "create_ticket",
     )
     .await;


### PR DESCRIPTION
## Summary
- model ticket creation and modification with separate schema-faithful option types
- require result, nested user assignee, and open note on create; preserve omission semantics on modify
- expose typed ticket modification and validate create/read/reassign through the stateful mock

## Validation
- cargo test -p gvm-gmp -p gvm-client -p gvm-mock-server --all-features
- cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings
- cargo fmt --all
- git diff --check

Fixes #427

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high