### PR TITLE
docs(journal): add 2026-08-04 entry

### DIFF
--- a/journal/2026-08-04.md
+++ b/journal/2026-08-04.md
@@ -1,0 +1,8 @@
+# 2026-08-04 — GMP Contract Corrections Opened for Review
+
+## Protocol Alignment
+- PR [#450](https://github.com/greenbone-hive/rust-gvm/pull/450) opened against `devel` to replace the obsolete boolean `modify_auth` request with gvmd's current named group and key/value setting structure. The change deliberately updates the public API because the old request succeeded without changing server state.
+- PR [#451](https://github.com/greenbone-hive/rust-gvm/pull/451) opened against `devel` to serialize `modify_license` with the current `<file>` child and optional `allow_empty` attribute, reject the obsolete `<key>` shape, and redact license payloads from wire traces.
+
+## Validation State
+- Both contract-correction PRs are fully green across the Rust test matrix, Python-GVM integration, coverage, static analysis, and security-policy gates. They remain open and require review; neither was exercised against a live gvmd deployment.


### PR DESCRIPTION
Documents the newly opened GMP contract-correction PRs and their validation state.