### PR TITLE
Fix target port-list update semantics

### DIFF
--- a/crates/gvm-client/src/error.rs
+++ b/crates/gvm-client/src/error.rs
@@ -6,6 +6,7 @@
 use std::time::Duration;
 
 use gvm_connection::ConnectionError;
+use gvm_gmp::commands::targets::ModifyTargetError;
 use gvm_gmp::responses::ParseError;
 use gvm_gmp::types::GmpVersion;
 use thiserror::Error;
@@ -20,6 +21,10 @@ pub enum GvmError {
     /// Response model parsing failure.
     #[error("parse error: {0}")]
     Parse(#[from] ParseError),
+
+    /// A typed `modify_target` update cannot be represented by gvmd.
+    #[error("modify_target request error: {0}")]
+    ModifyTarget(#[from] ModifyTargetError),
 
     /// Response or version XML could not be parsed.
     #[error("XML parse error: {0}")]

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -231,7 +231,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         target_id: &EntityId,
         opts: ModifyTargetOpts,
     ) -> Result<ModifyTargetResponse, GvmError> {
-        let response = self.send(modify_target(target_id, opts)).await?;
+        let request = modify_target(target_id, opts)?;
+        let response = self.send(request).await?;
         ModifyTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -51,7 +51,8 @@ use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::secinfo::{get_info, get_info_list, GenericInfoType, GetInfoListOpts};
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
-    create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts, ModifyTargetOpts,
+    create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts, ModifyTargetError,
+    ModifyTargetOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
 use gvm_gmp::commands::tickets::{
@@ -66,7 +67,8 @@ use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
     AlertCondition, AlertEvent, AlertMethod, CollectionUpdate, CredentialType, FeedType,
-    PermissionSubjectType, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
+    PermissionSubjectType, ScalarUpdate, SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder,
+    TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
@@ -2941,6 +2943,164 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
             && std::str::from_utf8(record.raw_xml())
                 .is_ok_and(|xml| xml.contains("<hosts></hosts>"))
     }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_port_list_updates_preserve_omit_and_set_semantics() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let first_port_list = client
+        .create_port_list("First Port List", PortListOpts::default())
+        .await
+        .expect("first port list should be created");
+    let second_port_list = client
+        .create_port_list("Second Port List", PortListOpts::default())
+        .await
+        .expect("second port list should be created");
+    let target = client
+        .create_target(
+            "Port List Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into()],
+                port_list_id: Some(first_port_list.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created with a port list");
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                comment: Some("port list omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("omitting the port list should preserve it");
+    let targets = client
+        .get_targets(GetTargetsOpts::default())
+        .await
+        .expect("targets should be retrieved");
+    let fetched_target = targets
+        .items
+        .iter()
+        .find(|item| item.meta.id == target.id)
+        .expect("target should be listed");
+    assert_eq!(
+        fetched_target
+            .port_list
+            .as_ref()
+            .map(|port_list| &port_list.id),
+        Some(&first_port_list.id)
+    );
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                port_list_id: ScalarUpdate::set(second_port_list.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("replacing the port list should succeed");
+    let targets = client
+        .get_targets(GetTargetsOpts::default())
+        .await
+        .expect("modified targets should be retrieved");
+    let fetched_target = targets
+        .items
+        .iter()
+        .find(|item| item.meta.id == target.id)
+        .expect("target should be listed");
+    assert_eq!(
+        fetched_target
+            .port_list
+            .as_ref()
+            .map(|port_list| &port_list.id),
+        Some(&second_port_list.id)
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_port_list_clear_is_rejected_before_send() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    let target = client
+        .create_target(
+            "Port List Clear Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created");
+
+    let modify_count_before_clear = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "modify_target")
+        .count();
+    let error = client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                port_list_id: ScalarUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("clearing a target port list should be rejected locally");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTarget(ModifyTargetError::UnsupportedPortListClear)
+    ));
+    let modify_count_after_clear = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "modify_target")
+        .count();
+    assert_eq!(modify_count_after_clear, modify_count_before_clear);
+
+    let error = client
+        .call(
+            format!(
+                "<modify_target target_id=\"{}\"><port_list id=\"0\"/></modify_target>",
+                target.id
+            )
+            .into_bytes(),
+        )
+        .await
+        .expect_err("the stateful mock should reject a manufactured clear sentinel");
+    assert!(matches!(error, GvmError::Server { status: 400, .. }));
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -65,8 +65,12 @@ pub struct ModifyTargetOpts {
     pub exclude_hosts: CollectionUpdate<String>,
     /// Optional alive-test strategy.
     pub alive_test: Option<AliveTest>,
-    /// Optional port-list identifier.
-    pub port_list_id: Option<EntityId>,
+    /// Port-list relationship update: omit or set/replace.
+    ///
+    /// Current gvmd versions do not support detaching an existing port list.
+    /// Passing [`ScalarUpdate::Clear`] is therefore rejected by
+    /// [`modify_target`] instead of being translated to a protocol sentinel.
+    pub port_list_id: ScalarUpdate<EntityId>,
     /// SSH credential relationship update: omit, set, or detach.
     pub ssh_credential_id: ScalarUpdate<EntityId>,
     /// SMB credential relationship update: omit, set, or detach.
@@ -79,6 +83,14 @@ pub struct ModifyTargetOpts {
     pub reverse_lookup_only: Option<bool>,
     /// Whether reverse-lookup unification should be enabled.
     pub reverse_lookup_unify: Option<bool>,
+}
+
+/// Errors raised while building a `modify_target` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ModifyTargetError {
+    /// gvmd has no wire representation for detaching a target port list.
+    #[error("gvmd does not support clearing a target port-list relationship")]
+    UnsupportedPortListClear,
 }
 
 /// Build a clone request for an existing target.
@@ -136,8 +148,19 @@ pub fn get_target(target_id: &EntityId) -> impl Request {
 }
 
 /// Build a `modify_target` request.
-#[must_use]
-pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Request {
+///
+/// # Errors
+/// Returns [`ModifyTargetError::UnsupportedPortListClear`] when the port-list
+/// update requests clearing. gvmd accepts omission and replacement, but does
+/// not define a sentinel for detaching an existing port list.
+pub fn modify_target(
+    target_id: &EntityId,
+    opts: ModifyTargetOpts,
+) -> Result<impl Request, ModifyTargetError> {
+    if matches!(opts.port_list_id, ScalarUpdate::Clear) {
+        return Err(ModifyTargetError::UnsupportedPortListClear);
+    }
+
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -146,7 +169,9 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
     if let Some(alive_test) = opts.alive_test {
         cmd.add_element_with_text("alive_test", alive_test.as_target_name());
     }
-    add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
+    if let ScalarUpdate::Set(port_list_id) = &opts.port_list_id {
+        add_optional_id_element(&mut cmd, "port_list", Some(port_list_id));
+    }
     add_modify_target_credentials(&mut cmd, &opts);
     if let Some(value) = opts.reverse_lookup_only {
         cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
@@ -154,7 +179,7 @@ pub fn modify_target(target_id: &EntityId, opts: ModifyTargetOpts) -> impl Reque
     if let Some(value) = opts.reverse_lookup_unify {
         cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
     }
-    cmd
+    Ok(cmd)
 }
 
 /// Build a `delete_target` request.
@@ -259,7 +284,8 @@ mod tests {
                 reverse_lookup_unify: Some(false),
                 ..Default::default()
             },
-        ));
+        )
+        .expect("valid target update"));
         assert!(rendered.contains("<name>n</name>"));
         assert!(rendered.contains("<alive_test>ICMP &amp; ARP Ping</alive_test>"));
         assert!(rendered.contains("<ssh_credential id=\"ssh1\"/>"));
@@ -277,7 +303,7 @@ mod tests {
     #[test]
     fn modify_target_distinguishes_omitted_replaced_and_cleared_hosts() {
         assert_eq!(
-            xml(modify_target(&id("t1"), ModifyTargetOpts::default())),
+            xml(modify_target(&id("t1"), ModifyTargetOpts::default()).expect("valid update")),
             "<modify_target target_id=\"t1\"/>"
         );
         assert_eq!(
@@ -288,7 +314,7 @@ mod tests {
                     exclude_hosts: CollectionUpdate::replace(["192.0.2.3".into()]),
                     ..Default::default()
                 }
-            )),
+            ).expect("valid update")),
             "<modify_target target_id=\"t1\"><hosts>192.0.2.1,192.0.2.2</hosts><exclude_hosts>192.0.2.3</exclude_hosts></modify_target>"
         );
         assert_eq!(
@@ -299,7 +325,7 @@ mod tests {
                     exclude_hosts: CollectionUpdate::Clear,
                     ..Default::default()
                 }
-            )),
+            ).expect("valid update")),
             "<modify_target target_id=\"t1\"><hosts></hosts><exclude_hosts></exclude_hosts></modify_target>"
         );
     }
