### PR TITLE
fix(gmp): align modify_auth with gvmd

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -101,7 +101,7 @@ use gvm_gmp::commands::secinfo::{
 };
 use gvm_gmp::commands::system::{
     describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
-    get_vulns, FilteredGetOpts,
+    get_vulns, modify_auth, FilteredGetOpts,
 };
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
@@ -157,13 +157,13 @@ use gvm_gmp::responses::{
     GetTagsResponse, GetTargetsResponse, GetTasksResponse, GetTicketsResponse,
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
     GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
-    ModifyAlertResponse, ModifyAssetResponse, ModifyConfigResponse, ModifyCredentialResponse,
-    ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse, ModifyPortListResponse,
-    ModifyScanConfigResponse, ModifyScannerResponse, ModifyScheduleResponse, ModifyTargetResponse,
-    ModifyTaskResponse, ModifyTicketResponse, ModifyUserResponse,
-    ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse, ResumeTaskResponse,
-    StartTaskResponse, StopTaskResponse, SyncConfigResponse, VerifyCredentialStoreResponse,
-    VerifyScannerResponse,
+    ModifyAlertResponse, ModifyAssetResponse, ModifyAuthResponse, ModifyConfigResponse,
+    ModifyCredentialResponse, ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse,
+    ModifyPortListResponse, ModifyScanConfigResponse, ModifyScannerResponse,
+    ModifyScheduleResponse, ModifyTargetResponse, ModifyTaskResponse, ModifyTicketResponse,
+    ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse,
+    ResumeTaskResponse, StartTaskResponse, StopTaskResponse, SyncConfigResponse,
+    VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::{CredentialStoreCredentialType, FeedType, ScheduleInput};
@@ -2340,6 +2340,24 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     pub async fn describe_auth(&mut self) -> Result<DescribeAuthResponse, GvmError> {
         let response = self.send(describe_auth()).await?;
         DescribeAuthResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Modify a named authentication group and return a typed
+    /// [`ModifyAuthResponse`].
+    ///
+    /// `auth_conf_settings` must contain at least one key/value pair.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_auth(
+        &mut self,
+        group_name: &str,
+        auth_conf_settings: &[(String, String)],
+    ) -> Result<ModifyAuthResponse, GvmError> {
+        let response = self
+            .send(modify_auth(group_name, auth_conf_settings))
+            .await?;
+        ModifyAuthResponse::from_response(&response).map_err(GvmError::Parse)
     }
 }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -519,6 +519,43 @@ async fn typed_word_count_aggregates_parse_current_gvmd_shape_over_unix_transpor
 }
 
 #[tokio::test]
