### PR TITLE
feat(gmp): retain task target variants

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -2907,6 +2907,23 @@ async fn full_crud_lifecycle_succeeds() {
     let task_id = task_response.id().expect("task id");
     let task_entity_id = task_id.parse().expect("entity id");
 
+    let typed_tasks = client
+        .get_tasks(Default::default())
+        .await
+        .expect("typed get_tasks should succeed");
+    let typed_task = typed_tasks
+        .items
+        .iter()
+        .find(|task| task.meta.id == task_entity_id)
+        .expect("created classic task should be returned");
+    assert_eq!(
+        typed_task.target.as_ref().map(|target| &target.id),
+        Some(&target_entity_id)
+    );
+    assert_eq!(typed_task.agent_group, None);
+    assert_eq!(typed_task.oci_image_target, None);
+    assert_eq!(typed_task.web_application_target, None);
+
     let start_response = client
         .call(start_task(&task_entity_id))
         .await

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -48,6 +48,24 @@ fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
     UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
 }
 
+async fn typed_task_by_id(server: &MockGmpServer, task_id: &EntityId) -> gvm_gmp::responses::Task {
+    let mut client = GmpClient::connect(unix_connection(server))
+        .await
+        .expect("typed task client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("typed task authentication should succeed");
+    client
+        .get_tasks(Default::default())
+        .await
+        .expect("typed get_tasks should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == *task_id)
+        .expect("created task should be returned")
+}
+
 async fn delete_task(server: &MockGmpServer, task_id: &EntityId) {
     let mut client = GmpClient::connect(unix_connection(server))
         .await
@@ -101,7 +119,15 @@ where
             agent_group_id.as_str()
         )
     );
-    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
+    let task_id =
+        EntityId::new(task_response.id().expect("created task id")).expect("valid task id");
+    let task = typed_task_by_id(server, &task_id).await;
+    assert_eq!(
+        task.agent_group.as_ref().map(|target| &target.id),
+        Some(agent_group_id)
+    );
+    assert_eq!(task.target, None);
+    task_id
 }
 
 async fn assert_create_oci_image_target_task_round_trip<C>(
@@ -141,7 +167,15 @@ where
             oci_image_target_id.as_str()
         )
     );
-    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
+    let task_id =
+        EntityId::new(task_response.id().expect("created task id")).expect("valid task id");
+    let task = typed_task_by_id(server, &task_id).await;
+    assert_eq!(
+        task.oci_image_target.as_ref().map(|target| &target.id),
+        Some(oci_image_target_id)
+    );
+    assert_eq!(task.target, None);
+    task_id
 }
 
 async fn assert_create_web_application_task_round_trip(
@@ -174,7 +208,17 @@ async fn assert_create_web_application_task_round_trip(
             "<create_task><name>Client Web Task</name><usage_type>scan</usage_type><web_application_target id=\"{target_id}\"/><scanner id=\"08b69003-5fc2-4037-a479-93b440211c73\"/><comment>created from versioned client</comment></create_task>"
         )
     );
