### PR TITLE
docs(journal): record 2026-08-02 issue reconciliation

### DIFF
--- a/journal/2026-08-02.md
+++ b/journal/2026-08-02.md
@@ -1,0 +1,9 @@
+# 2026-08-02 — Completed Compatibility Backlog Reconciled
+
+## Issue Backlog Closed Against Devel
+- Issues [#414](https://github.com/greenbone-hive/rust-gvm/issues/414), [#416](https://github.com/greenbone-hive/rust-gvm/issues/416), and [#422](https://github.com/greenbone-hive/rust-gvm/issues/422)–[#431](https://github.com/greenbone-hive/rust-gvm/issues/431) were manually closed as completed after their acceptance criteria were verified against protected `devel` at `50405425792a69e9bf77e79aceb440374230883c`.
+- The twelve issues cover parameterless configuration sync, Base64 setting values, alert and credential serialization, explicit collection clearing, rename and scanner fields, typed ticket assignees, response metadata, report parsing, structured scan reports, and non-classic task targets.
+
+## Verification and Remaining Work
+- Each closure received implementation evidence pointing to its merged PR and the exact integrated tree. Security run [`30629022909`](https://github.com/greenbone-hive/rust-gvm/actions/runs/30629022909) passed on that `devel` tip.
+- The reconciled open issue set is now [#4](https://github.com/greenbone-hive/rust-gvm/issues/4), [#9](https://github.com/greenbone-hive/rust-gvm/issues/9), [#20](https://github.com/greenbone-hive/rust-gvm/issues/20), [#38](https://github.com/greenbone-hive/rust-gvm/issues/38), [#71](https://github.com/greenbone-hive/rust-gvm/issues/71), and [#417](https://github.com/greenbone-hive/rust-gvm/issues/417); these remain open for deferred streaming/record-replay work, SBOM quality, gateway architecture, dependency-review strategy, and removal of the temporary `wnaf` exception.


### PR DESCRIPTION
## Summary

- record the completed closure of issues #414, #416, and #422-#431
- capture exact protected devel verification and the remaining open backlog

## Journal policy

This journal-only PR targets `journal-main`.