### PR TITLE
Validate target host specifications before transport

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -101,8 +101,8 @@ use gvm_gmp::commands::secinfo::{
 };
 use gvm_gmp::commands::system::{
     describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
-    get_vulns, modify_auth, modify_license_with_opts, run_wizard_with_opts,
-    FilteredGetOpts, ModifyLicenseOpts, RunWizardOpts,
+    get_vulns, modify_auth, modify_license_with_opts, run_wizard_with_opts, FilteredGetOpts,
+    ModifyLicenseOpts, RunWizardOpts,
 };
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
@@ -164,8 +164,7 @@ use gvm_gmp::responses::{
     ModifyScannerResponse, ModifyScheduleResponse, ModifyTargetResponse, ModifyTaskResponse,
     ModifyTicketResponse, ModifyUserResponse, ModifyWebApplicationTargetResponse, ReportExport,
     RestoreResponse, ResumeTaskResponse, RunWizardResponse, StartTaskResponse, StopTaskResponse,
-    SyncConfigResponse,
-    VerifyCredentialStoreResponse, VerifyScannerResponse,
+    SyncConfigResponse, VerifyCredentialStoreResponse, VerifyScannerResponse,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::{CredentialStoreCredentialType, FeedType, ScheduleInput};

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -55,7 +55,7 @@ use gvm_gmp::commands::system::ModifyLicenseOpts;
 use gvm_gmp::commands::system::RunWizardOpts;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetError, CreateTargetOpts, GetTargetsOpts,
-    ModifyTargetError, ModifyTargetOpts,
+    InvalidTargetHost, ModifyTargetError, ModifyTargetOpts, TargetHostField,
 };
 use gvm_gmp::commands::tasks::{
     create_task, delete_task, get_task, start_task, stop_task, CreateTaskOpts, GetTasksOpts,
@@ -3402,6 +3402,95 @@ async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
         .count();
     assert_eq!(create_count_after, create_count_before);
 
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_target_host_validation_rejects_before_send() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let create_count_before = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "create_target")
+        .count();
+
+    let create_error = client
+        .create_target(
+            "Invalid CIDR Target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into(), "198.51.100.1/31".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("invalid IPv4 CIDR should fail locally");
+    assert!(matches!(
+        create_error,
+        GvmError::CreateTarget(CreateTargetError::InvalidHostSpecification(
+            InvalidTargetHost {
+                field: TargetHostField::Hosts,
+                index: 1,
+                specification,
+            }
+        )) if specification == "198.51.100.1/31"
+    ));
+    let create_count_after = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "create_target")
+        .count();
+    assert_eq!(create_count_after, create_count_before);
+
+    let target = client
+        .create_target(
+            "Valid CIDR Target",
+            CreateTargetOpts {
+                hosts: vec!["198.51.100.1/30".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("supported IPv4 CIDR should be sent");
+    let modify_count_before = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "modify_target")
+        .count();
+
+    let modify_error = client
+        .modify_target(
+            &target.id,
+            ModifyTargetOpts {
+                exclude_hosts: CollectionUpdate::replace(["2001:db8::1/0".into()]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("invalid IPv6 CIDR should fail locally");
+    assert!(matches!(
+        modify_error,
+        GvmError::ModifyTarget(ModifyTargetError::InvalidHostSpecification(
+            InvalidTargetHost {
+                field: TargetHostField::ExcludeHosts,
+                index: 0,
+                specification,
+            }
+        )) if specification == "2001:db8::1/0"
+    ));
+    let modify_count_after = server
+        .command_history()
+        .iter()
+        .filter(|record| record.command_name() == "modify_target")
+        .count();
+    assert_eq!(modify_count_after, modify_count_before);
+
+    client
+        .delete_target(&target.id, true)
+        .await
+        .expect("target cleanup should succeed");
     server.shutdown().await;
 }
 

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -3,6 +3,8 @@
 
 //! Target command builders.
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{
@@ -96,16 +98,22 @@ pub struct ModifyTargetOpts {
 }
 
 /// Errors raised while building a `create_target` request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum CreateTargetError {
+    /// A host or excluded-host entry does not follow gvmd's host syntax.
+    #[error(transparent)]
+    InvalidHostSpecification(#[from] InvalidTargetHost),
     /// A service port cannot be encoded without an SSH credential identifier.
     #[error("setting an SSH credential port requires an SSH credential identifier")]
     SshPortWithoutCredential,
 }
 
 /// Errors raised while building a `modify_target` request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ModifyTargetError {
+    /// A host or excluded-host entry does not follow gvmd's host syntax.
+    #[error(transparent)]
+    InvalidHostSpecification(#[from] InvalidTargetHost),
     /// gvmd has no wire representation for detaching a target port list.
     #[error("gvmd does not support clearing a target port-list relationship")]
     UnsupportedPortListClear,
@@ -115,6 +123,36 @@ pub enum ModifyTargetError {
     /// A service-port update is incompatible with detaching the credential.
     #[error("an SSH credential port cannot be updated while detaching the SSH credential")]
     SshPortWithCredentialClear,
+}
+
+/// Target collection containing an invalid host specification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetHostField {
+    /// The target's included hosts.
+    Hosts,
+    /// The target's excluded hosts.
+    ExcludeHosts,
+}
+
+impl std::fmt::Display for TargetHostField {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Hosts => "hosts",
+            Self::ExcludeHosts => "exclude_hosts",
+        })
+    }
+}
+
+/// A target host specification rejected before the request is sent.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid target host specification in {field}[{index}]: {specification:?}")]
+pub struct InvalidTargetHost {
+    /// Collection containing the invalid entry.
+    pub field: TargetHostField,
+    /// Zero-based index of the invalid entry.
+    pub index: usize,
+    /// Invalid host specification supplied by the caller.
+    pub specification: String,
 }
 
 /// Build a clone request for an existing target.
@@ -128,6 +166,8 @@ pub fn clone_target(target_id: &EntityId) -> impl Request {
 /// # Errors
 /// Returns [`CreateTargetError::SshPortWithoutCredential`] when a service port
 /// is supplied without the SSH credential identifier required by GMP.
+/// Returns [`CreateTargetError::InvalidHostSpecification`] when a host or
+/// excluded-host entry is not accepted by gvmd's host grammar.
 pub fn create_target(
     name: &str,
     opts: CreateTargetOpts,
@@ -135,6 +175,8 @@ pub fn create_target(
     if opts.ssh_credential_port.is_some() && opts.ssh_credential_id.is_none() {
         return Err(CreateTargetError::SshPortWithoutCredential);
     }
+    validate_host_entries(&opts.hosts, TargetHostField::Hosts)?;
+    validate_host_entries(&opts.exclude_hosts, TargetHostField::ExcludeHosts)?;
 
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
@@ -187,6 +229,8 @@ pub fn get_target(target_id: &EntityId) -> impl Request {
 /// Returns [`ModifyTargetError::UnsupportedPortListClear`] when the port-list
 /// update requests clearing. gvmd accepts omission and replacement, but does
 /// not define a sentinel for detaching an existing port list.
+/// Returns [`ModifyTargetError::InvalidHostSpecification`] when a replacement
+/// host or excluded-host entry is not accepted by gvmd's host grammar.
 pub fn modify_target(
     target_id: &EntityId,
     opts: ModifyTargetOpts,
@@ -203,6 +247,8 @@ pub fn modify_target(
         }
         _ => {}
     }
+    validate_host_update(&opts.hosts, TargetHostField::Hosts)?;
+    validate_host_update(&opts.exclude_hosts, TargetHostField::ExcludeHosts)?;
 
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
@@ -299,6 +345,112 @@ fn add_collection_update(cmd: &mut XmlCommand, element: &str, update: &Collectio
             cmd.add_element_with_text(element, "");
         }
     }
+}
+
+fn validate_host_update(
+    update: &CollectionUpdate<String>,
+    field: TargetHostField,
+) -> Result<(), InvalidTargetHost> {
+    if let CollectionUpdate::Replace(entries) = update {
+        validate_host_entries(entries, field)?;
+    }
+    Ok(())
+}
+
+fn validate_host_entries(
+    entries: &[String],
+    field: TargetHostField,
+) -> Result<(), InvalidTargetHost> {
+    for (index, specification) in entries.iter().enumerate() {
+        let invalid = specification
+            .split([',', '\n'])
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| !is_valid_host_specification(entry));
+        if invalid {
+            return Err(InvalidTargetHost {
+                field,
+                index,
+                specification: specification.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn is_valid_host_specification(specification: &str) -> bool {
+    if specification.is_empty() {
+        return false;
+    }
+
+    specification.parse::<Ipv4Addr>().is_ok()
+        || specification.parse::<Ipv6Addr>().is_ok()
+        || is_valid_cidr(specification)
+        || is_valid_range(specification)
+        || is_valid_hostname(specification)
+}
+
+fn is_valid_cidr(specification: &str) -> bool {
+    let Some((address, prefix)) = specification.split_once('/') else {
+        return false;
+    };
+    if prefix.is_empty() || !prefix.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    let Ok(prefix) = prefix.parse::<u16>() else {
+        return false;
+    };
+
+    if address.parse::<Ipv4Addr>().is_ok() {
+        (1..=30).contains(&prefix)
+    } else if address.parse::<Ipv6Addr>().is_ok() {
+        (1..=128).contains(&prefix)
+    } else {
+        false
+    }
+}
+
+fn is_valid_range(specification: &str) -> bool {
+    let Some((first, last)) = specification.split_once('-') else {
+        return false;
+    };
+
+    if first.parse::<Ipv4Addr>().is_ok() {
+        return last.parse::<Ipv4Addr>().is_ok()
+            || (!last.is_empty()
+                && last.bytes().all(|byte| byte.is_ascii_digit())
+                && last.parse::<u8>().is_ok());
+    }
+    if first.parse::<Ipv6Addr>().is_ok() {
+        return last.parse::<Ipv6Addr>().is_ok()
+            || (!last.is_empty()
+                && last.len() <= 4
+                && last.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+    false
+}
+
+fn is_valid_hostname(specification: &str) -> bool {
+    let hostname = specification.strip_suffix('.').unwrap_or(specification);
+    if hostname.is_empty() || hostname.len() > 253 {
+        return false;
+    }
+
+    let mut labels = hostname.split('.').peekable();
+    while let Some(label) = labels.next() {
+        if label.is_empty()
+            || label.len() > 63
+            || label.starts_with('-')
+            || label.ends_with('-')
+            || !label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+            || (labels.peek().is_none() && label.bytes().all(|byte| byte.is_ascii_digit()))
+        {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -540,5 +692,147 @@ mod tests {
             .err(),
             Some(CreateTargetError::SshPortWithoutCredential)
         );
+    }
+
+    #[test]
+    fn target_host_validation_matches_gvmd_supported_forms() {
+        for specification in [
+            "192.0.2.1",
+            "2001:db8::1",
+            "192.0.2.1/1",
+            "192.0.2.1/30",
+            "2001:db8::1/1",
+            "2001:db8::1/128",
+            "192.0.2.1-25",
+            "192.0.2.1-192.0.2.25",
+            "2001:db8::1-ff",
+            "2001:db8::1-2001:db8::ff",
+            "scanner_1.example",
+            "scanner.example.",
+        ] {
+            assert!(
+                is_valid_host_specification(specification),
+                "expected {specification:?} to be valid"
+            );
+        }
+
+        for specification in [
+            "",
+            "192.0.2.1/0",
+            "192.0.2.1/31",
+            "192.0.2.1/32",
+            "2001:db8::1/0",
+            "2001:db8::1/129",
+            "192.0.2.1/30/1",
+            "2001:db8::1-fffff",
+            "-scanner.example",
+            "scanner-.example",
+            "scanner.123",
+            "scanner..example",
+        ] {
+            assert!(
+                !is_valid_host_specification(specification),
+                "expected {specification:?} to be invalid"
+            );
+        }
+
+        assert!(validate_host_entries(
+            &["scanner.example, 192.0.2.1\n2001:db8::1".into()],
+            TargetHostField::Hosts,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn create_target_classifies_invalid_host_and_excluded_host_entries() {
+        let hosts_error = create_target(
+            "target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1".into(), "192.0.2.2/31".into()],
+                ..Default::default()
+            },
+        )
+        .err();
+        assert_eq!(
+            hosts_error,
+            Some(CreateTargetError::InvalidHostSpecification(
+                InvalidTargetHost {
+                    field: TargetHostField::Hosts,
+                    index: 1,
+                    specification: "192.0.2.2/31".into(),
+                }
+            ))
+        );
+
+        let excluded_error = create_target(
+            "target",
+            CreateTargetOpts {
+                hosts: vec!["192.0.2.1/30".into()],
+                exclude_hosts: vec!["2001:db8::1/129".into()],
+                ..Default::default()
+            },
+        )
+        .err();
+        assert_eq!(
+            excluded_error,
+            Some(CreateTargetError::InvalidHostSpecification(
+                InvalidTargetHost {
+                    field: TargetHostField::ExcludeHosts,
+                    index: 0,
+                    specification: "2001:db8::1/129".into(),
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn modify_target_validates_replacements_but_allows_clear_and_omission() {
+        let hosts_error = modify_target(
+            &id("t1"),
+            ModifyTargetOpts {
+                hosts: CollectionUpdate::replace(["192.0.2.1/32".into()]),
+                ..Default::default()
+            },
+        )
+        .err();
+        assert_eq!(
+            hosts_error,
+            Some(ModifyTargetError::InvalidHostSpecification(
+                InvalidTargetHost {
+                    field: TargetHostField::Hosts,
+                    index: 0,
+                    specification: "192.0.2.1/32".into(),
+                }
+            ))
+        );
+
+        let excluded_error = modify_target(
+            &id("t1"),
+            ModifyTargetOpts {
+                exclude_hosts: CollectionUpdate::replace(["bad host".into()]),
+                ..Default::default()
+            },
+        )
+        .err();
+        assert_eq!(
+            excluded_error,
+            Some(ModifyTargetError::InvalidHostSpecification(
+                InvalidTargetHost {
+                    field: TargetHostField::ExcludeHosts,
+                    index: 0,
+                    specification: "bad host".into(),
+                }
+            ))
+        );
+
+        assert!(modify_target(
+            &id("t1"),
+            ModifyTargetOpts {
+                hosts: CollectionUpdate::Clear,
+                exclude_hosts: CollectionUpdate::Omitted,
+                ..Default::default()
+            }
+        )
+        .is_ok());
     }
 }

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -24,8 +24,8 @@ use gvm_gmp::commands::credentials::{
 };
 use gvm_gmp::commands::hosts::{create_host, get_host, get_hosts, HostOpts};
 use gvm_gmp::commands::system::{
-    modify_auth, modify_license, modify_license_with_opts, run_wizard_with_opts,
-    ModifyLicenseOpts, RunWizardOpts,
+    modify_auth, modify_license, modify_license_with_opts, run_wizard_with_opts, ModifyLicenseOpts,
+    RunWizardOpts,
 };
 use gvm_gmp::types::EntityId;
 use gvm_gmp::CredentialStoreCredentialType;


### PR DESCRIPTION
## What problem does this solve?

Typed target builders accepted arbitrary strings for hosts and excluded hosts. Invalid specifications therefore reached gvmd and surfaced only as a generic server-side `Error in host specification` response.

## What does this change?

- Validates target hosts and excluded hosts in both `create_target` and replacement updates in `modify_target` before a request is sent.
- Mirrors gvm-libs host forms: IPv4/IPv6 addresses, CIDRs, short and long ranges, and gvmd-compatible hostnames.
- Keeps the CIDR rules independent: IPv4 accepts `/1` through `/30`; IPv6 accepts `/1` through `/128`.
- Adds typed errors that identify `hosts` versus `exclude_hosts`, the collection index, and the rejected value.
- Preserves gvmd's comma/newline list parsing within existing string entries.
- Proves at the client layer that invalid create/modify values do not reach the transport.
- Applies the existing repository rustfmt normalization needed for this branch to pass formatting checks.

## Validation

- `cargo test -p gvm-gmp` (451 unit tests plus integration tests)
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_target_`
- `cargo clippy -p gvm-gmp -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes greenbone-hive/rust-gvm#480

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
