### PR TITLE
Fix typed task report lifecycle rendering

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -101,8 +101,8 @@ use gvm_gmp::commands::secinfo::{
 };
 use gvm_gmp::commands::system::{
     describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
-    get_vulns, modify_auth, modify_license_with_opts, run_wizard_with_opts,
-    FilteredGetOpts, ModifyLicenseOpts, RunWizardOpts,
+    get_vulns, modify_auth, modify_license_with_opts, run_wizard_with_opts, FilteredGetOpts,
+    ModifyLicenseOpts, RunWizardOpts,
 };
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
@@ -164,8 +164,7 @@ use gvm_gmp::responses::{
     ModifyScannerResponse, ModifyScheduleResponse, ModifyTargetResponse, ModifyTaskResponse,
     ModifyTicketResponse, ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport,
     RestoreResponse, ResumeTaskResponse, RunWizardResponse, StartTaskResponse, StopTaskResponse,
-    SyncConfigResponse,
-    VerifyCredentialStoreResponse, VerifyScannerResponse,
+    SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::{CredentialStoreCredentialType, FeedType, ScheduleInput};

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -4561,6 +4561,7 @@ async fn typed_trashcan_helpers_restore_deleted_task() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn typed_resume_task_returns_report_id() {
     let Some(server) = stateful_server().await else {
         return;
@@ -4611,19 +4612,62 @@ async fn typed_resume_task_returns_report_id() {
         .await
         .expect("start_task should succeed");
     assert_eq!(start_response.status, 202);
-    assert!(start_response.report_id.is_some());
+    let report_id = start_response
+        .report_id
+        .expect("start should return report id");
+    let running = client
+        .get_tasks(Default::default())
+        .await
+        .expect("running task should be observable")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == task_id)
+        .expect("started task should be returned");
+    assert_eq!(
+        running.current_report.as_ref().map(|report| &report.id),
+        Some(&report_id)
+    );
+    assert_eq!(running.last_report, None);
 
     client
         .call(stop_task(&task_id))
         .await
         .expect("stop_task should succeed");
+    let stopped = client
+        .get_tasks(Default::default())
+        .await
+        .expect("stopped task should be observable")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == task_id)
+        .expect("stopped task should be returned");
+    assert_eq!(stopped.status.as_deref(), Some("Stopped"));
+    assert_eq!(
+        stopped.current_report.as_ref().map(|report| &report.id),
+        Some(&report_id)
+    );
+    assert_eq!(stopped.last_report, None);
 
     let resume_response = client
         .resume_task(&task_id)
         .await
         .expect("resume_task should succeed");
     assert_eq!(resume_response.status, 202);
-    assert!(resume_response.report_id.is_some());
+    assert_eq!(resume_response.report_id.as_ref(), Some(&report_id));
+    let resumed = client
+        .get_tasks(Default::default())
+        .await
+        .expect("resumed task should be observable")
+        .items
+        .into_iter()
+        .find(|task| task.meta.id == task_id)
+        .expect("resumed task should be returned");
+    assert_eq!(resumed.status.as_deref(), Some("Running"));
+    assert_eq!(
+        resumed.current_report.as_ref().map(|report| &report.id),
+        Some(&report_id)
+    );
+    assert_eq!(resumed.last_report, None);
 
     client
         .call(delete_task(&task_id, true))

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -148,6 +148,17 @@ impl TaskStatus {
             Self::Interrupted => "Interrupted",
         }
     }
+
+    /// Return the gvmd task response wrapper used for the task's stored report.
+    fn report_reference_element(status: &str) -> Option<&'static str> {
+        match status {
+            "Requested" | "Running" | "Stop Requested" | "Stopped" | "Interrupted" => {
+                Some("current_report")
+            }
+            "Done" => Some("last_report"),
+            _ => None,
+        }
+    }
 }
 
 /// A stored GMP resource (generic for all resource types).
@@ -374,6 +385,16 @@ impl Resource {
                 "<schedule_periods>{}</schedule_periods>",
                 xml_escape(self.attr("schedule_periods").unwrap_or("0")),
             ));
