### PR TITLE
docs(journal): add 2026-08-05 entry

### DIFF
--- a/journal/2026-08-05.md
+++ b/journal/2026-08-05.md
@@ -1,0 +1,9 @@
+# 2026-08-05 — Wizard Contract Fix Opened as Remaining Parity Gaps Were Scoped
+
+## Protocol Alignment
+- PR [#455](https://github.com/greenbone-hive/rust-gvm/pull/455) opened against `devel` to align `run_wizard` with gvmd's current request shape, add a typed client response path, and upgrade the mock server from echo-only handling to request validation with a deterministic nested response.
+- The PR is fully green across formatting, Rust test matrices, Python-GVM integration, coverage, static analysis, dependency-policy, and security gates. It remains open for review and has not been exercised against a live gvmd deployment.
+
+## Follow-up Scope
+- Issue [#453](https://github.com/greenbone-hive/rust-gvm/issues/453) opened to add persistent `known_hosts` verification with an explicit trust-on-first-use mode. Current `devel` now provides strict known-host verification by default, but still lacks python-gvm / `gvm-cli ssh -A` parity for accepting and atomically persisting an unknown key while rejecting later key changes.
+- Issue [#454](https://github.com/greenbone-hive/rust-gvm/issues/454) documented the incorrect `modify_integration_config` XML contract. The correction is already present on `devel`—including mandatory containers, the current OIDC URL element, reset handling, and mock-server coverage—but the issue remains open until that work reaches `main`.


### PR DESCRIPTION
## Summary

- record the newly opened `run_wizard` contract-correction PR and its green validation state
- capture the remaining SSH TOFU parity gap and the `modify_integration_config` rollout state

## Scope

Journal documentation only. Base branch: `journal-main`.
