### PR TITLE
docs(journal): add 2026-08-01 update

### DIFF
--- a/journal/2026-08-01.md
+++ b/journal/2026-08-01.md
@@ -1,0 +1,8 @@
+# 2026-08-01 — Remaining GMP Compatibility Fixes Landed
+
+## Devel Compatibility Queue Completed
+- Five previously open implementation pull requests merged into `devel`: PRs [#436](https://github.com/greenbone-hive/rust-gvm/pull/436), [#437](https://github.com/greenbone-hive/rust-gvm/pull/437), [#440](https://github.com/greenbone-hive/rust-gvm/pull/440), [#441](https://github.com/greenbone-hive/rust-gvm/pull/441), and [#442](https://github.com/greenbone-hive/rust-gvm/pull/442).
+- The merged work completed alert data-map serialization, typed ticket assignees, explicit empty-versus-omitted modify collections, credential request fields, and remaining response metadata. Protected checks passed across the merge set.
+
+## Downstream Integration Impact
+- The completed model changes now expose concrete downstream migration work in `rust-gvm-api`, particularly for tri-state collection updates, credential and alert option fields, and typed response projections.


### PR DESCRIPTION
## Summary

- record the five GMP compatibility pull requests merged into `devel`
- capture the resulting downstream integration impact
