### PR TITLE
Expose typed credential kinds in credential responses

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -60,8 +60,8 @@ use gvm_gmp::commands::tickets::{
 };
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{
-    Asset, ConfigUsageKind, CreateScanConfigResponse, GetConfigsResponse, GetPermissionsResponse,
-    GetScanConfigsResponse, GetScanReportResponse, Permission,
+    Asset, ConfigUsageKind, CreateScanConfigResponse, CredentialKind, GetConfigsResponse,
+    GetPermissionsResponse, GetScanConfigsResponse, GetScanReportResponse, Permission,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
@@ -1982,6 +1982,18 @@ async fn typed_ssh_credential_lifecycle_uses_nested_key_shape() {
         )
         .await
         .expect("SSH credential should be modified");
+    let username_password = client
+        .create_credential(
+            "Username Password Credential",
+            CredentialOpts {
+                credential_type: Some(CredentialType::UsernamePassword),
+                login: Some("operator".into()),
+                password: Some("secret".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("username/password credential should be created");
 
     let credentials = client
         .get_credentials(Default::default())
@@ -1994,8 +2006,15 @@ async fn typed_ssh_credential_lifecycle_uses_nested_key_shape() {
         .expect("SSH credential should be listed");
     assert_eq!(fetched.meta.name, "Renamed SSH Credential");
     assert_eq!(fetched.type_.as_deref(), Some("usk"));
+    assert_eq!(fetched.kind, CredentialKind::UsernameSshKey);
     assert_eq!(fetched.login.as_deref(), Some("scanner"));
     assert!(fetched.allow_insecure);
+    let username_password = credentials
+        .items
+        .iter()
+        .find(|item| item.meta.id == username_password.id)
+        .expect("username/password credential should be listed");
+    assert_eq!(username_password.kind, CredentialKind::UsernamePassword);
 
     let history = server.command_history();
     let create_xml = std::str::from_utf8(history[0].raw_xml()).expect("create XML");
@@ -2074,6 +2093,8 @@ async fn typed_snmpv3_and_kerberos_credentials_use_current_wire_shapes() {
         .expect("Kerberos credential should be listed");
     assert_eq!(snmp.type_.as_deref(), Some("snmp"));
     assert_eq!(kerberos.type_.as_deref(), Some("krb5"));
+    assert_eq!(snmp.kind, CredentialKind::Snmp);
+    assert_eq!(kerberos.kind, CredentialKind::Kerberos5);
 
     let history = server.command_history();
     let snmp_xml = std::str::from_utf8(history[0].raw_xml()).expect("SNMP XML");

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -97,6 +97,7 @@ pub(crate) struct XmlNode {
     pub(crate) name: String,
     pub(crate) attributes: HashMap<String, String>,
     pub(crate) text: String,
+    raw_text: Option<Box<str>>,
     pub(crate) children: Vec<XmlNode>,
 }
 
@@ -118,6 +119,11 @@ impl XmlNode {
 
     pub(crate) fn child_text(&self, name: &str) -> Option<String> {
         self.child(name).map(|child| child.text.clone())
+    }
+
+    pub(crate) fn child_raw_text(&self, name: &str) -> Option<&str> {
+        self.child(name)
+            .map(|child| child.raw_text.as_deref().unwrap_or(&child.text))
     }
 
     pub(crate) fn required_child_text(&self, name: &str) -> Result<String, ParseError> {
@@ -162,6 +168,7 @@ pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
                     name: str::from_utf8(event.name().as_ref())?.to_string(),
                     attributes: collect_attributes(&event)?,
                     text: String::new(),
+                    raw_text: None,
                     children: Vec::new(),
                 });
             }
@@ -170,6 +177,7 @@ pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
                     name: str::from_utf8(event.name().as_ref())?.to_string(),
                     attributes: collect_attributes(&event)?,
                     text: String::new(),
+                    raw_text: None,
                     children: Vec::new(),
                 };
                 if let Some(parent) = stack.last_mut() {
@@ -213,7 +221,14 @@ pub(crate) fn parse_document(data: &[u8]) -> Result<XmlNode, ParseError> {
                 let Some(mut node) = stack.pop() else {
                     return Err(ParseError::MissingElement("root".to_string()));
                 };
-                node.text = node.text.trim().to_string();
+                let raw_text = std::mem::take(&mut node.text);
+                let trimmed_text = raw_text.trim();
+                if node.children.is_empty() && trimmed_text.len() != raw_text.len() {
+                    node.text = trimmed_text.to_string();
+                    node.raw_text = Some(raw_text.into_boxed_str());
+                } else {
+                    node.text = trimmed_text.to_string();
+                }
                 if let Some(parent) = stack.last_mut() {
                     parent.children.push(node);
                 } else {
@@ -457,10 +472,12 @@ mod tests {
             name: "schedule".to_string(),
             attributes,
             text: String::new(),
+            raw_text: None,
             children: vec![XmlNode {
                 name: "name".to_string(),
                 attributes: HashMap::new(),
                 text: name.to_string(),
+                raw_text: None,
                 children: Vec::new(),
             }],
         }
@@ -472,6 +489,7 @@ mod tests {
             name: "task".to_string(),
             attributes: HashMap::new(),
             text: String::new(),
+            raw_text: None,
             children: vec![entity_node(Some(""), "")],
         };
 
@@ -486,6 +504,7 @@ mod tests {
             name: "task".to_string(),
             attributes: HashMap::new(),
             text: String::new(),
+            raw_text: None,
             children: vec![entity_node(Some("not valid"), "Weekly")],
         };
 
@@ -515,6 +534,23 @@ mod tests {
 
         assert_eq!(root.attr("attr"), Some("A & B"));
         assert_eq!(root.child_text("value").as_deref(), Some("A & B < !!"));
+    }
+
+    #[test]
+    fn parse_document_retains_original_padded_leaf_text() {
+        let root = parse_document(
+            br#"<root><plain> up </plain><reference>&#x20;up&#x20;</reference><cdata><![CDATA[ up ]]></cdata><clean>up</clean><empty/></root>"#,
+        )
+        .expect("padded leaf text should parse");
+
+        assert_eq!(root.child_text("plain").as_deref(), Some("up"));
+        assert_eq!(root.child_raw_text("plain"), Some(" up "));
+        assert_eq!(root.child_text("reference").as_deref(), Some("up"));
+        assert_eq!(root.child_raw_text("reference"), Some(" up "));
+        assert_eq!(root.child_text("cdata").as_deref(), Some("up"));
+        assert_eq!(root.child_raw_text("cdata"), Some(" up "));
+        assert_eq!(root.child_raw_text("clean"), Some("up"));
+        assert_eq!(root.child_raw_text("empty"), Some(""));
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -9,12 +9,141 @@ use crate::responses::common::{
     count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
     status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
+use crate::{CredentialStoreCredentialType, CredentialType};
+
+/// Credential kind observed in a `get_credentials` response.
+///
+/// The variants map every distinct wire value emitted by the typed credential
+/// create APIs. GVMD uses `snmp` for both community-based SNMP and `SNMPv3`, so
+/// an observation cannot distinguish those create-time variants from the type
+/// code alone. Missing, malformed, and unknown values remain explicit so
+/// consumers can fail closed.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CredentialKind {
+    /// Client certificate (`cc`).
+    ClientCertificate,
+    /// Kerberos 5 (`krb5`).
+    Kerberos5,
+    /// Password-only credential (`pw`).
+    PasswordOnly,
+    /// PGP encryption key (`pgp`).
+    PgpEncryptionKey,
+    /// S/MIME certificate (`smime`).
+    SmimeCertificate,
+    /// SNMP credential (`snmp`), whose protocol code does not identify its version.
+    Snmp,
+    /// Username and password (`up`).
+    UsernamePassword,
+    /// Username and SSH key (`usk`).
+    UsernameSshKey,
+    /// Credential-store-backed client certificate (`cs_cc`).
+    CredentialStoreClientCertificate,
+    /// Credential-store-backed password-only credential (`cs_pw`).
+    CredentialStorePasswordOnly,
+    /// Credential-store-backed PGP encryption key (`cs_pgp`).
+    CredentialStorePgpEncryptionKey,
+    /// Credential-store-backed S/MIME certificate (`cs_smime`).
+    CredentialStoreSmimeCertificate,
+    /// Credential-store-backed SNMP credential (`cs_snmp`).
+    CredentialStoreSnmp,
+    /// Credential-store-backed username and password (`cs_up`).
+    CredentialStoreUsernamePassword,
+    /// Credential-store-backed username and SSH key (`cs_usk`).
+    CredentialStoreUsernameSshKey,
+    /// The response omitted the `type` element.
+    #[default]
+    Missing,
+    /// The response contained an empty, whitespace-padded, or whitespace-only value.
+    Malformed(String),
+    /// The response contained a well-formed but unsupported future value.
+    Unknown(String),
+}
+
+impl CredentialKind {
+    /// Parse an optional GMP credential type without defaulting missing or
+    /// unrecognized values to a supported kind.
+    #[must_use]
+    pub fn from_optional_gmp_str(value: Option<&str>) -> Self {
+        let Some(value) = value else {
+            return Self::Missing;
+        };
+        if value.is_empty()
+            || value.trim() != value
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            return Self::Malformed(value.to_string());
+        }
+        match value {
+            "cc" => Self::ClientCertificate,
+            "krb5" => Self::Kerberos5,
+            "pw" => Self::PasswordOnly,
+            "pgp" => Self::PgpEncryptionKey,
+            "smime" => Self::SmimeCertificate,
+            "snmp" => Self::Snmp,
+            "up" => Self::UsernamePassword,
+            "usk" => Self::UsernameSshKey,
+            "cs_cc" => Self::CredentialStoreClientCertificate,
+            "cs_pw" => Self::CredentialStorePasswordOnly,
+            "cs_pgp" => Self::CredentialStorePgpEncryptionKey,
+            "cs_smime" => Self::CredentialStoreSmimeCertificate,
+            "cs_snmp" => Self::CredentialStoreSnmp,
+            "cs_up" => Self::CredentialStoreUsernamePassword,
+            "cs_usk" => Self::CredentialStoreUsernameSshKey,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl From<CredentialType> for CredentialKind {
+    fn from(value: CredentialType) -> Self {
+        match value {
+            CredentialType::ClientCertificate => Self::ClientCertificate,
+            CredentialType::Kerberos5 => Self::Kerberos5,
+            CredentialType::PasswordOnly => Self::PasswordOnly,
+            CredentialType::PgpEncryptionKey => Self::PgpEncryptionKey,
+            CredentialType::SmimeCertificate => Self::SmimeCertificate,
+            CredentialType::SnmpV1Or2c | CredentialType::SnmpV3 => Self::Snmp,
+            CredentialType::UsernamePassword => Self::UsernamePassword,
+            CredentialType::UsernameSshKey => Self::UsernameSshKey,
+        }
+    }
+}
+
+impl From<CredentialStoreCredentialType> for CredentialKind {
+    fn from(value: CredentialStoreCredentialType) -> Self {
+        match value {
+            CredentialStoreCredentialType::ClientCertificate => {
+                Self::CredentialStoreClientCertificate
+            }
+            CredentialStoreCredentialType::PasswordOnly => Self::CredentialStorePasswordOnly,
+            CredentialStoreCredentialType::PgpEncryptionKey => {
+                Self::CredentialStorePgpEncryptionKey
+            }
+            CredentialStoreCredentialType::SmimeCertificate => {
+                Self::CredentialStoreSmimeCertificate
+            }
+            CredentialStoreCredentialType::Snmp => Self::CredentialStoreSnmp,
+            CredentialStoreCredentialType::UsernamePassword => {
+                Self::CredentialStoreUsernamePassword
+            }
+            CredentialStoreCredentialType::UsernameSshKey => Self::CredentialStoreUsernameSshKey,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Credential {
     pub meta: EntityMeta,
+    /// Typed credential kind. Missing and unsupported values are explicit.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub kind: CredentialKind,
+    /// Raw GMP type code retained for backward compatibility.
     pub type_: Option<String>,
     pub login: Option<String>,
     pub full_type: Option<String>,
@@ -61,8 +190,10 @@ pub struct CreateCredentialResponse {
 
 impl Credential {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let raw_type = node.child_raw_text("type");
         Ok(Self {
             meta: parse_entity_meta(node)?,
+            kind: CredentialKind::from_optional_gmp_str(raw_type),
             type_: node.optional_child_text("type"),
             login: node.optional_child_text("login"),
             full_type: node.optional_child_text("full_type"),
@@ -148,6 +279,114 @@ mod tests {
     use super::*;
 
     #[test]
+    fn maps_every_create_side_credential_type_code() {
+        let cases = [
+            ("cc", CredentialKind::ClientCertificate),
+            ("krb5", CredentialKind::Kerberos5),
+            ("pw", CredentialKind::PasswordOnly),
+            ("pgp", CredentialKind::PgpEncryptionKey),
+            ("smime", CredentialKind::SmimeCertificate),
+            ("snmp", CredentialKind::Snmp),
+            ("up", CredentialKind::UsernamePassword),
+            ("usk", CredentialKind::UsernameSshKey),
+            ("cs_cc", CredentialKind::CredentialStoreClientCertificate),
+            ("cs_pw", CredentialKind::CredentialStorePasswordOnly),
+            ("cs_pgp", CredentialKind::CredentialStorePgpEncryptionKey),
+            ("cs_smime", CredentialKind::CredentialStoreSmimeCertificate),
+            ("cs_snmp", CredentialKind::CredentialStoreSnmp),
+            ("cs_up", CredentialKind::CredentialStoreUsernamePassword),
+            ("cs_usk", CredentialKind::CredentialStoreUsernameSshKey),
+        ];
+
+        for (wire_value, expected) in cases {
+            assert_eq!(
+                CredentialKind::from_optional_gmp_str(Some(wire_value)),
+                expected,
+                "wire value {wire_value}"
+            );
+        }
+    }
+
+    #[test]
+    fn maps_create_types_to_observed_kinds() {
+        assert_eq!(
+            CredentialKind::from(CredentialType::UsernamePassword),
+            CredentialKind::UsernamePassword
+        );
+        assert_eq!(
+            CredentialKind::from(CredentialType::SnmpV3),
+            CredentialKind::Snmp
+        );
+        assert_eq!(
+            CredentialKind::from(CredentialStoreCredentialType::UsernameSshKey),
+            CredentialKind::CredentialStoreUsernameSshKey
+        );
+    }
+
+    #[test]
+    fn preserves_missing_malformed_and_unknown_types() {
+        assert_eq!(
+            CredentialKind::from_optional_gmp_str(None),
+            CredentialKind::Missing
+        );
+        assert_eq!(
+            CredentialKind::from_optional_gmp_str(Some("")),
+            CredentialKind::Malformed(String::new())
+        );
+        assert_eq!(
+            CredentialKind::from_optional_gmp_str(Some(" up ")),
+            CredentialKind::Malformed(" up ".to_string())
+        );
+        assert_eq!(
+            CredentialKind::from_optional_gmp_str(Some("future_kind")),
+            CredentialKind::Unknown("future_kind".to_string())
+        );
+    }
+
+    #[test]
+    fn response_parsing_keeps_unsupported_type_states_distinct() {
+        let response = Response::from(
+            r#"<get_credentials_response status="200" status_text="OK">
+                <credential id="missing"><name>Missing</name></credential>
+                <credential id="empty"><name>Empty</name><type></type></credential>
+                <credential id="padded"><name>Padded</name><type> up </type></credential>
+                <credential id="reference"><name>Reference</name><type>&#x20;up&#x20;</type></credential>
+                <credential id="cdata"><name>CDATA</name><type><![CDATA[ up ]]></type></credential>
+                <credential id="invalid"><name>Invalid</name><type>UP!</type></credential>
+                <credential id="unknown"><name>Unknown</name><type>future_kind</type></credential>
+            </get_credentials_response>"#,
+        );
+
+        let parsed = GetCredentialsResponse::from_response(&response).expect("credentials parse");
+
+        assert_eq!(parsed.items[0].kind, CredentialKind::Missing);
+        assert_eq!(
+            parsed.items[1].kind,
+            CredentialKind::Malformed(String::new())
+        );
+        assert_eq!(
+            parsed.items[2].kind,
+            CredentialKind::Malformed(" up ".to_string())
+        );
+        assert_eq!(
+            parsed.items[3].kind,
+            CredentialKind::Malformed(" up ".to_string())
+        );
+        assert_eq!(
+            parsed.items[4].kind,
+            CredentialKind::Malformed(" up ".to_string())
+        );
+        assert_eq!(
+            parsed.items[5].kind,
+            CredentialKind::Malformed("UP!".to_string())
+        );
+        assert_eq!(
+            parsed.items[6].kind,
+            CredentialKind::Unknown("future_kind".to_string())
+        );
+    }
+
+    #[test]
     fn parses_multiple_credentials() {
         let response = Response::from(
             r#"<get_credentials_response status="200" status_text="OK">
@@ -181,6 +420,7 @@ mod tests {
         assert_eq!(parsed.counts.filtered, Some(2));
         assert_eq!(parsed.counts.page, Some(1));
         assert_eq!(parsed.items[0].type_.as_deref(), Some("up"));
+        assert_eq!(parsed.items[0].kind, CredentialKind::UsernamePassword);
         assert_eq!(parsed.items[0].login.as_deref(), Some("admin"));
         assert_eq!(
             parsed.items[0].full_type.as_deref(),
@@ -263,6 +503,7 @@ mod tests {
 
         assert_eq!(cred.meta.comment, None);
         assert_eq!(cred.type_, None);
+        assert_eq!(cred.kind, CredentialKind::Missing);
         assert_eq!(cred.login, None);
         assert_eq!(cred.full_type, None);
         assert!(!cred.allow_insecure);

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -91,9 +91,9 @@ pub use config::{
     ModifyConfigResponse,
 };
 pub use credential::{
-    CreateCredentialResponse, Credential, CredentialStore, DeleteCredentialResponse,
-    GetCredentialStoresResponse, GetCredentialsResponse, ModifyCredentialResponse,
-    VerifyCredentialStoreResponse,
+    CreateCredentialResponse, Credential, CredentialKind, CredentialStore,
+    DeleteCredentialResponse, GetCredentialStoresResponse, GetCredentialsResponse,
+    ModifyCredentialResponse, VerifyCredentialStoreResponse,
 };
 pub use features::{Feature, GetFeaturesResponse};
 pub use feed::{Feed, GetFeedsResponse};


### PR DESCRIPTION
## Summary

- add a public non-exhaustive CredentialKind to credential observations with mappings for local and credential-store-backed types
- preserve missing, malformed, and unknown protocol values explicitly while retaining the raw response fields and serde compatibility
- retain original XML leaf text only when normalization changes it so whitespace-padded type codes remain malformed without changing existing normalized consumers
- cover all known wire codes and typed client observations for username/password, SSH, SNMP, and Kerberos credentials

Fixes #459