### PR TITLE
fix(gmp): preserve remaining response metadata

### DIFF
--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -41,6 +41,15 @@ pub struct NamedEntity {
     pub name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NvtReference {
+    pub oid: String,
+    pub name: Option<String>,
+    pub type_: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -238,6 +247,24 @@ pub(crate) fn parse_entity_id(value: &str, field: &str) -> Result<EntityId, Pars
         field: field.to_string(),
         value: value.to_string(),
     })
+}
+
+pub(crate) fn parse_nvt_reference(
+    node: &XmlNode,
+    field: &str,
+) -> Result<Option<NvtReference>, ParseError> {
+    node.child("nvt")
+        .map(|nvt| {
+            Ok(NvtReference {
+                oid: nvt
+                    .attr("oid")
+                    .ok_or_else(|| ParseError::MissingElement(format!("{field}.oid")))?
+                    .to_string(),
+                name: nvt.optional_child_text("name"),
+                type_: nvt.optional_child_text("type"),
+            })
+        })
+        .transpose()
 }
 
 pub(crate) fn parse_bool(value: &str, field: &str) -> Result<bool, ParseError> {

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -251,14 +251,14 @@ pub(crate) fn parse_entity_id(value: &str, field: &str) -> Result<EntityId, Pars
 
 pub(crate) fn parse_nvt_reference(
     node: &XmlNode,
-    field: &str,
+    field_prefix: &str,
 ) -> Result<Option<NvtReference>, ParseError> {
     node.child("nvt")
         .map(|nvt| {
             Ok(NvtReference {
                 oid: nvt
                     .attr("oid")
-                    .ok_or_else(|| ParseError::MissingElement(format!("{field}.oid")))?
+                    .ok_or_else(|| ParseError::MissingElement(format!("{field_prefix}.oid")))?
                     .to_string(),
                 name: nvt.optional_child_text("name"),
                 type_: nvt.optional_child_text("type"),

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -83,7 +83,9 @@ pub use audit_report::{
     StructuredReportResourceCounts, StructuredReportTarget, StructuredReportTask,
 };
 pub use auth::AuthenticateResponse;
-pub use common::{ActionResponse, CountInfo, EntityMeta, NamedEntity, Owner, ParseError};
+pub use common::{
+    ActionResponse, CountInfo, EntityMeta, NamedEntity, NvtReference, Owner, ParseError,
+};
 pub use config::{
     ConfigUsageKind, CreateConfigResponse, DeleteConfigResponse, GenericConfig, GetConfigsResponse,
     ModifyConfigResponse,
@@ -176,9 +178,9 @@ pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};
 pub use target::{CreateTargetResponse, GetTargetsResponse, Target};
 pub use task::{
-    CreateTaskResponse, DeleteTaskResponse, GetTasksResponse, LastReport, ModifyTaskResponse,
-    MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse, Task,
-    TaskTargetReference,
+    CreateTaskResponse, CurrentReport, DeleteTaskResponse, GetTasksResponse, LastReport,
+    ModifyTaskResponse, MoveTaskResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse,
+    Task, TaskReportComplianceCount, TaskReportResultCount, TaskTargetReference,
 };
 pub use ticket::{
     CreateTicketResponse, DeleteTicketResponse, GetTicketsResponse, ModifyTicketResponse, Ticket,

--- a/crates/gvm-gmp/src/responses/note.rs
+++ b/crates/gvm-gmp/src/responses/note.rs
@@ -7,8 +7,8 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
-    parse_entity_meta_optional_name, parse_entity_ref, status_from_response, ActionResponse,
-    CountInfo, EntityMeta, NamedEntity, ParseError,
+    parse_entity_meta_optional_name, parse_entity_ref, parse_nvt_reference, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, NamedEntity, NvtReference, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +17,7 @@ use crate::responses::common::{
 pub struct Note {
     pub meta: EntityMeta,
     pub text: Option<String>,
+    pub nvt: Option<NvtReference>,
     pub nvt_oid: Option<String>,
     pub hosts: Vec<String>,
     pub port: Option<String>,
@@ -48,13 +49,12 @@ pub struct CreateNoteResponse {
 
 impl Note {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let nvt = parse_nvt_reference(node, "nvt")?;
         Ok(Self {
             meta: parse_entity_meta_optional_name(node)?,
             text: node.optional_child_text("text"),
-            nvt_oid: node
-                .child("nvt")
-                .and_then(|n| n.attr("oid"))
-                .map(String::from),
+            nvt_oid: nvt.as_ref().map(|nvt| nvt.oid.clone()),
+            nvt,
             hosts: node
                 .optional_child_text("hosts")
                 .map(|value| parse_csv_list(&value))
@@ -159,6 +159,9 @@ mod tests {
             parsed.items[0].nvt_oid.as_deref(),
             Some("1.3.6.1.4.1.25623.1.0.12345")
         );
+        let nvt = parsed.items[0].nvt.as_ref().expect("NVT reference");
+        assert_eq!(nvt.name.as_deref(), Some("Some NVT"));
+        assert_eq!(nvt.type_, None);
         assert_eq!(
             parsed.items[0].hosts,
             vec!["192.168.1.1".to_string(), "192.168.1.2".to_string()]
@@ -227,6 +230,7 @@ mod tests {
         assert_eq!(note.meta.comment, None);
         assert_eq!(note.text, None);
         assert_eq!(note.nvt_oid, None);
+        assert_eq!(note.nvt, None);
         assert!(note.hosts.is_empty());
         assert_eq!(note.task, None);
         assert!(!note.active);
@@ -283,6 +287,9 @@ mod tests {
         assert_eq!(note.end_time.as_deref(), Some("2026-06-11T12:41:51Z"));
         assert_eq!(note.text.as_deref(), Some("raw gmp parser repro"));
         assert_eq!(note.nvt_oid.as_deref(), Some("1.3.6.1.4.1.25623.1.0.12288"));
+        let nvt = note.nvt.as_ref().expect("NVT reference");
+        assert_eq!(nvt.name.as_deref(), Some("Global variable settings"));
+        assert_eq!(nvt.type_.as_deref(), Some("nvt"));
         assert!(note.hosts.is_empty());
         assert_eq!(note.port, None);
         assert_eq!(note.severity, None);

--- a/crates/gvm-gmp/src/responses/override_.rs
+++ b/crates/gvm-gmp/src/responses/override_.rs
@@ -7,8 +7,8 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, parse_bool, parse_csv_list, parse_document, parse_entity_id,
-    parse_entity_meta_optional_name, parse_entity_ref, status_from_response, ActionResponse,
-    CountInfo, EntityMeta, NamedEntity, ParseError,
+    parse_entity_meta_optional_name, parse_entity_ref, parse_nvt_reference, status_from_response,
+    ActionResponse, CountInfo, EntityMeta, NamedEntity, NvtReference, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +17,7 @@ use crate::responses::common::{
 pub struct Override {
     pub meta: EntityMeta,
     pub text: Option<String>,
+    pub nvt: Option<NvtReference>,
     pub nvt_oid: Option<String>,
     pub hosts: Vec<String>,
     pub port: Option<String>,
@@ -49,13 +50,12 @@ pub struct CreateOverrideResponse {
 
 impl Override {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let nvt = parse_nvt_reference(node, "nvt")?;
         Ok(Self {
             meta: parse_entity_meta_optional_name(node)?,
             text: node.optional_child_text("text"),
-            nvt_oid: node
-                .child("nvt")
-                .and_then(|n| n.attr("oid"))
-                .map(String::from),
+            nvt_oid: nvt.as_ref().map(|nvt| nvt.oid.clone()),
+            nvt,
             hosts: node
                 .optional_child_text("hosts")
                 .map(|value| parse_csv_list(&value))
@@ -162,6 +162,9 @@ mod tests {
             parsed.items[0].nvt_oid.as_deref(),
             Some("1.3.6.1.4.1.25623.1.0.12345")
         );
+        let nvt = parsed.items[0].nvt.as_ref().expect("NVT reference");
+        assert_eq!(nvt.name.as_deref(), Some("Some NVT"));
+        assert_eq!(nvt.type_, None);
         assert_eq!(parsed.items[0].new_severity.as_deref(), Some("2.0"));
         assert_eq!(
             parsed.items[0].hosts,
@@ -230,6 +233,7 @@ mod tests {
         assert_eq!(ov.meta.comment, None);
         assert_eq!(ov.text, None);
         assert_eq!(ov.nvt_oid, None);
+        assert_eq!(ov.nvt, None);
         assert!(ov.hosts.is_empty());
         assert_eq!(ov.new_severity, None);
         assert_eq!(ov.task, None);
@@ -287,6 +291,9 @@ mod tests {
         assert_eq!(ov.end_time.as_deref(), Some("2026-06-11T12:42:24Z"));
         assert_eq!(ov.text.as_deref(), Some("raw gmp override parser repro"));
         assert_eq!(ov.nvt_oid.as_deref(), Some("1.3.6.1.4.1.25623.1.0.12288"));
+        let nvt = ov.nvt.as_ref().expect("NVT reference");
+        assert_eq!(nvt.name.as_deref(), Some("Global variable settings"));
+        assert_eq!(nvt.type_.as_deref(), Some("nvt"));
         assert!(ov.hosts.is_empty());
         assert_eq!(ov.port, None);
         assert_eq!(ov.severity, None);

--- a/crates/gvm-gmp/src/responses/scan_config.rs
+++ b/crates/gvm-gmp/src/responses/scan_config.rs
@@ -17,6 +17,8 @@ pub struct ScanConfig {
     pub meta: EntityMeta,
     pub usage_type: Option<String>,
     pub type_: Option<u32>,
+    pub family_count: Option<u32>,
+    pub nvt_count: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +46,8 @@ impl ScanConfig {
             meta: parse_entity_meta(node)?,
             usage_type: node.optional_child_text("usage_type"),
             type_: optional_u32(node, "type", "type")?,
+            family_count: optional_u32(node, "family_count", "family_count")?,
+            nvt_count: optional_u32(node, "nvt_count", "nvt_count")?,
         })
     }
 }
@@ -106,6 +110,8 @@ mod tests {
                     <in_use>0</in_use>
                     <usage_type>scan</usage_type>
                     <type>0</type>
+                    <family_count>12<growing>1</growing></family_count>
+                    <nvt_count>74231<growing>0</growing></nvt_count>
                 </config>
                 <config id="cfg-2">
                     <name>Policy</name>
@@ -124,6 +130,10 @@ mod tests {
         assert_eq!(parsed.items[1].usage_type.as_deref(), Some("policy"));
         assert_eq!(parsed.items[0].type_, Some(0));
         assert_eq!(parsed.items[1].type_, Some(7));
+        assert_eq!(parsed.items[0].family_count, Some(12));
+        assert_eq!(parsed.items[0].nvt_count, Some(74_231));
+        assert_eq!(parsed.items[1].family_count, None);
+        assert_eq!(parsed.items[1].nvt_count, None);
     }
 
     #[test]
@@ -181,7 +191,31 @@ mod tests {
         assert_eq!(config.meta.comment, None);
         assert_eq!(config.usage_type, None);
         assert_eq!(config.type_, None);
+        assert_eq!(config.family_count, None);
+        assert_eq!(config.nvt_count, None);
         assert!(!config.meta.in_use);
+    }
+
+    #[test]
+    fn rejects_invalid_scan_config_counts() {
+        for (element, field) in [
+            ("<family_count>many</family_count>", "family_count"),
+            ("<nvt_count>many</nvt_count>", "nvt_count"),
+        ] {
+            let xml = format!(
+                r#"<get_configs_response status="200" status_text="OK">
+                    <config id="cfg-1"><name>Invalid</name>{element}</config>
+                </get_configs_response>"#
+            );
+            let response = Response::from(xml.as_str());
+
+            let error =
+                GetScanConfigsResponse::from_response(&response).expect_err("count must fail");
+            assert!(
+                matches!(error, ParseError::InvalidValue { field: actual, value }
+                    if actual == field && value == "many")
+            );
+        }
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/schedule.rs
+++ b/crates/gvm-gmp/src/responses/schedule.rs
@@ -6,8 +6,8 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{
-    count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
-    ActionResponse, CountInfo, EntityMeta, ParseError,
+    count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
+    status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,7 +19,7 @@ pub struct Schedule {
     pub timezone: Option<String>,
     pub first_run: Option<String>,
     pub next_run: Option<String>,
-    pub duration: Option<String>,
+    pub duration: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,7 +49,7 @@ impl Schedule {
             timezone: node.optional_child_text("timezone"),
             first_run: node.optional_child_text("first_run"),
             next_run: node.optional_child_text("next_run"),
-            duration: node.optional_child_text("duration"),
+            duration: optional_u32(node, "duration", "duration")?,
         })
     }
 }
@@ -139,7 +139,7 @@ mod tests {
             parsed.items[0].next_run.as_deref(),
             Some("2026-01-04T00:00:00Z")
         );
-        assert_eq!(parsed.items[0].duration.as_deref(), Some("3600"));
+        assert_eq!(parsed.items[0].duration, Some(3600));
         assert!(parsed.items[1].meta.in_use);
     }
 
@@ -201,5 +201,21 @@ mod tests {
         assert_eq!(schedule.first_run, None);
         assert_eq!(schedule.next_run, None);
         assert_eq!(schedule.duration, None);
+    }
+
+    #[test]
+    fn rejects_invalid_schedule_duration() {
+        let response = Response::from(
+            r#"<get_schedules_response status="200" status_text="OK">
+                <schedule id="s-1">
+                    <name>Invalid Duration</name>
+                    <duration>forever</duration>
+                </schedule>
+            </get_schedules_response>"#,
+        );
+
+        let error = GetSchedulesResponse::from_response(&response).expect_err("duration must fail");
+        assert!(matches!(error, ParseError::InvalidValue { field, value }
+                if field == "duration" && value == "forever"));
     }
 }

--- a/crates/gvm-gmp/src/responses/task.rs
+++ b/crates/gvm-gmp/src/responses/task.rs
@@ -369,6 +369,7 @@ fn parse_report_reference(
     node: &XmlNode,
     field: &str,
 ) -> Result<Option<TaskReportReference>, ParseError> {
+    let include_summary = field == "last_report";
     node.child(field)
         .and_then(|report_wrapper| report_wrapper.child("report"))
         .map(|report| -> Result<TaskReportReference, ParseError> {
@@ -382,15 +383,25 @@ fn parse_report_reference(
                 timestamp: report.optional_child_text("timestamp"),
                 scan_start: report.optional_child_text("scan_start"),
                 scan_end: report.optional_child_text("scan_end"),
-                result_count: report
-                    .child("result_count")
-                    .map(parse_task_report_result_count)
-                    .transpose()?,
-                severity: report.optional_child_text("severity"),
-                compliance_count: report
-                    .child("compliance_count")
-                    .map(parse_task_report_compliance_count)
-                    .transpose()?,
+                result_count: if include_summary {
+                    report
+                        .child("result_count")
+                        .map(parse_task_report_result_count)
+                        .transpose()?
+                } else {
+                    None
+                },
+                severity: include_summary
+                    .then(|| report.optional_child_text("severity"))
+                    .flatten(),
+                compliance_count: if include_summary {
+                    report
+                        .child("compliance_count")
+                        .map(parse_task_report_compliance_count)
+                        .transpose()?
+                } else {
+                    None
+                },
             })
         })
         .transpose()
@@ -912,5 +923,34 @@ mod tests {
         let error = GetTasksResponse::from_response(&response).expect_err("count must fail");
         assert!(matches!(error, ParseError::InvalidValue { field, value }
                 if field == "last_report.result_count.high" && value == "many"));
+    }
+
+    #[test]
+    fn ignores_last_report_only_summary_fields_on_current_report() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-1">
+                    <name>Task</name>
+                    <current_report>
+                        <report id="report-1">
+                            <result_count><high>not-a-number</high></result_count>
+                            <severity>8.0</severity>
+                            <compliance_count><yes>also-not-a-number</yes></compliance_count>
+                        </report>
+                    </current_report>
+                </task>
+                <task_count>1<filtered>1</filtered></task_count>
+            </get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response)
+            .expect("current report summary fields must be ignored");
+        assert_eq!(
+            parsed.items[0]
+                .current_report
+                .as_ref()
+                .map(|report| report.id.as_str()),
+            Some("report-1")
+        );
     }
 }

--- a/crates/gvm-gmp/src/responses/task.rs
+++ b/crates/gvm-gmp/src/responses/task.rs
@@ -59,6 +59,11 @@ pub struct TaskTargetReference {
 pub struct LastReport {
     pub id: EntityId,
     pub timestamp: Option<String>,
+    pub scan_start: Option<String>,
+    pub scan_end: Option<String>,
+    pub result_count: Option<TaskReportResultCount>,
+    pub severity: Option<String>,
+    pub compliance_count: Option<TaskReportComplianceCount>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -67,11 +72,39 @@ pub struct LastReport {
 pub struct CurrentReport {
     pub id: EntityId,
     pub timestamp: Option<String>,
+    pub scan_start: Option<String>,
+    pub scan_end: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TaskReportResultCount {
+    pub critical: Option<u32>,
+    pub high: Option<u32>,
+    pub medium: Option<u32>,
+    pub low: Option<u32>,
+    pub log: Option<u32>,
+    pub false_positive: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TaskReportComplianceCount {
+    pub yes: Option<u32>,
+    pub no: Option<u32>,
+    pub incomplete: Option<u32>,
 }
 
 struct TaskReportReference {
     id: EntityId,
     timestamp: Option<String>,
+    scan_start: Option<String>,
+    scan_end: Option<String>,
+    result_count: Option<TaskReportResultCount>,
+    severity: Option<String>,
+    compliance_count: Option<TaskReportComplianceCount>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -312,6 +345,8 @@ fn parse_current_report(node: &XmlNode) -> Result<Option<CurrentReport>, ParseEr
         report.map(|report| CurrentReport {
             id: report.id,
             timestamp: report.timestamp,
+            scan_start: report.scan_start,
+            scan_end: report.scan_end,
         })
     })
 }
@@ -321,6 +356,11 @@ fn parse_last_report(node: &XmlNode) -> Result<Option<LastReport>, ParseError> {
         report.map(|report| LastReport {
             id: report.id,
             timestamp: report.timestamp,
+            scan_start: report.scan_start,
+            scan_end: report.scan_end,
+            result_count: report.result_count,
+            severity: report.severity,
+            compliance_count: report.compliance_count,
         })
     })
 }
@@ -340,9 +380,67 @@ fn parse_report_reference(
                     &format!("{field}.report.id"),
                 )?,
                 timestamp: report.optional_child_text("timestamp"),
+                scan_start: report.optional_child_text("scan_start"),
+                scan_end: report.optional_child_text("scan_end"),
+                result_count: report
+                    .child("result_count")
+                    .map(parse_task_report_result_count)
+                    .transpose()?,
+                severity: report.optional_child_text("severity"),
+                compliance_count: report
+                    .child("compliance_count")
+                    .map(parse_task_report_compliance_count)
+                    .transpose()?,
             })
         })
         .transpose()
+}
+
+fn parse_task_report_result_count(node: &XmlNode) -> Result<TaskReportResultCount, ParseError> {
+    Ok(TaskReportResultCount {
+        critical: optional_u32(node, "critical", "last_report.result_count.critical")?,
+        high: optional_u32_with_alias(node, "high", "hole", "last_report.result_count.high")?,
+        medium: optional_u32_with_alias(
+            node,
+            "medium",
+            "warning",
+            "last_report.result_count.medium",
+        )?,
+        low: optional_u32_with_alias(node, "low", "info", "last_report.result_count.low")?,
+        log: optional_u32(node, "log", "last_report.result_count.log")?,
+        false_positive: optional_u32(
+            node,
+            "false_positive",
+            "last_report.result_count.false_positive",
+        )?,
+    })
+}
+
+fn optional_u32_with_alias(
+    node: &XmlNode,
+    canonical: &str,
+    alias: &str,
+    field: &str,
+) -> Result<Option<u32>, ParseError> {
+    if node.child(canonical).is_some() {
+        optional_u32(node, canonical, field)
+    } else {
+        optional_u32(node, alias, field)
+    }
+}
+
+fn parse_task_report_compliance_count(
+    node: &XmlNode,
+) -> Result<TaskReportComplianceCount, ParseError> {
+    Ok(TaskReportComplianceCount {
+        yes: optional_u32(node, "yes", "last_report.compliance_count.yes")?,
+        no: optional_u32(node, "no", "last_report.compliance_count.no")?,
+        incomplete: optional_u32(
+            node,
+            "incomplete",
+            "last_report.compliance_count.incomplete",
+        )?,
+    })
 }
 
 fn parse_observers(node: &XmlNode) -> Result<Option<TaskObservers>, ParseError> {
@@ -399,56 +497,85 @@ mod tests {
 
     use super::*;
 
+    const CURRENT_GVMD_TASKS_RESPONSE: &str = r#"<get_tasks_response status="200" status_text="OK">
+            <task id="task-1">
+                <owner><name>admin</name></owner>
+                <name>Discovery Scan</name>
+                <comment>Network scan</comment>
+                <creation_time>2026-01-01T00:00:00Z</creation_time>
+                <modification_time>2026-01-02T00:00:00Z</modification_time>
+                <writable>1</writable>
+                <in_use>1</in_use>
+                <status>Done</status>
+                <progress>100</progress>
+                <alterable>1</alterable>
+                <target id="t-1"><name>Local Net</name></target>
+                <config id="cfg-1"><name>Full and fast</name></config>
+                <scanner id="sc-1"><name>Default</name></scanner>
+                <schedule id="sched-1"><name>Weekly</name></schedule>
+                <alert id="alert-1"><name>Email</name></alert>
+                <alert id="alert-2"><name>Ticket</name></alert>
+                <observers>
+                    alice bob carol
+                    <group id="grp-1"><name>Auditors</name></group>
+                    <role id="role-1"><name>Observer</name></role>
+                </observers>
+                <current_report>
+                    <report id="rpt-current-1">
+                        <timestamp>2026-01-15T10:00:00Z</timestamp>
+                        <scan_start>2026-01-15T10:00:01Z</scan_start>
+                        <scan_end></scan_end>
+                    </report>
+                </current_report>
+                <last_report>
+                    <report id="rpt-1">
+                        <timestamp>2026-01-15T10:30:00Z</timestamp>
+                        <scan_start>2026-01-15T10:00:01Z</scan_start>
+                        <scan_end>2026-01-15T10:29:59Z</scan_end>
+                        <result_count>
+                            <critical>2</critical>
+                            <hole deprecated="1">3</hole>
+                            <high>3</high>
+                            <info deprecated="1">5</info>
+                            <low>5</low>
+                            <log>7</log>
+                            <warning deprecated="1">11</warning>
+                            <medium>11</medium>
+                            <false_positive>13</false_positive>
+                        </result_count>
+                        <severity>8.8</severity>
+                    </report>
+                </last_report>
+                <report_count>5</report_count>
+                <schedule_periods>3</schedule_periods>
+                <trend>up</trend>
+                <usage_type>scan</usage_type>
+                <hosts_ordering>sequential</hosts_ordering>
+            </task>
+            <task id="task-2">
+                <name>Audit Task</name>
+                <status>Done</status>
+                <progress>42</progress>
+                <usage_type>audit</usage_type>
+                <last_report>
+                    <report id="audit-report-1">
+                        <timestamp>2026-01-16T12:00:00Z</timestamp>
+                        <scan_start>2026-01-16T11:00:00Z</scan_start>
+                        <scan_end>2026-01-16T12:00:00Z</scan_end>
+                        <compliance_count>
+                            <yes>17</yes>
+                            <no>19</no>
+                            <incomplete>23</incomplete>
+                        </compliance_count>
+                    </report>
+                </last_report>
+            </task>
+            <task_count>2<filtered>2</filtered><page>1</page></task_count>
+        </get_tasks_response>"#;
+
     #[test]
     fn parses_multiple_tasks() {
-        let response = Response::from(
-            r#"<get_tasks_response status="200" status_text="OK">
-                <task id="task-1">
-                    <owner><name>admin</name></owner>
-                    <name>Discovery Scan</name>
-                    <comment>Network scan</comment>
-                    <creation_time>2026-01-01T00:00:00Z</creation_time>
-                    <modification_time>2026-01-02T00:00:00Z</modification_time>
-                    <writable>1</writable>
-                    <in_use>1</in_use>
-                    <status>Done</status>
-                    <progress>100</progress>
-                    <alterable>1</alterable>
-                    <target id="t-1"><name>Local Net</name></target>
-                    <config id="cfg-1"><name>Full and fast</name></config>
-                    <scanner id="sc-1"><name>Default</name></scanner>
-                    <schedule id="sched-1"><name>Weekly</name></schedule>
-                    <alert id="alert-1"><name>Email</name></alert>
-                    <alert id="alert-2"><name>Ticket</name></alert>
-                    <observers>
-                        alice bob carol
-                        <group id="grp-1"><name>Auditors</name></group>
-                        <role id="role-1"><name>Observer</name></role>
-                    </observers>
-                    <current_report>
-                        <report id="rpt-current-1">
-                            <timestamp>2026-01-15T10:00:00Z</timestamp>
-                        </report>
-                    </current_report>
-                    <last_report>
-                        <report id="rpt-1">
-                            <timestamp>2026-01-15T10:30:00Z</timestamp>
-                        </report>
-                    </last_report>
-                    <report_count>5</report_count>
-                    <schedule_periods>3</schedule_periods>
-                    <trend>up</trend>
-                    <usage_type>scan</usage_type>
-                    <hosts_ordering>sequential</hosts_ordering>
-                </task>
-                <task id="task-2">
-                    <name>Running Task</name>
-                    <status>Running</status>
-                    <progress>42</progress>
-                </task>
-                <task_count>2<filtered>2</filtered><page>1</page></task_count>
-            </get_tasks_response>"#,
-        );
+        let response = Response::from(CURRENT_GVMD_TASKS_RESPONSE);
 
         let parsed = GetTasksResponse::from_response(&response).expect("tasks parse");
 
@@ -478,22 +605,41 @@ mod tests {
         );
         assert_eq!(observers.groups[0].id.as_str(), "grp-1");
         assert_eq!(observers.roles[0].id.as_str(), "role-1");
+        let current = parsed.items[0]
+            .current_report
+            .as_ref()
+            .expect("current report");
+        assert_eq!(current.id.as_str(), "rpt-current-1");
+        assert_eq!(current.scan_start.as_deref(), Some("2026-01-15T10:00:01Z"));
+        assert_eq!(current.scan_end, None);
+        let last = parsed.items[0].last_report.as_ref().expect("last report");
+        assert_eq!(last.id.as_str(), "rpt-1");
+        assert_eq!(last.scan_end.as_deref(), Some("2026-01-15T10:29:59Z"));
+        assert_eq!(last.severity.as_deref(), Some("8.8"));
         assert_eq!(
-            parsed.items[0]
-                .current_report
-                .as_ref()
-                .map(|report| report.id.as_str()),
-            Some("rpt-current-1")
-        );
-        assert_eq!(
-            parsed.items[0]
-                .last_report
-                .as_ref()
-                .map(|report| report.id.as_str()),
-            Some("rpt-1")
+            last.result_count,
+            Some(TaskReportResultCount {
+                critical: Some(2),
+                high: Some(3),
+                medium: Some(11),
+                low: Some(5),
+                log: Some(7),
+                false_positive: Some(13),
+            })
         );
         assert_eq!(parsed.items[0].schedule_periods, Some(3));
         assert_eq!(parsed.items[1].progress, Some(42));
+        assert_eq!(
+            parsed.items[1]
+                .last_report
+                .as_ref()
+                .and_then(|report| report.compliance_count.clone()),
+            Some(TaskReportComplianceCount {
+                yes: Some(17),
+                no: Some(19),
+                incomplete: Some(23),
+            })
+        );
     }
 
     #[test]
@@ -715,5 +861,56 @@ mod tests {
             ParseError::InvalidValue { field, value }
                 if field == "schedule.id" && value == "not valid"
         ));
+    }
+
+    #[test]
+    fn parses_deprecated_task_result_aliases_without_double_counting() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-1">
+                    <name>Legacy buckets</name>
+                    <last_report>
+                        <report id="report-1">
+                            <result_count>
+                                <hole>3</hole>
+                                <info>5</info>
+                                <warning>11</warning>
+                            </result_count>
+                        </report>
+                    </last_report>
+                </task>
+            </get_tasks_response>"#,
+        );
+
+        let parsed = GetTasksResponse::from_response(&response).expect("aliases parse");
+        let count = parsed.items[0]
+            .last_report
+            .as_ref()
+            .and_then(|report| report.result_count.as_ref())
+            .expect("result count");
+
+        assert_eq!(count.high, Some(3));
+        assert_eq!(count.low, Some(5));
+        assert_eq!(count.medium, Some(11));
+    }
+
+    #[test]
+    fn rejects_invalid_task_report_counts() {
+        let response = Response::from(
+            r#"<get_tasks_response status="200" status_text="OK">
+                <task id="task-1">
+                    <name>Invalid count</name>
+                    <last_report>
+                        <report id="report-1">
+                            <result_count><high>many</high></result_count>
+                        </report>
+                    </last_report>
+                </task>
+            </get_tasks_response>"#,
+        );
+
+        let error = GetTasksResponse::from_response(&response).expect_err("count must fail");
+        assert!(matches!(error, ParseError::InvalidValue { field, value }
+                if field == "last_report.result_count.high" && value == "many"));
     }
 }


### PR DESCRIPTION
## Summary
- parse typed scan-config family and NVT counts with malformed-value errors
- retain structured NVT OID, name, and type metadata for notes and overrides
- parse schedule duration as a typed numeric value
- preserve task report scan timing, normalized result counts, severity, and audit compliance counts
- keep missing optional metadata compatible and avoid double-counting deprecated result aliases

## Validation
- `cargo test -p gvm-gmp --all-features`
- `cargo test -p gvm-client --all-features`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy -p gvm-gmp -p gvm-client -p gvm-mock-server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #428

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high