+async fn typed_modify_auth_uses_current_gvmd_shape_over_unix_transport() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate");
+    server.clear_history();
+
+    let response = client
+        .modify_auth(
+            "method:ldap_connect",
+            &[
+                ("enable".into(), "true".into()),
+                ("ldaphost".into(), "ldap.example".into()),
+            ],
+        )
+        .await
+        .expect("current gvmd modify_auth response should parse");
+
+    assert_eq!(response.status, 200);
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0].raw_xml(),
+        br#"<modify_auth><group name="method:ldap_connect"><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting><auth_conf_setting><key>ldaphost</key><value>ldap.example</value></auth_conf_setting></group></modify_auth>"#
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn unsupported_version_returns_error() {
     let Some(server) = fixture_server_with_version_response("21.4").await else {
         return;

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -167,6 +167,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "get_help",
     "get_help_with_mode",
     "describe_auth",
+    "modify_auth",
 ];
 
 // Kept explicit so each public helper has exactly one of the three issue #398

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -240,10 +240,22 @@ pub fn describe_auth() -> impl Request {
     XmlCommand::new("describe_auth")
 }
 
-/// Build a `modify_auth` request.
+/// Build a `modify_auth` request for a named authentication group.
+///
+/// `auth_conf_settings` must contain at least one key/value pair. Current gvmd
+/// accepts a group containing authentication configuration settings; the old
+/// `enabled` root attribute is not part of the command contract.
 #[must_use]
-pub fn modify_auth(enabled: bool) -> impl Request {
-    XmlCommand::new("modify_auth").attribute("enabled", if enabled { "1" } else { "0" })
+pub fn modify_auth(group_name: &str, auth_conf_settings: &[(String, String)]) -> impl Request {
+    let mut cmd = XmlCommand::new("modify_auth");
+    let group = cmd.add_element("group");
+    group.set_attribute("name", group_name);
+    for (key, value) in auth_conf_settings {
+        let setting = group.add_child("auth_conf_setting");
+        setting.add_child_with_text("key", key);
+        setting.add_child_with_text("value", value);
+    }
+    cmd
 }
 
 /// Build a `modify_license` request.
@@ -342,7 +354,13 @@ mod tests {
             xml(get_vulnerability("vuln-1")),
             "<get_vulns vuln_id=\"vuln-1\"/>"
         );
-        assert_eq!(xml(modify_auth(true)), "<modify_auth enabled=\"1\"/>");
+        assert_eq!(
+            xml(modify_auth(
+                "method:ldap_connect",
+                &[("enable".into(), "true".into())]
+            )),
+            "<modify_auth><group name=\"method:ldap_connect\"><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting></group></modify_auth>"
+        );
         assert_eq!(
             xml(modify_license("abc")),
             "<modify_license><key>abc</key></modify_license>"

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -172,7 +172,7 @@ pub use secinfo::{
 };
 pub use system::{
     AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, GetTimezonesResponse,
-    HelpCommand, HelpResponse, HelpSchema, Setting, Timezone,
+    HelpCommand, HelpResponse, HelpSchema, ModifyAuthResponse, Setting, Timezone,
 };
 pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -5,7 +5,9 @@
 
 use gvm_protocol::Response;
 
-use crate::responses::common::{parse_document, parse_entity_id, status_from_response, ParseError};
+use crate::responses::common::{
+    parse_document, parse_entity_id, status_from_response, ActionResponse, ParseError,
+};
 use crate::EntityId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,6 +99,9 @@ pub struct AuthConfSetting {
     pub key: Option<String>,
     pub value: Option<String>,
 }
+
+/// Response returned after modifying authentication configuration.
+pub type ModifyAuthResponse = ActionResponse;
 
 impl Setting {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {

--- a/crates/gvm-gmp/tests/test_system.rs
+++ b/crates/gvm-gmp/tests/test_system.rs
@@ -82,7 +82,16 @@ fn test_system_aggregates_info_resource_names_and_mutations() {
     );
     assert_eq!(xml(get_license()), "<get_license/>");
     assert_eq!(xml(describe_auth()), "<describe_auth/>");
-    assert_eq!(xml(modify_auth(true)), "<modify_auth enabled=\"1\"/>");
+    assert_eq!(
+        xml(modify_auth(
+            "method:ldap_connect",
+            &[
+                ("enable".into(), "true".into()),
+                ("ldaphost".into(), "ldap.example".into()),
+            ]
+        )),
+        "<modify_auth><group name=\"method:ldap_connect\"><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting><auth_conf_setting><key>ldaphost</key><value>ldap.example</value></auth_conf_setting></group></modify_auth>"
+    );
     assert_eq!(
         xml(modify_license("abc")),
         "<modify_license><key>abc</key></modify_license>"

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1610,13 +1610,43 @@ impl SessionHandler {
     }
 
     fn handle_modify_auth(&self, cmd: &ParsedCommand) -> Vec<u8> {
-        match cmd.attr("enabled") {
-            Some("0" | "1") => {
-                format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
-            }
-            Some(_) => error_response(&cmd.name, 400, "Invalid enabled value"),
-            None => error_response(&cmd.name, 400, "Missing required attribute: enabled"),
+        let mut groups = cmd.children.iter().filter(|child| child.name == "group");
+        let Some(group) = groups.next() else {
+            return error_response(&cmd.name, 400, "Missing required element: group");
+        };
+        if groups.next().is_some() {
+            return error_response(&cmd.name, 400, "Only one group is supported");
         }
+        if group
+            .attributes
+            .get("name")
+            .is_none_or(|name| name.is_empty())
+        {
+            return error_response(&cmd.name, 400, "Missing required attribute: group name");
+        }
+
+        let mut settings = group
+            .children
+            .iter()
+            .filter(|child| child.name == "auth_conf_setting")
+            .peekable();
+        if settings.peek().is_none() {
+            return error_response(
+                &cmd.name,
+                400,
+                "Missing required element: auth_conf_setting",
+            );
+        }
+        for setting in settings {
+            if element_child_text(setting, "key").is_none_or(str::is_empty) {
+                return error_response(&cmd.name, 400, "Missing required element: key");
+            }
+            if !setting.children.iter().any(|child| child.name == "value") {
+                return error_response(&cmd.name, 400, "Missing required element: value");
+            }
+        }
+
+        format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
     }
 
     fn handle_modify_license(&self, cmd: &ParsedCommand) -> Vec<u8> {

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -417,8 +417,24 @@ async fn stateful_auth_and_license_modifiers_use_gmp_builder_shape() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
-    let auth = send_request(&mut stream, modify_auth(true)).await;
+    let auth = send_request(
+        &mut stream,
+        modify_auth("method:ldap_connect", &[("enable".into(), "true".into())]),
+    )
+    .await;
     assert_eq!(auth.status_code(), Some(200));
+
+    for invalid in [
+        br#"<modify_auth enabled="1"/>"#.as_slice(),
+        br#"<modify_auth><group name="method:ldap_connect"/><group name="method:radius_connect"><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting></group></modify_auth>"#.as_slice(),
+        br#"<modify_auth><group><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting></group></modify_auth>"#.as_slice(),
+        br#"<modify_auth><group name="method:ldap_connect"/></modify_auth>"#.as_slice(),
+        br#"<modify_auth><group name="method:ldap_connect"><auth_conf_setting><value>true</value></auth_conf_setting></group></modify_auth>"#.as_slice(),
+        br#"<modify_auth><group name="method:ldap_connect"><auth_conf_setting><key>enable</key></auth_conf_setting></group></modify_auth>"#.as_slice(),
+    ] {
+        let response = send_recv(&mut stream, invalid).await;
+        assert_eq!(response.status_code(), Some(400));
+    }
 
     let license = send_request(&mut stream, modify_license("abc")).await;
     assert_eq!(license.status_code(), Some(200));


### PR DESCRIPTION
## Summary

- replace the obsolete modify_auth(enabled) request with the current named group and auth_conf_setting key/value structure
- add a typed client helper and action response alias
- make the stateful mock reject the legacy silent-no-op request and malformed group/settings payloads
- verify the exact XML through GmpClient over a real Unix transport

This intentionally changes the public modify_auth signature. The previous boolean API emitted an enabled root attribute that current gvmd does not process, so preserving it would preserve a successful no-op.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo +1.85.0 check --workspace --all-features
- cargo +1.85.0 test --workspace
- python-gvm Unix, TLS, and mTLS integration suites
- cargo llvm-cov Cobertura plus diff-cover: 53/53 changed executable lines (100%)
- cargo deny, cargo audit, cargo machete, cargo vet, and the workspace zero-unsafe gate
- Semgrep p/rust, p/security-audit, and p/secrets with --disable-nosem --error: zero findings
- Gitleaks over the exact one-commit branch range: no leaks
- SBOM policy helper tests: pass

## Validation limits

- The request contract was checked against current public gvmd schema/source and python-gvm, but no live gvmd instance was used locally.
- Fuzzing was not run; deterministic builder, parser, malformed-input, and real-transport regressions cover this change.