### PR TITLE
Fix stateful target credential and alive-test round trips

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -106,8 +106,8 @@ use gvm_gmp::commands::system::{
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{
-    create_target, delete_target, get_targets, modify_target, CreateTargetOpts, GetTargetsOpts,
-    ModifyTargetOpts,
+    create_target, delete_target, get_target as get_target_cmd, get_targets, modify_target,
+    CreateTargetOpts, GetTargetsOpts, ModifyTargetOpts,
 };
 use gvm_gmp::commands::tasks::{
     create_import_task, create_task, delete_task, get_tasks, modify_task, resume_task, start_task,
@@ -206,6 +206,19 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         opts: GetTargetsOpts,
     ) -> Result<GetTargetsResponse, GvmError> {
         let response = self.send(get_targets(opts)).await?;
+        GetTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Send a detailed `get_targets` request for one target and return a typed
+    /// [`GetTargetsResponse`].
+    ///
+    /// # Errors
+    /// Returns an error if the request fails or response parsing fails.
+    pub async fn get_target(
+        &mut self,
+        target_id: &EntityId,
+    ) -> Result<GetTargetsResponse, GvmError> {
+        let response = self.send(get_target_cmd(target_id)).await?;
         GetTargetsResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -62,12 +62,13 @@ use gvm_gmp::commands::tickets::{
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{
     Asset, ConfigUsageKind, CreateScanConfigResponse, CredentialKind, GetConfigsResponse,
-    GetPermissionsResponse, GetScanConfigsResponse, GetScanReportResponse, Permission,
+    GetPermissionsResponse, GetScanConfigsResponse, GetScanReportResponse, ParseError, Permission,
+    Target,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
-    AlertCondition, AlertEvent, AlertMethod, CollectionUpdate, CredentialType, FeedType,
+    AlertCondition, AlertEvent, AlertMethod, AliveTest, CollectionUpdate, CredentialType, FeedType,
     PermissionSubjectType, ScalarUpdate, ScheduleDefinition, ScheduleInput, ScheduleRecurrence,
     ScheduleRecurrenceObservation, ScheduleTimestamp, ScheduleTimezone, SnmpAuthAlgorithm,
     SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
@@ -144,6 +145,80 @@ async fn echo_server(version: MockVersion) -> Option<MockGmpServer> {
 
 fn unix_connection(server: &MockGmpServer) -> UnixSocketConnection {
     UnixSocketConnection::with_path(server.socket_path().expect("unix socket path"))
+}
+
+async fn authenticated_client(server: &MockGmpServer) -> GmpClient<UnixSocketConnection> {
+    let mut client = GmpClient::connect(unix_connection(server))
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+    client
+}
+
+async fn target_by_id(
+    client: &mut GmpClient<UnixSocketConnection>,
+    target_id: &EntityId,
+) -> Target {
+    client
+        .get_target(target_id)
+        .await
+        .expect("target should be retrieved")
+        .items
+        .into_iter()
+        .next()
+        .expect("target should be present")
+}
+
+async fn create_test_credential(
+    client: &mut GmpClient<UnixSocketConnection>,
+    name: &str,
+) -> EntityId {
+    client
+        .create_credential(name, CredentialOpts::default())
+        .await
+        .expect("credential should be created")
+        .id
+}
+
+async fn assert_raw_server_error(
+    client: &mut GmpClient<UnixSocketConnection>,
+    xml: Vec<u8>,
+    expected_status: u16,
+) {
+    let error = client
+        .call(xml)
+        .await
+        .expect_err("raw request should be rejected");
+    assert!(matches!(
+        error,
+        GvmError::Server { status, .. } if status == expected_status
+    ));
+}
+
+fn assert_target_credentials(
+    target: &Target,
+    ssh_credential_id: &EntityId,
+    ssh_port: u16,
+    smb_credential_id: &EntityId,
+) {
+    assert_eq!(
+        target
+            .ssh_credential
+            .as_ref()
+            .map(|credential| &credential.id),
+        Some(ssh_credential_id)
+    );
+    assert_eq!(target.ssh_credential_port, Some(ssh_port));
+    assert_eq!(
+        target
+            .smb_credential
+            .as_ref()
+            .map(|credential| &credential.id),
+        Some(smb_credential_id)
+    );
 }
 
 fn event_text(event: &WireTraceEvent) -> String {
@@ -661,6 +736,43 @@ async fn create_target_and_get_targets_succeed() {
         .as_str()
         .expect("valid UTF-8 XML")
         .contains("Integration Target"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_fixture_targets_use_stateful_observation_vocabulary() {
+    let Some(server) = fixture_server(MockVersion::V22_5).await else {
+        return;
+    };
+    let mut client = GmpClient::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+
+    let targets = client
+        .get_targets(GetTargetsOpts::default())
+        .await
+        .expect("fixture targets should parse");
+    let target = targets.items.first().expect("fixture target should exist");
+    assert_eq!(
+        target.alive_tests.as_deref(),
+        Some(AliveTest::ScanConfigDefault.as_target_name())
+    );
+    assert_eq!(target.ssh_credential_port, Some(22));
+    assert_eq!(
+        target
+            .ssh_credential
+            .as_ref()
+            .map(|credential| credential.id.as_str()),
+        Some("11111111-1111-4111-8111-111111111111")
+    );
+    assert_eq!(
+        target
+            .smb_credential
+            .as_ref()
+            .map(|credential| credential.id.as_str()),
+        Some("22222222-2222-4222-8222-222222222222")
+    );
 
     server.shutdown().await;
 }
@@ -2966,6 +3078,206 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
             && std::str::from_utf8(record.raw_xml())
                 .is_ok_and(|xml| xml.contains("<hosts></hosts>"))
     }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_credentials_round_trip_in_stateful_mode() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let first_ssh = create_test_credential(&mut client, "First SSH").await;
+    let first_smb = create_test_credential(&mut client, "First SMB").await;
+    let second_ssh = create_test_credential(&mut client, "Second SSH").await;
+    let second_smb = create_test_credential(&mut client, "Second SMB").await;
+
+    let target = client
+        .create_target(
+            "Credential Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into()],
+                ssh_credential_id: Some(first_ssh.clone()),
+                ssh_credential_port: Some(2222),
+                smb_credential_id: Some(first_smb.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created");
+    let created = target_by_id(&mut client, &target.id).await;
+    assert_eq!(created.alive_tests, None);
+    assert_target_credentials(&created, &first_ssh, 2222, &first_smb);
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                comment: Some("relationships omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("omitted target fields should be preserved");
+    let preserved = target_by_id(&mut client, &target.id).await;
+    assert_eq!(preserved.alive_tests, None);
+    assert_target_credentials(&preserved, &first_ssh, 2222, &first_smb);
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::set(second_ssh.clone()),
+                ssh_credential_port: Some(22),
+                smb_credential_id: ScalarUpdate::set(second_smb.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target relationships should be replaced");
+    assert_target_credentials(
+        &target_by_id(&mut client, &target.id).await,
+        &second_ssh,
+        22,
+        &second_smb,
+    );
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::Clear,
+                smb_credential_id: ScalarUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target credentials should be cleared");
+    let cleared = target_by_id(&mut client, &target.id).await;
+    assert_eq!(cleared.ssh_credential, None);
+    assert_eq!(cleared.ssh_credential_port, None);
+    assert_eq!(cleared.smb_credential, None);
+
+    let missing_credential =
+        EntityId::new("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").expect("valid missing credential ID");
+    let error = client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::set(missing_credential),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("missing credential reference should be rejected");
+    assert!(matches!(
+        error,
+        GvmError::Parse(ParseError::ServerError { status: 404, .. })
+    ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    for alive_test in ["<alive_test/>", "<alive_test>   </alive_test>"] {
+        assert_raw_server_error(
+            &mut client,
+            format!(
+                "<create_target><name>Invalid Alive Test</name><hosts>192.0.2.2</hosts>{alive_test}</create_target>"
+            )
+            .into_bytes(),
+            400,
+        )
+        .await;
+    }
+    let target = client
+        .create_target(
+            "Alive Test Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into()],
+                alive_test: Some(AliveTest::ScanConfigDefault),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target should be created");
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                comment: Some("alive test omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("omitted alive test should be preserved");
+    let preserved = target_by_id(&mut client, &target.id).await;
+    assert_eq!(
+        preserved.alive_tests.as_deref(),
+        Some(AliveTest::ScanConfigDefault.as_target_name())
+    );
+
+    for alive_test in [
+        AliveTest::ScanConfigDefault,
+        AliveTest::IcmpPing,
+        AliveTest::TcpAckServicePing,
+        AliveTest::TcpSynServicePing,
+        AliveTest::ArpPing,
+        AliveTest::IcmpAndTcpAckServicePing,
+        AliveTest::IcmpAndArpPing,
+        AliveTest::TcpAckServiceAndArpPing,
+        AliveTest::IcmpTcpAckServiceAndArpPing,
+        AliveTest::ConsiderAlive,
+    ] {
+        client
+            .modify_target(
+                &target.id,
+                ModifyTargetOpts {
+                    alive_test: Some(alive_test),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("supported alive test should be accepted");
+        assert_eq!(
+            target_by_id(&mut client, &target.id)
+                .await
+                .alive_tests
+                .as_deref(),
+            Some(alive_test.as_target_name())
+        );
+    }
+
+    for alive_test in [
+        "<alive_test/>",
+        "<alive_test>   </alive_test>",
+        "<alive_test>Not An Alive Test</alive_test>",
+    ] {
+        assert_raw_server_error(
+            &mut client,
+            format!(
+                "<modify_target target_id=\"{}\">{alive_test}</modify_target>",
+                target.id,
+            )
+            .into_bytes(),
+            400,
+        )
+        .await;
+    }
+    assert_eq!(
+        target_by_id(&mut client, &target.id)
+            .await
+            .alive_tests
+            .as_deref(),
+        Some(AliveTest::ConsiderAlive.as_target_name())
+    );
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -301,6 +301,7 @@ async fn discovery_and_administration_families_parse_through_real_client() {
     assert_eq!(version.version, "22.8");
 
     assert_typed_success!(client.get_targets(GetTargetsOpts::default()));
+    assert_typed_success!(client.get_target(&id("11111111-1111-1111-1111-111111111111")));
     assert_typed_success!(client.get_oci_image_targets_parsed(GetOciImageTargetsOpts::default()));
     assert_typed_success!(
         client.get_web_application_targets_parsed(GetWebApplicationTargetsOpts::default())

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -9,6 +9,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "get_version",
     "authenticate",
     "get_targets",
+    "get_target",
     "create_target",
     "modify_target",
     "delete_target",

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -27,6 +27,8 @@ pub struct CreateTargetOpts {
     pub port_list_id: Option<EntityId>,
     /// Optional SSH credential identifier.
     pub ssh_credential_id: Option<EntityId>,
+    /// Optional SSH service port nested below the SSH credential.
+    pub ssh_credential_port: Option<u16>,
     /// Optional SMB credential identifier.
     pub smb_credential_id: Option<EntityId>,
     /// Optional `ESXi` credential identifier.
@@ -73,6 +75,8 @@ pub struct ModifyTargetOpts {
     pub port_list_id: ScalarUpdate<EntityId>,
     /// SSH credential relationship update: omit, set, or detach.
     pub ssh_credential_id: ScalarUpdate<EntityId>,
+    /// Optional SSH service port nested below a set SSH credential.
+    pub ssh_credential_port: Option<u16>,
     /// SMB credential relationship update: omit, set, or detach.
     pub smb_credential_id: ScalarUpdate<EntityId>,
     /// `ESXi` credential relationship update: omit, set, or detach.
@@ -191,17 +195,38 @@ pub fn delete_target(target_id: &EntityId, ultimate: bool) -> impl Request {
 }
 
 fn add_create_target_credentials(cmd: &mut XmlCommand, opts: &CreateTargetOpts) {
-    add_optional_id_element(cmd, "ssh_credential", opts.ssh_credential_id.as_ref());
+    add_ssh_credential(
+        cmd,
+        opts.ssh_credential_id.as_ref(),
+        opts.ssh_credential_port,
+    );
     add_optional_id_element(cmd, "smb_credential", opts.smb_credential_id.as_ref());
     add_optional_id_element(cmd, "esxi_credential", opts.esxi_credential_id.as_ref());
     add_optional_id_element(cmd, "snmp_credential", opts.snmp_credential_id.as_ref());
 }
 
 fn add_modify_target_credentials(cmd: &mut XmlCommand, opts: &ModifyTargetOpts) {
-    add_scalar_id_update(cmd, "ssh_credential", &opts.ssh_credential_id);
+    match &opts.ssh_credential_id {
+        ScalarUpdate::Omitted => {}
+        ScalarUpdate::Set(id) => add_ssh_credential(cmd, Some(id), opts.ssh_credential_port),
+        ScalarUpdate::Clear => {
+            add_scalar_id_update(cmd, "ssh_credential", &ScalarUpdate::<EntityId>::Clear);
+        }
+    }
     add_scalar_id_update(cmd, "smb_credential", &opts.smb_credential_id);
     add_scalar_id_update(cmd, "esxi_credential", &opts.esxi_credential_id);
     add_scalar_id_update(cmd, "snmp_credential", &opts.snmp_credential_id);
+}
+
+fn add_ssh_credential(cmd: &mut XmlCommand, id: Option<&EntityId>, port: Option<u16>) {
+    let Some(id) = id else {
+        return;
+    };
+    let credential = cmd.add_element("ssh_credential");
+    credential.set_attribute("id", id.as_str());
+    if let Some(port) = port {
+        credential.add_child_with_text("port", &port.to_string());
+    }
 }
 
 fn add_collection_update(cmd: &mut XmlCommand, element: &str, update: &CollectionUpdate<String>) {
@@ -236,6 +261,7 @@ mod tests {
                 alive_test: Some(AliveTest::IcmpPing),
                 port_list_id: Some(id("pl1")),
                 ssh_credential_id: Some(id("ssh1")),
+                ssh_credential_port: Some(2222),
                 smb_credential_id: Some(id("smb1")),
                 esxi_credential_id: Some(id("esxi1")),
                 snmp_credential_id: Some(id("snmp1")),
@@ -247,7 +273,7 @@ mod tests {
         assert!(rendered.contains("<hosts>1.1.1.1</hosts>"));
         assert!(rendered.contains("<alive_test>ICMP Ping</alive_test>"));
         assert!(rendered.contains("<port_list id=\"pl1\"/>"));
-        assert!(rendered.contains("<ssh_credential id=\"ssh1\"/>"));
+        assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
@@ -277,6 +303,7 @@ mod tests {
                 name: Some("n".into()),
                 alive_test: Some(AliveTest::IcmpAndArpPing),
                 ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                ssh_credential_port: Some(2222),
                 smb_credential_id: ScalarUpdate::set(id("smb1")),
                 esxi_credential_id: ScalarUpdate::set(id("esxi1")),
                 snmp_credential_id: ScalarUpdate::set(id("snmp1")),
@@ -288,7 +315,7 @@ mod tests {
         .expect("valid target update"));
         assert!(rendered.contains("<name>n</name>"));
         assert!(rendered.contains("<alive_test>ICMP &amp; ARP Ping</alive_test>"));
-        assert!(rendered.contains("<ssh_credential id=\"ssh1\"/>"));
+        assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
@@ -341,11 +368,12 @@ mod tests {
                 &id("t1"),
                 ModifyTargetOpts {
                     ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                    ssh_credential_port: Some(2222),
                     smb_credential_id: ScalarUpdate::set(id("smb1")),
                     ..Default::default()
                 }
             ).expect("valid update")),
-            "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"/><smb_credential id=\"smb1\"/></modify_target>"
+            "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential><smb_credential id=\"smb1\"/></modify_target>"
         );
         assert_eq!(
             xml(modify_target(

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -7,8 +7,8 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{
     count_info, optional_u32, parse_csv_list, parse_document, parse_entity_id, parse_entity_meta,
-    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
-    ParseError,
+    parse_named_entity, parse_u16, status_from_response, ActionResponse, CountInfo, EntityMeta,
+    NamedEntity, ParseError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,6 +23,7 @@ pub struct Target {
     pub reverse_lookup_unify: bool,
     pub port_list: Option<NamedEntity>,
     pub ssh_credential: Option<NamedEntity>,
+    pub ssh_credential_port: Option<u16>,
     pub smb_credential: Option<NamedEntity>,
     pub esxi_credential: Option<NamedEntity>,
     pub snmp_credential: Option<NamedEntity>,
@@ -73,6 +74,11 @@ impl Target {
                 .unwrap_or(false),
             port_list: parse_named_entity(node, "port_list")?,
             ssh_credential: parse_named_entity(node, "ssh_credential")?,
+            ssh_credential_port: node
+                .child("ssh_credential")
+                .and_then(|credential| credential.optional_child_text("port"))
+                .map(|port| parse_u16(&port, "ssh_credential.port"))
+                .transpose()?,
             smb_credential: parse_named_entity(node, "smb_credential")?,
             esxi_credential: parse_named_entity(node, "esxi_credential")?,
             snmp_credential: parse_named_entity(node, "snmp_credential")?,
@@ -142,7 +148,7 @@ mod tests {
                     <reverse_lookup_only>0</reverse_lookup_only>
                     <reverse_lookup_unify>1</reverse_lookup_unify>
                     <port_list id="pl-1"><name>All TCP</name></port_list>
-                    <ssh_credential id="cred-ssh"><name>SSH Cred</name></ssh_credential>
+                    <ssh_credential id="cred-ssh"><name>SSH Cred</name><port>2222</port></ssh_credential>
                     <smb_credential id="cred-smb"><name>SMB Cred</name></smb_credential>
                     <esxi_credential id="cred-esxi"><name>ESXi Cred</name></esxi_credential>
                     <snmp_credential id="cred-snmp"><name>SNMP Cred</name></snmp_credential>
@@ -185,6 +191,7 @@ mod tests {
                 .map(|credential| credential.name.as_str()),
             Some("SSH Cred")
         );
+        assert_eq!(parsed.items[0].ssh_credential_port, Some(2222));
         assert_eq!(
             parsed.items[0]
                 .smb_credential
@@ -275,10 +282,31 @@ mod tests {
         assert!(target.exclude_hosts.is_empty());
         assert_eq!(target.port_list, None);
         assert_eq!(target.ssh_credential, None);
+        assert_eq!(target.ssh_credential_port, None);
         assert_eq!(target.smb_credential, None);
         assert_eq!(target.esxi_credential, None);
         assert_eq!(target.snmp_credential, None);
         assert!(!target.meta.in_use);
         assert!(!target.meta.writable);
+    }
+
+    #[test]
+    fn rejects_invalid_ssh_credential_port() {
+        let response = Response::from(
+            r#"<get_targets_response status="200" status_text="OK">
+                <target id="t-1">
+                    <name>Target</name>
+                    <ssh_credential id="cred-ssh"><name>SSH</name><port>invalid</port></ssh_credential>
+                </target>
+            </get_targets_response>"#,
+        );
+
+        let error = GetTargetsResponse::from_response(&response).expect_err("invalid port");
+
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, value }
+                if field == "ssh_credential.port" && value == "invalid"
+        ));
     }
 }

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -38,6 +38,34 @@ fn test_create_target_with_optionals() {
 }
 
 #[test]
+fn test_target_ssh_credential_port_is_nested_in_credential() {
+    assert_eq!(
+        xml(create_target(
+            "target",
+            CreateTargetOpts {
+                ssh_credential_id: Some(id("ssh1")),
+                ssh_credential_port: Some(2222),
+                ..Default::default()
+            }
+        )),
+        "<create_target><name>target</name><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></create_target>"
+    );
+
+    assert_eq!(
+        xml(modify_target(
+            &id("target1"),
+            ModifyTargetOpts {
+                ssh_credential_id: gvm_gmp::ScalarUpdate::set(id("ssh1")),
+                ssh_credential_port: Some(2222),
+                ..Default::default()
+            }
+        )
+        .expect("valid target update")),
+        "<modify_target target_id=\"target1\"><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></modify_target>"
+    );
+}
+
+#[test]
 fn test_target_get_modify_delete() {
     assert_eq!(
         xml(clone_target(&id("t1"))),

--- a/crates/gvm-mock-server/src/fixtures.rs
+++ b/crates/gvm-mock-server/src/fixtures.rs
@@ -114,6 +114,9 @@ impl FixtureStore {
              <target id=\"{{uuid}}\">\
              <name>Local Network</name>\
              <hosts>192.168.1.0/24</hosts>\
+             <alive_tests>Scan Config Default</alive_tests>\
+             <ssh_credential id=\"11111111-1111-4111-8111-111111111111\"><name>Fixture SSH</name><port>22</port></ssh_credential>\
+             <smb_credential id=\"22222222-2222-4222-8222-222222222222\"><name>Fixture SMB</name></smb_credential>\
              <creation_time>{{now}}</creation_time>\
              <modification_time>{{now}}</modification_time>\
              </target>\
@@ -515,6 +518,16 @@ mod tests {
         let fixture = store.get("get_tasks").expect("should have fixture");
         assert!(fixture.contains("Discovery Scan"));
         assert!(fixture.contains("task_count"));
+    }
+
+    #[test]
+    fn test_fixture_get_targets_uses_observation_field_names() {
+        let store = FixtureStore::new(GmpVersion::V22_5);
+        let fixture = store.get("get_targets").expect("should have fixture");
+        assert!(fixture.contains("<alive_tests>Scan Config Default</alive_tests>"));
+        assert!(!fixture.contains("<alive_test>"));
+        assert!(fixture.contains("<ssh_credential id="));
+        assert!(fixture.contains("<smb_credential id="));
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -707,6 +707,22 @@ impl SessionHandler {
         } else {
             None
         };
+        let target_ssh_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "ssh_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let target_smb_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "smb_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
 
         // Extract comment
         let comment = if has_config_import_payload {
@@ -923,6 +939,8 @@ impl SessionHandler {
             if let Some(port_list_id) = target_port_list_id {
                 resource.set_attr("port_list_id", &port_list_id.to_string());
             }
+            apply_target_credential_update(&mut resource, "ssh_credential", &target_ssh_credential);
+            apply_target_credential_update(&mut resource, "smb_credential", &target_smb_credential);
         }
 
         if resource_type == "user" {
@@ -1168,6 +1186,22 @@ impl SessionHandler {
         } else {
             None
         };
+        let new_target_ssh_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "ssh_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let new_target_smb_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "smb_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
 
         let new_name = if resource_type == "user" {
             parse_element_text(raw_xml, "new_name")
@@ -1372,6 +1406,8 @@ impl SessionHandler {
             if let Some(port_list_id) = new_target_port_list_id {
                 r.set_attr("port_list_id", &port_list_id.to_string());
             }
+            apply_target_credential_update(r, "ssh_credential", &new_target_ssh_credential);
+            apply_target_credential_update(r, "smb_credential", &new_target_smb_credential);
             if let Some(ref role_ids) = new_role_ids {
                 r.set_attr("role_ids", &role_ids.join(","));
             }
@@ -3842,6 +3878,62 @@ fn nested_child_attr(cmd: &ParsedCommand, path: &[&str], attr: &str) -> Option<S
         element = element.children.iter().find(|child| child.name == **name)?;
     }
     element.attributes.get(attr).cloned()
+}
+
+enum TargetCredentialUpdate {
+    Omitted,
+    Clear,
+    Set { id: Uuid, port: Option<u16> },
+}
+
+fn target_credential_update(
+    cmd: &ParsedCommand,
+    store: &ResourceStore,
+    element: &str,
+) -> Result<TargetCredentialUpdate, (u16, &'static str)> {
+    let Some(id) = cmd.child_attr(element, "id") else {
+        return Ok(TargetCredentialUpdate::Omitted);
+    };
+    if id == "0" {
+        return Ok(TargetCredentialUpdate::Clear);
+    }
+    let id = Uuid::parse_str(id).map_err(|_| (400, "Invalid credential UUID"))?;
+    if store.get_typed(&id, "credential").is_none() {
+        return Err((404, "Credential not found"));
+    }
+    let port = nested_child_text(cmd, &[element, "port"])
+        .map(|value| value.parse::<u16>())
+        .transpose()
+        .map_err(|_| (400, "Invalid credential port"))?;
+    if port == Some(0) {
+        return Err((400, "Invalid credential port"));
+    }
+
+    Ok(TargetCredentialUpdate::Set { id, port })
+}
+
+fn apply_target_credential_update(
+    resource: &mut Resource,
+    prefix: &str,
+    update: &TargetCredentialUpdate,
+) {
+    let id_attr = format!("{prefix}_id");
+    let port_attr = format!("{prefix}_port");
+    match update {
+        TargetCredentialUpdate::Omitted => {}
+        TargetCredentialUpdate::Clear => {
+            resource.remove_attr(&id_attr);
+            resource.remove_attr(&port_attr);
+        }
+        TargetCredentialUpdate::Set { id, port } => {
+            resource.set_attr(&id_attr, &id.to_string());
+            if let Some(port) = port {
+                resource.set_attr(&port_attr, &port.to_string());
+            } else {
+                resource.remove_attr(&port_attr);
+            }
+        }
+    }
 }
 
 fn credential_kdcs(cmd: &ParsedCommand) -> Option<Vec<String>> {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -13,6 +13,7 @@ use base64::Engine as _;
 use gvm_gmp::schedule::{
     parse_icalendar_with_timezone, ScheduleStartObservation, ScheduleTimestamp,
 };
+use gvm_gmp::AliveTest;
 use uuid::Uuid;
 
 use crate::command_parser::{parse_command, parse_element_text, ParsedCommand, ParsedElement};
@@ -723,6 +724,14 @@ impl SessionHandler {
         } else {
             TargetCredentialUpdate::Omitted
         };
+        let target_alive_test = if resource_type == "target" {
+            match target_alive_test_update(cmd) {
+                Ok(update) => update,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            }
+        } else {
+            None
+        };
 
         // Extract comment
         let comment = if has_config_import_payload {
@@ -941,6 +950,9 @@ impl SessionHandler {
             }
             apply_target_credential_update(&mut resource, "ssh_credential", &target_ssh_credential);
             apply_target_credential_update(&mut resource, "smb_credential", &target_smb_credential);
+            if let Some(alive_test) = target_alive_test {
+                resource.set_attr("alive_test", alive_test.as_target_name());
+            }
         }
 
         if resource_type == "user" {
@@ -1202,6 +1214,14 @@ impl SessionHandler {
         } else {
             TargetCredentialUpdate::Omitted
         };
+        let new_target_alive_test = if resource_type == "target" {
+            match target_alive_test_update(cmd) {
+                Ok(update) => update,
+                Err(message) => return error_response(&cmd.name, 400, message),
+            }
+        } else {
+            None
+        };
 
         let new_name = if resource_type == "user" {
             parse_element_text(raw_xml, "new_name")
@@ -1408,6 +1428,9 @@ impl SessionHandler {
             }
             apply_target_credential_update(r, "ssh_credential", &new_target_ssh_credential);
             apply_target_credential_update(r, "smb_credential", &new_target_smb_credential);
+            if let Some(alive_test) = new_target_alive_test {
+                r.set_attr("alive_test", alive_test.as_target_name());
+            }
             if let Some(ref role_ids) = new_role_ids {
                 r.set_attr("role_ids", &role_ids.join(","));
             }
@@ -3886,6 +3909,19 @@ enum TargetCredentialUpdate {
     Set { id: Uuid, port: Option<u16> },
 }
 
+fn target_alive_test_update(cmd: &ParsedCommand) -> Result<Option<AliveTest>, &'static str> {
+    let Some(element) = cmd.children.iter().find(|child| child.name == "alive_test") else {
+        return Ok(None);
+    };
+    let value = element
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or("Invalid alive test")?;
+    value.parse().map(Some).map_err(|_| "Invalid alive test")
+}
+
 fn target_credential_update(
     cmd: &ParsedCommand,
     store: &ResourceStore,
@@ -4057,6 +4093,34 @@ mod tests {
             credential_kdcs(&command),
             Some(vec!["kdc1.example".into(), "kdc2.example".into()])
         );
+    }
+
+    #[test]
+    fn target_alive_test_update_distinguishes_omitted_empty_and_valid_values() {
+        let omitted = parse_command(b"<create_target/>").expect("parse omitted alive test");
+        assert_eq!(target_alive_test_update(&omitted), Ok(None));
+
+        let valid = parse_command(
+            b"<create_target><alive_test>ICMP &amp; ARP Ping</alive_test></create_target>",
+        )
+        .expect("parse valid alive test");
+        assert_eq!(
+            target_alive_test_update(&valid),
+            Ok(Some(AliveTest::IcmpAndArpPing))
+        );
+
+        for xml in [
+            "<create_target><alive_test/></create_target>",
+            "<create_target><alive_test></alive_test></create_target>",
+            "<create_target><alive_test>   </alive_test></create_target>",
+            "<create_target><alive_test>Unknown</alive_test></create_target>",
+        ] {
+            let command = parse_command(xml.as_bytes()).expect("parse invalid alive test");
+            assert_eq!(
+                target_alive_test_update(&command),
+                Err("Invalid alive test")
+            );
+        }
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -375,6 +375,19 @@ impl Resource {
                     xml_escape_attr(port_list_id),
                 ));
             }
+            for credential in ["ssh_credential", "smb_credential"] {
+                let Some(id) = self.attr(&format!("{credential}_id")) else {
+                    continue;
+                };
+                xml.push_str(&format!(
+                    "<{credential} id=\"{}\"><name></name>",
+                    xml_escape_attr(id),
+                ));
+                if let Some(port) = self.attr(&format!("{credential}_port")) {
+                    xml.push_str(&format!("<port>{}</port>", xml_escape(port)));
+                }
+                xml.push_str(&format!("</{credential}>"));
+            }
         }
         // Add type-specific attributes
         if self.resource_type == "alert" {
@@ -447,7 +460,16 @@ impl Resource {
             if self.resource_type == "user" && k == "role_ids" {
                 continue;
             }
-            if self.resource_type == "target" && k == "port_list_id" {
+            if self.resource_type == "target"
+                && matches!(
+                    k.as_str(),
+                    "port_list_id"
+                        | "ssh_credential_id"
+                        | "ssh_credential_port"
+                        | "smb_credential_id"
+                        | "smb_credential_port"
+                )
+            {
                 continue;
             }
             if self.resource_type == "nvt"

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -369,6 +369,12 @@ impl Resource {
             }
         }
         if self.resource_type == "target" {
+            if let Some(alive_test) = self.attr("alive_test") {
+                xml.push_str(&format!(
+                    "<alive_tests>{}</alive_tests>",
+                    xml_escape(alive_test),
+                ));
+            }
             if let Some(port_list_id) = self.attr("port_list_id") {
                 xml.push_str(&format!(
                     "<port_list id=\"{}\"><name></name></port_list>",
@@ -464,6 +470,7 @@ impl Resource {
                 && matches!(
                     k.as_str(),
                     "port_list_id"
+                        | "alive_test"
                         | "ssh_credential_id"
                         | "ssh_credential_port"
                         | "smb_credential_id"

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -85,9 +85,19 @@ async fn matrix_targets_create_get_delete() {
     let mut stream = connect(&server).await;
     auth_admin(&mut stream).await;
 
+    let credential_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Matrix SSH</name></create_credential>",
+        "create_credential",
+    )
+    .await;
+
     let target_id = create_and_get_id(
         &mut stream,
-        b"<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts></create_target>",
+        format!(
+            "<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts><ssh_credential id=\"{credential_id}\"><port>2222</port></ssh_credential></create_target>"
+        )
+        .as_bytes(),
         "create_target",
     )
     .await;
@@ -101,6 +111,28 @@ async fn matrix_targets_create_get_delete() {
     let get_text = get_resp.as_str().expect("valid utf8");
     assert!(get_text.contains(&target_id));
     assert!(get_text.contains("Matrix Target"));
+    assert!(get_text.contains(&format!(
+        "<ssh_credential id=\"{credential_id}\"><name></name><port>2222</port></ssh_credential>"
+    )));
+
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"{credential_id}\"><port>22</port></ssh_credential></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+    let modified = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(modified
+        .as_str()
+        .expect("valid utf8")
+        .contains("<port>22</port>"));
 
     let delete_resp = send_recv(
         &mut stream,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -328,9 +328,11 @@ the nested `<ssh_credential><port>` GMP field, and typed target observations
 parse the same nested field into `Target::ssh_credential_port`. Both list and
 single-target client reads therefore preserve explicit default and non-default
 ports without caller-side XML handling.
-The stateful mock server also preserves SSH/SMB target credential relationships
-and SSH ports across create, modify, and get operations for Unix composition
-tests.
+The stateful mock server also preserves alive-test values, SSH/SMB target
+credential relationships, and SSH ports across create, modify, and get
+operations for Unix composition tests. Stateful responses use gvmd's plural
+`alive_tests` observation field while requests retain the singular `alive_test`
+field.
 
 ### Command Modules (29)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -320,6 +320,18 @@ representation for detaching an existing port list. Consequently,
 `CreateTargetOpts::port_list_id` remains `Option<EntityId>` because target
 creation only needs to distinguish including a port list from leaving it out.
 
+### Target SSH Credential Ports
+
+`CreateTargetOpts` and `ModifyTargetOpts` carry an optional typed SSH service
+port next to the credential relationship. The command builders serialize it as
+the nested `<ssh_credential><port>` GMP field, and typed target observations
+parse the same nested field into `Target::ssh_credential_port`. Both list and
+single-target client reads therefore preserve explicit default and non-default
+ports without caller-side XML handling.
+The stateful mock server also preserves SSH/SMB target credential relationships
+and SSH ports across create, modify, and get operations for Unix composition
+tests.
+
 ### Command Modules (29)
 
 alerts, authentication, credentials, filters, groups, hosts, notes, nvts, overrides, permissions, port_lists, report_formats, reports, resource_names, results, roles, scan_configs, scanners, schedules, system, tags, targets, tasks, tickets, tls_certificates, trashcan, users, version


### PR DESCRIPTION
## Summary

- preserve optional SSH service ports in typed target create and modify commands and parse them from target observations, including single-target typed reads
- validate, store, replace, preserve, and clear SSH/SMB credential relationships and alive-test state in the stateful mock, rejecting invalid references and values
- emit gvmd-shaped alive-test and nested credential response fields consistently in stateful and fixture modes
- add command, parser, facade, and end-to-end lifecycle coverage for SSH ports, credential mutations, and alive-test variants
- document target SSH port and stateful observation support

Fixes #474