@@ -307,7 +333,7 @@ mod tests {
     #[test]
     fn modify_target_distinguishes_omitted_set_and_cleared_credentials() {
         assert_eq!(
-            xml(modify_target(&id("t1"), ModifyTargetOpts::default())),
+            xml(modify_target(&id("t1"), ModifyTargetOpts::default()).expect("valid update")),
             "<modify_target target_id=\"t1\"/>"
         );
         assert_eq!(
@@ -318,7 +344,7 @@ mod tests {
                     smb_credential_id: ScalarUpdate::set(id("smb1")),
                     ..Default::default()
                 }
-            )),
+            ).expect("valid update")),
             "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"/><smb_credential id=\"smb1\"/></modify_target>"
         );
         assert_eq!(
@@ -331,8 +357,38 @@ mod tests {
                     snmp_credential_id: ScalarUpdate::Clear,
                     ..Default::default()
                 }
-            )),
+            ).expect("valid update")),
             "<modify_target target_id=\"t1\"><ssh_credential id=\"0\"/><smb_credential id=\"0\"/><esxi_credential id=\"0\"/><snmp_credential id=\"0\"/></modify_target>"
+        );
+    }
+
+    #[test]
+    fn modify_target_distinguishes_omitted_set_and_unsupported_port_list_clear() {
+        assert_eq!(
+            xml(modify_target(&id("t1"), ModifyTargetOpts::default()).expect("valid update")),
+            "<modify_target target_id=\"t1\"/>"
+        );
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    port_list_id: ScalarUpdate::set(id("pl1")),
+                    ..Default::default()
+                }
+            )
+            .expect("setting a port list is supported")),
+            "<modify_target target_id=\"t1\"><port_list id=\"pl1\"/></modify_target>"
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    port_list_id: ScalarUpdate::Clear,
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::UnsupportedPortListClear)
         );
     }
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -662,6 +662,21 @@ impl SessionHandler {
 
         let mut resource = Resource::new(resource_type, &name);
 
+        let target_port_list_id = if resource_type == "target" {
+            let port_list_id = match optional_child_uuid(cmd, "port_list") {
+                Ok(port_list_id) => port_list_id,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            };
+            if let Some(port_list_id) = port_list_id {
+                if store.get_typed(&port_list_id, "port_list").is_none() {
+                    return error_response(&cmd.name, 404, "Port list not found");
+                }
+            }
+            port_list_id
+        } else {
+            None
+        };
+
         // Extract comment
         let comment = if has_config_import_payload {
             imported_config
@@ -853,6 +868,9 @@ impl SessionHandler {
             }
             if let Some(exclude_hosts) = parse_element_text(raw_xml, "exclude_hosts") {
                 resource.set_attr("exclude_hosts", &exclude_hosts);
+            }
+            if let Some(port_list_id) = target_port_list_id {
+                resource.set_attr("port_list_id", &port_list_id.to_string());
             }
         }
 
@@ -1085,6 +1103,21 @@ impl SessionHandler {
             return error_response(&cmd.name, 400, "Invalid UUID");
         };
 
+        let new_target_port_list_id = if resource_type == "target" {
+            let port_list_id = match optional_child_uuid(cmd, "port_list") {
+                Ok(port_list_id) => port_list_id,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            };
+            if let Some(port_list_id) = port_list_id {
+                if store.get_typed(&port_list_id, "port_list").is_none() {
+                    return error_response(&cmd.name, 404, "Port list not found");
+                }
+            }
+            port_list_id
+        } else {
+            None
+        };
+
         let new_name = if resource_type == "user" {
             parse_element_text(raw_xml, "new_name")
         } else if resource_type == "alert" {
@@ -1247,6 +1280,9 @@ impl SessionHandler {
             }
             if let Some(ref exclude_hosts) = new_exclude_hosts {
                 r.set_attr("exclude_hosts", exclude_hosts);
+            }
+            if let Some(port_list_id) = new_target_port_list_id {
+                r.set_attr("port_list_id", &port_list_id.to_string());
             }
             if let Some(ref role_ids) = new_role_ids {
                 r.set_attr("role_ids", &role_ids.join(","));
@@ -3027,6 +3063,7 @@ fn optional_child_uuid(
             "config" => "Missing config id",
             "scanner" => "Missing scanner id",
             "task" => "Missing task id",
+            "port_list" => "Missing port list id",
             _ => "Missing resource id",
         });
     };
@@ -3035,6 +3072,7 @@ fn optional_child_uuid(
         "config" => "Invalid config UUID",
         "scanner" => "Invalid scanner UUID",
         "task" => "Invalid task UUID",
+        "port_list" => "Invalid port list UUID",
         _ => "Invalid resource UUID",
     })
 }
