### PR TITLE
fix(gmp): complete credential request fields

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -27,10 +27,10 @@ use gvm_gmp::commands::configs::{
 };
 use gvm_gmp::commands::credentials::{
     create_credential, create_credential_store_credential, get_credential_store,
-    get_credential_stores, get_credential_stores_with_opts, get_credentials,
+    get_credential_stores, get_credential_stores_with_opts, get_credentials, modify_credential,
     modify_credential_store_credential, verify_credential_store, CredentialOpts,
     CredentialStoreCredentialOpts, GetCredentialStoresOpts, GetCredentialsOpts,
-    ModifyCredentialStoreCredentialOpts,
+    ModifyCredentialOpts, ModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::feed::{get_feed, get_feeds};
@@ -1408,6 +1408,20 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<CreateCredentialResponse, GvmError> {
         let response = self.send(create_credential(name, opts)).await?;
         CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a `modify_credential` request and return a typed
+    /// [`ModifyCredentialResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_credential(
+        &mut self,
+        credential_id: &EntityId,
+        opts: ModifyCredentialOpts,
+    ) -> Result<ModifyCredentialResponse, GvmError> {
+        let response = self.send(modify_credential(credential_id, opts)).await?;
+        ModifyCredentialResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a credential-store-backed `create_credential` request and return a

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -27,7 +27,8 @@ use gvm_gmp::commands::configs::{
 };
 use gvm_gmp::commands::credentials::{
     create_credential_store_credential, get_credential, modify_credential_store,
-    modify_credential_store_credential, CredentialStorePreference,
+    modify_credential_store_credential, CredentialOpts, CredentialStorePreference,
+    ModifyCredentialOpts,
     ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
     ModifyCredentialStoreOpts,
 };
@@ -64,8 +65,8 @@ use gvm_gmp::responses::{
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
-    AlertCondition, AlertEvent, AlertMethod, CollectionUpdate, FeedType, PermissionSubjectType,
-    SortOrder, TicketStatus,
+    AlertCondition, AlertEvent, AlertMethod, CollectionUpdate, CredentialType, FeedType,
+    PermissionSubjectType, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
@@ -1933,6 +1934,155 @@ async fn typed_port_list_and_user_renames_round_trip() {
         renamed_user.meta.comment.as_deref(),
         Some("renamed through typed client")
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_ssh_credential_lifecycle_uses_nested_key_shape() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let credential = client
+        .create_credential(
+            "SSH Credential",
+            CredentialOpts {
+                credential_type: Some(CredentialType::UsernameSshKey),
+                login: Some("root".into()),
+                private_key: Some("PRIVATE KEY".into()),
+                key_phrase: Some("key phrase".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SSH credential should be created");
+    client
+        .modify_credential(
+            &credential.id,
+            ModifyCredentialOpts {
+                name: Some("Renamed SSH Credential".into()),
+                login: Some("scanner".into()),
+                private_key: Some("UPDATED PRIVATE KEY".into()),
+                key_phrase: Some("updated phrase".into()),
+                allow_insecure: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SSH credential should be modified");
+
+    let credentials = client
+        .get_credentials(Default::default())
+        .await
+        .expect("credentials should be retrieved");
+    let fetched = credentials
+        .items
+        .iter()
+        .find(|item| item.meta.id == credential.id)
+        .expect("SSH credential should be listed");
+    assert_eq!(fetched.meta.name, "Renamed SSH Credential");
+    assert_eq!(fetched.type_.as_deref(), Some("usk"));
+    assert_eq!(fetched.login.as_deref(), Some("scanner"));
+    assert!(fetched.allow_insecure);
+
+    let history = server.command_history();
+    let create_xml = std::str::from_utf8(history[0].raw_xml()).expect("create XML");
+    assert!(
+        create_xml.contains("<key><phrase>key phrase</phrase><private>PRIVATE KEY</private></key>")
+    );
+    assert!(!create_xml.contains("<private_key>"));
+    let modify_xml = std::str::from_utf8(history[1].raw_xml()).expect("modify XML");
+    assert!(modify_xml.contains("<name>Renamed SSH Credential</name>"));
+    assert!(modify_xml.contains(
+        "<key><phrase>updated phrase</phrase><private>UPDATED PRIVATE KEY</private></key>"
+    ));
+    assert!(modify_xml.contains("<allow_insecure>1</allow_insecure>"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_snmpv3_and_kerberos_credentials_use_current_wire_shapes() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    server.clear_history();
+
+    let snmp = client
+        .create_credential(
+            "SNMPv3 Credential",
+            CredentialOpts {
+                credential_type: Some(CredentialType::SnmpV3),
+                login: Some("snmp-user".into()),
+                password: Some("auth secret".into()),
+                auth_algorithm: Some(SnmpAuthAlgorithm::Sha1),
+                privacy_password: Some("privacy secret".into()),
+                privacy_algorithm: Some(SnmpPrivacyAlgorithm::Aes),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SNMPv3 credential should be created");
+    let kerberos = client
+        .create_credential(
+            "Kerberos Credential",
+            CredentialOpts {
+                credential_type: Some(CredentialType::Kerberos5),
+                login: Some("principal".into()),
+                password: Some("kerberos secret".into()),
+                kdcs: vec!["kdc1.example".into(), "kdc2.example".into()],
+                realm: Some("EXAMPLE.COM".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Kerberos credential should be created");
+
+    let credentials = client
+        .get_credentials(Default::default())
+        .await
+        .expect("credentials should be retrieved");
+    let snmp = credentials
+        .items
+        .iter()
+        .find(|item| item.meta.id == snmp.id)
+        .expect("SNMPv3 credential should be listed");
+    let kerberos = credentials
+        .items
+        .iter()
+        .find(|item| item.meta.id == kerberos.id)
+        .expect("Kerberos credential should be listed");
+    assert_eq!(snmp.type_.as_deref(), Some("snmp"));
+    assert_eq!(kerberos.type_.as_deref(), Some("krb5"));
+
+    let history = server.command_history();
+    let snmp_xml = std::str::from_utf8(history[0].raw_xml()).expect("SNMP XML");
+    assert!(snmp_xml.contains("<type>snmp</type>"));
+    assert!(snmp_xml.contains(
+        "<privacy><algorithm>aes</algorithm><password>privacy secret</password></privacy>"
+    ));
+    assert!(!snmp_xml.contains("<privacy_algorithm>"));
+    let kerberos_xml = std::str::from_utf8(history[1].raw_xml()).expect("Kerberos XML");
+    assert!(kerberos_xml.contains("<kdcs><kdc>kdc1.example</kdc><kdc>kdc2.example</kdc></kdcs>"));
+    assert!(kerberos_xml.contains("<realm>EXAMPLE.COM</realm>"));
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -98,6 +98,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "modify_alert",
     "get_credentials",
     "create_credential",
+    "modify_credential",
     "create_credential_store_credential",
     "modify_credential_store_credential",
     "get_filters",

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -99,6 +99,30 @@ pub struct ModifyCredentialOpts {
     pub realm: Option<String>,
 }
 
+#[allow(deprecated)]
+impl From<CredentialOpts> for ModifyCredentialOpts {
+    fn from(opts: CredentialOpts) -> Self {
+        Self {
+            name: None,
+            comment: opts.comment,
+            login: opts.login,
+            password: opts.password,
+            private_key: opts.private_key,
+            key_phrase: opts.key_phrase,
+            public_key: opts.public_key,
+            certificate: opts.certificate,
+            community: opts.community,
+            auth_algorithm: opts.auth_algorithm,
+            privacy_password: opts.privacy_password,
+            privacy_algorithm: opts.privacy_algorithm,
+            allow_insecure: opts.allow_insecure,
+            kdc: opts.kdc,
+            kdcs: opts.kdcs,
+            realm: opts.realm,
+        }
+    }
+}
+
 fn redacted(value: &Option<String>) -> Option<&'static str> {
     value.as_ref().map(|_| "<redacted>")
 }
@@ -370,7 +394,11 @@ pub fn modify_credential_store(
 
 /// Build a `modify_credential` request.
 #[must_use]
-pub fn modify_credential(credential_id: &EntityId, opts: ModifyCredentialOpts) -> impl Request {
+pub fn modify_credential(
+    credential_id: &EntityId,
+    opts: impl Into<ModifyCredentialOpts>,
+) -> impl Request {
+    let opts = opts.into();
     let mut cmd =
         XmlCommand::new("modify_credential").attribute("credential_id", credential_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
@@ -757,6 +785,27 @@ mod tests {
                 }
             )),
             "<modify_credential credential_id=\"c1\"><name>renamed</name><kdcs><kdc>kdc.example</kdc></kdcs><key><phrase>phrase</phrase><private>PRIVATE</private></key><privacy><algorithm>des</algorithm><password>privacy-secret</password></privacy><realm>EXAMPLE.COM</realm></modify_credential>"
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn modify_credential_accepts_legacy_create_options() {
+        let rendered = xml(modify_credential(
+            &id("c1"),
+            CredentialOpts {
+                comment: Some("legacy".into()),
+                login: Some("alice".into()),
+                password: Some("secret".into()),
+                credential_type: Some(CredentialType::UsernamePassword),
+                format: Some(CredentialFormat::Pem),
+                ..Default::default()
+            },
+        ));
+
+        assert_eq!(
+            rendered,
+            "<modify_credential credential_id=\"c1\"><comment>legacy</comment><login>alice</login><password>secret</password></modify_credential>"
         );
     }
 

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -3,6 +3,8 @@
 
 //! Credential command builders.
 
+use std::fmt;
+
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
@@ -12,8 +14,8 @@ use crate::enums::{
 };
 use crate::types::EntityId;
 
-/// Optional fields for credential create and modify requests.
-#[derive(Debug, Clone, Default)]
+/// Optional fields for credential create requests.
+#[derive(Clone, Default)]
 pub struct CredentialOpts {
     /// Optional comment text included in the request.
     pub comment: Option<String>,
@@ -25,14 +27,131 @@ pub struct CredentialOpts {
     pub password: Option<String>,
     /// Optional private key material.
     pub private_key: Option<String>,
+    /// Optional private-key passphrase.
+    pub key_phrase: Option<String>,
+    /// Optional public key material.
+    pub public_key: Option<String>,
     /// Optional certificate data.
     pub certificate: Option<String>,
+    /// Optional SNMP community value.
+    pub community: Option<String>,
     /// Optional SNMP authentication algorithm.
     pub auth_algorithm: Option<SnmpAuthAlgorithm>,
+    /// Optional SNMP privacy password.
+    pub privacy_password: Option<String>,
     /// Optional SNMP privacy algorithm.
     pub privacy_algorithm: Option<SnmpPrivacyAlgorithm>,
-    /// Optional credential or report format value.
+    /// Whether the credential may be used over an insecure transport.
+    pub allow_insecure: Option<bool>,
+    /// Deprecated comma-separated Kerberos KDC value accepted by gvmd.
+    ///
+    /// Prefer [`Self::kdcs`].
+    pub kdc: Option<String>,
+    /// Kerberos key distribution centers.
+    pub kdcs: Vec<String>,
+    /// Optional Kerberos realm.
+    pub realm: Option<String>,
+    /// Historical credential format field.
+    ///
+    /// Current gvmd does not consume `<format>` in create or modify credential
+    /// requests. This value is retained for source compatibility but is not
+    /// emitted.
+    #[deprecated(note = "current gvmd ignores credential request format")]
     pub format: Option<CredentialFormat>,
+}
+
+/// Optional fields for `modify_credential` requests.
+#[derive(Clone, Default)]
+pub struct ModifyCredentialOpts {
+    /// Optional replacement credential name.
+    pub name: Option<String>,
+    /// Optional comment text included in the request.
+    pub comment: Option<String>,
+    /// Optional login or username value.
+    pub login: Option<String>,
+    /// Optional password value.
+    pub password: Option<String>,
+    /// Optional private key material.
+    pub private_key: Option<String>,
+    /// Optional private-key passphrase.
+    pub key_phrase: Option<String>,
+    /// Optional public key material.
+    pub public_key: Option<String>,
+    /// Optional certificate data.
+    pub certificate: Option<String>,
+    /// Optional SNMP community value.
+    pub community: Option<String>,
+    /// Optional SNMP authentication algorithm.
+    pub auth_algorithm: Option<SnmpAuthAlgorithm>,
+    /// Optional SNMP privacy password.
+    pub privacy_password: Option<String>,
+    /// Optional SNMP privacy algorithm.
+    pub privacy_algorithm: Option<SnmpPrivacyAlgorithm>,
+    /// Whether the credential may be used over an insecure transport.
+    pub allow_insecure: Option<bool>,
+    /// Deprecated comma-separated Kerberos KDC value accepted by gvmd.
+    ///
+    /// Prefer [`Self::kdcs`].
+    pub kdc: Option<String>,
+    /// Kerberos key distribution centers.
+    pub kdcs: Vec<String>,
+    /// Optional Kerberos realm.
+    pub realm: Option<String>,
+}
+
+fn redacted(value: &Option<String>) -> Option<&'static str> {
+    value.as_ref().map(|_| "<redacted>")
+}
+
+fn present(value: &Option<String>) -> Option<&'static str> {
+    value.as_ref().map(|_| "<present>")
+}
+
+impl fmt::Debug for CredentialOpts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CredentialOpts")
+            .field("comment", &self.comment)
+            .field("credential_type", &self.credential_type)
+            .field("login", &self.login)
+            .field("password", &redacted(&self.password))
+            .field("private_key", &redacted(&self.private_key))
+            .field("key_phrase", &redacted(&self.key_phrase))
+            .field("public_key", &present(&self.public_key))
+            .field("certificate", &present(&self.certificate))
+            .field("community", &redacted(&self.community))
+            .field("auth_algorithm", &self.auth_algorithm)
+            .field("privacy_password", &redacted(&self.privacy_password))
+            .field("privacy_algorithm", &self.privacy_algorithm)
+            .field("allow_insecure", &self.allow_insecure)
+            .field("kdc", &self.kdc)
+            .field("kdcs", &self.kdcs)
+            .field("realm", &self.realm)
+            .field("format", &"<ignored>")
+            .finish()
+    }
+}
+
+impl fmt::Debug for ModifyCredentialOpts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ModifyCredentialOpts")
+            .field("name", &self.name)
+            .field("comment", &self.comment)
+            .field("login", &self.login)
+            .field("password", &redacted(&self.password))
+            .field("private_key", &redacted(&self.private_key))
+            .field("key_phrase", &redacted(&self.key_phrase))
+            .field("public_key", &present(&self.public_key))
+            .field("certificate", &present(&self.certificate))
+            .field("community", &redacted(&self.community))
+            .field("auth_algorithm", &self.auth_algorithm)
+            .field("privacy_password", &redacted(&self.privacy_password))
+            .field("privacy_algorithm", &self.privacy_algorithm)
+            .field("allow_insecure", &self.allow_insecure)
+            .field("kdc", &self.kdc)
+            .field("kdcs", &self.kdcs)
+            .field("realm", &self.realm)
+            .finish()
+    }
 }
 
 /// Optional fields for credential-store-backed credential creation.
@@ -135,7 +254,11 @@ pub fn clone_credential(credential_id: &EntityId) -> impl Request {
 pub fn create_credential(name: &str, opts: CredentialOpts) -> impl Request {
     let mut cmd = XmlCommand::new("create_credential");
     cmd.add_element_with_text("name", name);
-    add_credential_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    if let Some(credential_type) = opts.credential_type {
+        cmd.add_element_with_text("type", credential_type.as_gmp_str());
+    }
+    add_credential_values(&mut cmd, CredentialValues::from(&opts));
     cmd
 }
 
@@ -247,10 +370,12 @@ pub fn modify_credential_store(
 
 /// Build a `modify_credential` request.
 #[must_use]
-pub fn modify_credential(credential_id: &EntityId, opts: CredentialOpts) -> impl Request {
+pub fn modify_credential(credential_id: &EntityId, opts: ModifyCredentialOpts) -> impl Request {
     let mut cmd =
         XmlCommand::new("modify_credential").attribute("credential_id", credential_id.as_str());
-    add_credential_body(&mut cmd, &opts);
+    add_text_element(&mut cmd, "name", opts.name.as_deref());
+    add_text_element(&mut cmd, "comment", opts.comment.as_deref());
+    add_credential_values(&mut cmd, CredentialValues::from(&opts));
     cmd
 }
 
@@ -283,24 +408,105 @@ pub fn delete_credential(credential_id: &EntityId, ultimate: bool) -> impl Reque
         .attribute("ultimate", bool_str(ultimate))
 }
 
-fn add_credential_body(cmd: &mut XmlCommand, opts: &CredentialOpts) {
-    add_text_element(cmd, "comment", opts.comment.as_deref());
-    if let Some(credential_type) = opts.credential_type {
-        cmd.add_element_with_text("type", credential_type.as_gmp_str());
+struct CredentialValues<'a> {
+    login: Option<&'a str>,
+    password: Option<&'a str>,
+    private_key: Option<&'a str>,
+    key_phrase: Option<&'a str>,
+    public_key: Option<&'a str>,
+    certificate: Option<&'a str>,
+    community: Option<&'a str>,
+    auth_algorithm: Option<SnmpAuthAlgorithm>,
+    privacy_password: Option<&'a str>,
+    privacy_algorithm: Option<SnmpPrivacyAlgorithm>,
+    allow_insecure: Option<bool>,
+    kdc: Option<&'a str>,
+    kdcs: &'a [String],
+    realm: Option<&'a str>,
+}
+
+impl<'a> From<&'a CredentialOpts> for CredentialValues<'a> {
+    fn from(opts: &'a CredentialOpts) -> Self {
+        Self {
+            login: opts.login.as_deref(),
+            password: opts.password.as_deref(),
+            private_key: opts.private_key.as_deref(),
+            key_phrase: opts.key_phrase.as_deref(),
+            public_key: opts.public_key.as_deref(),
+            certificate: opts.certificate.as_deref(),
+            community: opts.community.as_deref(),
+            auth_algorithm: opts.auth_algorithm,
+            privacy_password: opts.privacy_password.as_deref(),
+            privacy_algorithm: opts.privacy_algorithm,
+            allow_insecure: opts.allow_insecure,
+            kdc: opts.kdc.as_deref(),
+            kdcs: &opts.kdcs,
+            realm: opts.realm.as_deref(),
+        }
     }
-    add_text_element(cmd, "login", opts.login.as_deref());
-    add_text_element(cmd, "password", opts.password.as_deref());
-    add_text_element(cmd, "private", opts.private_key.as_deref());
-    add_text_element(cmd, "certificate", opts.certificate.as_deref());
-    if let Some(auth_algorithm) = opts.auth_algorithm {
+}
+
+impl<'a> From<&'a ModifyCredentialOpts> for CredentialValues<'a> {
+    fn from(opts: &'a ModifyCredentialOpts) -> Self {
+        Self {
+            login: opts.login.as_deref(),
+            password: opts.password.as_deref(),
+            private_key: opts.private_key.as_deref(),
+            key_phrase: opts.key_phrase.as_deref(),
+            public_key: opts.public_key.as_deref(),
+            certificate: opts.certificate.as_deref(),
+            community: opts.community.as_deref(),
+            auth_algorithm: opts.auth_algorithm,
+            privacy_password: opts.privacy_password.as_deref(),
+            privacy_algorithm: opts.privacy_algorithm,
+            allow_insecure: opts.allow_insecure,
+            kdc: opts.kdc.as_deref(),
+            kdcs: &opts.kdcs,
+            realm: opts.realm.as_deref(),
+        }
+    }
+}
+
+fn add_credential_values(cmd: &mut XmlCommand, values: CredentialValues<'_>) {
+    if let Some(allow_insecure) = values.allow_insecure {
+        cmd.add_element_with_text("allow_insecure", bool_str(allow_insecure));
+    }
+    add_text_element(cmd, "certificate", values.certificate);
+    add_text_element(cmd, "kdc", values.kdc);
+    if !values.kdcs.is_empty() {
+        let kdcs = cmd.add_element("kdcs");
+        for kdc in values.kdcs {
+            kdcs.add_child_with_text("kdc", kdc);
+        }
+    }
+    if values.private_key.is_some() || values.key_phrase.is_some() || values.public_key.is_some() {
+        let key = cmd.add_element("key");
+        if let Some(phrase) = values.key_phrase {
+            key.add_child_with_text("phrase", phrase);
+        }
+        if let Some(private_key) = values.private_key {
+            key.add_child_with_text("private", private_key);
+        }
+        if let Some(public_key) = values.public_key {
+            key.add_child_with_text("public", public_key);
+        }
+    }
+    add_text_element(cmd, "login", values.login);
+    add_text_element(cmd, "password", values.password);
+    if let Some(auth_algorithm) = values.auth_algorithm {
         cmd.add_element_with_text("auth_algorithm", auth_algorithm.as_gmp_str());
     }
-    if let Some(privacy_algorithm) = opts.privacy_algorithm {
-        cmd.add_element_with_text("privacy_algorithm", privacy_algorithm.as_gmp_str());
+    add_text_element(cmd, "community", values.community);
+    if values.privacy_algorithm.is_some() || values.privacy_password.is_some() {
+        let privacy = cmd.add_element("privacy");
+        if let Some(privacy_algorithm) = values.privacy_algorithm {
+            privacy.add_child_with_text("algorithm", privacy_algorithm.as_gmp_str());
+        }
+        if let Some(privacy_password) = values.privacy_password {
+            privacy.add_child_with_text("password", privacy_password);
+        }
     }
-    if let Some(format) = opts.format {
-        cmd.add_element_with_text("format", format.as_gmp_str());
-    }
+    add_text_element(cmd, "realm", values.realm);
 }
 
 #[cfg(test)]
@@ -313,6 +519,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn credential_commands_build_xml() {
         let rendered = xml(create_credential(
             "cred",
@@ -326,6 +533,7 @@ mod tests {
         ));
         assert!(rendered.contains("<type>up</type>"));
         assert!(rendered.contains("<password>pass</password>"));
+        assert!(!rendered.contains("<format>"));
         assert_eq!(
             xml(create_credential_store_credential(
                 "stored",
@@ -396,7 +604,7 @@ mod tests {
         assert!(rendered.contains("details=\"1\""));
         let rendered = xml(modify_credential(
             &id("c1"),
-            CredentialOpts {
+            ModifyCredentialOpts {
                 comment: Some("updated".into()),
                 ..Default::default()
             },
@@ -426,5 +634,152 @@ mod tests {
             xml(delete_credential(&id("c1"), true)),
             "<delete_credential credential_id=\"c1\" ultimate=\"1\"/>"
         );
+    }
+
+    #[test]
+    fn credential_value_variants_match_current_gvmd_shape() {
+        assert_eq!(
+            xml(create_credential(
+                "username-password",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::UsernamePassword),
+                    login: Some("user".into()),
+                    password: Some("password".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>username-password</name><type>up</type><login>user</login><password>password</password></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "password-only",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::PasswordOnly),
+                    password: Some("password".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>password-only</name><type>pw</type><password>password</password></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "ssh",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::UsernameSshKey),
+                    login: Some("root".into()),
+                    private_key: Some("PRIVATE".into()),
+                    key_phrase: Some("phrase".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>ssh</name><type>usk</type><key><phrase>phrase</phrase><private>PRIVATE</private></key><login>root</login></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "public",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::PgpEncryptionKey),
+                    public_key: Some("PUBLIC".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>public</name><type>pgp</type><key><public>PUBLIC</public></key></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "certificate",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::ClientCertificate),
+                    certificate: Some("CERTIFICATE".into()),
+                    allow_insecure: Some(true),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>certificate</name><type>cc</type><allow_insecure>1</allow_insecure><certificate>CERTIFICATE</certificate></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "community",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::SnmpV1Or2c),
+                    community: Some("public".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>community</name><type>snmp</type><community>public</community></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "snmpv3",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::SnmpV3),
+                    login: Some("snmp-user".into()),
+                    password: Some("auth-secret".into()),
+                    auth_algorithm: Some(SnmpAuthAlgorithm::Sha1),
+                    privacy_password: Some("privacy-secret".into()),
+                    privacy_algorithm: Some(SnmpPrivacyAlgorithm::Aes),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>snmpv3</name><type>snmp</type><login>snmp-user</login><password>auth-secret</password><auth_algorithm>sha1</auth_algorithm><privacy><algorithm>aes</algorithm><password>privacy-secret</password></privacy></create_credential>"
+        );
+        assert_eq!(
+            xml(create_credential(
+                "kerberos",
+                CredentialOpts {
+                    credential_type: Some(CredentialType::Kerberos5),
+                    login: Some("principal".into()),
+                    password: Some("secret".into()),
+                    kdc: Some("legacy.example".into()),
+                    kdcs: vec!["kdc1.example".into(), "kdc2.example".into()],
+                    realm: Some("EXAMPLE.COM".into()),
+                    ..Default::default()
+                }
+            )),
+            "<create_credential><name>kerberos</name><type>krb5</type><kdc>legacy.example</kdc><kdcs><kdc>kdc1.example</kdc><kdc>kdc2.example</kdc></kdcs><login>principal</login><password>secret</password><realm>EXAMPLE.COM</realm></create_credential>"
+        );
+    }
+
+    #[test]
+    fn modify_credential_supports_name_and_nested_secret_updates() {
+        assert_eq!(
+            xml(modify_credential(
+                &id("c1"),
+                ModifyCredentialOpts {
+                    name: Some("renamed".into()),
+                    private_key: Some("PRIVATE".into()),
+                    key_phrase: Some("phrase".into()),
+                    privacy_password: Some("privacy-secret".into()),
+                    privacy_algorithm: Some(SnmpPrivacyAlgorithm::Des),
+                    kdcs: vec!["kdc.example".into()],
+                    realm: Some("EXAMPLE.COM".into()),
+                    ..Default::default()
+                }
+            )),
+            "<modify_credential credential_id=\"c1\"><name>renamed</name><kdcs><kdc>kdc.example</kdc></kdcs><key><phrase>phrase</phrase><private>PRIVATE</private></key><privacy><algorithm>des</algorithm><password>privacy-secret</password></privacy><realm>EXAMPLE.COM</realm></modify_credential>"
+        );
+    }
+
+    #[test]
+    fn credential_debug_output_redacts_secret_values() {
+        let opts = CredentialOpts {
+            password: Some("password-secret".into()),
+            private_key: Some("private-secret".into()),
+            key_phrase: Some("phrase-secret".into()),
+            community: Some("community-secret".into()),
+            privacy_password: Some("privacy-secret".into()),
+            ..Default::default()
+        };
+        let debug = format!("{opts:?}");
+
+        for secret in [
+            "password-secret",
+            "private-secret",
+            "phrase-secret",
+            "community-secret",
+            "privacy-secret",
+        ] {
+            assert!(!debug.contains(secret));
+        }
     }
 }

--- a/crates/gvm-gmp/src/enums.rs
+++ b/crates/gvm-gmp/src/enums.rs
@@ -366,14 +366,72 @@ gmp_enum!(CredentialFormat {
     Pgp => "pgp",
     Rpm => "rpm"
 });
-gmp_enum!(CredentialType {
-    ClientCertificate => "cc",
-    PasswordOnly => "pw",
-    SnmpV1Or2c => "snmp",
-    SnmpV3 => "snmpv3",
-    UsernamePassword => "up",
-    UsernameSshKey => "usk"
-});
+/// Credential types accepted by current gvmd.
+///
+/// gvmd uses the same `snmp` wire type for community-based and `SNMPv3`
+/// credentials; the presence of authentication/privacy fields distinguishes
+/// the latter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CredentialType {
+    /// Client certificate (`cc`).
+    ClientCertificate,
+    /// Kerberos 5 (`krb5`).
+    Kerberos5,
+    /// Password-only credential (`pw`).
+    PasswordOnly,
+    /// PGP encryption key (`pgp`).
+    PgpEncryptionKey,
+    /// S/MIME certificate (`smime`).
+    SmimeCertificate,
+    /// Community-based SNMP credential (`snmp`).
+    SnmpV1Or2c,
+    /// `SNMPv3` credential (`snmp` with authentication/privacy fields).
+    SnmpV3,
+    /// Username and password (`up`).
+    UsernamePassword,
+    /// Username and SSH key (`usk`).
+    UsernameSshKey,
+}
+
+impl CredentialType {
+    /// Returns the GMP wire-format string for this credential type.
+    #[must_use]
+    pub const fn as_gmp_str(self) -> &'static str {
+        match self {
+            Self::ClientCertificate => "cc",
+            Self::Kerberos5 => "krb5",
+            Self::PasswordOnly => "pw",
+            Self::PgpEncryptionKey => "pgp",
+            Self::SmimeCertificate => "smime",
+            Self::SnmpV1Or2c | Self::SnmpV3 => "snmp",
+            Self::UsernamePassword => "up",
+            Self::UsernameSshKey => "usk",
+        }
+    }
+}
+
+impl FromStr for CredentialType {
+    type Err = EnumParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cc" => Ok(Self::ClientCertificate),
+            "krb5" => Ok(Self::Kerberos5),
+            "pw" => Ok(Self::PasswordOnly),
+            "pgp" => Ok(Self::PgpEncryptionKey),
+            "smime" => Ok(Self::SmimeCertificate),
+            "snmp" => Ok(Self::SnmpV1Or2c),
+            "snmpv3" => Ok(Self::SnmpV3),
+            "up" => Ok(Self::UsernamePassword),
+            "usk" => Ok(Self::UsernameSshKey),
+            _ => Err(EnumParseError {
+                enum_name: "CredentialType",
+                value: s.to_string(),
+            }),
+        }
+    }
+}
 gmp_enum!(CredentialStoreCredentialType {
     ClientCertificate => "cs_cc",
     PasswordOnly => "cs_pw",

--- a/crates/gvm-gmp/tests/test_credentials.rs
+++ b/crates/gvm-gmp/tests/test_credentials.rs
@@ -8,8 +8,7 @@ mod common;
 use common::{id, xml};
 use gvm_gmp::commands::credentials::*;
 use gvm_gmp::{
-    CredentialFormat, CredentialStoreCredentialType, CredentialType, SnmpAuthAlgorithm,
-    SnmpPrivacyAlgorithm,
+    CredentialStoreCredentialType, CredentialType, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm,
 };
 
 #[test]
@@ -31,13 +30,21 @@ fn test_create_credential_with_all_optionals() {
                 login: Some("u".into()),
                 password: Some("p".into()),
                 private_key: Some("k".into()),
+                key_phrase: Some("phrase".into()),
+                public_key: None,
                 certificate: Some("cert".into()),
+                community: Some("community".into()),
                 auth_algorithm: Some(SnmpAuthAlgorithm::Sha1),
+                privacy_password: Some("privacy".into()),
                 privacy_algorithm: Some(SnmpPrivacyAlgorithm::Aes),
-                format: Some(CredentialFormat::Pem),
+                allow_insecure: Some(true),
+                kdc: Some("legacy-kdc".into()),
+                kdcs: vec!["kdc-1".into(), "kdc-2".into()],
+                realm: Some("EXAMPLE.COM".into()),
+                ..Default::default()
             }
         )),
-        "<create_credential><name>cred</name><comment>c</comment><type>up</type><login>u</login><password>p</password><private>k</private><certificate>cert</certificate><auth_algorithm>sha1</auth_algorithm><privacy_algorithm>aes</privacy_algorithm><format>pem</format></create_credential>"
+        "<create_credential><name>cred</name><comment>c</comment><type>up</type><allow_insecure>1</allow_insecure><certificate>cert</certificate><kdc>legacy-kdc</kdc><kdcs><kdc>kdc-1</kdc><kdc>kdc-2</kdc></kdcs><key><phrase>phrase</phrase><private>k</private></key><login>u</login><password>p</password><auth_algorithm>sha1</auth_algorithm><community>community</community><privacy><algorithm>aes</algorithm><password>privacy</password></privacy><realm>EXAMPLE.COM</realm></create_credential>"
     );
 }
 

--- a/crates/gvm-gmp/tests/test_enums.rs
+++ b/crates/gvm-gmp/tests/test_enums.rs
@@ -335,13 +335,18 @@ canonical_inventory!(
     CredentialType,
     {
         ClientCertificate => ("cc", ClientCertificate),
+        Kerberos5 => ("krb5", Kerberos5),
         PasswordOnly => ("pw", PasswordOnly),
+        PgpEncryptionKey => ("pgp", PgpEncryptionKey),
+        SmimeCertificate => ("smime", SmimeCertificate),
         SnmpV1Or2c => ("snmp", SnmpV1Or2c),
-        SnmpV3 => ("snmpv3", SnmpV3),
+        SnmpV3 => ("snmp", SnmpV1Or2c),
         UsernamePassword => ("up", UsernamePassword),
         UsernameSshKey => ("usk", UsernameSshKey),
     },
-    aliases {}
+    aliases {
+        "snmpv3" => SnmpV3,
+    }
 );
 
 canonical_inventory!(

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -3707,12 +3707,17 @@ fn credential_kdcs(cmd: &ParsedCommand) -> Option<Vec<String>> {
     cmd.children
         .iter()
         .find(|child| child.name == "kdcs")
-        .map(|kdcs| {
-            kdcs.children
+        .and_then(|kdcs| {
+            let values = kdcs
+                .children
                 .iter()
                 .filter(|child| child.name == "kdc")
-                .map(|child| child.text.clone().unwrap_or_default())
-                .collect()
+                .filter_map(|child| child.text.as_deref())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            (!values.is_empty()).then_some(values)
         })
 }
 
@@ -3797,6 +3802,27 @@ mod tests {
         assert_eq!(
             role_id_update(&replace),
             Ok(Some(vec!["r1".into(), "r2".into()]))
+        );
+    }
+
+    #[test]
+    fn credential_kdcs_ignores_empty_lists_and_values() {
+        for xml in [
+            "<create_credential><kdcs/></create_credential>",
+            "<create_credential><kdcs><kdc/></kdcs></create_credential>",
+            "<create_credential><kdcs><kdc>  </kdc></kdcs></create_credential>",
+        ] {
+            let command = parse_command(xml.as_bytes()).expect("parse KDC list");
+            assert_eq!(credential_kdcs(&command), None);
+        }
+
+        let command = parse_command(
+            b"<create_credential><kdcs><kdc> kdc1.example </kdc><kdc/><kdc>kdc2.example</kdc></kdcs></create_credential>",
+        )
+        .expect("parse populated KDC list");
+        assert_eq!(
+            credential_kdcs(&command),
+            Some(vec!["kdc1.example".into(), "kdc2.example".into()])
         );
     }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -740,6 +740,27 @@ impl SessionHandler {
             if let Some(credential_type) = parse_element_text(raw_xml, "type") {
                 resource.set_attr("type", &credential_type);
             }
+            if let Some(login) = parse_element_text(raw_xml, "login") {
+                resource.set_attr("login", &login);
+            }
+            if let Some(allow_insecure) = parse_element_text(raw_xml, "allow_insecure") {
+                resource.set_attr("allow_insecure", &allow_insecure);
+            }
+            if let Some(kdc) = credential_kdcs(cmd)
+                .map(|kdcs| kdcs.join(","))
+                .or_else(|| parse_element_text(raw_xml, "kdc"))
+            {
+                resource.set_attr("kdc", &kdc);
+            }
+            if let Some(realm) = parse_element_text(raw_xml, "realm") {
+                resource.set_attr("realm", &realm);
+            }
+            if let Some(auth_algorithm) = parse_element_text(raw_xml, "auth_algorithm") {
+                resource.set_attr("auth_algorithm", &auth_algorithm);
+            }
+            if let Some(privacy_algorithm) = nested_child_text(cmd, &["privacy", "algorithm"]) {
+                resource.set_attr("privacy_algorithm", &privacy_algorithm);
+            }
             if let Some(credential_store_id) = parse_element_text(raw_xml, "credential_store_id") {
                 resource.set_attr("credential_store_id", &credential_store_id);
             }
@@ -1130,6 +1151,14 @@ impl SessionHandler {
         } else {
             None
         };
+        let new_login = parse_element_text(raw_xml, "login");
+        let new_allow_insecure = parse_element_text(raw_xml, "allow_insecure");
+        let new_kdc = credential_kdcs(cmd)
+            .map(|kdcs| kdcs.join(","))
+            .or_else(|| parse_element_text(raw_xml, "kdc"));
+        let new_realm = parse_element_text(raw_xml, "realm");
+        let new_auth_algorithm = parse_element_text(raw_xml, "auth_algorithm");
+        let new_privacy_algorithm = nested_child_text(cmd, &["privacy", "algorithm"]);
         let task_reference_updates = if resource_type == "task" {
             match task_reference_updates(cmd) {
                 Ok(references) => references,
@@ -1287,6 +1316,24 @@ impl SessionHandler {
                 set_alert_fields(r, cmd);
             }
             if resource_type == "credential" {
+                if let Some(ref login) = new_login {
+                    r.set_attr("login", login);
+                }
+                if let Some(ref allow_insecure) = new_allow_insecure {
+                    r.set_attr("allow_insecure", allow_insecure);
+                }
+                if let Some(ref kdc) = new_kdc {
+                    r.set_attr("kdc", kdc);
+                }
+                if let Some(ref realm) = new_realm {
+                    r.set_attr("realm", realm);
+                }
+                if let Some(ref auth_algorithm) = new_auth_algorithm {
+                    r.set_attr("auth_algorithm", auth_algorithm);
+                }
+                if let Some(ref privacy_algorithm) = new_privacy_algorithm {
+                    r.set_attr("privacy_algorithm", privacy_algorithm);
+                }
                 if let Some(ref credential_store_id) = new_credential_store_id {
                     r.set_attr("credential_store_id", credential_store_id);
                 }
@@ -3654,6 +3701,19 @@ fn nested_child_attr(cmd: &ParsedCommand, path: &[&str], attr: &str) -> Option<S
         element = element.children.iter().find(|child| child.name == **name)?;
     }
     element.attributes.get(attr).cloned()
+}
+
+fn credential_kdcs(cmd: &ParsedCommand) -> Option<Vec<String>> {
+    cmd.children
+        .iter()
+        .find(|child| child.name == "kdcs")
+        .map(|kdcs| {
+            kdcs.children
+                .iter()
+                .filter(|child| child.name == "kdc")
+                .map(|child| child.text.clone().unwrap_or_default())
+                .collect()
+        })
 }
 
 fn set_permission_references(resource: &mut Resource, cmd: &ParsedCommand) {


### PR DESCRIPTION
## Summary
- emit current gvmd credential shapes for nested SSH/PGP keys and SNMP privacy data
- support SNMP community, SNMPv3, Kerberos, certificates, insecure transport, and credential renames
- expose typed credential modification and extend the stateful mock without persisting secrets
- retain the legacy `snmpv3` parse alias while emitting canonical `snmp`; stop emitting ignored `<format>` values

## Validation
- `cargo test -p gvm-gmp --all-features`
- `cargo test -p gvm-client --all-features`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #423

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high