### PR TITLE
docs(journal): 2026-08-03 activity

### DIFF
--- a/journal/2026-08-03.md
+++ b/journal/2026-08-03.md
@@ -1,0 +1,8 @@
+# 2026-08-03 — Dependency Updates Opened With a New Vetting Blocker
+
+## Dependency Update Queue
+- Dependabot opened PR [#447](https://github.com/greenbone-hive/rust-gvm/pull/447) to update the runtime `rustls` dependency from 0.23.42 to 0.23.43. The normal CI matrix, Cargo Audit, Cargo Deny, and static-analysis checks pass.
+- Dependabot also opened PR [#448](https://github.com/greenbone-hive/rust-gvm/pull/448) to update `taiki-e/install-action`, `docker/login-action`, and the CodeQL SARIF upload action. Its CI and security checks are green.
+
+## Action Required
+- PR #447 is blocked by a new Cargo Vet failure, which causes its aggregate Security check to fail. The `rustls` update needs an approved audit or exemption before it can merge; PR #448 is clean and mergeable.


### PR DESCRIPTION
## Summary

- record two newly opened dependency-update PRs
- flag the new Cargo Vet/security blocker on the `rustls` update
- note that the grouped GitHub Actions update is green and mergeable
