### PR TITLE
Expose native schedule last_run in typed observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ keeps the existing value. Valid but unsupported timezone or recurrence semantics
 typed observation instead of being treated as one-time schedules. Floating or
 `TZID`-qualified iCalendar starts remain observable but are not converted locally;
 typed `first_run_at` and `next_run_at` values use gvmd's normalized response fields.
+The native nullable `last_run` response is likewise available both as raw
+`last_run` text and as a validated, UTC-normalized `last_run_at` timestamp; it
+is never inferred from task reports or recurrence data.
 
 #### Raw API (send/call)
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -4939,6 +4939,8 @@ async fn typed_schedule_create_observe_modify_and_reobserve() {
         .expect("created schedule should be listed");
     assert_eq!(schedule.first_run_at.as_ref(), Some(&first_run));
     assert_eq!(schedule.next_run_at.as_ref(), Some(&first_run));
+    assert_eq!(schedule.last_run, None);
+    assert_eq!(schedule.last_run_at, None);
     assert_eq!(
         schedule.observation.as_ref().map(|value| &value.recurrence),
         Some(&ScheduleRecurrenceObservation::Supported(
@@ -4996,6 +4998,59 @@ async fn typed_schedule_create_observe_modify_and_reobserve() {
             ScheduleRecurrence::Weekly
         ))
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_schedule_observes_native_last_run_from_stateful_server() {
+    let mut seeded = Resource::new("schedule", "Previously Run Schedule");
+    seeded.set_attr(
+        "icalendar",
+        "BEGIN:VEVENT\nDTSTART:20300101T000000Z\nRRULE:FREQ=DAILY\nEND:VEVENT",
+    );
+    seeded.set_attr("timezone", "UTC");
+    seeded.set_attr("first_run", "2030-01-01T00:00:00Z");
+    seeded.set_attr("next_run", "2030-01-03T00:00:00Z");
+    seeded.set_attr("last_run", "2030-01-02T01:00:00+01:00");
+    let schedule_id = seeded.id.to_string();
+
+    let server = match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(MockVersion::V22_5)
+        .unix_socket_auto()
+        .seed(move |store| store.seed(seeded))
+        .build()
+        .await
+    {
+        Ok(server) => server,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+        Err(error) => panic!("server should start: {error}"),
+    };
+    let mut client = GmpClient::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let schedules = client
+        .get_schedules(GetSchedulesOpts::default())
+        .await
+        .expect("schedule observation should succeed");
+    let schedule = schedules
+        .items
+        .iter()
+        .find(|schedule| schedule.meta.id.as_str() == schedule_id)
+        .expect("seeded schedule is listed");
+    let expected =
+        ScheduleTimestamp::parse("2030-01-02T00:00:00Z").expect("valid expected timestamp");
+    assert_eq!(
+        schedule.last_run.as_deref(),
+        Some("2030-01-02T01:00:00+01:00")
+    );
+    assert_eq!(schedule.last_run_at.as_ref(), Some(&expected));
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/responses/schedule.rs
+++ b/crates/gvm-gmp/src/responses/schedule.rs
@@ -23,6 +23,8 @@ pub struct Schedule {
     pub first_run: Option<String>,
     /// Raw next-run value retained for compatibility.
     pub next_run: Option<String>,
+    /// Raw last-run value reported by gvmd and retained for compatibility.
+    pub last_run: Option<String>,
     pub duration: Option<u32>,
     /// Typed semantics parsed from `icalendar`.
     pub observation: Option<ScheduleObservation>,
@@ -30,6 +32,8 @@ pub struct Schedule {
     pub first_run_at: Option<ScheduleTimestamp>,
     /// Validated next-run timestamp reported by gvmd.
     pub next_run_at: Option<ScheduleTimestamp>,
+    /// Validated nullable last-run timestamp reported by gvmd.
+    pub last_run_at: Option<ScheduleTimestamp>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,16 +85,27 @@ impl Schedule {
                 field: "schedule.next_run".to_string(),
                 value: next_run.clone().unwrap_or_default(),
             })?;
+        let last_run = node.optional_child_text("last_run");
+        let last_run_at = last_run
+            .as_deref()
+            .map(ScheduleTimestamp::parse)
+            .transpose()
+            .map_err(|_| ParseError::InvalidValue {
+                field: "schedule.last_run".to_string(),
+                value: last_run.clone().unwrap_or_default(),
+            })?;
         Ok(Self {
             meta: parse_entity_meta(node)?,
             icalendar,
             timezone,
             first_run,
             next_run,
+            last_run,
             duration: optional_u32(node, "duration", "duration")?,
             observation,
             first_run_at,
             next_run_at,
+            last_run_at,
         })
     }
 }
@@ -154,6 +169,7 @@ mod tests {
                     <timezone>UTC</timezone>
                     <first_run>2026-01-03T00:00:00Z</first_run>
                     <next_run>2026-01-04T00:00:00Z</next_run>
+                    <last_run>2026-01-02T23:00:00-01:00</last_run>
                     <duration>3600</duration>
                 </schedule>
                 <schedule id="s-2">
@@ -180,6 +196,10 @@ mod tests {
             parsed.items[0].next_run.as_deref(),
             Some("2026-01-04T00:00:00Z")
         );
+        assert_eq!(
+            parsed.items[0].last_run.as_deref(),
+            Some("2026-01-02T23:00:00-01:00")
+        );
         assert_eq!(parsed.items[0].duration, Some(3600));
         assert_eq!(
             parsed.items[0]
@@ -194,6 +214,13 @@ mod tests {
                 .as_ref()
                 .map(ScheduleTimestamp::as_str),
             Some("2026-01-04T00:00:00Z")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .last_run_at
+                .as_ref()
+                .map(ScheduleTimestamp::as_str),
+            Some("2026-01-03T00:00:00Z")
         );
         assert!(parsed.items[1].meta.in_use);
     }
@@ -255,10 +282,12 @@ mod tests {
         assert_eq!(schedule.timezone, None);
         assert_eq!(schedule.first_run, None);
         assert_eq!(schedule.next_run, None);
+        assert_eq!(schedule.last_run, None);
         assert_eq!(schedule.duration, None);
         assert_eq!(schedule.observation, None);
         assert_eq!(schedule.first_run_at, None);
         assert_eq!(schedule.next_run_at, None);
+        assert_eq!(schedule.last_run_at, None);
     }
 
     #[test]
@@ -288,6 +317,19 @@ mod tests {
         let error = GetSchedulesResponse::from_response(&response).expect_err("time must fail");
         assert!(matches!(error, ParseError::InvalidValue { field, value }
                 if field == "schedule.next_run" && value == "tomorrow"));
+    }
+
+    #[test]
+    fn rejects_invalid_last_run_timestamp() {
+        let response = Response::from(
+            r#"<get_schedules_response status="200" status_text="OK">
+                <schedule id="s-1"><name>Invalid Last Run</name><last_run>yesterday</last_run></schedule>
+            </get_schedules_response>"#,
+        );
+
+        let error = GetSchedulesResponse::from_response(&response).expect_err("time must fail");
+        assert!(matches!(error, ParseError::InvalidValue { field, value }
+                if field == "schedule.last_run" && value == "yesterday"));
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/fixtures.rs
+++ b/crates/gvm-mock-server/src/fixtures.rs
@@ -346,10 +346,11 @@ impl FixtureStore {
             "<get_schedules_response status=\"200\" status_text=\"OK\">\
              <schedule id=\"{{uuid}}\">\
              <name>Weekly Scan</name>\
-             <icalendar>BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:20300101T000000Z\nRRULE:FREQ=WEEKLY\nEND:VEVENT\nEND:VCALENDAR</icalendar>\
+             <icalendar>BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:20291218T000000Z\nRRULE:FREQ=WEEKLY\nEND:VEVENT\nEND:VCALENDAR</icalendar>\
              <timezone>UTC</timezone>\
-             <first_run>2030-01-01T00:00:00Z</first_run>\
+             <first_run>2029-12-18T00:00:00Z</first_run>\
              <next_run>2030-01-01T00:00:00Z</next_run>\
+             <last_run>2029-12-25T00:00:00Z</last_run>\
              <creation_time>{{now}}</creation_time>\
              <modification_time>{{now}}</modification_time>\
              </schedule>\

--- a/crates/gvm-mock-server/tests/fixture_coverage.rs
+++ b/crates/gvm-mock-server/tests/fixture_coverage.rs
@@ -203,6 +203,10 @@ async fn fixture_get_schedules() {
     };
     let r = send_recv(&mut s, b"<get_schedules/>").await;
     assert!(r.is_success());
+    assert!(r
+        .as_str()
+        .expect("utf8")
+        .contains("<last_run>2029-12-25T00:00:00Z</last_run>"));
     server.shutdown().await;
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -22,7 +22,8 @@ See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility polic
 
 Schedule create/modify supports typed first-run input and once, hourly, daily,
 weekly, and yearly recurrence. Schedule observations expose normalized typed
-first-run/next-run timestamps reported by gvmd and distinguish floating or
+first-run/next-run timestamps and the nullable native last-run timestamp reported
+by gvmd, and distinguish floating or
 `TZID`-qualified starts, recurrence dates, exclusions, and unsupported recurrence
 rules from one-time schedules; raw iCalendar remains available for compatibility.
 Raw create follows gvmd's default-timezone behavior, and raw modify requires an


### PR DESCRIPTION
## Summary

- add raw nullable `last_run` and validated UTC-normalized `last_run_at` fields to typed schedule responses
- preserve absent values while surfacing malformed native timestamps as typed parse errors
- cover populated, missing, and malformed values in parser, fixture, stateful mock, and typed client integration paths
- document native schedule last-run observations without deriving them from recurrence data or task reports

Fixes #471