### PR TITLE
Fix: Make target SSH credential ports lossless

### DIFF
--- a/crates/gvm-client/src/error.rs
+++ b/crates/gvm-client/src/error.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use gvm_connection::ConnectionError;
-use gvm_gmp::commands::targets::ModifyTargetError;
+use gvm_gmp::commands::targets::{CreateTargetError, ModifyTargetError};
 use gvm_gmp::responses::ParseError;
 use gvm_gmp::types::GmpVersion;
 use thiserror::Error;
@@ -21,6 +21,10 @@ pub enum GvmError {
     /// Response model parsing failure.
     #[error("parse error: {0}")]
     Parse(#[from] ParseError),
+
+    /// A typed `create_target` input cannot be represented by GMP.
+    #[error("create_target request error: {0}")]
+    CreateTarget(#[from] CreateTargetError),
 
     /// A typed `modify_target` update cannot be represented by gvmd.
     #[error("modify_target request error: {0}")]

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -231,7 +231,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         name: &str,
         opts: CreateTargetOpts,
     ) -> Result<CreateTargetResponse, GvmError> {
-        let response = self.send(create_target(name, opts)).await?;
+        let request = create_target(name, opts)?;
+        let response = self.send(request).await?;
         CreateTargetResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -52,8 +52,8 @@ use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::{get_info, get_info_list, GenericInfoType, GetInfoListOpts};
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::targets::{
-    create_target, delete_target, get_targets, CreateTargetOpts, GetTargetsOpts, ModifyTargetError,
-    ModifyTargetOpts,
+    create_target, delete_target, get_targets, CreateTargetError, CreateTargetOpts, GetTargetsOpts,
+    ModifyTargetError, ModifyTargetOpts,
 };
 use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
 use gvm_gmp::commands::tickets::{
@@ -70,8 +70,8 @@ use gvm_gmp::types::GmpVersion;
 use gvm_gmp::{
     AlertCondition, AlertEvent, AlertMethod, AliveTest, CollectionUpdate, CredentialType, FeedType,
     PermissionSubjectType, ScalarUpdate, ScheduleDefinition, ScheduleInput, ScheduleRecurrence,
-    ScheduleRecurrenceObservation, ScheduleTimestamp, ScheduleTimezone, SnmpAuthAlgorithm,
-    SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
+    ScheduleRecurrenceObservation, ScheduleTimestamp, ScheduleTimezone, ServicePort,
+    SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
@@ -183,6 +183,25 @@ async fn create_test_credential(
         .id
 }
 
+async fn create_test_smb_credential(
+    client: &mut GmpClient<UnixSocketConnection>,
+    name: &str,
+) -> EntityId {
+    client
+        .create_credential(
+            name,
+            CredentialOpts {
+                credential_type: Some(CredentialType::UsernamePassword),
+                login: Some("scanner".into()),
+                password: Some("secret".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SMB credential should be created")
+        .id
+}
+
 async fn assert_raw_server_error(
     client: &mut GmpClient<UnixSocketConnection>,
     xml: Vec<u8>,
@@ -211,7 +230,10 @@ fn assert_target_credentials(
             .map(|credential| &credential.id),
         Some(ssh_credential_id)
     );
-    assert_eq!(target.ssh_credential_port, Some(ssh_port));
+    assert_eq!(
+        target.ssh_credential_port.map(ServicePort::get),
+        Some(ssh_port)
+    );
     assert_eq!(
         target
             .smb_credential
@@ -3089,9 +3111,28 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
     };
     let mut client = authenticated_client(&server).await;
     let first_ssh = create_test_credential(&mut client, "First SSH").await;
-    let first_smb = create_test_credential(&mut client, "First SMB").await;
+    let first_smb = create_test_smb_credential(&mut client, "First SMB").await;
     let second_ssh = create_test_credential(&mut client, "Second SSH").await;
-    let second_smb = create_test_credential(&mut client, "Second SMB").await;
+    let second_smb = create_test_smb_credential(&mut client, "Second SMB").await;
+
+    let default_target = client
+        .create_target(
+            "Default Credential Port Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.9".into()],
+                ssh_credential_id: Some(first_ssh.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target with default SSH port should be created");
+    assert_eq!(
+        target_by_id(&mut client, &default_target.id)
+            .await
+            .ssh_credential_port
+            .map(ServicePort::get),
+        Some(22)
+    );
 
     let target = client
         .create_target(
@@ -3099,7 +3140,7 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
             CreateTargetOpts {
                 hosts: vec!["192.0.2.1".into()],
                 ssh_credential_id: Some(first_ssh.clone()),
-                ssh_credential_port: Some(2222),
+                ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
                 smb_credential_id: Some(first_smb.clone()),
                 ..Default::default()
             },
@@ -3129,13 +3170,31 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
             &target.id,
             ModifyTargetOpts {
                 ssh_credential_id: ScalarUpdate::set(second_ssh.clone()),
-                ssh_credential_port: Some(22),
+                ssh_credential_port: ScalarUpdate::set(ServicePort::new(2200).expect("valid port")),
                 smb_credential_id: ScalarUpdate::set(second_smb.clone()),
                 ..Default::default()
             },
         )
         .await
         .expect("target relationships should be replaced");
+    assert_target_credentials(
+        &target_by_id(&mut client, &target.id).await,
+        &second_ssh,
+        2200,
+        &second_smb,
+    );
+
+    client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::set(second_ssh.clone()),
+                ssh_credential_port: ScalarUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target SSH port should reset to gvmd's default");
     assert_target_credentials(
         &target_by_id(&mut client, &target.id).await,
         &second_ssh,
@@ -3175,6 +3234,43 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
         error,
         GvmError::Parse(ParseError::ServerError { status: 404, .. })
     ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let create_count_before = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "create_target")
+        .count();
+
+    let error = client
+        .create_target(
+            "Invalid Credential Port Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.11".into()],
+                ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("orphaned SSH port should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::CreateTarget(CreateTargetError::SshPortWithoutCredential)
+    ));
+    let create_count_after = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "create_target")
+        .count();
+    assert_eq!(create_count_after, create_count_before);
 
     server.shutdown().await;
 }

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3108,6 +3108,7 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn typed_target_credentials_round_trip_in_stateful_mode() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -734,13 +734,16 @@ async fn create_target_and_get_targets_succeed() {
         .expect("authenticate should succeed");
 
     let create_response = client
-        .call(create_target(
-            "Integration Target",
-            CreateTargetOpts {
-                hosts: vec!["127.0.0.1".to_string()],
-                ..CreateTargetOpts::default()
-            },
-        ))
+        .call(
+            create_target(
+                "Integration Target",
+                CreateTargetOpts {
+                    hosts: vec!["127.0.0.1".to_string()],
+                    ..CreateTargetOpts::default()
+                },
+            )
+            .expect("valid target"),
+        )
         .await
         .expect("create_target should succeed");
     assert_eq!(create_response.status_code(), Some(201));
@@ -780,7 +783,7 @@ async fn typed_fixture_targets_use_stateful_observation_vocabulary() {
         target.alive_tests.as_deref(),
         Some(AliveTest::ScanConfigDefault.as_target_name())
     );
-    assert_eq!(target.ssh_credential_port, Some(22));
+    assert_eq!(target.ssh_credential_port.map(ServicePort::get), Some(22));
     assert_eq!(
         target
             .ssh_credential
@@ -4174,13 +4177,16 @@ async fn full_crud_lifecycle_succeeds() {
         .expect("authenticate should succeed");
 
     let target_response = client
-        .call(create_target(
-            "Lifecycle Target",
-            CreateTargetOpts {
-                hosts: vec!["127.0.0.1".to_string()],
-                ..CreateTargetOpts::default()
-            },
-        ))
+        .call(
+            create_target(
+                "Lifecycle Target",
+                CreateTargetOpts {
+                    hosts: vec!["127.0.0.1".to_string()],
+                    ..CreateTargetOpts::default()
+                },
+            )
+            .expect("valid target"),
+        )
         .await
         .expect("create_target should succeed");
     let target_id = target_response.id().expect("target id");

--- a/crates/gvm-connection/tests/large_response.rs
+++ b/crates/gvm-connection/tests/large_response.rs
@@ -69,7 +69,8 @@ async fn create_large_report(conn: &mut UnixSocketConnection) -> (EntityId, Vec<
                 hosts: vec!["10.0.0.0/24".to_string()],
                 ..CreateTargetOpts::default()
             },
-        ),
+        )
+        .expect("valid target"),
     )
     .await;
     assert_eq!(target_response.status_code(), Some(201));

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -10,7 +10,7 @@ use crate::common::{
     set_optional_bool_attr,
 };
 use crate::enums::AliveTest;
-use crate::types::{CollectionUpdate, EntityId, ScalarUpdate};
+use crate::types::{CollectionUpdate, EntityId, ScalarUpdate, ServicePort};
 
 /// Optional fields for `create_target` requests.
 #[derive(Debug, Clone, Default)]
@@ -28,7 +28,7 @@ pub struct CreateTargetOpts {
     /// Optional SSH credential identifier.
     pub ssh_credential_id: Option<EntityId>,
     /// Optional SSH service port nested below the SSH credential.
-    pub ssh_credential_port: Option<u16>,
+    pub ssh_credential_port: Option<ServicePort>,
     /// Optional SMB credential identifier.
     pub smb_credential_id: Option<EntityId>,
     /// Optional `ESXi` credential identifier.
@@ -75,8 +75,14 @@ pub struct ModifyTargetOpts {
     pub port_list_id: ScalarUpdate<EntityId>,
     /// SSH credential relationship update: omit, set, or detach.
     pub ssh_credential_id: ScalarUpdate<EntityId>,
-    /// Optional SSH service port nested below a set SSH credential.
-    pub ssh_credential_port: Option<u16>,
+    /// SSH service-port update: omit, set/replace, or reset to gvmd's default.
+    ///
+    /// Setting or clearing the port requires [`Self::ssh_credential_id`] to
+    /// contain [`ScalarUpdate::Set`] because GMP nests the port below a
+    /// credential element carrying the credential identifier. When the
+    /// credential is set and this update is omitted, gvmd selects its default
+    /// SSH port (22); omitting both updates preserves the existing binding.
+    pub ssh_credential_port: ScalarUpdate<ServicePort>,
     /// SMB credential relationship update: omit, set, or detach.
     pub smb_credential_id: ScalarUpdate<EntityId>,
     /// `ESXi` credential relationship update: omit, set, or detach.
@@ -89,12 +95,26 @@ pub struct ModifyTargetOpts {
     pub reverse_lookup_unify: Option<bool>,
 }
 
+/// Errors raised while building a `create_target` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CreateTargetError {
+    /// A service port cannot be encoded without an SSH credential identifier.
+    #[error("setting an SSH credential port requires an SSH credential identifier")]
+    SshPortWithoutCredential,
+}
+
 /// Errors raised while building a `modify_target` request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ModifyTargetError {
     /// gvmd has no wire representation for detaching a target port list.
     #[error("gvmd does not support clearing a target port-list relationship")]
     UnsupportedPortListClear,
+    /// A service-port update cannot be encoded without a credential identifier.
+    #[error("updating an SSH credential port requires setting the SSH credential identifier")]
+    SshPortWithoutCredential,
+    /// A service-port update is incompatible with detaching the credential.
+    #[error("an SSH credential port cannot be updated while detaching the SSH credential")]
+    SshPortWithCredentialClear,
 }
 
 /// Build a clone request for an existing target.
@@ -104,8 +124,18 @@ pub fn clone_target(target_id: &EntityId) -> impl Request {
 }
 
 /// Build a `create_target` request.
-#[must_use]
-pub fn create_target(name: &str, opts: CreateTargetOpts) -> impl Request {
+///
+/// # Errors
+/// Returns [`CreateTargetError::SshPortWithoutCredential`] when a service port
+/// is supplied without the SSH credential identifier required by GMP.
+pub fn create_target(
+    name: &str,
+    opts: CreateTargetOpts,
+) -> Result<impl Request, CreateTargetError> {
+    if opts.ssh_credential_port.is_some() && opts.ssh_credential_id.is_none() {
+        return Err(CreateTargetError::SshPortWithoutCredential);
+    }
+
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -126,7 +156,7 @@ pub fn create_target(name: &str, opts: CreateTargetOpts) -> impl Request {
     if let Some(value) = opts.reverse_lookup_unify {
         cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
     }
-    cmd
+    Ok(cmd)
 }
 
 /// Build a `get_targets` request.
@@ -163,6 +193,15 @@ pub fn modify_target(
 ) -> Result<impl Request, ModifyTargetError> {
     if matches!(opts.port_list_id, ScalarUpdate::Clear) {
         return Err(ModifyTargetError::UnsupportedPortListClear);
+    }
+    match (&opts.ssh_credential_id, &opts.ssh_credential_port) {
+        (ScalarUpdate::Omitted, ScalarUpdate::Set(_) | ScalarUpdate::Clear) => {
+            return Err(ModifyTargetError::SshPortWithoutCredential);
+        }
+        (ScalarUpdate::Clear, ScalarUpdate::Set(_) | ScalarUpdate::Clear) => {
+            return Err(ModifyTargetError::SshPortWithCredentialClear);
+        }
+        _ => {}
     }
 
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
@@ -208,7 +247,19 @@ fn add_create_target_credentials(cmd: &mut XmlCommand, opts: &CreateTargetOpts) 
 fn add_modify_target_credentials(cmd: &mut XmlCommand, opts: &ModifyTargetOpts) {
     match &opts.ssh_credential_id {
         ScalarUpdate::Omitted => {}
-        ScalarUpdate::Set(id) => add_ssh_credential(cmd, Some(id), opts.ssh_credential_port),
+        ScalarUpdate::Set(id) => {
+            let credential = add_credential(cmd, "ssh_credential", id);
+            match opts.ssh_credential_port {
+                ScalarUpdate::Omitted => {}
+                ScalarUpdate::Set(port) => {
+                    credential.add_child_with_text("port", &port.to_string());
+                }
+                ScalarUpdate::Clear => {
+                    // gvmd treats zero on modify as a request to restore port 22.
+                    credential.add_child_with_text("port", "0");
+                }
+            }
+        }
         ScalarUpdate::Clear => {
             add_scalar_id_update(cmd, "ssh_credential", &ScalarUpdate::<EntityId>::Clear);
         }
@@ -218,15 +269,24 @@ fn add_modify_target_credentials(cmd: &mut XmlCommand, opts: &ModifyTargetOpts) 
     add_scalar_id_update(cmd, "snmp_credential", &opts.snmp_credential_id);
 }
 
-fn add_ssh_credential(cmd: &mut XmlCommand, id: Option<&EntityId>, port: Option<u16>) {
+fn add_ssh_credential(cmd: &mut XmlCommand, id: Option<&EntityId>, port: Option<ServicePort>) {
     let Some(id) = id else {
         return;
     };
-    let credential = cmd.add_element("ssh_credential");
-    credential.set_attribute("id", id.as_str());
+    let credential = add_credential(cmd, "ssh_credential", id);
     if let Some(port) = port {
         credential.add_child_with_text("port", &port.to_string());
     }
+}
+
+fn add_credential<'a>(
+    cmd: &'a mut XmlCommand,
+    element: &str,
+    id: &EntityId,
+) -> &'a mut gvm_protocol::xml_command::XmlElement {
+    let credential = cmd.add_element(element);
+    credential.set_attribute("id", id.as_str());
+    credential
 }
 
 fn add_collection_update(cmd: &mut XmlCommand, element: &str, update: &CollectionUpdate<String>) {
@@ -261,14 +321,15 @@ mod tests {
                 alive_test: Some(AliveTest::IcmpPing),
                 port_list_id: Some(id("pl1")),
                 ssh_credential_id: Some(id("ssh1")),
-                ssh_credential_port: Some(2222),
+                ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
                 smb_credential_id: Some(id("smb1")),
                 esxi_credential_id: Some(id("esxi1")),
                 snmp_credential_id: Some(id("snmp1")),
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
             },
-        ));
+        )
+        .expect("valid target"));
         assert!(rendered.contains("<name>target</name>"));
         assert!(rendered.contains("<hosts>1.1.1.1</hosts>"));
         assert!(rendered.contains("<alive_test>ICMP Ping</alive_test>"));
@@ -303,7 +364,7 @@ mod tests {
                 name: Some("n".into()),
                 alive_test: Some(AliveTest::IcmpAndArpPing),
                 ssh_credential_id: ScalarUpdate::set(id("ssh1")),
-                ssh_credential_port: Some(2222),
+                ssh_credential_port: ScalarUpdate::set(ServicePort::new(2222).expect("valid port")),
                 smb_credential_id: ScalarUpdate::set(id("smb1")),
                 esxi_credential_id: ScalarUpdate::set(id("esxi1")),
                 snmp_credential_id: ScalarUpdate::set(id("snmp1")),
@@ -368,7 +429,9 @@ mod tests {
                 &id("t1"),
                 ModifyTargetOpts {
                     ssh_credential_id: ScalarUpdate::set(id("ssh1")),
-                    ssh_credential_port: Some(2222),
+                    ssh_credential_port: ScalarUpdate::set(
+                        ServicePort::new(2222).expect("valid port"),
+                    ),
                     smb_credential_id: ScalarUpdate::set(id("smb1")),
                     ..Default::default()
                 }
@@ -417,6 +480,65 @@ mod tests {
             )
             .err(),
             Some(ModifyTargetError::UnsupportedPortListClear)
+        );
+    }
+
+    #[test]
+    fn modify_target_resets_ssh_port_without_exposing_the_wire_sentinel() {
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                    ssh_credential_port: ScalarUpdate::Clear,
+                    ..Default::default()
+                }
+            )
+            .expect("valid reset")),
+            "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"><port>0</port></ssh_credential></modify_target>"
+        );
+    }
+
+    #[test]
+    fn modify_target_rejects_orphaned_ssh_port_updates() {
+        let port = ServicePort::new(2222).expect("valid port");
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_port: ScalarUpdate::set(port),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SshPortWithoutCredential)
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_id: ScalarUpdate::Clear,
+                    ssh_credential_port: ScalarUpdate::Clear,
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SshPortWithCredentialClear)
+        );
+    }
+
+    #[test]
+    fn create_target_rejects_an_ssh_port_without_a_credential() {
+        assert_eq!(
+            create_target(
+                "target",
+                CreateTargetOpts {
+                    ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(CreateTargetError::SshPortWithoutCredential)
         );
     }
 }

--- a/crates/gvm-gmp/src/lib.rs
+++ b/crates/gvm-gmp/src/lib.rs
@@ -32,4 +32,7 @@ pub use schedule::{
     ScheduleTimestampError, ScheduleTimezone, ScheduleTimezoneError,
 };
 /// Re-exported shared GMP types.
-pub use types::{CollectionUpdate, EntityId, EntityIdError, GmpVersion, ScalarUpdate};
+pub use types::{
+    CollectionUpdate, EntityId, EntityIdError, GmpVersion, ScalarUpdate, ServicePort,
+    ServicePortError,
+};

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -10,6 +10,7 @@ use crate::responses::common::{
     parse_named_entity, parse_u16, status_from_response, ActionResponse, CountInfo, EntityMeta,
     NamedEntity, ParseError,
 };
+use crate::ServicePort;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -23,7 +24,7 @@ pub struct Target {
     pub reverse_lookup_unify: bool,
     pub port_list: Option<NamedEntity>,
     pub ssh_credential: Option<NamedEntity>,
-    pub ssh_credential_port: Option<u16>,
+    pub ssh_credential_port: Option<ServicePort>,
     pub smb_credential: Option<NamedEntity>,
     pub esxi_credential: Option<NamedEntity>,
     pub snmp_credential: Option<NamedEntity>,
@@ -51,6 +52,31 @@ pub struct CreateTargetResponse {
 
 impl Target {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let ssh_credential = parse_named_entity(node, "ssh_credential")?;
+        let raw_ssh_credential_port = node
+            .child("ssh_credential")
+            .and_then(|credential| credential.child_text("port"));
+        let ssh_credential_port = match (ssh_credential.as_ref(), raw_ssh_credential_port) {
+            (None, None) => None,
+            (None, Some(ref port)) if port.is_empty() => None,
+            (None, Some(port)) => {
+                return Err(ParseError::InvalidValue {
+                    field: "ssh_credential.port".to_string(),
+                    value: port,
+                });
+            }
+            (Some(_), None) => None,
+            (Some(_), Some(port)) => {
+                let parsed = parse_u16(&port, "ssh_credential.port")?;
+                Some(
+                    ServicePort::new(parsed).map_err(|_| ParseError::InvalidValue {
+                        field: "ssh_credential.port".to_string(),
+                        value: port,
+                    })?,
+                )
+            }
+        };
+
         Ok(Self {
             meta: parse_entity_meta(node)?,
             hosts: node
@@ -73,12 +99,8 @@ impl Target {
                 .transpose()?
                 .unwrap_or(false),
             port_list: parse_named_entity(node, "port_list")?,
-            ssh_credential: parse_named_entity(node, "ssh_credential")?,
-            ssh_credential_port: node
-                .child("ssh_credential")
-                .and_then(|credential| credential.optional_child_text("port"))
-                .map(|port| parse_u16(&port, "ssh_credential.port"))
-                .transpose()?,
+            ssh_credential,
+            ssh_credential_port,
             smb_credential: parse_named_entity(node, "smb_credential")?,
             esxi_credential: parse_named_entity(node, "esxi_credential")?,
             snmp_credential: parse_named_entity(node, "snmp_credential")?,
@@ -191,7 +213,10 @@ mod tests {
                 .map(|credential| credential.name.as_str()),
             Some("SSH Cred")
         );
-        assert_eq!(parsed.items[0].ssh_credential_port, Some(2222));
+        assert_eq!(
+            parsed.items[0].ssh_credential_port.map(ServicePort::get),
+            Some(2222)
+        );
         assert_eq!(
             parsed.items[0]
                 .smb_credential
@@ -291,6 +316,22 @@ mod tests {
     }
 
     #[test]
+    fn parses_gvmd_unbound_ssh_credential_shape() {
+        let response = Response::from(
+            r#"<get_targets_response status="200" status_text="OK">
+                <target id="t-1">
+                    <name>Target</name>
+                    <ssh_credential id=""><name></name><port></port></ssh_credential>
+                </target>
+            </get_targets_response>"#,
+        );
+
+        let parsed = GetTargetsResponse::from_response(&response).expect("target parses");
+        assert_eq!(parsed.items[0].ssh_credential, None);
+        assert_eq!(parsed.items[0].ssh_credential_port, None);
+    }
+
+    #[test]
     fn rejects_invalid_ssh_credential_port() {
         let response = Response::from(
             r#"<get_targets_response status="200" status_text="OK">
@@ -307,6 +348,47 @@ mod tests {
             error,
             ParseError::InvalidValue { field, value }
                 if field == "ssh_credential.port" && value == "invalid"
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_and_out_of_range_ssh_credential_ports() {
+        for port in ["", "0", "65536"] {
+            let xml = format!(
+                r#"<get_targets_response status="200" status_text="OK">
+                    <target id="t-1">
+                        <name>Target</name>
+                        <ssh_credential id="cred-ssh"><name>SSH</name><port>{port}</port></ssh_credential>
+                    </target>
+                </get_targets_response>"#
+            );
+            let response = Response::from(xml.as_str());
+
+            let error = GetTargetsResponse::from_response(&response).expect_err("invalid port");
+            assert!(matches!(
+                error,
+                ParseError::InvalidValue { field, value }
+                    if field == "ssh_credential.port" && value == port
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_ssh_port_without_a_bound_credential() {
+        let response = Response::from(
+            r#"<get_targets_response status="200" status_text="OK">
+                <target id="t-1">
+                    <name>Target</name>
+                    <ssh_credential id=""><name></name><port>22</port></ssh_credential>
+                </target>
+            </get_targets_response>"#,
+        );
+
+        let error = GetTargetsResponse::from_response(&response).expect_err("inconsistent port");
+        assert!(matches!(
+            error,
+            ParseError::InvalidValue { field, value }
+                if field == "ssh_credential.port" && value == "22"
         ));
     }
 }

--- a/crates/gvm-gmp/src/types.rs
+++ b/crates/gvm-gmp/src/types.rs
@@ -4,6 +4,7 @@
 //! Shared GMP types.
 
 use std::fmt;
+use std::num::NonZeroU16;
 use std::str::FromStr;
 
 /// A collection-valued update in a GMP modify request.
@@ -134,6 +135,58 @@ pub enum EntityIdError {
     Invalid(String),
 }
 
+/// A validated TCP or UDP service port in the range `1..=65535`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct ServicePort(NonZeroU16);
+
+impl ServicePort {
+    /// Create a service port.
+    ///
+    /// # Errors
+    /// Returns an error when `port` is zero.
+    pub fn new(port: u16) -> Result<Self, ServicePortError> {
+        NonZeroU16::new(port)
+            .map(Self)
+            .ok_or(ServicePortError::Zero)
+    }
+
+    /// Return the numeric port value.
+    #[must_use]
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+impl fmt::Display for ServicePort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+impl TryFrom<u16> for ServicePort {
+    type Error = ServicePortError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ServicePort> for u16 {
+    fn from(value: ServicePort) -> Self {
+        value.get()
+    }
+}
+
+/// Errors raised while validating a [`ServicePort`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ServicePortError {
+    /// Port zero is reserved as a gvmd protocol sentinel and is not a service port.
+    #[error("service port must be in the range 1..=65535")]
+    Zero,
+}
+
 /// GMP protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -160,6 +213,16 @@ mod tests {
     fn entity_id_accepts_valid_values() {
         let id = EntityId::new("550e8400-e29b-41d4-a716-446655440000").expect("valid id");
         assert_eq!(id.as_str(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn service_port_rejects_zero() {
+        assert_eq!(ServicePort::new(22).expect("valid port").get(), 22);
+        assert_eq!(
+            ServicePort::new(u16::MAX).expect("valid port").get(),
+            65_535
+        );
+        assert_eq!(ServicePort::new(0), Err(ServicePortError::Zero));
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -7,12 +7,12 @@ mod common;
 
 use common::{id, xml};
 use gvm_gmp::commands::targets::*;
-use gvm_gmp::AliveTest;
+use gvm_gmp::{AliveTest, ScalarUpdate, ServicePort};
 
 #[test]
 fn test_create_target_basic() {
     assert_eq!(
-        xml(create_target("target", Default::default())),
+        xml(create_target("target", Default::default()).expect("valid target")),
         "<create_target><name>target</name></create_target>"
     );
 }
@@ -20,9 +20,10 @@ fn test_create_target_basic() {
 #[test]
 fn test_create_target_with_optionals() {
     assert_eq!(
-        xml(create_target(
-            "target",
-            CreateTargetOpts {
+        xml(
+            create_target(
+                "target",
+                CreateTargetOpts {
                 comment: Some("c".into()),
                 hosts: vec!["1.1.1.1".into(), "2.2.2.2".into()],
                 exclude_hosts: vec!["3.3.3.3".into()],
@@ -31,8 +32,10 @@ fn test_create_target_with_optionals() {
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
                 ..Default::default()
-            }
-        )),
+                },
+            )
+            .expect("valid target"),
+        ),
         "<create_target><name>target</name><comment>c</comment><hosts>1.1.1.1,2.2.2.2</hosts><exclude_hosts>3.3.3.3</exclude_hosts><alive_test>ICMP &amp; ARP Ping</alive_test><port_list id=\"pl1\"/><reverse_lookup_only>1</reverse_lookup_only><reverse_lookup_unify>0</reverse_lookup_unify></create_target>"
     );
 }
@@ -40,14 +43,17 @@ fn test_create_target_with_optionals() {
 #[test]
 fn test_target_ssh_credential_port_is_nested_in_credential() {
     assert_eq!(
-        xml(create_target(
-            "target",
-            CreateTargetOpts {
+        xml(
+            create_target(
+                "target",
+                CreateTargetOpts {
                 ssh_credential_id: Some(id("ssh1")),
-                ssh_credential_port: Some(2222),
+                ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
                 ..Default::default()
-            }
-        )),
+                },
+            )
+            .expect("valid target"),
+        ),
         "<create_target><name>target</name><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></create_target>"
     );
 
@@ -55,13 +61,28 @@ fn test_target_ssh_credential_port_is_nested_in_credential() {
         xml(modify_target(
             &id("target1"),
             ModifyTargetOpts {
-                ssh_credential_id: gvm_gmp::ScalarUpdate::set(id("ssh1")),
-                ssh_credential_port: Some(2222),
+                ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                ssh_credential_port: ScalarUpdate::set(
+                    ServicePort::new(2222).expect("valid port"),
+                ),
                 ..Default::default()
             }
         )
         .expect("valid target update")),
         "<modify_target target_id=\"target1\"><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></modify_target>"
+    );
+
+    assert_eq!(
+        xml(modify_target(
+            &id("target1"),
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                ssh_credential_port: ScalarUpdate::Clear,
+                ..Default::default()
+            }
+        )
+        .expect("valid target update")),
+        "<modify_target target_id=\"target1\"><ssh_credential id=\"ssh1\"><port>0</port></ssh_credential></modify_target>"
     );
 }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -830,6 +830,16 @@ impl SessionHandler {
         if resource_type == "credential" {
             if let Some(credential_type) = parse_element_text(raw_xml, "type") {
                 resource.set_attr("type", &credential_type);
+            } else {
+                // Match gvmd's legacy inference: a password produces a
+                // username/password credential; otherwise gvmd accepts or
+                // generates username/SSH-key material.
+                let inferred_type = if parse_element_text(raw_xml, "password").is_some() {
+                    "up"
+                } else {
+                    "usk"
+                };
+                resource.set_attr("type", inferred_type);
             }
             if let Some(login) = parse_element_text(raw_xml, "login") {
                 resource.set_attr("login", &login);
@@ -3931,19 +3941,46 @@ fn target_credential_update(
         return Ok(TargetCredentialUpdate::Omitted);
     };
     if id == "0" {
-        return Ok(TargetCredentialUpdate::Clear);
+        return if cmd.name == "modify_target" {
+            Ok(TargetCredentialUpdate::Clear)
+        } else {
+            Err((400, "Credential detach sentinel is only valid on modify"))
+        };
     }
     let id = Uuid::parse_str(id).map_err(|_| (400, "Invalid credential UUID"))?;
-    if store.get_typed(&id, "credential").is_none() {
-        return Err((404, "Credential not found"));
+    let credential = store
+        .get_typed(&id, "credential")
+        .ok_or((404, "Credential not found"))?;
+    let credential_type = credential.attr("type").unwrap_or("usk");
+    let type_supported = match element {
+        "ssh_credential" => matches!(credential_type, "up" | "usk" | "cs_up" | "cs_usk"),
+        "smb_credential" => matches!(credential_type, "up" | "cs_up"),
+        _ => true,
+    };
+    if !type_supported {
+        return Err((400, "Credential type is not valid for target binding"));
     }
-    let port = nested_child_text(cmd, &[element, "port"])
-        .map(|value| value.parse::<u16>())
-        .transpose()
-        .map_err(|_| (400, "Invalid credential port"))?;
-    if port == Some(0) {
-        return Err((400, "Invalid credential port"));
+    let raw_port = nested_child_text(cmd, &[element, "port"]);
+    if element != "ssh_credential" && raw_port.is_some() {
+        return Err((400, "Credential type does not support a service port"));
     }
+    let port = if element == "ssh_credential" {
+        match raw_port.as_deref().map(str::trim) {
+            None => Some(22),
+            Some("") | Some("0") if cmd.name == "modify_target" => Some(22),
+            Some(value) => {
+                let port = value
+                    .parse::<u16>()
+                    .map_err(|_| (400, "Invalid credential port"))?;
+                if port == 0 {
+                    return Err((400, "Invalid credential port"));
+                }
+                Some(port)
+            }
+        }
+    } else {
+        None
+    };
 
     Ok(TargetCredentialUpdate::Set { id, port })
 }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -381,18 +381,25 @@ impl Resource {
                     xml_escape_attr(port_list_id),
                 ));
             }
-            for credential in ["ssh_credential", "smb_credential"] {
-                let Some(id) = self.attr(&format!("{credential}_id")) else {
-                    continue;
-                };
+            if let Some(id) = self.attr("ssh_credential_id") {
                 xml.push_str(&format!(
-                    "<{credential} id=\"{}\"><name></name>",
+                    "<ssh_credential id=\"{}\"><name></name>",
                     xml_escape_attr(id),
                 ));
-                if let Some(port) = self.attr(&format!("{credential}_port")) {
+                if let Some(port) = self.attr("ssh_credential_port") {
                     xml.push_str(&format!("<port>{}</port>", xml_escape(port)));
                 }
-                xml.push_str(&format!("</{credential}>"));
+                xml.push_str("</ssh_credential>");
+            } else {
+                xml.push_str("<ssh_credential id=\"\"><name></name><port></port></ssh_credential>");
+            }
+            if let Some(id) = self.attr("smb_credential_id") {
+                xml.push_str(&format!(
+                    "<smb_credential id=\"{}\"><name></name></smb_credential>",
+                    xml_escape_attr(id),
+                ));
+            } else {
+                xml.push_str("<smb_credential id=\"\"><name></name></smb_credential>");
             }
         }
         // Add type-specific attributes
@@ -474,7 +481,6 @@ impl Resource {
                         | "ssh_credential_id"
                         | "ssh_credential_port"
                         | "smb_credential_id"
-                        | "smb_credential_port"
                 )
             {
                 continue;

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -78,6 +78,7 @@ async fn connect(server: &MockGmpServer) -> UnixStream {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn matrix_targets_create_get_delete() {
     let Some(server) = stateful_server().await else {
         return;
@@ -87,7 +88,19 @@ async fn matrix_targets_create_get_delete() {
 
     let credential_id = create_and_get_id(
         &mut stream,
-        b"<create_credential><name>Matrix SSH</name></create_credential>",
+        b"<create_credential><name>Matrix SSH</name><type>usk</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let smb_credential_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Matrix SMB</name><type>up</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let invalid_credential_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Matrix Password</name><type>pw</type></create_credential>",
         "create_credential",
     )
     .await;
@@ -118,21 +131,117 @@ async fn matrix_targets_create_get_delete() {
     let modify_resp = send_recv(
         &mut stream,
         format!(
-            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"{credential_id}\"><port>22</port></ssh_credential></modify_target>"
+            "<modify_target target_id=\"{target_id}\"><comment>port omitted</comment></modify_target>"
         )
         .as_bytes(),
     )
     .await;
     assert_eq!(modify_resp.status_code(), Some(200));
-    let modified = send_recv(
+    let preserved = send_recv(
         &mut stream,
         format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
     )
     .await;
-    assert!(modified
+    assert!(preserved
+        .as_str()
+        .expect("valid utf8")
+        .contains("<port>2222</port>"));
+
+    let reset_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"{credential_id}\"><port>0</port></ssh_credential></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(reset_resp.status_code(), Some(200));
+    let reset = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(reset
         .as_str()
         .expect("valid utf8")
         .contains("<port>22</port>"));
+
+    let detach_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"0\"/></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(detach_resp.status_code(), Some(200));
+    let detached = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(detached
+        .as_str()
+        .expect("valid utf8")
+        .contains("<ssh_credential id=\"\"><name></name><port></port></ssh_credential>"));
+
+    let default_target_id = create_and_get_id(
+        &mut stream,
+        format!(
+            "<create_target><name>Default SSH Port</name><hosts>127.0.0.2</hosts><ssh_credential id=\"{credential_id}\"/></create_target>"
+        )
+        .as_bytes(),
+        "create_target",
+    )
+    .await;
+    let default_target = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{default_target_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert!(default_target
+        .as_str()
+        .expect("valid utf8")
+        .contains("<port>22</port>"));
+
+    let smb_port_resp = send_recv(
+        &mut stream,
+        format!(
+            "<create_target><name>Invalid SMB Port</name><hosts>127.0.0.3</hosts><smb_credential id=\"{smb_credential_id}\"><port>445</port></smb_credential></create_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(smb_port_resp.status_code(), Some(400));
+
+    let create_detach_resp = send_recv(
+        &mut stream,
+        b"<create_target><name>Invalid Detach</name><hosts>127.0.0.4</hosts><ssh_credential id=\"0\"/></create_target>",
+    )
+    .await;
+    assert_eq!(create_detach_resp.status_code(), Some(400));
+
+    for credential_element in ["ssh_credential", "smb_credential"] {
+        let invalid_type_resp = send_recv(
+            &mut stream,
+            format!(
+                "<create_target><name>Invalid Type {credential_element}</name><hosts>127.0.0.5</hosts><{credential_element} id=\"{invalid_credential_id}\"/></create_target>"
+            )
+            .as_bytes(),
+        )
+        .await;
+        assert_eq!(invalid_type_resp.status_code(), Some(400));
+
+        let invalid_modify_type_resp = send_recv(
+            &mut stream,
+            format!(
+                "<modify_target target_id=\"{default_target_id}\"><{credential_element} id=\"{invalid_credential_id}\"/></modify_target>"
+            )
+            .as_bytes(),
+        )
+        .await;
+        assert_eq!(invalid_modify_type_resp.status_code(), Some(400));
+    }
 
     let delete_resp = send_recv(
         &mut stream,

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -194,7 +194,8 @@ async fn base_commands_work_on_all_versions() {
                     hosts: vec!["127.0.0.1".to_string()],
                     ..CreateTargetOpts::default()
                 },
-            ),
+            )
+            .expect("valid target"),
         )
         .await;
         assert_eq!(response.status_code(), Some(201));

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -320,19 +320,32 @@ representation for detaching an existing port list. Consequently,
 `CreateTargetOpts::port_list_id` remains `Option<EntityId>` because target
 creation only needs to distinguish including a port list from leaving it out.
 
-### Target SSH Credential Ports
+### Target Credential Service Ports
 
-`CreateTargetOpts` and `ModifyTargetOpts` carry an optional typed SSH service
-port next to the credential relationship. The command builders serialize it as
-the nested `<ssh_credential><port>` GMP field, and typed target observations
-parse the same nested field into `Target::ssh_credential_port`. Both list and
-single-target client reads therefore preserve explicit default and non-default
-ports without caller-side XML handling.
-The stateful mock server also preserves alive-test values, SSH/SMB target
-credential relationships, and SSH ports across create, modify, and get
-operations for Unix composition tests. Stateful responses use gvmd's plural
-`alive_tests` observation field while requests retain the singular `alive_test`
-field.
+`CreateTargetOpts` and `ModifyTargetOpts` expose the SSH service port next to
+the credential relationship. `ServicePort` validates the gvmd-supported
+range `1..=65535`; typed target observations reject zero, nonnumeric, and
+out-of-range backend values instead of losing malformed data. Both list and
+single-target client reads preserve effective default and custom ports.
+
+This is an intentional pre-1.0 API break: create ports use
+`Option<ServicePort>`, modify ports use `ScalarUpdate<ServicePort>`, and the
+low-level `create_target` builder now returns `Result` so a port without an SSH
+credential ID fails explicitly. The high-level client exposes the same failure
+as `GvmError::CreateTarget` before any request is sent.
+
+Modify requests distinguish leaving the binding untouched, setting or replacing
+the port, resetting it to gvmd's default port 22, and detaching the credential.
+The reset operation keeps gvmd's numeric sentinel internal to the command
+builder. The stateful mock mirrors these defaults and round trips SSH and SMB
+credential identifiers, but rejects SMB service ports because current GMP/gvmd
+only defines a nested port for the SSH credential. It also rejects create-time
+detach sentinels and credential types that gvmd does not allow for SSH or SMB
+target bindings.
+
+The stateful mock also preserves target alive-test values. Stateful responses
+use gvmd's plural `alive_tests` observation field while requests retain the
+singular `alive_test` field.
 
 ### Command Modules (29)
 


### PR DESCRIPTION
## Summary

- Replace raw target SSH port integers with a validated ServicePort type covering the supported 1 through 65535 range.
- Make create_target reject ports without an SSH credential before transport, and model modify omission, replacement, default reset, and detach semantics explicitly.
- Parse gvmd bound and unbound SSH credential response shapes without accepting malformed, zero, or inconsistent ports.
- Align the stateful mock with gvmd default port, empty binding, credential type, detach sentinel, and SSH-versus-SMB validation behavior.
- Extend command, parser, typed client, fixture, and stateful mock coverage for default and custom ports, replacement, reset, detach, invalid inputs, and preserved unrelated target fields.
- Document the intentional pre-1.0 API break and current SSH-only credential-port protocol support.

Fixes #473