### PR TITLE
docs(journal): 2026-08-12 project update

### DIFF
--- a/journal/2026-08-12.md
+++ b/journal/2026-08-12.md
@@ -1,0 +1,10 @@
+# 2026-08-12 — GMP Contracts Advanced While Main E2E Broke
+
+## Mainline Movement
+- Nine non-journal PRs merged into `main`, including GMP contract corrections for authentication, licensing, and wizard execution ([#450](https://github.com/greenbone-hive/rust-gvm/pull/450), [#451](https://github.com/greenbone-hive/rust-gvm/pull/451), and [#455](https://github.com/greenbone-hive/rust-gvm/pull/455)).
+- Stateful mock behavior now preserves task schedule relationships via [#482](https://github.com/greenbone-hive/rust-gvm/pull/482), while [#486](https://github.com/greenbone-hive/rust-gvm/pull/486) corrected typed current/last task-report rendering and [#487](https://github.com/greenbone-hive/rust-gvm/pull/487) added target-host validation before transport.
+- [#485](https://github.com/greenbone-hive/rust-gvm/pull/485) merged the renewed GitHub Actions dependency group. The superseded Cargo update was replaced by [#484](https://github.com/greenbone-hive/rust-gvm/pull/484), which remains blocked by its Security/Cargo Vet gate.
+
+## New Work and Validation State
+- [#488](https://github.com/greenbone-hive/rust-gvm/pull/488) opened to add persistent trust-on-first-use SSH host-key policies; its reported CI and Security workflows are green.
+- Every reported `main` CI run after the merges is red because the downstream E2E dispatch cannot start `gvm-community-e2e`: the executable is missing from the runner image `PATH`. Security and OpenSSF Scorecard checks remain green, but the cross-repository E2E regression is an active mainline blocker.


### PR DESCRIPTION
Documents substantive mainline merges, new SSH policy work, and the actionable downstream E2E regression.