### PR TITLE
journal: 2026-08-10 dependency update queue

### DIFF
--- a/journal/2026-08-10.md
+++ b/journal/2026-08-10.md
@@ -1,0 +1,10 @@
+# 2026-08-10 — Dependency Update Queue Renewed with a Security Gate Blocker
+
+## Dependency Automation
+- Dependabot closed superseded cargo PR [#447](https://github.com/greenbone-hive/rust-gvm/pull/447) and Actions PR [#448](https://github.com/greenbone-hive/rust-gvm/pull/448), then opened replacement PRs [#462](https://github.com/greenbone-hive/rust-gvm/pull/462) and [#463](https://github.com/greenbone-hive/rust-gvm/pull/463).
+- PR #462 groups updates to `rustls` 0.23.43, `russh` 0.62.5, and `clap` 4.6.6. The `russh` release includes the GHSA-m65r-rprj-r5rg channel-ID validation fix.
+- PR #463 updates six workflow dependencies, including harden-runner, rust-cache, install-action, Docker login, build-provenance attestation, and CodeQL upload.
+
+## Validation State
+- PR #463 is open, mergeable, and green across its reported formatting, test, documentation, dependency-policy, static-analysis, and security checks.
+- PR #462 is open and mergeable, but Cargo Vet fails and consequently leaves the aggregate Security check red. The dependency update requires a vet-policy review before merge; its remaining reported checks pass.


### PR DESCRIPTION
## Summary

- records the renewed cargo and GitHub Actions dependency update queue
- captures the security-relevant `russh` update
- documents the Cargo Vet blocker on PR #462 and the green state of PR #463