@@ -3833,6 +3871,11 @@ mod tests {
             ("config", "Missing config id", "Invalid config UUID"),
             ("scanner", "Missing scanner id", "Invalid scanner UUID"),
             ("task", "Missing task id", "Invalid task UUID"),
+            (
+                "port_list",
+                "Missing port list id",
+                "Invalid port list UUID",
+            ),
             ("resource", "Missing resource id", "Invalid resource UUID"),
         ] {
             let missing = parse_command(format!("<command><{child_name}/></command>").as_bytes())

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -363,6 +363,14 @@ impl Resource {
                 }
             }
         }
+        if self.resource_type == "target" {
+            if let Some(port_list_id) = self.attr("port_list_id") {
+                xml.push_str(&format!(
+                    "<port_list id=\"{}\"><name></name></port_list>",
+                    xml_escape_attr(port_list_id),
+                ));
+            }
+        }
         // Add type-specific attributes
         if self.resource_type == "alert" {
             for field in ["event", "condition", "method"] {
@@ -432,6 +440,9 @@ impl Resource {
                 continue;
             }
             if self.resource_type == "user" && k == "role_ids" {
+                continue;
+            }
+            if self.resource_type == "target" && k == "port_list_id" {
                 continue;
             }
             if self.resource_type == "nvt"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -300,6 +300,18 @@ late responses from being associated with a later GMP command.
 
 Typed GMP command builders covering all entity types, system commands, and enums. Full rustdoc coverage.
 
+### Target Port-List Updates
+
+`ModifyTargetOpts::port_list_id` models omission and replacement with
+`ScalarUpdate<EntityId>`. Current gvmd accepts a real port-list UUID when
+replacing the relationship, but it does not define a sentinel or other wire
+representation for detaching an existing port list. Consequently,
+`ScalarUpdate::Clear` is rejected locally with
+`ModifyTargetError::UnsupportedPortListClear`; no GMP request is sent.
+
+`CreateTargetOpts::port_list_id` remains `Option<EntityId>` because target
+creation only needs to distinguish including a port list from leaving it out.
+
 ### Command Modules (29)
 
 alerts, authentication, credentials, filters, groups, hosts, notes, nvts, overrides, permissions, port_lists, report_formats, reports, resource_names, results, roles, scan_configs, scanners, schedules, system, tags, targets, tasks, tickets, tls_certificates, trashcan, users, version


### PR DESCRIPTION
## Summary

- model target port-list changes with ScalarUpdate, preserving omission and replacement while rejecting unsupported clearing before transport
- surface modify-target builder errors through the typed client and document current gvmd behavior
- align the stateful mock with gvmd port-list validation, persistence, and response rendering, with coverage for omit, replace, and rejected-clear semantics

References #466