### PR TITLE
fix(gmp): preserve explicit empty modify collections

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -104,7 +104,9 @@ use gvm_gmp::commands::system::{
 };
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
-use gvm_gmp::commands::targets::{create_target, get_targets, CreateTargetOpts, GetTargetsOpts};
+use gvm_gmp::commands::targets::{
+    create_target, get_targets, modify_target, CreateTargetOpts, GetTargetsOpts, ModifyTargetOpts,
+};
 use gvm_gmp::commands::tasks::{
     create_import_task, create_task, get_tasks, resume_task, start_task, CreateTaskOpts,
     GetTasksOpts,
@@ -154,9 +156,10 @@ use gvm_gmp::responses::{
     GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
     ModifyAlertResponse, ModifyAssetResponse, ModifyConfigResponse, ModifyCredentialResponse,
     ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyPortListResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ModifyTicketResponse, ModifyUserResponse,
-    ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
-    StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
+    ModifyScanConfigResponse, ModifyScannerResponse, ModifyTargetResponse, ModifyTicketResponse,
+    ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse,
+    ResumeTaskResponse, StartTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse,
+    VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::{CredentialStoreCredentialType, FeedType};
@@ -213,6 +216,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<CreateTargetResponse, GvmError> {
         let response = self.send(create_target(name, opts)).await?;
         CreateTargetResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_target` request and return a typed [`ModifyTargetResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_target(
+        &mut self,
+        target_id: &EntityId,
+        opts: ModifyTargetOpts,
+    ) -> Result<ModifyTargetResponse, GvmError> {
+        let response = self.send(modify_target(target_id, opts)).await?;
+        ModifyTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a `create_oci_image_target` request and return a typed

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -50,7 +50,7 @@ use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::secinfo::{get_info, get_info_list, GenericInfoType, GetInfoListOpts};
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
-    create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts,
+    create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts, ModifyTargetOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
 use gvm_gmp::commands::tickets::{
@@ -64,8 +64,8 @@ use gvm_gmp::responses::{
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
-    AlertCondition, AlertEvent, AlertMethod, FeedType, PermissionSubjectType, SortOrder,
-    TicketStatus,
+    AlertCondition, AlertEvent, AlertMethod, CollectionUpdate, FeedType, PermissionSubjectType,
+    SortOrder, TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
@@ -2707,6 +2707,192 @@ async fn typed_permission_lifecycle_uses_nested_references() {
         )
     );
     assert_eq!(commands[3], "<get_permissions/>");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_host_updates_preserve_replace_and_clear_state() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let target = client
+        .create_target(
+            "Collection Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into(), "192.0.2.2".into()],
+                exclude_hosts: vec!["192.0.2.3".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created");
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                comment: Some("hosts omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be modified without changing hosts");
+    let targets = client
+        .get_targets(GetTargetsOpts::default())
+        .await
+        .expect("targets should be retrieved");
+    let fetched_target = targets
+        .items
+        .iter()
+        .find(|item| item.meta.id == target.id)
+        .expect("target should be listed");
+    assert_eq!(
+        fetched_target.hosts,
+        vec!["192.0.2.1".to_string(), "192.0.2.2".to_string()]
+    );
+    assert_eq!(fetched_target.exclude_hosts, vec!["192.0.2.3".to_string()]);
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                hosts: CollectionUpdate::Clear,
+                exclude_hosts: CollectionUpdate::replace(["192.0.2.4".into()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target hosts should be cleared and exclusions replaced");
+    let targets = client
+        .get_targets(GetTargetsOpts::default())
+        .await
+        .expect("modified targets should be retrieved");
+    let fetched_target = targets
+        .items
+        .iter()
+        .find(|item| item.meta.id == target.id)
+        .expect("target should be listed");
+    assert!(fetched_target.hosts.is_empty());
+    assert_eq!(fetched_target.exclude_hosts, vec!["192.0.2.4".to_string()]);
+
+    let history = server.command_history();
+    assert!(history.iter().any(|record| {
+        record.command_name() == "modify_target"
+            && std::str::from_utf8(record.raw_xml())
+                .is_ok_and(|xml| xml.contains("<hosts></hosts>"))
+    }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_user_role_updates_preserve_replace_and_clear_state() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let role_one = client
+        .create_role("Collection Role One", RoleOpts::default())
+        .await
+        .expect("first role should be created");
+    let role_two = client
+        .create_role("Collection Role Two", RoleOpts::default())
+        .await
+        .expect("second role should be created");
+    let user = client
+        .create_user(
+            "Collection User",
+            UserOpts {
+                role_ids: vec![role_one.id.clone()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("user should be created");
+    client
+        .modify_user(
+            &user.id,
+            ModifyUserOpts {
+                comment: Some("roles omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("user should be modified without changing roles");
+    let users = client
+        .get_users(GetUsersOpts::default())
+        .await
+        .expect("users should be retrieved");
+    let fetched_user = users
+        .items
+        .iter()
+        .find(|item| item.meta.id == user.id)
+        .expect("user should be listed");
+    assert_eq!(
+        fetched_user
+            .roles
+            .iter()
+            .map(|role| role.id.clone())
+            .collect::<Vec<_>>(),
+        vec![role_one.id.clone()]
+    );
+
+    client
+        .modify_user(
+            &user.id,
+            ModifyUserOpts {
+                role_ids: CollectionUpdate::replace([role_two.id.clone()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("user roles should be replaced");
+    client
+        .modify_user(
+            &user.id,
+            ModifyUserOpts {
+                role_ids: CollectionUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("user roles should be cleared");
+    let users = client
+        .get_users(GetUsersOpts::default())
+        .await
+        .expect("modified users should be retrieved");
+    let fetched_user = users
+        .items
+        .iter()
+        .find(|item| item.meta.id == user.id)
+        .expect("user should be listed");
+    assert!(fetched_user.roles.is_empty());
+
+    let history = server.command_history();
+    assert!(history.iter().any(|record| {
+        record.command_name() == "modify_user"
+            && std::str::from_utf8(record.raw_xml())
+                .is_ok_and(|xml| xml.contains("<role id=\"0\"/>"))
+    }));
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -10,6 +10,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "authenticate",
     "get_targets",
     "create_target",
+    "modify_target",
     "create_oci_image_target_parsed",
     "clone_oci_image_target_parsed",
     "get_oci_image_target_parsed",

--- a/crates/gvm-gmp/src/commands/notes.rs
+++ b/crates/gvm-gmp/src/commands/notes.rs
@@ -6,15 +6,36 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
-use crate::types::EntityId;
+use crate::types::{CollectionUpdate, EntityId};
 
-/// Optional fields for note create and modify requests.
+/// Optional fields for note create requests.
 #[derive(Debug, Clone, Default)]
 pub struct NoteOpts {
     /// Optional text body.
     pub text: Option<String>,
     /// Host entries associated with the request.
     pub hosts: Vec<String>,
+    /// Optional port selector.
+    pub port: Option<String>,
+    /// Optional severity value.
+    pub severity: Option<String>,
+    /// Optional task identifier.
+    pub task_id: Option<EntityId>,
+    /// Optional result identifier.
+    pub result_id: Option<EntityId>,
+    /// Whether the resource should be active.
+    pub active: Option<bool>,
+    /// Whether the note should be marked as orphaned.
+    pub orphan: Option<bool>,
+}
+
+/// Optional fields for `modify_note` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyNoteOpts {
+    /// Optional text body.
+    pub text: Option<String>,
+    /// Host update: omit, replace, or explicitly clear.
+    pub hosts: CollectionUpdate<String>,
     /// Optional port selector.
     pub port: Option<String>,
     /// Optional severity value.
@@ -55,7 +76,19 @@ pub fn clone_note(note_id: &EntityId) -> impl Request {
 pub fn create_note(nvt_oid: &str, opts: NoteOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_note");
     cmd.add_element("nvt").set_attribute("oid", nvt_oid);
-    add_note_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "text", opts.text.as_deref());
+    if !opts.hosts.is_empty() {
+        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
+    }
+    add_note_tail(
+        &mut cmd,
+        opts.port.as_deref(),
+        opts.severity.as_deref(),
+        opts.task_id.as_ref(),
+        opts.result_id.as_ref(),
+        opts.active,
+        opts.orphan,
+    );
     cmd
 }
 
@@ -84,9 +117,19 @@ pub fn get_note(note_id: &EntityId) -> impl Request {
 
 /// Build a `modify_note` request.
 #[must_use]
-pub fn modify_note(note_id: &EntityId, opts: NoteOpts) -> impl Request {
+pub fn modify_note(note_id: &EntityId, opts: ModifyNoteOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_note").attribute("note_id", note_id.as_str());
-    add_note_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "text", opts.text.as_deref());
+    add_hosts_update(&mut cmd, &opts.hosts);
+    add_note_tail(
+        &mut cmd,
+        opts.port.as_deref(),
+        opts.severity.as_deref(),
+        opts.task_id.as_ref(),
+        opts.result_id.as_ref(),
+        opts.active,
+        opts.orphan,
+    );
     cmd
 }
 
@@ -98,26 +141,42 @@ pub fn delete_note(note_id: &EntityId, ultimate: bool) -> impl Request {
         .attribute("ultimate", bool_str(ultimate))
 }
 
-fn add_note_body(cmd: &mut XmlCommand, opts: &NoteOpts) {
-    add_text_element(cmd, "text", opts.text.as_deref());
-    if !opts.hosts.is_empty() {
-        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
-    }
-    add_text_element(cmd, "port", opts.port.as_deref());
-    add_text_element(cmd, "severity", opts.severity.as_deref());
-    if let Some(task_id) = opts.task_id.as_ref() {
+fn add_note_tail(
+    cmd: &mut XmlCommand,
+    port: Option<&str>,
+    severity: Option<&str>,
+    task_id: Option<&EntityId>,
+    result_id: Option<&EntityId>,
+    active: Option<bool>,
+    orphan: Option<bool>,
+) {
+    add_text_element(cmd, "port", port);
+    add_text_element(cmd, "severity", severity);
+    if let Some(task_id) = task_id {
         cmd.add_element("task")
             .set_attribute("id", task_id.as_str());
     }
-    if let Some(result_id) = opts.result_id.as_ref() {
+    if let Some(result_id) = result_id {
         cmd.add_element("result")
             .set_attribute("id", result_id.as_str());
     }
-    if let Some(active) = opts.active {
+    if let Some(active) = active {
         cmd.add_element_with_text("active", bool_str(active));
     }
-    if let Some(orphan) = opts.orphan {
+    if let Some(orphan) = orphan {
         cmd.add_element_with_text("orphan", bool_str(orphan));
+    }
+}
+
+fn add_hosts_update(cmd: &mut XmlCommand, update: &CollectionUpdate<String>) {
+    match update {
+        CollectionUpdate::Omitted => {}
+        CollectionUpdate::Replace(hosts) => {
+            cmd.add_element_with_text("hosts", &hosts.join(","));
+        }
+        CollectionUpdate::Clear => {
+            cmd.add_element_with_text("hosts", "");
+        }
     }
 }
 
@@ -167,7 +226,7 @@ mod tests {
         assert!(rendered.contains("result=\"1\""));
         let rendered = xml(modify_note(
             &id("n1"),
-            NoteOpts {
+            ModifyNoteOpts {
                 text: Some("updated".into()),
                 ..Default::default()
             },
@@ -179,6 +238,34 @@ mod tests {
         assert_eq!(
             xml(delete_note(&id("n1"), true)),
             "<delete_note note_id=\"n1\" ultimate=\"1\"/>"
+        );
+    }
+
+    #[test]
+    fn modify_note_distinguishes_omitted_replaced_and_cleared_hosts() {
+        assert_eq!(
+            xml(modify_note(&id("n1"), ModifyNoteOpts::default())),
+            "<modify_note note_id=\"n1\"/>"
+        );
+        assert_eq!(
+            xml(modify_note(
+                &id("n1"),
+                ModifyNoteOpts {
+                    hosts: CollectionUpdate::replace(["192.0.2.1".into(), "192.0.2.2".into()]),
+                    ..Default::default()
+                }
+            )),
+            "<modify_note note_id=\"n1\"><hosts>192.0.2.1,192.0.2.2</hosts></modify_note>"
+        );
+        assert_eq!(
+            xml(modify_note(
+                &id("n1"),
+                ModifyNoteOpts {
+                    hosts: CollectionUpdate::Clear,
+                    ..Default::default()
+                }
+            )),
+            "<modify_note note_id=\"n1\"><hosts></hosts></modify_note>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/overrides.rs
+++ b/crates/gvm-gmp/src/commands/overrides.rs
@@ -6,15 +6,36 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
-use crate::types::EntityId;
+use crate::types::{CollectionUpdate, EntityId};
 
-/// Optional fields for override create and modify requests.
+/// Optional fields for override create requests.
 #[derive(Debug, Clone, Default)]
 pub struct OverrideOpts {
     /// Optional text body.
     pub text: Option<String>,
     /// Host entries associated with the request.
     pub hosts: Vec<String>,
+    /// Optional port selector.
+    pub port: Option<String>,
+    /// Optional severity value.
+    pub severity: Option<String>,
+    /// Optional replacement severity value.
+    pub new_severity: Option<String>,
+    /// Optional task identifier.
+    pub task_id: Option<EntityId>,
+    /// Optional result identifier.
+    pub result_id: Option<EntityId>,
+    /// Whether the resource should be active.
+    pub active: Option<bool>,
+}
+
+/// Optional fields for `modify_override` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyOverrideOpts {
+    /// Optional text body.
+    pub text: Option<String>,
+    /// Host update: omit, replace, or explicitly clear.
+    pub hosts: CollectionUpdate<String>,
     /// Optional port selector.
     pub port: Option<String>,
     /// Optional severity value.
@@ -55,7 +76,19 @@ pub fn clone_override(override_id: &EntityId) -> impl Request {
 pub fn create_override(nvt_oid: &str, opts: OverrideOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_override");
     cmd.add_element("nvt").set_attribute("oid", nvt_oid);
-    add_override_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "text", opts.text.as_deref());
+    if !opts.hosts.is_empty() {
+        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
+    }
+    add_override_tail(
+        &mut cmd,
+        opts.port.as_deref(),
+        opts.severity.as_deref(),
+        opts.new_severity.as_deref(),
+        opts.task_id.as_ref(),
+        opts.result_id.as_ref(),
+        opts.active,
+    );
     cmd
 }
 
@@ -84,9 +117,19 @@ pub fn get_override(override_id: &EntityId) -> impl Request {
 
 /// Build a `modify_override` request.
 #[must_use]
-pub fn modify_override(override_id: &EntityId, opts: OverrideOpts) -> impl Request {
+pub fn modify_override(override_id: &EntityId, opts: ModifyOverrideOpts) -> impl Request {
     let mut cmd = XmlCommand::new("modify_override").attribute("override_id", override_id.as_str());
-    add_override_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "text", opts.text.as_deref());
+    add_hosts_update(&mut cmd, &opts.hosts);
+    add_override_tail(
+        &mut cmd,
+        opts.port.as_deref(),
+        opts.severity.as_deref(),
+        opts.new_severity.as_deref(),
+        opts.task_id.as_ref(),
+        opts.result_id.as_ref(),
+        opts.active,
+    );
     cmd
 }
 
@@ -98,24 +141,40 @@ pub fn delete_override(override_id: &EntityId, ultimate: bool) -> impl Request {
         .attribute("ultimate", bool_str(ultimate))
 }
 
-fn add_override_body(cmd: &mut XmlCommand, opts: &OverrideOpts) {
-    add_text_element(cmd, "text", opts.text.as_deref());
-    if !opts.hosts.is_empty() {
-        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
-    }
-    add_text_element(cmd, "port", opts.port.as_deref());
-    add_text_element(cmd, "severity", opts.severity.as_deref());
-    add_text_element(cmd, "new_severity", opts.new_severity.as_deref());
-    if let Some(task_id) = opts.task_id.as_ref() {
+fn add_override_tail(
+    cmd: &mut XmlCommand,
+    port: Option<&str>,
+    severity: Option<&str>,
+    new_severity: Option<&str>,
+    task_id: Option<&EntityId>,
+    result_id: Option<&EntityId>,
+    active: Option<bool>,
+) {
+    add_text_element(cmd, "port", port);
+    add_text_element(cmd, "severity", severity);
+    add_text_element(cmd, "new_severity", new_severity);
+    if let Some(task_id) = task_id {
         cmd.add_element("task")
             .set_attribute("id", task_id.as_str());
     }
-    if let Some(result_id) = opts.result_id.as_ref() {
+    if let Some(result_id) = result_id {
         cmd.add_element("result")
             .set_attribute("id", result_id.as_str());
     }
-    if let Some(active) = opts.active {
+    if let Some(active) = active {
         cmd.add_element_with_text("active", bool_str(active));
+    }
+}
+
+fn add_hosts_update(cmd: &mut XmlCommand, update: &CollectionUpdate<String>) {
+    match update {
+        CollectionUpdate::Omitted => {}
+        CollectionUpdate::Replace(hosts) => {
+            cmd.add_element_with_text("hosts", &hosts.join(","));
+        }
+        CollectionUpdate::Clear => {
+            cmd.add_element_with_text("hosts", "");
+        }
     }
 }
 
@@ -162,7 +221,7 @@ mod tests {
         assert!(rendered.contains("result=\"1\""));
         let rendered = xml(modify_override(
             &id("o1"),
-            OverrideOpts {
+            ModifyOverrideOpts {
                 text: Some("updated".into()),
                 ..Default::default()
             },
@@ -174,6 +233,34 @@ mod tests {
         assert_eq!(
             xml(delete_override(&id("o1"), false)),
             "<delete_override override_id=\"o1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn modify_override_distinguishes_omitted_replaced_and_cleared_hosts() {
+        assert_eq!(
+            xml(modify_override(&id("o1"), ModifyOverrideOpts::default())),
+            "<modify_override override_id=\"o1\"/>"
+        );
+        assert_eq!(
+            xml(modify_override(
+                &id("o1"),
+                ModifyOverrideOpts {
+                    hosts: CollectionUpdate::replace(["192.0.2.1".into(), "192.0.2.2".into()]),
+                    ..Default::default()
+                }
+            )),
+            "<modify_override override_id=\"o1\"><hosts>192.0.2.1,192.0.2.2</hosts></modify_override>"
+        );
+        assert_eq!(
+            xml(modify_override(
+                &id("o1"),
+                ModifyOverrideOpts {
+                    hosts: CollectionUpdate::Clear,
+                    ..Default::default()
+                }
+            )),
+            "<modify_override override_id=\"o1\"><hosts></hosts></modify_override>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -9,7 +9,7 @@ use crate::common::{
     add_filter_attrs, add_optional_id_element, add_text_element, bool_str, set_optional_bool_attr,
 };
 use crate::enums::AliveTest;
-use crate::types::EntityId;
+use crate::types::{CollectionUpdate, EntityId};
 
 /// Optional fields for `create_target` requests.
 #[derive(Debug, Clone, Default)]
@@ -58,10 +58,10 @@ pub struct ModifyTargetOpts {
     pub name: Option<String>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Host entries associated with the request.
-    pub hosts: Vec<String>,
-    /// Hosts to exclude from the request.
-    pub exclude_hosts: Vec<String>,
+    /// Host update: omit, replace, or explicitly clear.
+    pub hosts: CollectionUpdate<String>,
+    /// Excluded-host update: omit, replace, or explicitly clear.
+    pub exclude_hosts: CollectionUpdate<String>,
     /// Optional alive-test strategy.
     pub alive_test: Option<AliveTest>,
     /// Optional port-list identifier.
@@ -140,12 +140,8 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    if !opts.hosts.is_empty() {
-        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
-    }
-    if !opts.exclude_hosts.is_empty() {
-        cmd.add_element_with_text("exclude_hosts", &opts.exclude_hosts.join(","));
-    }
+    add_collection_update(&mut cmd, "hosts", &opts.hosts);
+    add_collection_update(&mut cmd, "exclude_hosts", &opts.exclude_hosts);
     if let Some(alive_test) = opts.alive_test {
         cmd.add_element_with_text("alive_test", alive_test.as_target_name());
     }
@@ -216,6 +212,18 @@ fn add_target_credentials(cmd: &mut XmlCommand, opts: &impl TargetCredentialOpts
     add_optional_id_element(cmd, "smb_credential", opts.smb_credential_id());
     add_optional_id_element(cmd, "esxi_credential", opts.esxi_credential_id());
     add_optional_id_element(cmd, "snmp_credential", opts.snmp_credential_id());
+}
+
+fn add_collection_update(cmd: &mut XmlCommand, element: &str, update: &CollectionUpdate<String>) {
+    match update {
+        CollectionUpdate::Omitted => {}
+        CollectionUpdate::Replace(values) => {
+            cmd.add_element_with_text(element, &values.join(","));
+        }
+        CollectionUpdate::Clear => {
+            cmd.add_element_with_text(element, "");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -298,6 +306,36 @@ mod tests {
         assert_eq!(
             xml(delete_target(&id("t1"), false)),
             "<delete_target target_id=\"t1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn modify_target_distinguishes_omitted_replaced_and_cleared_hosts() {
+        assert_eq!(
+            xml(modify_target(&id("t1"), ModifyTargetOpts::default())),
+            "<modify_target target_id=\"t1\"/>"
+        );
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    hosts: CollectionUpdate::replace(["192.0.2.1".into(), "192.0.2.2".into()]),
+                    exclude_hosts: CollectionUpdate::replace(["192.0.2.3".into()]),
+                    ..Default::default()
+                }
+            )),
+            "<modify_target target_id=\"t1\"><hosts>192.0.2.1,192.0.2.2</hosts><exclude_hosts>192.0.2.3</exclude_hosts></modify_target>"
+        );
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    hosts: CollectionUpdate::Clear,
+                    exclude_hosts: CollectionUpdate::Clear,
+                    ..Default::default()
+                }
+            )),
+            "<modify_target target_id=\"t1\"><hosts></hosts><exclude_hosts></exclude_hosts></modify_target>"
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/users.rs
+++ b/crates/gvm-gmp/src/commands/users.rs
@@ -7,9 +7,9 @@ use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
 use crate::enums::UserAuthType;
-use crate::types::EntityId;
+use crate::types::{CollectionUpdate, EntityId};
 
-/// Optional fields for user create and modify requests.
+/// Optional fields for user create requests.
 #[derive(Debug, Clone, Default)]
 pub struct UserOpts {
     /// Optional comment text included in the request.
@@ -35,20 +35,25 @@ pub struct ModifyUserOpts {
     pub password: Option<String>,
     /// Optional host-access restrictions.
     pub host_access: Option<UserHostAccess>,
-    /// Role identifiers assigned to the user.
-    pub role_ids: Vec<EntityId>,
+    /// Role update: omit, replace, or explicitly clear.
+    pub role_ids: CollectionUpdate<EntityId>,
     /// Optional user authentication type.
     pub auth_type: Option<UserAuthType>,
 }
 
 impl From<UserOpts> for ModifyUserOpts {
     fn from(opts: UserOpts) -> Self {
+        let role_ids = if opts.role_ids.is_empty() {
+            CollectionUpdate::Omitted
+        } else {
+            CollectionUpdate::Replace(opts.role_ids)
+        };
         Self {
             new_name: None,
             comment: opts.comment,
             password: opts.password,
             host_access: opts.host_access,
-            role_ids: opts.role_ids,
+            role_ids,
             auth_type: opts.auth_type,
         }
     }
@@ -126,7 +131,14 @@ pub fn clone_user(user_id: &EntityId) -> impl Request {
 pub fn create_user(name: &str, opts: UserOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_user");
     cmd.add_element_with_text("name", name);
-    add_user_body(&mut cmd, &opts);
+    add_user_common(
+        &mut cmd,
+        opts.comment.as_deref(),
+        opts.password.as_deref(),
+        opts.host_access.as_ref(),
+        opts.auth_type,
+    );
+    add_roles(&mut cmd, &opts.role_ids);
     cmd
 }
 
@@ -170,18 +182,27 @@ pub fn delete_user(user_id: &EntityId, ultimate: bool) -> impl Request {
         .attribute("ultimate", bool_str(ultimate))
 }
 
-fn add_user_body(cmd: &mut XmlCommand, opts: &UserOpts) {
-    add_text_element(cmd, "comment", opts.comment.as_deref());
-    add_text_element(cmd, "password", opts.password.as_deref());
-    if let Some(host_access) = &opts.host_access {
+fn add_user_common(
+    cmd: &mut XmlCommand,
+    comment: Option<&str>,
+    password: Option<&str>,
+    host_access: Option<&UserHostAccess>,
+    auth_type: Option<UserAuthType>,
+) {
+    add_text_element(cmd, "comment", comment);
+    add_text_element(cmd, "password", password);
+    if let Some(host_access) = host_access {
         cmd.add_element("hosts")
             .set_attribute("allow", bool_str(host_access.allow))
             .set_text(&host_access.hosts);
     }
-    if let Some(auth_type) = opts.auth_type {
+    if let Some(auth_type) = auth_type {
         cmd.add_element_with_text("authentication", auth_type.as_gmp_str());
     }
-    for role_id in &opts.role_ids {
+}
+
+fn add_roles(cmd: &mut XmlCommand, role_ids: &[EntityId]) {
+    for role_id in role_ids {
         cmd.add_element("role")
             .set_attribute("id", role_id.as_str());
     }
@@ -198,9 +219,14 @@ fn add_modify_user_body(cmd: &mut XmlCommand, opts: &ModifyUserOpts) {
     if let Some(auth_type) = opts.auth_type {
         cmd.add_element_with_text("authentication", auth_type.as_gmp_str());
     }
-    for role_id in &opts.role_ids {
-        cmd.add_element("role")
-            .set_attribute("id", role_id.as_str());
+    match &opts.role_ids {
+        CollectionUpdate::Omitted => {}
+        CollectionUpdate::Replace(role_ids) if !role_ids.is_empty() => {
+            add_roles(cmd, role_ids);
+        }
+        CollectionUpdate::Replace(_) | CollectionUpdate::Clear => {
+            cmd.add_element("role").set_attribute("id", "0");
+        }
     }
 }
 
@@ -269,7 +295,7 @@ mod tests {
     fn modify_user_emits_host_access_allow_mode() {
         let rendered = xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::allow("192.0.2.0/24")),
                 ..Default::default()
             },
@@ -285,7 +311,7 @@ mod tests {
     fn modify_user_emits_host_access_deny_mode() {
         let rendered = xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::deny("192.0.2.0/24")),
                 ..Default::default()
             },
@@ -301,7 +327,7 @@ mod tests {
     fn modify_user_emits_explicit_empty_host_access() {
         let rendered = xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::deny("")),
                 ..Default::default()
             },
@@ -310,6 +336,34 @@ mod tests {
         assert_eq!(
             rendered,
             "<modify_user user_id=\"u1\"><hosts allow=\"0\"></hosts></modify_user>"
+        );
+    }
+
+    #[test]
+    fn modify_user_distinguishes_omitted_replaced_and_cleared_roles() {
+        assert_eq!(
+            xml(modify_user(&id("u1"), ModifyUserOpts::default())),
+            "<modify_user user_id=\"u1\"/>"
+        );
+        assert_eq!(
+            xml(modify_user(
+                &id("u1"),
+                ModifyUserOpts {
+                    role_ids: CollectionUpdate::replace([id("r1"), id("r2")]),
+                    ..Default::default()
+                }
+            )),
+            "<modify_user user_id=\"u1\"><role id=\"r1\"/><role id=\"r2\"/></modify_user>"
+        );
+        assert_eq!(
+            xml(modify_user(
+                &id("u1"),
+                ModifyUserOpts {
+                    role_ids: CollectionUpdate::Clear,
+                    ..Default::default()
+                }
+            )),
+            "<modify_user user_id=\"u1\"><role id=\"0\"/></modify_user>"
         );
     }
 }

--- a/crates/gvm-gmp/src/lib.rs
+++ b/crates/gvm-gmp/src/lib.rs
@@ -24,4 +24,4 @@ pub use enums::*;
 /// Re-exported gvmd filter helpers.
 pub use filtering::{FilterFragment, FilterFragmentError, PaginatedFilter, Pagination};
 /// Re-exported shared GMP types.
-pub use types::{EntityId, EntityIdError, GmpVersion};
+pub use types::{CollectionUpdate, EntityId, EntityIdError, GmpVersion};

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -176,7 +176,7 @@ pub use system::{
 };
 pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};
-pub use target::{CreateTargetResponse, GetTargetsResponse, Target};
+pub use target::{CreateTargetResponse, GetTargetsResponse, ModifyTargetResponse, Target};
 pub use task::{
     CreateTaskResponse, CurrentReport, DeleteTaskResponse, GetTasksResponse, LastReport,
     ModifyTaskResponse, MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse,

--- a/crates/gvm-gmp/src/responses/user.rs
+++ b/crates/gvm-gmp/src/responses/user.rs
@@ -151,7 +151,7 @@ pub type DeleteUserResponse = ActionResponse;
 mod tests {
     use gvm_protocol::{Request, Response};
 
-    use crate::commands::users::{modify_user, UserOpts};
+    use crate::commands::users::{modify_user, ModifyUserOpts};
 
     use super::*;
 
@@ -313,7 +313,7 @@ mod tests {
         let rendered = String::from_utf8(
             modify_user(
                 &user.meta.id,
-                UserOpts {
+                ModifyUserOpts {
                     comment: Some("updated".into()),
                     host_access: user.host_access(),
                     ..Default::default()

--- a/crates/gvm-gmp/src/types.rs
+++ b/crates/gvm-gmp/src/types.rs
@@ -6,6 +6,46 @@
 use std::fmt;
 use std::str::FromStr;
 
+/// A collection-valued update in a GMP modify request.
+///
+/// GMP distinguishes an omitted field (leave the current value unchanged),
+/// a non-empty replacement, and an explicit request to clear the collection.
+/// Command builders map [`Self::Clear`] to each command's gvmd-specific clear
+/// representation.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CollectionUpdate<T> {
+    /// Omit the field and leave the stored collection unchanged.
+    #[default]
+    Omitted,
+    /// Replace the stored collection with these values.
+    Replace(Vec<T>),
+    /// Explicitly clear the stored collection.
+    Clear,
+}
+
+impl<T> CollectionUpdate<T> {
+    /// Build a replacement for a non-empty collection.
+    ///
+    /// An empty iterator maps to [`Self::Clear`] so callers cannot
+    /// accidentally lose the distinction between omission and clearing.
+    #[must_use]
+    pub fn replace(values: impl IntoIterator<Item = T>) -> Self {
+        let values = values.into_iter().collect::<Vec<_>>();
+        if values.is_empty() {
+            Self::Clear
+        } else {
+            Self::Replace(values)
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for CollectionUpdate<T> {
+    fn from(values: Vec<T>) -> Self {
+        Self::replace(values)
+    }
+}
+
 /// A validated GMP entity identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -110,5 +150,21 @@ mod tests {
     #[test]
     fn gmp_version_formats() {
         assert_eq!(GmpVersion(22, 5).to_string(), "22.5");
+    }
+
+    #[test]
+    fn collection_update_preserves_omitted_replace_and_clear_states() {
+        assert_eq!(
+            CollectionUpdate::<String>::default(),
+            CollectionUpdate::Omitted
+        );
+        assert_eq!(
+            CollectionUpdate::replace(["one".to_string(), "two".to_string()]),
+            CollectionUpdate::Replace(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            CollectionUpdate::<String>::replace(Vec::new()),
+            CollectionUpdate::Clear
+        );
     }
 }

--- a/crates/gvm-gmp/tests/test_users.rs
+++ b/crates/gvm-gmp/tests/test_users.rs
@@ -39,7 +39,7 @@ fn test_modify_user_with_host_access_modes() {
     assert_eq!(
         xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::allow("192.0.2.0/24")),
                 ..Default::default()
             }
@@ -49,7 +49,7 @@ fn test_modify_user_with_host_access_modes() {
     assert_eq!(
         xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::deny("192.0.2.0/24")),
                 ..Default::default()
             }
@@ -59,7 +59,7 @@ fn test_modify_user_with_host_access_modes() {
     assert_eq!(
         xml(modify_user(
             &id("u1"),
-            UserOpts {
+            ModifyUserOpts {
                 host_access: Some(UserHostAccess::deny("")),
                 ..Default::default()
             }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -830,6 +830,15 @@ impl SessionHandler {
             if let Some(hosts) = parse_element_text(raw_xml, "hosts") {
                 resource.set_attr("hosts", &hosts);
             }
+            if let Some(exclude_hosts) = parse_element_text(raw_xml, "exclude_hosts") {
+                resource.set_attr("exclude_hosts", &exclude_hosts);
+            }
+        }
+
+        if resource_type == "user" {
+            if let Some(role_ids) = role_id_update(cmd) {
+                resource.set_attr("role_ids", &role_ids.join(","));
+            }
         }
 
         if resource_type == "asset" {
@@ -1064,6 +1073,7 @@ impl SessionHandler {
         let new_comment = parse_element_text(raw_xml, "comment");
         let new_host = parse_element_text(raw_xml, "host");
         let new_hosts = parse_element_text(raw_xml, "hosts");
+        let new_exclude_hosts = parse_element_text(raw_xml, "exclude_hosts");
         let new_image_references = parse_element_text(raw_xml, "image_references");
         let new_urls = parse_element_text(raw_xml, "urls");
         let new_exclude_urls = parse_element_text(raw_xml, "exclude_urls");
@@ -1110,6 +1120,11 @@ impl SessionHandler {
         let new_credential_store_id = parse_element_text(raw_xml, "credential_store_id");
         let new_vault_id = parse_element_text(raw_xml, "vault_id");
         let new_host_identifier = parse_element_text(raw_xml, "host_identifier");
+        let new_role_ids = if resource_type == "user" {
+            role_id_update(cmd)
+        } else {
+            None
+        };
         let task_reference_updates = if resource_type == "task" {
             match task_reference_updates(cmd) {
                 Ok(references) => references,
@@ -1195,6 +1210,12 @@ impl SessionHandler {
             }
             if let Some(ref hosts) = new_hosts {
                 r.set_attr("hosts", hosts);
+            }
+            if let Some(ref exclude_hosts) = new_exclude_hosts {
+                r.set_attr("exclude_hosts", exclude_hosts);
+            }
+            if let Some(ref role_ids) = new_role_ids {
+                r.set_attr("role_ids", &role_ids.join(","));
             }
             if resource_type == "oci_image_target" {
                 if let Some(ref image_references) = new_image_references {
@@ -2878,6 +2899,29 @@ fn has_agent_ids(cmd: &ParsedCommand) -> bool {
                 .iter()
                 .any(|agent| agent.name == "agent" && agent.attributes.contains_key("id"))
         })
+}
+
+fn role_id_update(cmd: &ParsedCommand) -> Option<Vec<String>> {
+    let roles = cmd
+        .children
+        .iter()
+        .filter(|child| child.name == "role")
+        .collect::<Vec<_>>();
+    if roles.is_empty() {
+        return None;
+    }
+    if roles
+        .iter()
+        .any(|role| role.attributes.get("id").map(String::as_str) == Some("0"))
+    {
+        return Some(Vec::new());
+    }
+    Some(
+        roles
+            .into_iter()
+            .filter_map(|role| role.attributes.get("id").cloned())
+            .collect(),
+    )
 }
 
 fn has_config_import_payload(cmd: &ParsedCommand) -> bool {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -836,8 +836,10 @@ impl SessionHandler {
         }
 
         if resource_type == "user" {
-            if let Some(role_ids) = role_id_update(cmd) {
-                resource.set_attr("role_ids", &role_ids.join(","));
+            match role_id_update(cmd) {
+                Ok(Some(role_ids)) => resource.set_attr("role_ids", &role_ids.join(",")),
+                Ok(None) => {}
+                Err(message) => return error_response(&cmd.name, 400, message),
             }
         }
 
@@ -1121,7 +1123,10 @@ impl SessionHandler {
         let new_vault_id = parse_element_text(raw_xml, "vault_id");
         let new_host_identifier = parse_element_text(raw_xml, "host_identifier");
         let new_role_ids = if resource_type == "user" {
-            role_id_update(cmd)
+            match role_id_update(cmd) {
+                Ok(role_ids) => role_ids,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            }
         } else {
             None
         };
@@ -2901,27 +2906,32 @@ fn has_agent_ids(cmd: &ParsedCommand) -> bool {
         })
 }
 
-fn role_id_update(cmd: &ParsedCommand) -> Option<Vec<String>> {
+fn role_id_update(cmd: &ParsedCommand) -> Result<Option<Vec<String>>, &'static str> {
     let roles = cmd
         .children
         .iter()
         .filter(|child| child.name == "role")
         .collect::<Vec<_>>();
     if roles.is_empty() {
-        return None;
+        return Ok(None);
     }
-    if roles
-        .iter()
-        .any(|role| role.attributes.get("id").map(String::as_str) == Some("0"))
-    {
-        return Some(Vec::new());
+
+    let mut role_ids = Vec::with_capacity(roles.len());
+    for role in roles {
+        let Some(role_id) = role
+            .attributes
+            .get("id")
+            .filter(|role_id| !role_id.trim().is_empty())
+        else {
+            return Err("Missing required attribute: role id");
+        };
+        if role_id == "0" {
+            return Ok(Some(Vec::new()));
+        }
+        role_ids.push(role_id.clone());
     }
-    Some(
-        roles
-            .into_iter()
-            .filter_map(|role| role.attributes.get("id").cloned())
-            .collect(),
-    )
+
+    Ok(Some(role_ids))
 }
 
 fn has_config_import_payload(cmd: &ParsedCommand) -> bool {
@@ -3701,6 +3711,33 @@ mod tests {
         assert!(!xml.contains("<subject"));
         assert!(xml.contains(r#"<resource id="target-1"><name></name></resource>"#));
         assert!(!xml.contains("<type>"));
+    }
+
+    #[test]
+    fn role_updates_reject_missing_or_empty_ids() {
+        for xml in [
+            "<modify_user><role/></modify_user>",
+            r#"<modify_user><role id=""/></modify_user>"#,
+            r#"<modify_user><role id="  "/></modify_user>"#,
+        ] {
+            let command = parse_command(xml.as_bytes()).expect("parse role update");
+            assert_eq!(
+                role_id_update(&command),
+                Err("Missing required attribute: role id")
+            );
+        }
+
+        let clear = parse_command(br#"<modify_user><role id="0"/></modify_user>"#)
+            .expect("parse role clear");
+        assert_eq!(role_id_update(&clear), Ok(Some(Vec::new())));
+
+        let replace =
+            parse_command(br#"<modify_user><role id="r1"/><role id="r2"/></modify_user>"#)
+                .expect("parse role replacement");
+        assert_eq!(
+            role_id_update(&replace),
+            Ok(Some(vec!["r1".into(), "r2".into()]))
+        );
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -352,6 +352,17 @@ impl Resource {
                 }
             }
         }
+        if self.resource_type == "user" {
+            if let Some(role_ids) = self.attr("role_ids") {
+                for role_id in role_ids.split(',').filter(|role_id| !role_id.is_empty()) {
+                    let role_id_attr = xml_escape_attr(role_id);
+                    let role_id = xml_escape(role_id);
+                    xml.push_str(&format!(
+                        "<role id=\"{role_id_attr}\"><name>{role_id}</name></role>"
+                    ));
+                }
+            }
+        }
         // Add type-specific attributes
         if self.resource_type == "alert" {
             for field in ["event", "condition", "method"] {
@@ -418,6 +429,9 @@ impl Resource {
                     "subject_id" | "subject_type" | "resource_id" | "resource_type"
                 )
             {
+                continue;
+            }
+            if self.resource_type == "user" && k == "role_ids" {
                 continue;
             }
             if self.resource_type == "nvt"


### PR DESCRIPTION
## Summary

- add a reusable `CollectionUpdate<T>` tri-state for omitted, replaced, and explicitly cleared modify fields
- split note, override, and user modify options from their create-only counterparts while keeping create XML unchanged
- emit current-gvmd empty host elements and the `<role id="0"/>` user-role clear sentinel
- add typed target/user modification helpers and stateful mock persistence for omission, replacement, and clearing

## Validation

- `cargo test -p gvm-gmp --all-features` (399 unit tests plus all integration suites)
- `cargo test -p gvm-client --all-features` (54 Unix client integration tests plus all typed/versioned suites)
- `cargo test -p gvm-mock-server --all-features` (complete mock-server suite)
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #424

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high