### PR TITLE
fix(gmp): align modify_license with gvmd

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -150,10 +150,10 @@ pub struct WireTraceEvent {
 /// Sink for opt-in GMP wire trace events.
 ///
 /// Events are structurally parsed and redacted before this callback is invoked.
-/// Known GMP secret fields, generic `value`, `default_value`, and `param`
-/// payloads, sensitive attributes, comments, and processing instructions are
-/// removed. Malformed or non-UTF-8 payloads are replaced entirely with a fixed
-/// marker.
+/// Known GMP secret fields, the `modify_license/file` payload, generic `value`,
+/// `default_value`, and `param` payloads, sensitive attributes, comments, and
+/// processing instructions are removed. Malformed or non-UTF-8 payloads are
+/// replaced entirely with a fixed marker.
 ///
 /// This policy is not a general secret detector for arbitrary custom XML field
 /// names. Applications sending raw custom requests should still restrict trace
@@ -2433,16 +2433,20 @@ mod tests {
     }
 
     #[test]
-    fn redacts_modify_license_key_element() {
+    fn redacts_modify_license_file_without_hiding_generic_files() {
         let request = gvm_gmp::commands::system::modify_license("license-secret").to_bytes();
 
         let redacted = String::from_utf8(redact_wire_bytes(&request)).expect("utf-8");
 
         assert_eq!(
             redacted,
-            "<modify_license><key><redacted/></key></modify_license>"
+            "<modify_license><file><redacted/></file></modify_license>"
         );
         assert!(!redacted.contains("license-secret"));
+        assert_eq!(
+            redact_wire_bytes(b"<root><file>visible</file></root>"),
+            b"<root><file>visible</file></root>"
+        );
     }
 
     #[test]

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -101,7 +101,7 @@ use gvm_gmp::commands::secinfo::{
 };
 use gvm_gmp::commands::system::{
     describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
-    get_vulns, modify_auth, FilteredGetOpts,
+    get_vulns, modify_auth, modify_license_with_opts, FilteredGetOpts, ModifyLicenseOpts,
 };
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
@@ -158,11 +158,11 @@ use gvm_gmp::responses::{
     GetTimezonesResponse, GetTlsCertificatesResponse, GetUsersResponse, GetVersionResponse,
     GetVulnerabilitiesResponse, GetWebApplicationTargetsResponse, HelpResponse,
     ModifyAlertResponse, ModifyAssetResponse, ModifyAuthResponse, ModifyConfigResponse,
-    ModifyCredentialResponse, ModifyIntegrationConfigResponse, ModifyOciImageTargetResponse,
-    ModifyPortListResponse, ModifyScanConfigResponse, ModifyScannerResponse,
-    ModifyScheduleResponse, ModifyTargetResponse, ModifyTaskResponse, ModifyTicketResponse,
-    ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport, RestoreResponse,
-    ResumeTaskResponse, StartTaskResponse, StopTaskResponse, SyncConfigResponse,
+    ModifyCredentialResponse, ModifyIntegrationConfigResponse, ModifyLicenseResponse,
+    ModifyOciImageTargetResponse, ModifyPortListResponse, ModifyScanConfigResponse,
+    ModifyScannerResponse, ModifyScheduleResponse, ModifyTargetResponse, ModifyTaskResponse,
+    ModifyTicketResponse, ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport,
+    RestoreResponse, ResumeTaskResponse, StartTaskResponse, StopTaskResponse, SyncConfigResponse,
     VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
@@ -2358,6 +2358,20 @@ impl<C: GvmConnection + Send> GmpClient<C> {
             .send(modify_auth(group_name, auth_conf_settings))
             .await?;
         ModifyAuthResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Upload a base64-encoded license file and return a typed
+    /// [`ModifyLicenseResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn modify_license(
+        &mut self,
+        file: &str,
+        opts: ModifyLicenseOpts,
+    ) -> Result<ModifyLicenseResponse, GvmError> {
+        let response = self.send(modify_license_with_opts(file, opts)).await?;
+        ModifyLicenseResponse::from_response(&response).map_err(GvmError::Parse)
     }
 }
 

--- a/crates/gvm-client/src/wire_trace.rs
+++ b/crates/gvm-client/src/wire_trace.rs
@@ -38,7 +38,8 @@ fn redact_xml(xml: &str) -> Option<Vec<u8>> {
                 }
                 let local_name = local_name(start.name().local_name().as_ref())?;
                 let redacted_start = redact_attributes(&start, &stack, &local_name)?;
-                let redact_contents = sensitive_depth == 0 && is_sensitive_element(&local_name);
+                let redact_contents =
+                    sensitive_depth == 0 && is_sensitive_element(&stack, &local_name);
                 stack.push(local_name);
 
                 if sensitive_depth > 0 {
@@ -177,8 +178,10 @@ fn redact_attributes(
     Some(redacted)
 }
 
-fn is_sensitive_element(element_name: &str) -> bool {
-    is_sensitive_name(element_name) || matches!(element_name, "value" | "param" | "default_value")
+fn is_sensitive_element(stack: &[String], element_name: &str) -> bool {
+    is_sensitive_name(element_name)
+        || matches!(element_name, "value" | "param" | "default_value")
+        || (element_name == "file" && stack.first().is_some_and(|root| root == "modify_license"))
 }
 
 fn is_credential_store_preference(stack: &[String], element_name: &str) -> bool {

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -51,6 +51,7 @@ use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::{get_info, get_info_list, GenericInfoType, GetInfoListOpts};
 use gvm_gmp::commands::system::get_timezones;
+use gvm_gmp::commands::system::ModifyLicenseOpts;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetError, CreateTargetOpts, GetTargetsOpts,
     ModifyTargetError, ModifyTargetOpts,
@@ -550,6 +551,42 @@ async fn typed_modify_auth_uses_current_gvmd_shape_over_unix_transport() {
     assert_eq!(
         history[0].raw_xml(),
         br#"<modify_auth><group name="method:ldap_connect"><auth_conf_setting><key>enable</key><value>true</value></auth_conf_setting><auth_conf_setting><key>ldaphost</key><value>ldap.example</value></auth_conf_setting></group></modify_auth>"#
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_modify_license_uses_current_gvmd_shape_over_unix_transport() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate");
+    server.clear_history();
+
+    let response = client
+        .modify_license(
+            "YWJj",
+            ModifyLicenseOpts {
+                allow_empty: Some(false),
+            },
+        )
+        .await
+        .expect("current gvmd modify_license response should parse");
+
+    assert_eq!(response.status, 200);
+    let history = server.command_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0].raw_xml(),
+        br#"<modify_license allow_empty="0"><file>YWJj</file></modify_license>"#
     );
 
     server.shutdown().await;

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -168,6 +168,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "get_help_with_mode",
     "describe_auth",
     "modify_auth",
+    "modify_license",
 ];
 
 // Kept explicit so each public helper has exactly one of the three issue #398

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -77,6 +77,13 @@ pub struct FilteredGetOpts {
     pub filter_id: Option<EntityId>,
 }
 
+/// Options for `modify_license` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ModifyLicenseOpts {
+    /// Whether gvmd may accept an empty license file.
+    pub allow_empty: Option<bool>,
+}
+
 /// Build a `help` request.
 #[must_use]
 pub fn help(format: Option<HelpFormat>) -> impl Request {
@@ -258,10 +265,21 @@ pub fn modify_auth(group_name: &str, auth_conf_settings: &[(String, String)]) ->
     cmd
 }
 
-/// Build a `modify_license` request.
+/// Build a `modify_license` request with a base64-encoded license file.
 #[must_use]
-pub fn modify_license(key: &str) -> impl Request {
-    XmlCommand::new("modify_license").child_with_text("key", key)
+pub fn modify_license(file: &str) -> impl Request {
+    modify_license_with_opts(file, ModifyLicenseOpts::default())
+}
+
+/// Build a `modify_license` request with explicit options.
+#[must_use]
+pub fn modify_license_with_opts(file: &str, opts: ModifyLicenseOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("modify_license");
+    if let Some(allow_empty) = opts.allow_empty {
+        cmd.set_attribute("allow_empty", if allow_empty { "1" } else { "0" });
+    }
+    cmd.add_element_with_text("file", file);
+    cmd
 }
 
 /// Build a `modify_setting` request, Base64-encoding the UTF-8 value for GMP.
@@ -363,7 +381,16 @@ mod tests {
         );
         assert_eq!(
             xml(modify_license("abc")),
-            "<modify_license><key>abc</key></modify_license>"
+            "<modify_license><file>abc</file></modify_license>"
+        );
+        assert_eq!(
+            xml(modify_license_with_opts(
+                "",
+                ModifyLicenseOpts {
+                    allow_empty: Some(true)
+                }
+            )),
+            "<modify_license allow_empty=\"1\"><file></file></modify_license>"
         );
         assert_eq!(
             xml(modify_setting(&id("s1"), "Europe/Berlin")),

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -172,7 +172,8 @@ pub use secinfo::{
 };
 pub use system::{
     AuthConfSetting, AuthGroup, DescribeAuthResponse, GetSettingsResponse, GetTimezonesResponse,
-    HelpCommand, HelpResponse, HelpSchema, ModifyAuthResponse, Setting, Timezone,
+    HelpCommand, HelpResponse, HelpSchema, ModifyAuthResponse, ModifyLicenseResponse, Setting,
+    Timezone,
 };
 pub use system_reports::{GetSystemReportsResponse, SystemReport};
 pub use tag::{CreateTagResponse, DeleteTagResponse, GetTagsResponse, ModifyTagResponse, Tag};

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -103,6 +103,9 @@ pub struct AuthConfSetting {
 /// Response returned after modifying authentication configuration.
 pub type ModifyAuthResponse = ActionResponse;
 
+/// Response returned after modifying the gvmd license.
+pub type ModifyLicenseResponse = ActionResponse;
+
 impl Setting {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {

--- a/crates/gvm-gmp/tests/test_system.rs
+++ b/crates/gvm-gmp/tests/test_system.rs
@@ -94,7 +94,16 @@ fn test_system_aggregates_info_resource_names_and_mutations() {
     );
     assert_eq!(
         xml(modify_license("abc")),
-        "<modify_license><key>abc</key></modify_license>"
+        "<modify_license><file>abc</file></modify_license>"
+    );
+    assert_eq!(
+        xml(modify_license_with_opts(
+            "",
+            ModifyLicenseOpts {
+                allow_empty: Some(true)
+            }
+        )),
+        "<modify_license allow_empty=\"1\"><file></file></modify_license>"
     );
     assert_eq!(
         xml(modify_setting(&id("s1"), "Europe/Berlin")),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1650,6 +1650,18 @@ impl SessionHandler {
     }
 
     fn handle_modify_license(&self, cmd: &ParsedCommand) -> Vec<u8> {
+        let allow_empty = match cmd.attr("allow_empty") {
+            None | Some("0") => false,
+            Some("1") => true,
+            Some(_) => return error_response(&cmd.name, 400, "Invalid allow_empty value"),
+        };
+        let Some(file) = cmd.children.iter().find(|child| child.name == "file") else {
+            return error_response(&cmd.name, 400, "Missing required element: file");
+        };
+        if file.text.as_deref().unwrap_or_default().is_empty() && !allow_empty {
+            return error_response(&cmd.name, 400, "A non-empty FILE is required");
+        }
+
         format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name).into_bytes()
     }
 

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -23,7 +23,9 @@ use gvm_gmp::commands::credentials::{
     CredentialStoreCredentialOpts, ModifyCredentialStoreCredentialOpts, ModifyCredentialStoreOpts,
 };
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
-use gvm_gmp::commands::system::{modify_auth, modify_license};
+use gvm_gmp::commands::system::{
+    modify_auth, modify_license, modify_license_with_opts, ModifyLicenseOpts,
+};
 use gvm_gmp::types::EntityId;
 use gvm_gmp::CredentialStoreCredentialType;
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
@@ -436,8 +438,30 @@ async fn stateful_auth_and_license_modifiers_use_gmp_builder_shape() {
         assert_eq!(response.status_code(), Some(400));
     }
 
-    let license = send_request(&mut stream, modify_license("abc")).await;
+    let license = send_request(&mut stream, modify_license("YWJj")).await;
     assert_eq!(license.status_code(), Some(200));
+
+    let empty_license = send_request(
+        &mut stream,
+        modify_license_with_opts(
+            "",
+            ModifyLicenseOpts {
+                allow_empty: Some(true),
+            },
+        ),
+    )
+    .await;
+    assert_eq!(empty_license.status_code(), Some(200));
+
+    for invalid in [
+        br#"<modify_license><key>legacy</key></modify_license>"#.as_slice(),
+        br#"<modify_license><file></file></modify_license>"#.as_slice(),
+        br#"<modify_license allow_empty="0"><file></file></modify_license>"#.as_slice(),
+        br#"<modify_license allow_empty="invalid"><file>YWJj</file></modify_license>"#.as_slice(),
+    ] {
+        let response = send_recv(&mut stream, invalid).await;
+        assert_eq!(response.status_code(), Some(400));
+    }
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- serialize `modify_license` with the current gvmd `<file>` child and optional `allow_empty` attribute
- add a typed client response path and keep the existing simple builder source-compatible
- make the stateful mock reject the obsolete `<key>` shape and invalid empty-file requests
- redact the license file payload from opt-in wire traces without hiding unrelated `<file>` elements

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- Rust 1.85 workspace check and all-features test suite
- python-gvm Unix, TLS, and mutual-TLS integration suites
- `cargo deny check`, `cargo audit`, `cargo machete`, and `cargo vet`
- workspace unsafe-usage and SBOM policy helper gates
- Semgrep (`p/rust`, `p/security-audit`, `p/secrets`) with `--disable-nosem --error`: 0 findings
- Gitleaks exact commit scan: 0 leaks
- Cobertura diff coverage against `upstream/devel`: 42/42 changed executable lines (100%)

## Validation boundary

The corrected request was verified through the real `GmpClient` Unix transport against the stateful `gvm-mock-server`, including rejection of legacy and malformed shapes. It was not exercised against a live gvmd deployment. Fuzzing was not run; deterministic malformed-request regressions cover the changed parser/validation paths.