### PR TITLE
Fix target alive-test GMP element

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3285,7 +3285,7 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
         return;
     };
     let mut client = authenticated_client(&server).await;
-    for alive_test in ["<alive_test/>", "<alive_test>   </alive_test>"] {
+    for alive_test in ["<alive_tests/>", "<alive_tests>   </alive_tests>"] {
         assert_raw_server_error(
             &mut client,
             format!(
@@ -3296,6 +3296,7 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
         )
         .await;
     }
+
     let target = client
         .create_target(
             "Alive Test Target",
@@ -3356,9 +3357,9 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
     }
 
     for alive_test in [
-        "<alive_test/>",
-        "<alive_test>   </alive_test>",
-        "<alive_test>Not An Alive Test</alive_test>",
+        "<alive_tests/>",
+        "<alive_tests>   </alive_tests>",
+        "<alive_tests>Not An Alive Test</alive_tests>",
     ] {
         assert_raw_server_error(
             &mut client,
@@ -3371,6 +3372,63 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
         )
         .await;
     }
+    assert_eq!(
+        target_by_id(&mut client, &target.id)
+            .await
+            .alive_tests
+            .as_deref(),
+        Some(AliveTest::ConsiderAlive.as_target_name())
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn raw_singular_target_alive_test_matches_gvmd_behavior() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let singular_create = client
+        .call(
+            b"<create_target><name>Singular Alive Test</name><hosts>192.0.2.3</hosts><alive_test>ICMP Ping</alive_test></create_target>"
+                .to_vec(),
+        )
+        .await
+        .expect("singular alive test should be ignored on create");
+    let singular_target_id = singular_create
+        .id()
+        .expect("created target ID")
+        .parse()
+        .expect("valid target ID");
+    assert_eq!(
+        target_by_id(&mut client, &singular_target_id)
+            .await
+            .alive_tests,
+        None
+    );
+
+    let target = client
+        .create_target(
+            "Plural Alive Test",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.4".into()],
+                alive_test: Some(AliveTest::ConsiderAlive),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("plural alive test should be applied on create");
+    assert_raw_server_error(
+        &mut client,
+        format!(
+            "<modify_target target_id=\"{}\"><alive_test>ICMP Ping</alive_test></modify_target>",
+            target.id,
+        )
+        .into_bytes(),
+        400,
+    )
+    .await;
     assert_eq!(
         target_by_id(&mut client, &target.id)
             .await

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3152,7 +3152,10 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
         .await
         .expect("target should be created");
     let created = target_by_id(&mut client, &target.id).await;
-    assert_eq!(created.alive_tests, None);
+    assert_eq!(
+        created.alive_tests.as_deref(),
+        Some(AliveTest::ScanConfigDefault.as_target_name())
+    );
     assert_target_credentials(&created, &first_ssh, 2222, &first_smb);
 
     client
@@ -3166,7 +3169,10 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
         .await
         .expect("omitted target fields should be preserved");
     let preserved = target_by_id(&mut client, &target.id).await;
-    assert_eq!(preserved.alive_tests, None);
+    assert_eq!(
+        preserved.alive_tests.as_deref(),
+        Some(AliveTest::ScanConfigDefault.as_target_name())
+    );
     assert_target_credentials(&preserved, &first_ssh, 2222, &first_smb);
 
     client
@@ -3404,8 +3410,9 @@ async fn raw_singular_target_alive_test_matches_gvmd_behavior() {
     assert_eq!(
         target_by_id(&mut client, &singular_target_id)
             .await
-            .alive_tests,
-        None
+            .alive_tests
+            .as_deref(),
+        Some(AliveTest::ScanConfigDefault.as_target_name())
     );
 
     let target = client

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -146,7 +146,7 @@ pub fn create_target(
         cmd.add_element_with_text("exclude_hosts", &opts.exclude_hosts.join(","));
     }
     if let Some(alive_test) = opts.alive_test {
-        cmd.add_element_with_text("alive_test", alive_test.as_target_name());
+        cmd.add_element_with_text("alive_tests", alive_test.as_target_name());
     }
     add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
     add_create_target_credentials(&mut cmd, &opts);
@@ -210,7 +210,7 @@ pub fn modify_target(
     add_collection_update(&mut cmd, "hosts", &opts.hosts);
     add_collection_update(&mut cmd, "exclude_hosts", &opts.exclude_hosts);
     if let Some(alive_test) = opts.alive_test {
-        cmd.add_element_with_text("alive_test", alive_test.as_target_name());
+        cmd.add_element_with_text("alive_tests", alive_test.as_target_name());
     }
     if let ScalarUpdate::Set(port_list_id) = &opts.port_list_id {
         add_optional_id_element(&mut cmd, "port_list", Some(port_list_id));
@@ -332,7 +332,7 @@ mod tests {
         .expect("valid target"));
         assert!(rendered.contains("<name>target</name>"));
         assert!(rendered.contains("<hosts>1.1.1.1</hosts>"));
-        assert!(rendered.contains("<alive_test>ICMP Ping</alive_test>"));
+        assert!(rendered.contains("<alive_tests>ICMP Ping</alive_tests>"));
         assert!(rendered.contains("<port_list id=\"pl1\"/>"));
         assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
@@ -375,7 +375,7 @@ mod tests {
         )
         .expect("valid target update"));
         assert!(rendered.contains("<name>n</name>"));
-        assert!(rendered.contains("<alive_test>ICMP &amp; ARP Ping</alive_test>"));
+        assert!(rendered.contains("<alive_tests>ICMP &amp; ARP Ping</alive_tests>"));
         assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -36,7 +36,24 @@ fn test_create_target_with_optionals() {
             )
             .expect("valid target"),
         ),
-        "<create_target><name>target</name><comment>c</comment><hosts>1.1.1.1,2.2.2.2</hosts><exclude_hosts>3.3.3.3</exclude_hosts><alive_test>ICMP &amp; ARP Ping</alive_test><port_list id=\"pl1\"/><reverse_lookup_only>1</reverse_lookup_only><reverse_lookup_unify>0</reverse_lookup_unify></create_target>"
+        "<create_target><name>target</name><comment>c</comment><hosts>1.1.1.1,2.2.2.2</hosts><exclude_hosts>3.3.3.3</exclude_hosts><alive_tests>ICMP &amp; ARP Ping</alive_tests><port_list id=\"pl1\"/><reverse_lookup_only>1</reverse_lookup_only><reverse_lookup_unify>0</reverse_lookup_unify></create_target>"
+    );
+}
+
+#[test]
+fn test_modify_target_uses_plural_alive_tests_element() {
+    let request = modify_target(
+        &id("target1"),
+        ModifyTargetOpts {
+            alive_test: Some(AliveTest::IcmpPing),
+            ..Default::default()
+        },
+    )
+    .expect("valid target update");
+
+    assert_eq!(
+        xml(request),
+        "<modify_target target_id=\"target1\"><alive_tests>ICMP Ping</alive_tests></modify_target>"
     );
 }
 

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -3920,7 +3920,14 @@ enum TargetCredentialUpdate {
 }
 
 fn target_alive_test_update(cmd: &ParsedCommand) -> Result<Option<AliveTest>, &'static str> {
-    let Some(element) = cmd.children.iter().find(|child| child.name == "alive_test") else {
+    if cmd.name == "modify_target" && cmd.children.iter().any(|child| child.name == "alive_test") {
+        return Err("Invalid element: alive_test");
+    }
+    let Some(element) = cmd
+        .children
+        .iter()
+        .find(|child| child.name == "alive_tests")
+    else {
         return Ok(None);
     };
     let value = element
@@ -4138,7 +4145,7 @@ mod tests {
         assert_eq!(target_alive_test_update(&omitted), Ok(None));
 
         let valid = parse_command(
-            b"<create_target><alive_test>ICMP &amp; ARP Ping</alive_test></create_target>",
+            b"<create_target><alive_tests>ICMP &amp; ARP Ping</alive_tests></create_target>",
         )
         .expect("parse valid alive test");
         assert_eq!(
@@ -4146,11 +4153,24 @@ mod tests {
             Ok(Some(AliveTest::IcmpAndArpPing))
         );
 
+        let singular_create =
+            parse_command(b"<create_target><alive_test>ICMP Ping</alive_test></create_target>")
+                .expect("parse singular create alive test");
+        assert_eq!(target_alive_test_update(&singular_create), Ok(None));
+
+        let singular_modify =
+            parse_command(b"<modify_target><alive_test>ICMP Ping</alive_test></modify_target>")
+                .expect("parse singular modify alive test");
+        assert_eq!(
+            target_alive_test_update(&singular_modify),
+            Err("Invalid element: alive_test")
+        );
+
         for xml in [
-            "<create_target><alive_test/></create_target>",
-            "<create_target><alive_test></alive_test></create_target>",
-            "<create_target><alive_test>   </alive_test></create_target>",
-            "<create_target><alive_test>Unknown</alive_test></create_target>",
+            "<create_target><alive_tests/></create_target>",
+            "<create_target><alive_tests></alive_tests></create_target>",
+            "<create_target><alive_tests>   </alive_tests></create_target>",
+            "<create_target><alive_tests>Unknown</alive_tests></create_target>",
         ] {
             let command = parse_command(xml.as_bytes()).expect("parse invalid alive test");
             assert_eq!(

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -6,6 +6,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
+use gvm_gmp::AliveTest;
 use uuid::Uuid;
 
 use crate::util::{now_iso, xml_escape, xml_escape_attr};
@@ -369,12 +370,13 @@ impl Resource {
             }
         }
         if self.resource_type == "target" {
-            if let Some(alive_test) = self.attr("alive_test") {
-                xml.push_str(&format!(
-                    "<alive_tests>{}</alive_tests>",
-                    xml_escape(alive_test),
-                ));
-            }
+            let alive_test = self
+                .attr("alive_test")
+                .unwrap_or(AliveTest::ScanConfigDefault.as_target_name());
+            xml.push_str(&format!(
+                "<alive_tests>{}</alive_tests>",
+                xml_escape(alive_test),
+            ));
             if let Some(port_list_id) = self.attr("port_list_id") {
                 xml.push_str(&format!(
                     "<port_list id=\"{}\"><name></name></port_list>",
@@ -1707,6 +1709,24 @@ mod tests {
         let xml = resource.to_xml();
 
         assert!(xml.find("<alpha>").unwrap() < xml.find("<zeta>").unwrap());
+    }
+
+    #[test]
+    fn target_xml_always_observes_an_alive_test() {
+        let default_target = Resource::new("target", "Default");
+        assert!(default_target
+            .to_xml()
+            .contains("<alive_tests>Scan Config Default</alive_tests>"));
+
+        let mut explicit_target = Resource::new("target", "Explicit");
+        explicit_target.set_attr("alive_test", AliveTest::IcmpPing.as_target_name());
+        assert!(explicit_target
+            .to_xml()
+            .contains("<alive_tests>ICMP Ping</alive_tests>"));
+
+        assert!(!Resource::new("task", "Task")
+            .to_xml()
+            .contains("<alive_tests>"));
     }
 
     #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -344,8 +344,8 @@ detach sentinels and credential types that gvmd does not allow for SSH or SMB
 target bindings.
 
 The stateful mock also preserves target alive-test values. Stateful responses
-use gvmd's plural `alive_tests` observation field while requests retain the
-singular `alive_test` field.
+and create/modify requests use gvmd's plural `alive_tests` field. The typed
+request option remains named `alive_test` for source compatibility.
 
 ### Command Modules (29)
 
@@ -357,13 +357,16 @@ AlertEvent, AlertCondition, AlertMethod, AliveTest, AggregateStatistic, Credenti
 
 ### Tests
 
-| Category | Count |
-|----------|-------|
+`cargo test -p gvm-gmp --all-features -- --list` currently discovers 640 tests.
+The categories below are a tracked subset of that complete inventory.
+
+| Tracked category | Count |
+|------------------|-------|
 | Inline unit tests (command XML) | 80 |
-| External command tests | 53 |
+| External command tests | 54 |
 | Enum exhaustive tests | 347 |
 | EntityId/type tests | 6 |
-| **Total gvm-gmp** | **480** |
+| **Tracked subset** | **487** |
 
 ## gvm-client
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -345,7 +345,9 @@ target bindings.
 
 The stateful mock also preserves target alive-test values. Stateful responses
 and create/modify requests use gvmd's plural `alive_tests` field. The typed
-request option remains named `alive_test` for source compatibility.
+request option remains named `alive_test` for source compatibility. Target
+responses without an explicit alive-test value report `Scan Config Default`,
+matching gvmd's observation behavior.
 
 ### Command Modules (29)
 


### PR DESCRIPTION
## Summary

- serialize target create and modify alive-test options with GMP's plural `alive_tests` element while preserving the public Rust option name
- align the stateful mock with gvmd behavior for plural requests and obsolete singular create/modify requests
- make target observations always expose `alive_tests`, defaulting to `Scan Config Default` when no explicit value is stored
- add builder, store, and Unix-socket round-trip regressions for typed, raw, default, and explicit target behavior
- clarify the gvm-gmp test inventory and correct its tracked-subset count

Fixes #478