### PR TITLE
Fix stateful task schedule relationships

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -55,7 +55,10 @@ use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetError, CreateTargetOpts, GetTargetsOpts,
     ModifyTargetError, ModifyTargetOpts,
 };
-use gvm_gmp::commands::tasks::{create_task, delete_task, get_task, start_task, stop_task};
+use gvm_gmp::commands::tasks::{
+    create_task, delete_task, get_task, start_task, stop_task, CreateTaskOpts, GetTasksOpts,
+    ModifyTaskOpts,
+};
 use gvm_gmp::commands::tickets::{
     CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts, TicketOpenNote,
 };
@@ -4996,6 +4999,332 @@ async fn typed_schedule_create_observe_modify_and_reobserve() {
             ScheduleRecurrence::Weekly
         ))
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn typed_task_schedule_relationship_round_trip_and_dependency_ordering() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = GmpClient::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let target = client
+        .create_target(
+            "Scheduled Task Target",
+            CreateTargetOpts {
+                hosts: vec!["127.0.0.1".to_string()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("target create should succeed");
+    let config_id = "daba56c8-73ec-11df-a475-002264764cea"
+        .parse()
+        .expect("config id");
+    let scanner_id = "08b69003-5fc2-4037-a479-93b440211c73"
+        .parse()
+        .expect("scanner id");
+    let schedule_input = |timestamp: &str| {
+        ScheduleInput::new(
+            ScheduleDefinition {
+                first_run: ScheduleTimestamp::parse(timestamp).expect("valid timestamp"),
+                recurrence: ScheduleRecurrence::Daily,
+            },
+            ScheduleTimezone::new("UTC").expect("valid timezone"),
+        )
+    };
+    let first_schedule = client
+        .create_typed_schedule(
+            "First Task Schedule",
+            schedule_input("2030-01-01T00:00:00Z"),
+        )
+        .await
+        .expect("first schedule create should succeed");
+    let second_schedule = client
+        .create_typed_schedule(
+            "Second Task Schedule",
+            schedule_input("2031-01-01T00:00:00Z"),
+        )
+        .await
+        .expect("second schedule create should succeed");
+
+    let unscheduled = client
+        .create_task(
+            "Unscheduled Task",
+            &config_id,
+            &target.id,
+            &scanner_id,
+            CreateTaskOpts::default(),
+        )
+        .await
+        .expect("unscheduled task create should succeed");
+    let tasks = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed");
+    let unscheduled_task = tasks
+        .items
+        .iter()
+        .find(|task| task.meta.id == unscheduled.id)
+        .expect("unscheduled task should be listed");
+    assert!(unscheduled_task.schedule.is_none());
+    assert_eq!(unscheduled_task.schedule_periods, Some(0));
+    client
+        .delete_task(&unscheduled.id, true)
+        .await
+        .expect("unscheduled task delete should succeed");
+
+    let scheduled = client
+        .create_task(
+            "Scheduled Task",
+            &config_id,
+            &target.id,
+            &scanner_id,
+            CreateTaskOpts {
+                schedule_id: Some(first_schedule.id.clone()),
+                schedule_periods: Some(3),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("scheduled task create should succeed");
+    let observed = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("created task should be listed");
+    assert_eq!(
+        observed
+            .schedule
+            .as_ref()
+            .expect("created task should expose its schedule")
+            .id,
+        first_schedule.id
+    );
+    assert_eq!(observed.schedule_periods, Some(3));
+
+    client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                comment: Some("schedule omitted".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("omitting schedule should preserve it");
+    let preserved = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("scheduled task should be listed");
+    assert_eq!(
+        preserved
+            .schedule
+            .as_ref()
+            .expect("omitted schedule should remain attached")
+            .id,
+        first_schedule.id
+    );
+    assert_eq!(preserved.schedule_periods, Some(3));
+
+    client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                schedule_id: ScalarUpdate::set(second_schedule.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("schedule replacement should succeed");
+    let replaced = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("scheduled task should be listed");
+    assert_eq!(
+        replaced
+            .schedule
+            .as_ref()
+            .expect("replaced schedule should be exposed")
+            .id,
+        second_schedule.id
+    );
+    assert_eq!(replaced.schedule_periods, Some(0));
+
+    client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                schedule_periods: Some(7),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("period-only update should succeed");
+    let period_updated = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("scheduled task should be listed");
+    assert_eq!(
+        period_updated
+            .schedule
+            .as_ref()
+            .expect("period-only update should preserve the schedule")
+            .id,
+        second_schedule.id
+    );
+    assert_eq!(period_updated.schedule_periods, Some(7));
+
+    let missing_schedule: EntityId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        .parse()
+        .expect("missing schedule id");
+    let create_error = client
+        .create_task(
+            "Missing Schedule Task",
+            &config_id,
+            &target.id,
+            &scanner_id,
+            CreateTaskOpts {
+                schedule_id: Some(missing_schedule.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("missing schedule create should fail");
+    assert!(
+        matches!(
+            &create_error,
+            GvmError::Parse(ParseError::ServerError { status: 404, .. })
+        ),
+        "unexpected create error: {create_error:?}"
+    );
+    let modify_error = client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                schedule_id: ScalarUpdate::set(missing_schedule),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("missing schedule replacement should fail");
+    assert!(
+        matches!(
+            &modify_error,
+            GvmError::Parse(ParseError::ServerError { status: 404, .. })
+        ),
+        "unexpected modify error: {modify_error:?}"
+    );
+    let after_failed_update = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("scheduled task should be listed");
+    assert_eq!(
+        after_failed_update
+            .schedule
+            .as_ref()
+            .expect("failed update must preserve the schedule")
+            .id,
+        second_schedule.id
+    );
+    assert_eq!(after_failed_update.schedule_periods, Some(7));
+
+    let dependency_error = client
+        .delete_schedule(&second_schedule.id, true)
+        .await
+        .expect_err("attached schedule deletion should fail");
+    assert!(matches!(
+        dependency_error,
+        GvmError::Parse(ParseError::ServerError { status: 409, .. })
+    ));
+    client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                schedule_id: ScalarUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("schedule clearing should succeed");
+    let cleared = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task observation should succeed")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == scheduled.id)
+        .expect("scheduled task should be listed");
+    assert!(cleared.schedule.is_none());
+    assert_eq!(cleared.schedule_periods, Some(0));
+
+    client
+        .delete_schedule(&second_schedule.id, true)
+        .await
+        .expect("detached schedule delete should succeed");
+    client
+        .modify_task(
+            &scheduled.id,
+            ModifyTaskOpts {
+                schedule_id: ScalarUpdate::set(first_schedule.id.clone()),
+                schedule_periods: Some(4),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("schedule reattachment should succeed");
+    client
+        .delete_task(&scheduled.id, false)
+        .await
+        .expect("task trash should succeed");
+    let trashed_dependency_error = client
+        .delete_schedule(&first_schedule.id, true)
+        .await
+        .expect_err("trashed dependent task should block permanent schedule deletion");
+    assert!(matches!(
+        trashed_dependency_error,
+        GvmError::Parse(ParseError::ServerError { status: 409, .. })
+    ));
+    client
+        .delete_task(&scheduled.id, true)
+        .await
+        .expect("permanent task delete should succeed");
+    client
+        .delete_schedule(&first_schedule.id, true)
+        .await
+        .expect("schedule delete after dependent task should succeed");
+    client
+        .delete_target(&target.id, true)
+        .await
+        .expect("target delete should succeed");
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -27,8 +27,8 @@ use crate::response_gen::{
 use crate::scenario::{ScenarioEngine, ScenarioMode, ScenarioOutcome, ScenarioStep};
 use crate::store::{
     AssetInputProfile, DeleteAssetResult, Resource, ResourceStore, SpecializedTaskTarget,
-    StoreError, TaskReferenceUpdates, TaskReferences, TaskStatus, DEFAULT_CONFIG_ID,
-    DEFAULT_SCANNER_ID,
+    StoreError, TaskReferenceUpdates, TaskReferences, TaskScheduleUpdate, TaskStatus,
+    DEFAULT_CONFIG_ID, DEFAULT_SCANNER_ID,
 };
 use crate::util::{xml_escape, xml_escape_attr};
 use crate::version::{command_available, GmpVersion};
@@ -3234,6 +3234,7 @@ fn optional_child_uuid(
             "target" => "Missing target id",
             "config" => "Missing config id",
             "scanner" => "Missing scanner id",
+            "schedule" => "Missing schedule id",
             "task" => "Missing task id",
             "port_list" => "Missing port list id",
             _ => "Missing resource id",
@@ -3243,6 +3244,7 @@ fn optional_child_uuid(
         "target" => "Invalid target UUID",
         "config" => "Invalid config UUID",
         "scanner" => "Invalid scanner UUID",
+        "schedule" => "Invalid schedule UUID",
         "task" => "Invalid task UUID",
         "port_list" => "Invalid port list UUID",
         _ => "Invalid resource UUID",
@@ -3262,6 +3264,8 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
             specialized_target: None,
             config: None,
             scanner: None,
+            schedule: None,
+            schedule_periods: None,
         });
     }
     if let Some(specialized_target) = specialized_target {
@@ -3273,6 +3277,8 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
             specialized_target: Some(specialized_target),
             config: optional_child_uuid(cmd, "config")?,
             scanner: Some(optional_child_uuid(cmd, "scanner")?.ok_or("A scanner is required")?),
+            schedule: optional_child_uuid(cmd, "schedule")?,
+            schedule_periods: task_schedule_periods(cmd)?,
         });
     }
     let target = optional_child_uuid(cmd, "target")?.ok_or("A target is required")?;
@@ -3283,6 +3289,8 @@ fn task_references(cmd: &ParsedCommand) -> Result<TaskReferences, &'static str> 
         specialized_target: None,
         config: Some(config),
         scanner: Some(scanner),
+        schedule: optional_child_uuid(cmd, "schedule")?,
+        schedule_periods: task_schedule_periods(cmd)?,
     })
 }
 
@@ -3297,7 +3305,41 @@ fn task_reference_updates(cmd: &ParsedCommand) -> Result<TaskReferenceUpdates, &
         specialized_target,
         config: optional_child_uuid(cmd, "config")?,
         scanner: optional_child_uuid(cmd, "scanner")?,
+        schedule: task_schedule_update(cmd)?,
+        schedule_periods: task_schedule_periods(cmd)?,
     })
+}
+
+fn task_schedule_periods(cmd: &ParsedCommand) -> Result<Option<u32>, &'static str> {
+    let Some(periods) = cmd
+        .children
+        .iter()
+        .find(|child| child.name == "schedule_periods")
+    else {
+        return Ok(None);
+    };
+    let Some(periods) = periods.text.as_deref() else {
+        return Err("Invalid schedule periods");
+    };
+    periods
+        .parse::<u32>()
+        .map(Some)
+        .map_err(|_| "Invalid schedule periods")
+}
+
+fn task_schedule_update(cmd: &ParsedCommand) -> Result<TaskScheduleUpdate, &'static str> {
+    let Some(schedule) = cmd.children.iter().find(|child| child.name == "schedule") else {
+        return Ok(TaskScheduleUpdate::Omitted);
+    };
+    let Some(id) = schedule.attributes.get("id") else {
+        return Err("Missing schedule id");
+    };
+    if id == "0" {
+        return Ok(TaskScheduleUpdate::Clear);
+    }
+    Uuid::parse_str(id)
+        .map(TaskScheduleUpdate::Set)
+        .map_err(|_| "Invalid schedule UUID")
 }
 
 fn specialized_task_target(
@@ -3335,6 +3377,7 @@ fn store_error_response(command_name: &str, error: StoreError) -> Vec<u8> {
         StoreError::InUse(resource_type) => {
             error_response(command_name, 409, &format!("{resource_type} is in use"))
         }
+        StoreError::InvalidArgument(message) => error_response(command_name, 400, message),
         StoreError::InvalidState(message) => error_response(command_name, 409, message),
         StoreError::Inconsistent(resource_type) => error_response(
             command_name,
@@ -4186,6 +4229,7 @@ mod tests {
             ("target", "Missing target id", "Invalid target UUID"),
             ("config", "Missing config id", "Invalid config UUID"),
             ("scanner", "Missing scanner id", "Invalid scanner UUID"),
+            ("schedule", "Missing schedule id", "Invalid schedule UUID"),
             ("task", "Missing task id", "Invalid task UUID"),
             (
                 "port_list",
@@ -4208,6 +4252,29 @@ mod tests {
             assert_eq!(
                 optional_child_uuid(&invalid, child_name),
                 Err(invalid_message)
+            );
+        }
+    }
+
+    #[test]
+    fn task_schedule_periods_accepts_u32_and_rejects_invalid_values() {
+        let omitted = parse_command(b"<modify_task/>").expect("parse omitted periods");
+        assert_eq!(task_schedule_periods(&omitted), Ok(None));
+
+        let valid =
+            parse_command(b"<modify_task><schedule_periods>7</schedule_periods></modify_task>")
+                .expect("parse valid periods");
+        assert_eq!(task_schedule_periods(&valid), Ok(Some(7)));
+
+        for value in ["", "-1", "not-a-number", "4294967296"] {
+            let command = parse_command(
+                format!("<modify_task><schedule_periods>{value}</schedule_periods></modify_task>")
+                    .as_bytes(),
+            )
+            .expect("parse invalid periods");
+            assert_eq!(
+                task_schedule_periods(&command),
+                Err("Invalid schedule periods")
             );
         }
     }

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -43,6 +43,7 @@ pub(crate) const DEFAULT_SCANNER_ID: Uuid =
 pub(crate) enum StoreError {
     NotFound(String),
     InUse(&'static str),
+    InvalidArgument(&'static str),
     InvalidState(&'static str),
     Inconsistent(&'static str),
 }
@@ -84,6 +85,16 @@ pub(crate) struct TaskReferences {
     pub specialized_target: Option<SpecializedTaskTarget>,
     pub config: Option<Uuid>,
     pub scanner: Option<Uuid>,
+    pub schedule: Option<Uuid>,
+    pub schedule_periods: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum TaskScheduleUpdate {
+    #[default]
+    Omitted,
+    Set(Uuid),
+    Clear,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -92,14 +103,16 @@ pub(crate) struct TaskReferenceUpdates {
     pub specialized_target: Option<SpecializedTaskTarget>,
     pub config: Option<Uuid>,
     pub scanner: Option<Uuid>,
+    pub schedule: TaskScheduleUpdate,
+    pub schedule_periods: Option<u32>,
 }
 
 impl TaskReferenceUpdates {
-    fn is_empty(self) -> bool {
-        self.target.is_none()
-            && self.specialized_target.is_none()
-            && self.config.is_none()
-            && self.scanner.is_none()
+    fn changes_scan_definition(self) -> bool {
+        self.target.is_some()
+            || self.specialized_target.is_some()
+            || self.config.is_some()
+            || self.scanner.is_some()
     }
 }
 
@@ -357,6 +370,10 @@ impl Resource {
                     ));
                 }
             }
+            xml.push_str(&format!(
+                "<schedule_periods>{}</schedule_periods>",
+                xml_escape(self.attr("schedule_periods").unwrap_or("0")),
+            ));
         }
         if self.resource_type == "user" {
             if let Some(role_ids) = self.attr("role_ids") {
@@ -505,6 +522,7 @@ impl Resource {
                         | "config_id"
                         | "scanner_id"
                         | "schedule_id"
+                        | "schedule_periods"
                 )
             {
                 continue;
@@ -643,6 +661,11 @@ fn stored_task_reference(
 }
 
 fn validate_stored_task_references(inner: &StoreInner, task: &Resource) -> Result<(), StoreError> {
+    if let Some(schedule_id) = task.attr("schedule_id") {
+        let schedule_id =
+            Uuid::parse_str(schedule_id).map_err(|_| StoreError::Inconsistent("schedule"))?;
+        validate_task_reference(inner, &schedule_id, "schedule")?;
+    }
     if task.attr("import_task") == Some("1") {
         return Ok(());
     }
@@ -770,6 +793,14 @@ impl ResourceStore {
             validate_task_reference(&inner, &scanner, "scanner")?;
             task.set_attr("scanner_id", &scanner.to_string());
         }
+        if let Some(schedule) = references.schedule {
+            validate_task_reference(&inner, &schedule, "schedule")?;
+            task.set_attr("schedule_id", &schedule.to_string());
+        }
+        task.set_attr(
+            "schedule_periods",
+            &references.schedule_periods.unwrap_or(0).to_string(),
+        );
         if references.target.is_none() && references.specialized_target.is_none() {
             task.attrs.remove("target_id");
             task.set_attr("import_task", "1");
@@ -904,12 +935,20 @@ impl ResourceStore {
         F: FnOnce(&mut Resource),
     {
         let mut inner = self.inner.write().expect("store lock poisoned");
-        let status = active_typed_resource(&inner, id, "task")?
+        let task = active_typed_resource(&inner, id, "task")?;
+        let status = task
             .attr("status")
             .ok_or(StoreError::Inconsistent("task status"))?
             .to_string();
+        let import_task = task.attr("import_task") == Some("1");
 
-        if !references.is_empty() && status != TaskStatus::New.as_str() {
+        if import_task && references.schedule != TaskScheduleUpdate::Omitted {
+            return Err(StoreError::InvalidArgument(
+                "Import tasks cannot have a schedule",
+            ));
+        }
+
+        if references.changes_scan_definition() && status != TaskStatus::New.as_str() {
             return Err(StoreError::InvalidState(
                 "Task references can only be changed while the task is New",
             ));
@@ -925,6 +964,9 @@ impl ResourceStore {
         }
         if let Some(scanner) = references.scanner {
             validate_task_reference(&inner, &scanner, "scanner")?;
+        }
+        if let TaskScheduleUpdate::Set(schedule) = references.schedule {
+            validate_task_reference(&inner, &schedule, "schedule")?;
         }
 
         let task = inner
@@ -957,6 +999,27 @@ impl ResourceStore {
         }
         if let Some(scanner) = references.scanner {
             task.set_attr("scanner_id", &scanner.to_string());
+        }
+        match references.schedule {
+            TaskScheduleUpdate::Omitted => {
+                if let Some(schedule_periods) = references.schedule_periods {
+                    task.set_attr("schedule_periods", &schedule_periods.to_string());
+                }
+            }
+            TaskScheduleUpdate::Set(schedule) => {
+                task.set_attr("schedule_id", &schedule.to_string());
+                task.set_attr(
+                    "schedule_periods",
+                    &references.schedule_periods.unwrap_or(0).to_string(),
+                );
+            }
+            TaskScheduleUpdate::Clear => {
+                task.attrs.remove("schedule_id");
+                task.set_attr(
+                    "schedule_periods",
+                    &references.schedule_periods.unwrap_or(0).to_string(),
+                );
+            }
         }
         f(task);
         task.modification_time = now_iso();
@@ -1024,6 +1087,7 @@ impl ResourceStore {
             }
             "config" => Some(("config_id", "config")),
             "scanner" => Some(("scanner_id", "scanner")),
+            "schedule" => Some(("schedule_id", "schedule")),
             _ => None,
         };
         if let Some((reference_key, referenced_type)) = task_reference {
@@ -1031,7 +1095,7 @@ impl ResourceStore {
             let referenced = inner.resources.values().any(|candidate| {
                 candidate.resource_type == "task"
                     && candidate.attr(reference_key) == Some(id.as_str())
-                    && !candidate.trashed
+                    && (!candidate.trashed || (resource_type == "schedule" && ultimate))
             });
             if referenced {
                 return Err(StoreError::InUse(referenced_type));
@@ -1453,6 +1517,8 @@ mod tests {
                     specialized_target: None,
                     config: Some(DEFAULT_CONFIG_ID),
                     scanner: Some(DEFAULT_SCANNER_ID),
+                    schedule: None,
+                    schedule_periods: None,
                 },
             )
             .expect("valid task graph")
@@ -1783,6 +1849,8 @@ mod tests {
                     specialized_target: None,
                     config: Some(config_id),
                     scanner: Some(scanner_id),
+                    schedule: TaskScheduleUpdate::Omitted,
+                    schedule_periods: None,
                 },
                 |_| {},
             )
@@ -1796,6 +1864,145 @@ mod tests {
             Some(scanner_id.to_string().as_str())
         );
         assert!(!store.modify_typed(&target_id, "task", |_| {}));
+    }
+
+    #[test]
+    fn task_schedule_periods_follow_gvmd_update_semantics_in_any_task_state() {
+        let store = ResourceStore::new();
+        let target_id = store.create(Resource::new("target", "Scheduled Target"));
+        let first_schedule = store.create(Resource::new("schedule", "First Schedule"));
+        let second_schedule = store.create(Resource::new("schedule", "Second Schedule"));
+        let task_id = store
+            .create_task(
+                Resource::new("task", "Scheduled Task"),
+                TaskReferences {
+                    target: Some(target_id),
+                    specialized_target: None,
+                    config: Some(DEFAULT_CONFIG_ID),
+                    scanner: Some(DEFAULT_SCANNER_ID),
+                    schedule: Some(first_schedule),
+                    schedule_periods: Some(5),
+                },
+            )
+            .expect("create scheduled task");
+        assert!(store.modify(&task_id, |task| {
+            task.set_attr("status", TaskStatus::Running.as_str());
+        }));
+
+        store
+            .modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule_periods: Some(4),
+                    ..Default::default()
+                },
+                |_| {},
+            )
+            .expect("period-only update should preserve the schedule");
+        let task = store.get(&task_id).expect("task");
+        assert_eq!(
+            task.attr("schedule_id"),
+            Some(first_schedule.to_string().as_str())
+        );
+        assert_eq!(task.attr("schedule_periods"), Some("4"));
+
+        store
+            .modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule: TaskScheduleUpdate::Set(second_schedule),
+                    ..Default::default()
+                },
+                |_| {},
+            )
+            .expect("schedule replacement should reset omitted periods");
+        let task = store.get(&task_id).expect("task");
+        assert_eq!(
+            task.attr("schedule_id"),
+            Some(second_schedule.to_string().as_str())
+        );
+        assert_eq!(task.attr("schedule_periods"), Some("0"));
+
+        store
+            .modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule: TaskScheduleUpdate::Clear,
+                    schedule_periods: Some(2),
+                    ..Default::default()
+                },
+                |_| {},
+            )
+            .expect("schedule clearing should apply supplied periods");
+        let task = store.get(&task_id).expect("task");
+        assert_eq!(task.attr("schedule_id"), None);
+        assert_eq!(task.attr("schedule_periods"), Some("2"));
+    }
+
+    #[test]
+    fn import_task_schedule_updates_are_rejected_atomically() {
+        let store = ResourceStore::new();
+        let schedule_id = store.create(Resource::new("schedule", "Ignored Schedule"));
+        let task_id = store
+            .create_task(
+                Resource::new("task", "Imported"),
+                TaskReferences {
+                    target: None,
+                    specialized_target: None,
+                    config: None,
+                    scanner: None,
+                    schedule: None,
+                    schedule_periods: None,
+                },
+            )
+            .expect("create import task");
+
+        assert_eq!(
+            store.modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule: TaskScheduleUpdate::Set(schedule_id),
+                    schedule_periods: Some(4),
+                    ..Default::default()
+                },
+                |_| {},
+            ),
+            Err(StoreError::InvalidArgument(
+                "Import tasks cannot have a schedule"
+            ))
+        );
+        let task = store.get(&task_id).expect("import task");
+        assert_eq!(task.attr("schedule_id"), None);
+        assert_eq!(task.attr("schedule_periods"), Some("0"));
+
+        store
+            .modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule_periods: Some(7),
+                    ..Default::default()
+                },
+                |_| {},
+            )
+            .expect("period-only import task update");
+
+        assert_eq!(
+            store.modify_task(
+                &task_id,
+                TaskReferenceUpdates {
+                    schedule: TaskScheduleUpdate::Clear,
+                    schedule_periods: Some(3),
+                    ..Default::default()
+                },
+                |_| {},
+            ),
+            Err(StoreError::InvalidArgument(
+                "Import tasks cannot have a schedule"
+            ))
+        );
+        let task = store.get(&task_id).expect("import task");
+        assert_eq!(task.attr("schedule_id"), None);
+        assert_eq!(task.attr("schedule_periods"), Some("7"));
     }
 
     #[test]
@@ -1848,6 +2055,8 @@ mod tests {
                     specialized_target: None,
                     config: Some(config_id),
                     scanner: Some(scanner_id),
+                    schedule: None,
+                    schedule_periods: None,
                 },
             )
             .expect("create task");
@@ -1866,6 +2075,49 @@ mod tests {
                 .expect("trashed task must not block permanent deletion");
             assert!(store.get(&id).is_none());
         }
+    }
+
+    #[test]
+    fn trashed_tasks_block_permanent_schedule_deletion() {
+        let store = ResourceStore::new();
+        let target_id = store.create(Resource::new("target", "Scheduled Target"));
+        let schedule_id = store.create(Resource::new("schedule", "Retained Schedule"));
+        let task_id = store
+            .create_task(
+                Resource::new("task", "Trashed Scheduled Task"),
+                TaskReferences {
+                    target: Some(target_id),
+                    specialized_target: None,
+                    config: Some(DEFAULT_CONFIG_ID),
+                    scanner: Some(DEFAULT_SCANNER_ID),
+                    schedule: Some(schedule_id),
+                    schedule_periods: Some(2),
+                },
+            )
+            .expect("create scheduled task");
+
+        store
+            .delete_typed(&task_id, "task", false)
+            .expect("trash task");
+        assert_eq!(
+            store.delete_typed(&schedule_id, "schedule", true),
+            Err(StoreError::InUse("schedule"))
+        );
+
+        store
+            .delete_typed(&schedule_id, "schedule", false)
+            .expect("trash schedule referenced only by a trashed task");
+        assert_eq!(
+            store.delete_typed(&schedule_id, "schedule", true),
+            Err(StoreError::InUse("schedule"))
+        );
+
+        store
+            .delete_typed(&task_id, "task", true)
+            .expect("permanently delete dependent task");
+        store
+            .delete_typed(&schedule_id, "schedule", true)
+            .expect("permanently delete unreferenced schedule");
     }
 
     #[test]
@@ -1953,6 +2205,8 @@ mod tests {
                     specialized_target: None,
                     config: None,
                     scanner: None,
+                    schedule: None,
+                    schedule_periods: None,
                 },
             )
             .expect("import task");

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -39,6 +39,24 @@ async fn server() -> Option<MockGmpServer> {
     }
 }
 
+async fn server_with_schedule() -> Option<(MockGmpServer, String)> {
+    let schedule = Resource::new("schedule", "Import-Ignored Schedule");
+    let schedule_id = schedule.id.to_string();
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .seed(move |store| store.seed(schedule))
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some((server, schedule_id)),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server start failed: {error}"),
+    }
+}
+
 async fn connect_and_auth(server: &MockGmpServer) -> UnixStream {
     let mut stream = UnixStream::connect(server.socket_path().expect("socket path"))
         .await
@@ -83,6 +101,95 @@ async fn create_task(stream: &mut UnixStream, name: &str, target_id: &str) -> St
     .await;
     assert_eq!(response.status_code(), Some(201));
     id(&response)
+}
+
+async fn assert_import_schedule_state(stream: &mut UnixStream, task_id: &str, periods: u32) {
+    let response = send_recv(
+        stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+    let text = response.as_str().expect("UTF-8 response");
+    assert!(!text.contains("<schedule id="), "{text}");
+    assert!(
+        text.contains(&format!("<schedule_periods>{periods}</schedule_periods>")),
+        "{text}"
+    );
+}
+
+#[tokio::test]
+async fn import_task_creation_ignores_schedule_fields_without_validating_them() {
+    let Some((server, schedule_id)) = server_with_schedule().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+
+    let commands = [
+        format!(
+            "<create_task><name>Valid Ignored Schedule</name><target id=\"0\"/><schedule id=\"{schedule_id}\"/><schedule_periods>3</schedule_periods></create_task>"
+        ),
+        "<create_task><name>Missing Ignored Schedule</name><target id=\"0\"/><schedule/><schedule_periods/></create_task>".to_string(),
+        "<create_task><name>Malformed Ignored Schedule</name><target id=\"0\"/><schedule id=\"not-a-uuid\"/><schedule_periods>not-a-number</schedule_periods></create_task>".to_string(),
+    ];
+
+    for command in commands {
+        let response = send_recv(&mut stream, command.as_bytes()).await;
+        assert_eq!(response.status_code(), Some(201), "{command}");
+        assert_import_schedule_state(&mut stream, &id(&response), 0).await;
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn import_task_modify_rejects_schedule_ids_but_allows_periods_only() {
+    let Some((server, schedule_id)) = server_with_schedule().await else {
+        return;
+    };
+    let mut stream = connect_and_auth(&server).await;
+    let create = send_recv(
+        &mut stream,
+        b"<create_task><name>Mutable Import</name><target id=\"0\"/></create_task>",
+    )
+    .await;
+    assert_eq!(create.status_code(), Some(201));
+    let task_id = id(&create);
+
+    let set = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><schedule id=\"{schedule_id}\"/><schedule_periods>4</schedule_periods></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(set.status_code(), Some(400));
+    assert_import_schedule_state(&mut stream, &task_id, 0).await;
+
+    let periods_only = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><schedule_periods>7</schedule_periods></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(periods_only.status_code(), Some(200));
+    assert_import_schedule_state(&mut stream, &task_id, 7).await;
+
+    let clear = send_recv(
+        &mut stream,
+        format!(
+            "<modify_task task_id=\"{task_id}\"><schedule id=\"0\"/><schedule_periods>3</schedule_periods></modify_task>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(clear.status_code(), Some(400));
+    assert_import_schedule_state(&mut stream, &task_id, 7).await;
+
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -149,6 +149,7 @@ iCalendar payload.
 | create_ticket (result_id + comment) | ✅ | Non-standard element parsing |
 | modify_ticket (status attribute) | ✅ | Ticket-specific handling |
 | Trash/restore/empty_trashcan | ✅ | Full trashcan lifecycle |
+| Task schedule relationships | ✅ | Stateful create/get persistence, schedule-period round trips, omit/set/clear modify semantics, reference validation, and dependency-safe deletion |
 
 ### Fault Injection
 


### PR DESCRIPTION
## Summary

- Persist, validate, and render optional task schedule references and schedule periods in stateful mock mode.
- Implement GVMD-compatible schedule omit, replace, clear, and period-only modification semantics, including atomic rejection of schedule changes on import tasks.
- Ignore schedule fields during import-task creation, matching GVMD behavior.
- Prevent permanent deletion of schedules still referenced by active or trashed tasks.
- Add typed-client, raw-protocol, and store-level regression coverage for relationship round trips, invalid references, import behavior, and dependency ordering.
- Record task schedule relationship support in the implementation status documentation.

Fixes #472