-    EntityId::new(task_response.id().expect("created task id")).expect("valid task id")
+    let task_id =
+        EntityId::new(task_response.id().expect("created task id")).expect("valid task id");
+    let task = typed_task_by_id(server, &task_id).await;
+    assert_eq!(
+        task.web_application_target
+            .as_ref()
+            .map(|target| &target.id),
+        Some(target_id)
+    );
+    assert_eq!(task.target, None);
+    task_id
 }
 
 #[tokio::test]

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -174,6 +174,7 @@ pub use target::{CreateTargetResponse, GetTargetsResponse, Target};
 pub use task::{
     CreateTaskResponse, DeleteTaskResponse, GetTasksResponse, LastReport, ModifyTaskResponse,
     MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse, Task,
+    TaskTargetReference,
 };
 pub use ticket::{
     CreateTicketResponse, DeleteTicketResponse, GetTicketsResponse, ModifyTicketResponse, Ticket,

--- a/crates/gvm-gmp/src/responses/task.rs
+++ b/crates/gvm-gmp/src/responses/task.rs
@@ -23,6 +23,14 @@ pub struct Task {
     pub progress: Option<i32>,
     pub alterable: Option<bool>,
     pub target: Option<NamedEntity>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub agent_group: Option<NamedEntity>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub oci_image_target: Option<NamedEntity>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub web_application_target: Option<NamedEntity>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub additional_targets: Vec<TaskTargetReference>,
     pub config: Option<NamedEntity>,
     pub scanner: Option<NamedEntity>,
     pub schedule: Option<NamedEntity>,
@@ -35,6 +43,14 @@ pub struct Task {
     pub trend: Option<String>,
     pub usage_type: Option<String>,
     pub hosts_ordering: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TaskTargetReference {
+    pub kind: String,
+    pub entity: NamedEntity,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,6 +122,18 @@ pub struct ResumeTaskResponse {
 
 impl Task {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let target = parse_named_entity(node, "target")?;
+        let agent_group = parse_named_entity(node, "agent_group")?;
+        let oci_image_target = parse_named_entity(node, "oci_image_target")?;
+        let web_application_target = parse_named_entity(node, "web_application_target")?;
+        let additional_targets = parse_additional_targets(node)?;
+        validate_target_selectors(
+            target.as_ref(),
+            agent_group.as_ref(),
+            oci_image_target.as_ref(),
+            web_application_target.as_ref(),
+            &additional_targets,
+        )?;
         Ok(Self {
             meta: parse_entity_meta(node)?,
             status: node.optional_child_text("status"),
@@ -122,7 +150,11 @@ impl Task {
                 .optional_child_text("alterable")
                 .map(|value| parse_bool(&value, "alterable"))
                 .transpose()?,
-            target: parse_named_entity(node, "target")?,
+            target,
+            agent_group,
+            oci_image_target,
+            web_application_target,
+            additional_targets,
             config: parse_named_entity(node, "config")?,
             scanner: parse_named_entity(node, "scanner")?,
             schedule: parse_named_entity(node, "schedule")?,
@@ -149,6 +181,62 @@ impl Task {
             hosts_ordering: node.optional_child_text("hosts_ordering"),
         })
     }
+}
+
+fn parse_additional_targets(node: &XmlNode) -> Result<Vec<TaskTargetReference>, ParseError> {
+    node.children
+        .iter()
+        .filter(|child| {
+            child.name.ends_with("_target")
+                && !matches!(
+                    child.name.as_str(),
+                    "oci_image_target" | "web_application_target"
+                )
+        })
+        .map(|child| {
+            let raw_id = child
+                .attr("id")
+                .ok_or_else(|| ParseError::MissingElement(format!("{}.id", child.name)))?;
+            let entity = NamedEntity {
+                id: parse_entity_id(raw_id, &format!("{}.id", child.name))?,
+                name: child.required_child_text("name")?,
+            };
+            Ok(TaskTargetReference {
+                kind: child.name.clone(),
+                entity,
+            })
+        })
+        .collect()
+}
+
+fn validate_target_selectors(
+    target: Option<&NamedEntity>,
+    agent_group: Option<&NamedEntity>,
+    oci_image_target: Option<&NamedEntity>,
+    web_application_target: Option<&NamedEntity>,
+    additional_targets: &[TaskTargetReference],
+) -> Result<(), ParseError> {
+    let mut selectors = Vec::new();
+    if target.is_some() {
+        selectors.push("target");
+    }
+    if agent_group.is_some() {
+        selectors.push("agent_group");
+    }
+    if oci_image_target.is_some() {
+        selectors.push("oci_image_target");
+    }
+    if web_application_target.is_some() {
+        selectors.push("web_application_target");
+    }
+    selectors.extend(additional_targets.iter().map(|target| target.kind.as_str()));
+    if selectors.len() > 1 {
+        return Err(ParseError::InvalidValue {
+            field: "task.target_selector".to_string(),
+            value: selectors.join(", "),
+        });
+    }
+    Ok(())
 }
 
 impl GetTasksResponse {
@@ -371,6 +459,13 @@ mod tests {
         assert_eq!(parsed.items[0].status.as_deref(), Some("Done"));
         assert_eq!(parsed.items[0].progress, Some(100));
         assert_eq!(parsed.items[0].alterable, Some(true));
+        assert_eq!(
+            parsed.items[0]
+                .target
+                .as_ref()
+                .map(|target| target.id.as_str()),
+            Some("t-1")
+        );
         assert_eq!(parsed.items[0].alerts.len(), 2);
         let observers = parsed.items[0].observers.as_ref().expect("observers parse");
         assert_eq!(
@@ -399,6 +494,92 @@ mod tests {
         );
         assert_eq!(parsed.items[0].schedule_periods, Some(3));
         assert_eq!(parsed.items[1].progress, Some(42));
+    }
+
+    #[test]
+    fn parses_specialized_future_and_targetless_tasks() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-agent">
+                    <name>Agent task</name>
+                    <target id=""><name></name></target>
+                    <agent_group id="group-1"><name>Agents</name></agent_group>
+                </task>
+                <task id="task-oci">
+                    <name>OCI task</name>
+                    <target id=""><name></name></target>
+                    <oci_image_target id="oci-1"><name>Container</name></oci_image_target>
+                </task>
+                <task id="task-web">
+                    <name>Web task</name>
+                    <target id=""><name></name></target>
+                    <web_application_target id="web-1"><name>Web app</name></web_application_target>
+                </task>
+                <task id="task-import">
+                    <name>Import task</name>
+                    <target id=""><name></name></target>
+                </task>
+                <task id="task-future">
+                    <name>Future task</name>
+                    <cloud_target id="cloud-1"><name>Cloud</name></cloud_target>
+                </task>
+                <task_count>5<filtered>5</filtered></task_count>
+            </get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response).expect("task variants parse");
+
+        assert_eq!(
+            parsed.items[0]
+                .agent_group
+                .as_ref()
+                .map(|target| target.id.as_str()),
+            Some("group-1")
+        );
+        assert_eq!(parsed.items[0].target, None);
+        assert_eq!(
+            parsed.items[1]
+                .oci_image_target
+                .as_ref()
+                .map(|target| target.id.as_str()),
+            Some("oci-1")
+        );
+        assert_eq!(
+            parsed.items[2]
+                .web_application_target
+                .as_ref()
+                .map(|target| target.id.as_str()),
+            Some("web-1")
+        );
+        assert_eq!(parsed.items[3].target, None);
+        assert!(parsed.items[3].additional_targets.is_empty());
+        assert_eq!(parsed.items[4].additional_targets.len(), 1);
+        assert_eq!(parsed.items[4].additional_targets[0].kind, "cloud_target");
+        assert_eq!(
+            parsed.items[4].additional_targets[0].entity.id.as_str(),
+            "cloud-1"
+        );
+    }
+
+    #[test]
+    fn rejects_tasks_with_multiple_target_selectors() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-invalid">
+                    <name>Invalid task</name>
+                    <target id="target-1"><name>Classic</name></target>
+                    <agent_group id="group-1"><name>Agents</name></agent_group>
+                </task>
+            </get_tasks_response>"#,
+        );
+
+        let error = GetTasksResponse::from_response(&response).expect_err("multiple targets fail");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, value }
+                if field == "task.target_selector" && value == "target, agent_group"
+        ));
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -331,6 +331,27 @@ impl Resource {
                 }
             }
         }