+            if let (Some(report_id), Some(report_element)) = (
+                self.attr("report_id"),
+                self.attr("status")
+                    .and_then(TaskStatus::report_reference_element),
+            ) {
+                xml.push_str(&format!(
+                    "<{report_element}><report id=\"{}\"></report></{report_element}>",
+                    xml_escape_attr(report_id),
+                ));
+            }
         }
         if self.resource_type == "user" {
             if let Some(role_ids) = self.attr("role_ids") {
@@ -523,6 +544,7 @@ impl Resource {
                         | "scanner_id"
                         | "schedule_id"
                         | "schedule_periods"
+                        | "report_id"
                 )
             {
                 continue;
@@ -1793,6 +1815,28 @@ mod tests {
         assert!(!Resource::new("task", "Task")
             .to_xml()
             .contains("<alive_tests>"));
+    }
+
+    #[test]
+    fn task_xml_uses_typed_report_reference_vocabulary() {
+        let report_id = Uuid::new_v4();
+        let mut running = Resource::new("task", "Running Task");
+        running.set_attr("status", TaskStatus::Running.as_str());
+        running.set_attr("report_id", &report_id.to_string());
+        let running_xml = running.to_xml();
+        assert!(running_xml.contains(&format!(
+            "<current_report><report id=\"{report_id}\"></report></current_report>"
+        )));
+        assert!(!running_xml.contains("<report_id>"));
+
+        let mut done = Resource::new("task", "Done Task");
+        done.set_attr("status", TaskStatus::Done.as_str());
+        done.set_attr("report_id", &report_id.to_string());
+        let done_xml = done.to_xml();
+        assert!(done_xml.contains(&format!(
+            "<last_report><report id=\"{report_id}\"></report></last_report>"
+        )));
+        assert!(!done_xml.contains("<report_id>"));
     }
 
     #[test]

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -24,8 +24,8 @@ use gvm_gmp::commands::credentials::{
 };
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
 use gvm_gmp::commands::system::{
-    modify_auth, modify_license, modify_license_with_opts, run_wizard_with_opts,
-    ModifyLicenseOpts, RunWizardOpts,
+    modify_auth, modify_license, modify_license_with_opts, run_wizard_with_opts, ModifyLicenseOpts,
+    RunWizardOpts,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::CredentialStoreCredentialType;

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -443,6 +443,16 @@ async fn stop_and_resume_preserve_one_report_and_update_both_statuses() {
     )
     .await;
     let started_report_id = report_id(&start);
+    let running_task = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let running_task = running_task.as_str().expect("UTF-8 response");
+    assert!(running_task.contains(&format!(
+        "<current_report><report id=\"{started_report_id}\"></report></current_report>"
+    )));
+    assert!(!running_task.contains("<report_id>"));
     let active_delete = send_recv(
         &mut stream,
         format!("<delete_report report_id=\"{started_report_id}\" ultimate=\"1\"/>").as_bytes(),
@@ -456,6 +466,16 @@ async fn stop_and_resume_preserve_one_report_and_update_both_statuses() {
     )
     .await;
     assert_eq!(stop.status_code(), Some(200));
+    let stopped_task = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let stopped_task = stopped_task.as_str().expect("UTF-8 response");
+    assert!(stopped_task.contains(&format!(
+        "<current_report><report id=\"{started_report_id}\"></report></current_report>"
+    )));
+    assert!(!stopped_task.contains("<report_id>"));
     let stopped_report = send_recv(
         &mut stream,
         format!("<get_reports report_id=\"{started_report_id}\"/>").as_bytes(),
@@ -472,6 +492,16 @@ async fn stop_and_resume_preserve_one_report_and_update_both_statuses() {
     )
     .await;
     assert_eq!(report_id(&resume), started_report_id);
+    let resumed_task = send_recv(
+        &mut stream,
+        format!("<get_tasks task_id=\"{task_id}\"/>").as_bytes(),
+    )
+    .await;
+    let resumed_task = resumed_task.as_str().expect("UTF-8 response");
+    assert!(resumed_task.contains(&format!(
+        "<current_report><report id=\"{started_report_id}\"></report></current_report>"
+    )));
+    assert!(!resumed_task.contains("<report_id>"));
     let reports = send_recv(&mut stream, b"<get_reports/>").await;
     assert!(reports
         .as_str()


### PR DESCRIPTION
## What problem does this solve?

The stateful mock stored a task's report ID as an internal `report_id` attribute and serialized it as a raw `<report_id>` element. Typed task responses expect gvmd's nested `<current_report><report id="...">` or `<last_report><report id="...">` shape, so clients could not observe the report associated with a started, stopped, or resumed task.

## What does this change?

- Renders the stored report under `current_report` for requested, running, stopping, stopped, and interrupted tasks.
- Renders it under `last_report` for completed tasks.
- Suppresses the internal raw `report_id` field from task XML.
- Extends raw and typed lifecycle tests to verify one stable report ID across start, stop, and resume.
- Applies the existing repository rustfmt normalization needed for this branch to pass formatting checks.

## Validation

- `cargo test -p gvm-mock-server --features unix-socket-tests`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration`
- `cargo clippy -p gvm-mock-server -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes greenbone-hive/rust-gvm#481

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