+        if self.resource_type == "task" {
+            if self.attr("target_id").is_none() {
+                xml.push_str("<target id=\"\"><name></name></target>");
+            }
+            for (attribute, element) in [
+                ("target_id", "target"),
+                ("agent_group_id", "agent_group"),
+                ("oci_image_target_id", "oci_image_target"),
+                ("web_application_target_id", "web_application_target"),
+                ("config_id", "config"),
+                ("scanner_id", "scanner"),
+                ("schedule_id", "schedule"),
+            ] {
+                if let Some(id) = self.attr(attribute) {
+                    xml.push_str(&format!(
+                        "<{element} id=\"{}\"><name></name></{element}>",
+                        xml_escape_attr(id),
+                    ));
+                }
+            }
+        }
         // Add type-specific attributes
         for (k, v) in &self.attrs {
             if self.resource_type == "permission"
@@ -345,6 +366,20 @@ impl Resource {
                 && matches!(
                     k.as_str(),
                     "oid" | "nvt_oid" | "config_id" | "preferences_config_id"
+                )
+            {
+                continue;
+            }
+            if self.resource_type == "task"
+                && matches!(
+                    k.as_str(),
+                    "target_id"
+                        | "agent_group_id"
+                        | "oci_image_target_id"
+                        | "web_application_target_id"
+                        | "config_id"
+                        | "scanner_id"
+                        | "schedule_id"
                 )
             {
                 continue;
@@ -611,6 +646,7 @@ impl ResourceStore {
             task.set_attr("scanner_id", &scanner.to_string());
         }
         if references.target.is_none() && references.specialized_target.is_none() {
+            task.attrs.remove("target_id");
             task.set_attr("import_task", "1");
             task.set_attr("status", TaskStatus::Done.as_str());
         } else {

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -242,9 +242,11 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("Agent Group Task"));
     assert!(text.contains(&format!(
-        "<agent_group_id>{agent_group_id}</agent_group_id>"
+        "<agent_group id=\"{agent_group_id}\"><name></name></agent_group>"
     )));
-    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
+    assert!(text.contains(&format!(
+        "<scanner id=\"{DEFAULT_SCANNER_ID}\"><name></name></scanner>"
+    )));
 
     let replacement = send_recv(
         &mut stream,
@@ -271,7 +273,7 @@ async fn stateful_create_agent_group_task_preserves_agent_group_id() {
         .as_str()
         .expect("valid utf8")
         .contains(&format!(
-            "<agent_group_id>{replacement_id}</agent_group_id>"
+            "<agent_group id=\"{replacement_id}\"><name></name></agent_group>"
         )));
 
     let start_resp = send_recv(
@@ -337,9 +339,11 @@ async fn stateful_create_oci_image_target_task_preserves_target_id() {
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains("OCI Target Task"));
     assert!(text.contains(&format!(
-        "<oci_image_target_id>{target_id}</oci_image_target_id>"
+        "<oci_image_target id=\"{target_id}\"><name></name></oci_image_target>"
     )));
-    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
+    assert!(text.contains(&format!(
+        "<scanner id=\"{DEFAULT_SCANNER_ID}\"><name></name></scanner>"
+    )));
 
     server.shutdown().await;
 }
@@ -388,9 +392,11 @@ async fn stateful_create_web_application_task_preserves_target_id() {
 
     let text = get_resp.as_str().expect("valid utf8");
     assert!(text.contains(&format!(
-        "<web_application_target_id>{target_id}</web_application_target_id>"
+        "<web_application_target id=\"{target_id}\"><name></name></web_application_target>"
     )));
-    assert!(text.contains(&format!("<scanner_id>{DEFAULT_SCANNER_ID}</scanner_id>")));
+    assert!(text.contains(&format!(
+        "<scanner id=\"{DEFAULT_SCANNER_ID}\"><name></name></scanner>"
+    )));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -291,10 +291,9 @@ async fn task_reference_updates_are_validated_and_only_allowed_while_new() {
         format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
     )
     .await;
-    assert!(task
-        .as_str()
-        .expect("UTF-8 response")
-        .contains(&format!("<target_id>{second_target_id}</target_id>")));
+    assert!(task.as_str().expect("UTF-8 response").contains(&format!(
+        "<target id=\"{second_target_id}\"><name></name></target>"
+    )));
 
     let old_target_delete = send_recv(
         &mut stream,


### PR DESCRIPTION
## Summary
- expose agent-group, OCI-image, and web-application target references in typed task responses while preserving the classic target field
- preserve additive future target families as named references and reject malformed responses with multiple active selectors
- keep new serde fields backward-compatible through defaults
- render canonical task references in the stateful mock and verify classic, specialized, future, and targetless task shapes

## Validation
- cargo test -p gvm-gmp -p gvm-client -p gvm-mock-server --all-features
- cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings
- cargo fmt --all
- git diff --check

Fixes #431

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high