### PR TITLE
Add validated target host and port selections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
  "quick-xml",
  "rstest",
  "serde",
+ "serde_json",
  "thiserror",
  "uuid",
 ]
@@ -1145,6 +1146,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2128,6 +2135,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,3 +3018,9 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,6 @@ dependencies = [
  "quick-xml",
  "rstest",
  "serde",
- "serde_json",
  "thiserror",
  "uuid",
 ]
@@ -1146,12 +1145,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -2135,19 +2128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.151"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,9 +2998,3 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for the support direction, version policy
 The high-level client handles version negotiation automatically and exposes typed convenience methods for every GMP domain:
 
 ```rust
-use gvm_client::{GmpClient, GvmError};
+use gvm_client::GmpClient;
 use gvm_connection::{UnixSocketConfig, UnixSocketConnection};
 use gvm_gmp::commands::targets::CreateTargetOpts;
 use gvm_gmp::commands::tasks::CreateTaskOpts;
+use gvm_gmp::{TargetHost, TargetHosts, TargetPortSelection};
 
 #[tokio::main]
-async fn main() -> Result<(), GvmError> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Create a transport and connect — auto-negotiates GMP version (22.4–22.8+)
     let conn = UnixSocketConnection::new(UnixSocketConfig::new("/run/gvmd/gvmd.sock"));
     let mut client = GmpClient::connect(conn).await?;
@@ -70,10 +71,11 @@ async fn main() -> Result<(), GvmError> {
     client.authenticate("admin", "admin").await?;
 
     // 3. Create a target — typed response, no manual XML parsing
-    let target = client.create_target("My Target", CreateTargetOpts {
-        hosts: vec!["192.168.1.0/24".to_string()],
-        ..Default::default()
-    }).await?;
+    let hosts = TargetHosts::new(["192.168.1.0/24".parse::<TargetHost>()?], [])?;
+    let ports = TargetPortSelection::PortRange("T:1-65535".parse()?);
+    let target = client
+        .create_target("My Target", CreateTargetOpts::new(hosts, ports))
+        .await?;
     println!("Created target: {}", target.id);
 
     // 4. List all targets
@@ -134,6 +136,56 @@ keeps the existing value. Valid but unsupported timezone or recurrence semantics
 typed observation instead of being treated as one-time schedules. Floating or
 `TZID`-qualified iCalendar starts remain observable but are not converted locally;
 typed `first_run_at` and `next_run_at` values use gvmd's normalized response fields.
+
+#### Validated target hosts
+
+Target create and modify options use [`TargetHost`](crates/gvm-gmp/src/target.rs)
+and the non-empty [`TargetHosts`](crates/gvm-gmp/src/target.rs) aggregate, so
+invalid individual specifications, fully excluded host sets, and invalid request
+shapes are rejected before a GMP request is built or sent. Included and excluded
+hosts are replaced together on modify, matching gvmd. Individual IPv4 and IPv6
+addresses, gvmd-supported CIDR networks, address ranges, and ASCII hostnames can
+be parsed directly. IPv4 components with leading zeroes are normalized before
+serialization:
+
+```rust
+use gvm_gmp::{TargetHost, TargetHosts};
+
+let hosts: Vec<TargetHost> = ["192.0.2.1", "10.0.0.0/24", "scanner.example.com"]
+    .into_iter()
+    .map(str::parse)
+    .collect::<Result<_, _>>()?;
+let target_hosts = TargetHosts::new(hosts, [])?;
+assert!(target_hosts.has_effective_hosts());
+```
+
+This is a source-level change from the earlier `Vec<String>` fields. Callers
+should parse external text into `TargetHost` before constructing
+`CreateTargetOpts` or `ModifyTargetOpts`. IPv4 CIDR prefixes are limited to
+`/1` through `/30`; IPv6 prefixes are validated independently through `/128`.
+Hostname labels intentionally use an ASCII policy; Unicode case-fold lookalikes
+accepted incidentally by some GLib regex versions are rejected.
+Canonical identities de-duplicate equivalent IP, network, range, and ASCII
+hostname spellings while retaining the first wire spelling; a hostname with a
+trailing dot remains distinct from the same spelling without one, as in gvmd.
+The aggregate can also detect when exclusions cover every included specification
+without expanding large networks. CIDR coverage follows gvmd's usable-address
+rules (excluding the first and last addresses except for IPv6 `/127` and `/128`).
+gvmd remains authoritative for DNS resolution and deployment policy such as its
+configured maximum number of IPs per target.
+
+The typed `CreateTargetOpts` models manual-host creation. Raw GMP callers can
+still use gvmd's `<asset_hosts filter="..."/>` target form; stateful mock mode
+resolves matching host assets and gives that filter precedence over `<hosts>`,
+matching gvmd. Its shared asset-filter subset supports quoted values, equality,
+case-insensitive containment (`~` and `:`), comparisons, sorting, and pagination;
+malformed or explicitly unsupported predicates receive a client error.
+Creation also requires a typed `TargetPortSelection`: either an existing port-list
+ID or a validated direct range such as `"T:22, U:53, T:80-443"`. This is an
+intentional one-of restriction in the typed API. Raw GMP permits both elements;
+gvmd validates the supplied range and gives `<port_list>` precedence. Existing
+callers should replace `CreateTargetOpts::port_list_id` with `ports` and pass that
+selection as the second argument to `CreateTargetOpts::new`.
 
 #### Raw API (send/call)
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -76,12 +76,29 @@ use gvm_gmp::{
     AlertCondition, AlertEvent, AlertMethod, AliveTest, CollectionUpdate, CredentialType, FeedType,
     PermissionSubjectType, ScalarUpdate, ScheduleDefinition, ScheduleInput, ScheduleRecurrence,
     ScheduleRecurrenceObservation, ScheduleTimestamp, ScheduleTimezone, ServicePort,
-    SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder, TicketStatus,
+    SnmpAuthAlgorithm, SnmpPrivacyAlgorithm, SortOrder, TargetHost, TargetHosts,
+    TargetPortSelection, TicketStatus,
 };
 use gvm_mock_server::{
     GmpVersion as MockVersion, MockGmpServer, Resource, ResourceStore, ServerMode,
 };
 use std::sync::{Arc, Mutex};
+
+fn target_host(value: &str) -> TargetHost {
+    value.parse().expect("valid target host")
+}
+
+fn target_hosts(included: &[&str], excluded: &[&str]) -> TargetHosts {
+    TargetHosts::new(
+        included.iter().map(|value| target_host(value)),
+        excluded.iter().map(|value| target_host(value)),
+    )
+    .expect("valid target hosts")
+}
+
+fn target_ports() -> TargetPortSelection {
+    TargetPortSelection::PortRange("T:1-65535".parse().expect("valid port range"))
+}
 
 async fn stateful_server() -> Option<MockGmpServer> {
     stateful_server_with_version(MockVersion::V22_5).await
@@ -858,8 +875,8 @@ async fn create_target_and_get_targets_succeed() {
             create_target(
                 "Integration Target",
                 CreateTargetOpts {
-                    hosts: vec!["127.0.0.1".to_string()],
-                    ..CreateTargetOpts::default()
+                    hosts: target_hosts(&["127.0.0.1"], &[]),
+                    ..CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports())
                 },
             )
             .expect("valid target"),
@@ -3060,8 +3077,8 @@ async fn typed_permission_lifecycle_uses_nested_references() {
         .create_target(
             "Permission Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into()],
-                ..Default::default()
+                hosts: target_hosts(&["192.0.2.1"], &[]),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3144,7 +3161,7 @@ async fn typed_permission_lifecycle_uses_nested_references() {
 }
 
 #[tokio::test]
-async fn typed_target_host_updates_preserve_replace_and_clear_state() {
+async fn typed_target_host_updates_are_atomic_and_can_clear_exclusions() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -3162,9 +3179,8 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
         .create_target(
             "Collection Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into(), "192.0.2.2".into()],
-                exclude_hosts: vec!["192.0.2.3".into()],
-                ..Default::default()
+                hosts: target_hosts(&["192.0.2.1", "192.0.2.2"], &["192.0.2.3"]),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3198,13 +3214,12 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
         .modify_target(
             &target.id,
             ModifyTargetOpts {
-                hosts: CollectionUpdate::Clear,
-                exclude_hosts: CollectionUpdate::replace(["192.0.2.4".into()]),
+                hosts: Some(target_hosts(&["192.0.2.4"], &[])),
                 ..Default::default()
             },
         )
         .await
-        .expect("target hosts should be cleared and exclusions replaced");
+        .expect("target hosts should be atomically replaced");
     let targets = client
         .get_targets(GetTargetsOpts::default())
         .await
@@ -3214,14 +3229,15 @@ async fn typed_target_host_updates_preserve_replace_and_clear_state() {
         .iter()
         .find(|item| item.meta.id == target.id)
         .expect("target should be listed");
-    assert!(fetched_target.hosts.is_empty());
-    assert_eq!(fetched_target.exclude_hosts, vec!["192.0.2.4".to_string()]);
+    assert_eq!(fetched_target.hosts, vec!["192.0.2.4".to_string()]);
+    assert!(fetched_target.exclude_hosts.is_empty());
 
     let history = server.command_history();
     assert!(history.iter().any(|record| {
         record.command_name() == "modify_target"
-            && std::str::from_utf8(record.raw_xml())
-                .is_ok_and(|xml| xml.contains("<hosts></hosts>"))
+            && std::str::from_utf8(record.raw_xml()).is_ok_and(|xml| {
+                xml.contains("<hosts>192.0.2.4</hosts><exclude_hosts></exclude_hosts>")
+            })
     }));
 
     server.shutdown().await;
@@ -3243,9 +3259,9 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
         .create_target(
             "Default Credential Port Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.9".into()],
+                hosts: target_hosts(&["192.0.2.9"], &[]),
                 ssh_credential_id: Some(first_ssh.clone()),
-                ..Default::default()
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3262,11 +3278,11 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
         .create_target(
             "Credential Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into()],
+                hosts: target_hosts(&["192.0.2.1"], &[]),
                 ssh_credential_id: Some(first_ssh.clone()),
                 ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
                 smb_credential_id: Some(first_smb.clone()),
-                ..Default::default()
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3384,9 +3400,9 @@ async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
         .create_target(
             "Invalid Credential Port Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.11".into()],
+                hosts: target_hosts(&["192.0.2.11"], &[]),
                 ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
-                ..Default::default()
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.11"], &[]), target_ports())
             },
         )
         .await
@@ -3504,7 +3520,7 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
         assert_raw_server_error(
             &mut client,
             format!(
-                "<create_target><name>Invalid Alive Test</name><hosts>192.0.2.2</hosts>{alive_test}</create_target>"
+                "<create_target><name>Invalid Alive Test</name><hosts>192.0.2.2</hosts>{alive_test}<port_range>T:1-65535</port_range></create_target>"
             )
             .into_bytes(),
             400,
@@ -3516,9 +3532,9 @@ async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
         .create_target(
             "Alive Test Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into()],
+                hosts: target_hosts(&["192.0.2.1"], &[]),
                 alive_test: Some(AliveTest::ScanConfigDefault),
-                ..Default::default()
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3606,7 +3622,7 @@ async fn raw_singular_target_alive_test_matches_gvmd_behavior() {
     let mut client = authenticated_client(&server).await;
     let singular_create = client
         .call(
-            b"<create_target><name>Singular Alive Test</name><hosts>192.0.2.3</hosts><alive_test>ICMP Ping</alive_test></create_target>"
+            b"<create_target><name>Singular Alive Test</name><hosts>192.0.2.3</hosts><alive_test>ICMP Ping</alive_test><port_range>T:1-65535</port_range></create_target>"
                 .to_vec(),
         )
         .await
@@ -3628,9 +3644,9 @@ async fn raw_singular_target_alive_test_matches_gvmd_behavior() {
         .create_target(
             "Plural Alive Test",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.4".into()],
+                hosts: target_hosts(&["192.0.2.4"], &[]),
                 alive_test: Some(AliveTest::ConsiderAlive),
-                ..Default::default()
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.4"], &[]), target_ports())
             },
         )
         .await
@@ -3683,9 +3699,9 @@ async fn typed_target_port_list_updates_preserve_omit_and_set_semantics() {
         .create_target(
             "Port List Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into()],
-                port_list_id: Some(first_port_list.id.clone()),
-                ..Default::default()
+                hosts: target_hosts(&["192.0.2.1"], &[]),
+                ports: TargetPortSelection::PortList(first_port_list.id.clone()),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -3766,8 +3782,8 @@ async fn typed_target_port_list_clear_is_rejected_before_send() {
         .create_target(
             "Port List Clear Target",
             CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into()],
-                ..Default::default()
+                hosts: target_hosts(&["192.0.2.1"], &[]),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.1"], &[]), target_ports())
             },
         )
         .await
@@ -4456,8 +4472,8 @@ async fn full_crud_lifecycle_succeeds() {
             create_target(
                 "Lifecycle Target",
                 CreateTargetOpts {
-                    hosts: vec!["127.0.0.1".to_string()],
-                    ..CreateTargetOpts::default()
+                    hosts: target_hosts(&["127.0.0.1"], &[]),
+                    ..CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports())
                 },
             )
             .expect("valid target"),
@@ -4601,8 +4617,8 @@ async fn typed_trashcan_helpers_restore_deleted_task() {
         .create_target(
             "Trashcan Target",
             CreateTargetOpts {
-                hosts: vec!["127.0.0.1".to_string()],
-                ..CreateTargetOpts::default()
+                hosts: target_hosts(&["127.0.0.1"], &[]),
+                ..CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports())
             },
         )
         .await
@@ -4669,8 +4685,8 @@ async fn typed_resume_task_returns_report_id() {
         .create_target(
             "Typed Resume Target",
             CreateTargetOpts {
-                hosts: vec!["127.0.0.1".to_string()],
-                ..CreateTargetOpts::default()
+                hosts: target_hosts(&["127.0.0.1"], &[]),
+                ..CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports())
             },
         )
         .await

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -55,7 +55,7 @@ use gvm_gmp::commands::system::ModifyLicenseOpts;
 use gvm_gmp::commands::system::RunWizardOpts;
 use gvm_gmp::commands::targets::{
     create_target, delete_target, get_targets, CreateTargetError, CreateTargetOpts, GetTargetsOpts,
-    InvalidTargetHost, ModifyTargetError, ModifyTargetOpts, TargetHostField,
+    ModifyTargetError, ModifyTargetOpts,
 };
 use gvm_gmp::commands::tasks::{
     create_task, delete_task, get_task, start_task, stop_task, CreateTaskOpts, GetTasksOpts,
@@ -3422,95 +3422,6 @@ async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
 }
 
 #[tokio::test]
-async fn typed_target_host_validation_rejects_before_send() {
-    let Some(server) = stateful_server().await else {
-        return;
-    };
-    let mut client = authenticated_client(&server).await;
-    let create_count_before = server
-        .command_history()
-        .iter()
-        .filter(|record| record.command_name() == "create_target")
-        .count();
-
-    let create_error = client
-        .create_target(
-            "Invalid CIDR Target",
-            CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into(), "198.51.100.1/31".into()],
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("invalid IPv4 CIDR should fail locally");
-    assert!(matches!(
-        create_error,
-        GvmError::CreateTarget(CreateTargetError::InvalidHostSpecification(
-            InvalidTargetHost {
-                field: TargetHostField::Hosts,
-                index: 1,
-                specification,
-            }
-        )) if specification == "198.51.100.1/31"
-    ));
-    let create_count_after = server
-        .command_history()
-        .iter()
-        .filter(|record| record.command_name() == "create_target")
-        .count();
-    assert_eq!(create_count_after, create_count_before);
-
-    let target = client
-        .create_target(
-            "Valid CIDR Target",
-            CreateTargetOpts {
-                hosts: vec!["198.51.100.1/30".into()],
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("supported IPv4 CIDR should be sent");
-    let modify_count_before = server
-        .command_history()
-        .iter()
-        .filter(|record| record.command_name() == "modify_target")
-        .count();
-
-    let modify_error = client
-        .modify_target(
-            &target.id,
-            ModifyTargetOpts {
-                exclude_hosts: CollectionUpdate::replace(["2001:db8::1/0".into()]),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("invalid IPv6 CIDR should fail locally");
-    assert!(matches!(
-        modify_error,
-        GvmError::ModifyTarget(ModifyTargetError::InvalidHostSpecification(
-            InvalidTargetHost {
-                field: TargetHostField::ExcludeHosts,
-                index: 0,
-                specification,
-            }
-        )) if specification == "2001:db8::1/0"
-    ));
-    let modify_count_after = server
-        .command_history()
-        .iter()
-        .filter(|record| record.command_name() == "modify_target")
-        .count();
-    assert_eq!(modify_count_after, modify_count_before);
-
-    client
-        .delete_target(&target.id, true)
-        .await
-        .expect("target cleanup should succeed");
-    server.shutdown().await;
-}
-
-#[tokio::test]
 async fn typed_target_alive_tests_preserve_replace_and_validate_state() {
     let Some(server) = stateful_server().await else {
         return;
@@ -5286,10 +5197,7 @@ async fn typed_task_schedule_relationship_round_trip_and_dependency_ordering() {
     let target = client
         .create_target(
             "Scheduled Task Target",
-            CreateTargetOpts {
-                hosts: vec!["127.0.0.1".to_string()],
-                ..Default::default()
-            },
+            CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports()),
         )
         .await
         .expect("target create should succeed");

--- a/crates/gvm-client/tests/readme_examples.rs
+++ b/crates/gvm-client/tests/readme_examples.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Compile coverage for the complete public README quick start.
+
+#![allow(clippy::print_stdout, dead_code, missing_docs)]
+
+use gvm_client::GmpClient;
+use gvm_connection::{UnixSocketConfig, UnixSocketConnection};
+use gvm_gmp::commands::targets::CreateTargetOpts;
+use gvm_gmp::commands::tasks::CreateTaskOpts;
+use gvm_gmp::{TargetHost, TargetHosts, TargetPortSelection};
+
+async fn quick_start_compiles() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = UnixSocketConnection::new(UnixSocketConfig::new("/run/gvmd/gvmd.sock"));
+    let mut client = GmpClient::connect(conn).await?;
+    println!("Connected, GMP version: {}", client.version());
+
+    client.authenticate("admin", "admin").await?;
+
+    let hosts = TargetHosts::new(["192.168.1.0/24".parse::<TargetHost>()?], [])?;
+    let ports = TargetPortSelection::PortRange("T:1-65535".parse()?);
+    let target = client
+        .create_target("My Target", CreateTargetOpts::new(hosts, ports))
+        .await?;
+    println!("Created target: {}", target.id);
+
+    let targets = client.get_targets(Default::default()).await?;
+    for target in &targets.items {
+        println!("  {} — {}", target.meta.id, target.meta.name);
+    }
+
+    let config_id = "daba56c8-73ec-11df-a475-002264764cea".parse()?;
+    let scanner_id = "08b69003-5fc2-4037-a479-93b440211c73".parse()?;
+    let task = client
+        .create_task(
+            "My Scan",
+            &config_id,
+            &target.id,
+            &scanner_id,
+            CreateTaskOpts::default(),
+        )
+        .await?;
+    client.start_task(&task.id).await?;
+    println!("Started task: {}", task.id);
+
+    client.disconnect().await?;
+    Ok(())
+}
+
+#[test]
+fn quick_start_target_options_have_required_port_selection(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let hosts = TargetHosts::new(["192.168.1.0/24".parse::<TargetHost>()?], [])?;
+    let ports = TargetPortSelection::PortRange("T:1-65535".parse()?);
+    let options = CreateTargetOpts::new(hosts, ports);
+
+    assert_eq!(options.hosts.included()[0].as_str(), "192.168.1.0/24");
+    assert!(matches!(options.ports, TargetPortSelection::PortRange(_)));
+    Ok(())
+}

--- a/crates/gvm-connection/tests/large_response.rs
+++ b/crates/gvm-connection/tests/large_response.rs
@@ -10,6 +10,7 @@ use gvm_gmp::commands::scan_configs::{get_scan_configs, GetScanConfigsOpts};
 use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
 use gvm_gmp::commands::tasks::{create_task, start_task, CreateTaskOpts};
 use gvm_gmp::types::EntityId;
+use gvm_gmp::TargetHost;
 use gvm_mock_server::{GmpVersion, LargeReportConfig, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response};
 
@@ -66,8 +67,21 @@ async fn create_large_report(conn: &mut UnixSocketConnection) -> (EntityId, Vec<
         create_target(
             "large-test",
             CreateTargetOpts {
-                hosts: vec!["10.0.0.0/24".to_string()],
-                ..CreateTargetOpts::default()
+                hosts: gvm_gmp::TargetHosts::new(
+                    [TargetHost::new("10.0.0.0/24").expect("valid target host")],
+                    [],
+                )
+                .expect("valid target hosts"),
+                ..CreateTargetOpts::new(
+                    gvm_gmp::TargetHosts::new(
+                        [TargetHost::new("127.0.0.1").expect("valid target host")],
+                        [],
+                    )
+                    .expect("valid target hosts"),
+                    gvm_gmp::TargetPortSelection::PortRange(
+                        "T:1-65535".parse().expect("valid port range"),
+                    ),
+                )
             },
         )
         .expect("valid target"),

--- a/crates/gvm-connection/tests/ssh_e2e.rs
+++ b/crates/gvm-connection/tests/ssh_e2e.rs
@@ -516,7 +516,7 @@ async fn ssh_authenticate_and_crud() {
     );
 
     conn.send(
-        b"<create_target><name>SSH Target</name><hosts>192.168.1.0/24</hosts></create_target>",
+        b"<create_target><name>SSH Target</name><hosts>192.168.1.0/24</hosts><port_range>T:1-65535</port_range></create_target>",
     )
     .await
     .expect("send create failed");

--- a/crates/gvm-connection/tests/unix_connection.rs
+++ b/crates/gvm-connection/tests/unix_connection.rs
@@ -75,7 +75,7 @@ async fn connect_authenticate_and_create_target() {
     assert_eq!(auth_response.status_code(), Some(200));
 
     let create_xml =
-        b"<create_target><name>Test Target</name><hosts>192.168.1.0/24</hosts></create_target>";
+        b"<create_target><name>Test Target</name><hosts>192.168.1.0/24</hosts><port_range>T:1-65535</port_range></create_target>";
     conn.send(create_xml).await.expect("send create failed");
     let create_resp = conn.read().await.expect("read create failed");
     let create_response = Response::new(create_resp);

--- a/crates/gvm-gmp/Cargo.toml
+++ b/crates/gvm-gmp/Cargo.toml
@@ -27,7 +27,6 @@ clap.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 proptest.workspace = true
-serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/gvm-gmp/Cargo.toml
+++ b/crates/gvm-gmp/Cargo.toml
@@ -27,6 +27,7 @@ clap.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 proptest.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -12,21 +12,20 @@ use crate::common::{
     set_optional_bool_attr,
 };
 use crate::enums::AliveTest;
-use crate::types::{CollectionUpdate, EntityId, ScalarUpdate, ServicePort};
+use crate::target::{TargetHost, TargetHosts, TargetPortSelection};
+use crate::types::{EntityId, ScalarUpdate, ServicePort};
 
-/// Optional fields for `create_target` requests.
-#[derive(Debug, Clone, Default)]
+/// Required and optional fields for `create_target` requests.
+#[derive(Debug, Clone)]
 pub struct CreateTargetOpts {
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Host entries associated with the request.
-    pub hosts: Vec<String>,
-    /// Hosts to exclude from the request.
-    pub exclude_hosts: Vec<String>,
+    /// Validated included and excluded target hosts.
+    pub hosts: TargetHosts,
     /// Optional alive-test strategy.
     pub alive_test: Option<AliveTest>,
-    /// Optional port-list identifier.
-    pub port_list_id: Option<EntityId>,
+    /// Required port list or direct port range.
+    pub ports: TargetPortSelection,
     /// Optional SSH credential identifier.
     pub ssh_credential_id: Option<EntityId>,
     /// Optional SSH service port nested below the SSH credential.
@@ -41,6 +40,26 @@ pub struct CreateTargetOpts {
     pub reverse_lookup_only: Option<bool>,
     /// Whether reverse-lookup unification should be enabled.
     pub reverse_lookup_unify: Option<bool>,
+}
+
+impl CreateTargetOpts {
+    /// Create options for the required manual target host selection.
+    #[must_use]
+    pub fn new(hosts: TargetHosts, ports: TargetPortSelection) -> Self {
+        Self {
+            comment: None,
+            hosts,
+            alive_test: None,
+            ports,
+            ssh_credential_id: None,
+            ssh_credential_port: None,
+            smb_credential_id: None,
+            esxi_credential_id: None,
+            snmp_credential_id: None,
+            reverse_lookup_only: None,
+            reverse_lookup_unify: None,
+        }
+    }
 }
 
 /// Options for `get_targets` requests.
@@ -63,10 +82,8 @@ pub struct ModifyTargetOpts {
     pub name: Option<String>,
     /// Optional comment text included in the request.
     pub comment: Option<String>,
-    /// Host update: omit, replace, or explicitly clear.
-    pub hosts: CollectionUpdate<String>,
-    /// Excluded-host update: omit, replace, or explicitly clear.
-    pub exclude_hosts: CollectionUpdate<String>,
+    /// Atomic replacement of included and excluded hosts, or `None` to omit.
+    pub hosts: Option<TargetHosts>,
     /// Optional alive-test strategy.
     pub alive_test: Option<AliveTest>,
     /// Port-list relationship update: omit or set/replace.
@@ -181,16 +198,19 @@ pub fn create_target(
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    if !opts.hosts.is_empty() {
-        cmd.add_element_with_text("hosts", &opts.hosts.join(","));
-    }
-    if !opts.exclude_hosts.is_empty() {
-        cmd.add_element_with_text("exclude_hosts", &opts.exclude_hosts.join(","));
-    }
+    cmd.add_element_with_text("hosts", &join_hosts(opts.hosts.included()));
+    cmd.add_element_with_text("exclude_hosts", &join_hosts(opts.hosts.excluded()));
     if let Some(alive_test) = opts.alive_test {
         cmd.add_element_with_text("alive_tests", alive_test.as_target_name());
     }
-    add_optional_id_element(&mut cmd, "port_list", opts.port_list_id.as_ref());
+    match &opts.ports {
+        TargetPortSelection::PortList(port_list_id) => {
+            add_optional_id_element(&mut cmd, "port_list", Some(port_list_id));
+        }
+        TargetPortSelection::PortRange(port_range) => {
+            cmd.add_element_with_text("port_range", port_range.as_str());
+        }
+    }
     add_create_target_credentials(&mut cmd, &opts);
     if let Some(value) = opts.reverse_lookup_only {
         cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
@@ -253,8 +273,10 @@ pub fn modify_target(
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    add_collection_update(&mut cmd, "hosts", &opts.hosts);
-    add_collection_update(&mut cmd, "exclude_hosts", &opts.exclude_hosts);
+    if let Some(hosts) = &opts.hosts {
+        cmd.add_element_with_text("hosts", &join_hosts(hosts.included()));
+        cmd.add_element_with_text("exclude_hosts", &join_hosts(hosts.excluded()));
+    }
     if let Some(alive_test) = opts.alive_test {
         cmd.add_element_with_text("alive_tests", alive_test.as_target_name());
     }
@@ -335,16 +357,12 @@ fn add_credential<'a>(
     credential
 }
 
-fn add_collection_update(cmd: &mut XmlCommand, element: &str, update: &CollectionUpdate<String>) {
-    match update {
-        CollectionUpdate::Omitted => {}
-        CollectionUpdate::Replace(values) => {
-            cmd.add_element_with_text(element, &values.join(","));
-        }
-        CollectionUpdate::Clear => {
-            cmd.add_element_with_text(element, "");
-        }
-    }
+fn join_hosts(hosts: &[TargetHost]) -> String {
+    hosts
+        .iter()
+        .map(TargetHost::as_str)
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn validate_host_update(
@@ -462,16 +480,31 @@ mod tests {
         EntityId::new(value).expect("valid id")
     }
 
+    fn host(value: &str) -> TargetHost {
+        value.parse().expect("valid target host")
+    }
+
+    fn hosts(included: &[&str], excluded: &[&str]) -> TargetHosts {
+        TargetHosts::new(
+            included.iter().map(|value| host(value)),
+            excluded.iter().map(|value| host(value)),
+        )
+        .expect("valid target hosts")
+    }
+
+    fn direct_ports() -> TargetPortSelection {
+        TargetPortSelection::PortRange("T:1-65535".parse().expect("valid port range"))
+    }
+
     #[test]
     fn target_commands_build_xml() {
         let rendered = xml(create_target(
             "target",
             CreateTargetOpts {
                 comment: Some("c".into()),
-                hosts: vec!["1.1.1.1".into()],
-                exclude_hosts: vec!["2.2.2.2".into()],
+                hosts: hosts(&["1.1.1.1"], &["2.2.2.2"]),
                 alive_test: Some(AliveTest::IcmpPing),
-                port_list_id: Some(id("pl1")),
+                ports: TargetPortSelection::PortList(id("pl1")),
                 ssh_credential_id: Some(id("ssh1")),
                 ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
                 smb_credential_id: Some(id("smb1")),
@@ -541,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn modify_target_distinguishes_omitted_replaced_and_cleared_hosts() {
+    fn modify_target_omits_or_atomically_replaces_hosts() {
         assert_eq!(
             xml(modify_target(&id("t1"), ModifyTargetOpts::default()).expect("valid update")),
             "<modify_target target_id=\"t1\"/>"
@@ -550,8 +583,10 @@ mod tests {
             xml(modify_target(
                 &id("t1"),
                 ModifyTargetOpts {
-                    hosts: CollectionUpdate::replace(["192.0.2.1".into(), "192.0.2.2".into()]),
-                    exclude_hosts: CollectionUpdate::replace(["192.0.2.3".into()]),
+                    hosts: Some(hosts(
+                        &["192.0.2.1", "192.0.2.2"],
+                        &["192.0.2.3"],
+                    )),
                     ..Default::default()
                 }
             ).expect("valid update")),
@@ -561,12 +596,12 @@ mod tests {
             xml(modify_target(
                 &id("t1"),
                 ModifyTargetOpts {
-                    hosts: CollectionUpdate::Clear,
-                    exclude_hosts: CollectionUpdate::Clear,
+                    hosts: Some(hosts(&["192.0.2.1"], &[])),
                     ..Default::default()
                 }
-            ).expect("valid update")),
-            "<modify_target target_id=\"t1\"><hosts></hosts><exclude_hosts></exclude_hosts></modify_target>"
+            )
+            .expect("valid update")),
+            "<modify_target target_id=\"t1\"><hosts>192.0.2.1</hosts><exclude_hosts></exclude_hosts></modify_target>"
         );
     }
 
@@ -686,7 +721,7 @@ mod tests {
                 "target",
                 CreateTargetOpts {
                     ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
-                    ..Default::default()
+                    ..CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports())
                 }
             )
             .err(),

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -3,8 +3,6 @@
 
 //! Target command builders.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
-
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{
@@ -115,22 +113,16 @@ pub struct ModifyTargetOpts {
 }
 
 /// Errors raised while building a `create_target` request.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum CreateTargetError {
-    /// A host or excluded-host entry does not follow gvmd's host syntax.
-    #[error(transparent)]
-    InvalidHostSpecification(#[from] InvalidTargetHost),
     /// A service port cannot be encoded without an SSH credential identifier.
     #[error("setting an SSH credential port requires an SSH credential identifier")]
     SshPortWithoutCredential,
 }
 
 /// Errors raised while building a `modify_target` request.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum ModifyTargetError {
-    /// A host or excluded-host entry does not follow gvmd's host syntax.
-    #[error(transparent)]
-    InvalidHostSpecification(#[from] InvalidTargetHost),
     /// gvmd has no wire representation for detaching a target port list.
     #[error("gvmd does not support clearing a target port-list relationship")]
     UnsupportedPortListClear,
@@ -140,36 +132,6 @@ pub enum ModifyTargetError {
     /// A service-port update is incompatible with detaching the credential.
     #[error("an SSH credential port cannot be updated while detaching the SSH credential")]
     SshPortWithCredentialClear,
-}
-
-/// Target collection containing an invalid host specification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TargetHostField {
-    /// The target's included hosts.
-    Hosts,
-    /// The target's excluded hosts.
-    ExcludeHosts,
-}
-
-impl std::fmt::Display for TargetHostField {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(match self {
-            Self::Hosts => "hosts",
-            Self::ExcludeHosts => "exclude_hosts",
-        })
-    }
-}
-
-/// A target host specification rejected before the request is sent.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("invalid target host specification in {field}[{index}]: {specification:?}")]
-pub struct InvalidTargetHost {
-    /// Collection containing the invalid entry.
-    pub field: TargetHostField,
-    /// Zero-based index of the invalid entry.
-    pub index: usize,
-    /// Invalid host specification supplied by the caller.
-    pub specification: String,
 }
 
 /// Build a clone request for an existing target.
@@ -183,8 +145,6 @@ pub fn clone_target(target_id: &EntityId) -> impl Request {
 /// # Errors
 /// Returns [`CreateTargetError::SshPortWithoutCredential`] when a service port
 /// is supplied without the SSH credential identifier required by GMP.
-/// Returns [`CreateTargetError::InvalidHostSpecification`] when a host or
-/// excluded-host entry is not accepted by gvmd's host grammar.
 pub fn create_target(
     name: &str,
     opts: CreateTargetOpts,
@@ -192,9 +152,6 @@ pub fn create_target(
     if opts.ssh_credential_port.is_some() && opts.ssh_credential_id.is_none() {
         return Err(CreateTargetError::SshPortWithoutCredential);
     }
-    validate_host_entries(&opts.hosts, TargetHostField::Hosts)?;
-    validate_host_entries(&opts.exclude_hosts, TargetHostField::ExcludeHosts)?;
-
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -249,8 +206,6 @@ pub fn get_target(target_id: &EntityId) -> impl Request {
 /// Returns [`ModifyTargetError::UnsupportedPortListClear`] when the port-list
 /// update requests clearing. gvmd accepts omission and replacement, but does
 /// not define a sentinel for detaching an existing port list.
-/// Returns [`ModifyTargetError::InvalidHostSpecification`] when a replacement
-/// host or excluded-host entry is not accepted by gvmd's host grammar.
 pub fn modify_target(
     target_id: &EntityId,
     opts: ModifyTargetOpts,
@@ -267,9 +222,6 @@ pub fn modify_target(
         }
         _ => {}
     }
-    validate_host_update(&opts.hosts, TargetHostField::Hosts)?;
-    validate_host_update(&opts.exclude_hosts, TargetHostField::ExcludeHosts)?;
-
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -363,112 +315,6 @@ fn join_hosts(hosts: &[TargetHost]) -> String {
         .map(TargetHost::as_str)
         .collect::<Vec<_>>()
         .join(",")
-}
-
-fn validate_host_update(
-    update: &CollectionUpdate<String>,
-    field: TargetHostField,
-) -> Result<(), InvalidTargetHost> {
-    if let CollectionUpdate::Replace(entries) = update {
-        validate_host_entries(entries, field)?;
-    }
-    Ok(())
-}
-
-fn validate_host_entries(
-    entries: &[String],
-    field: TargetHostField,
-) -> Result<(), InvalidTargetHost> {
-    for (index, specification) in entries.iter().enumerate() {
-        let invalid = specification
-            .split([',', '\n'])
-            .map(str::trim)
-            .filter(|entry| !entry.is_empty())
-            .any(|entry| !is_valid_host_specification(entry));
-        if invalid {
-            return Err(InvalidTargetHost {
-                field,
-                index,
-                specification: specification.clone(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn is_valid_host_specification(specification: &str) -> bool {
-    if specification.is_empty() {
-        return false;
-    }
-
-    specification.parse::<Ipv4Addr>().is_ok()
-        || specification.parse::<Ipv6Addr>().is_ok()
-        || is_valid_cidr(specification)
-        || is_valid_range(specification)
-        || is_valid_hostname(specification)
-}
-
-fn is_valid_cidr(specification: &str) -> bool {
-    let Some((address, prefix)) = specification.split_once('/') else {
-        return false;
-    };
-    if prefix.is_empty() || !prefix.bytes().all(|byte| byte.is_ascii_digit()) {
-        return false;
-    }
-    let Ok(prefix) = prefix.parse::<u16>() else {
-        return false;
-    };
-
-    if address.parse::<Ipv4Addr>().is_ok() {
-        (1..=30).contains(&prefix)
-    } else if address.parse::<Ipv6Addr>().is_ok() {
-        (1..=128).contains(&prefix)
-    } else {
-        false
-    }
-}
-
-fn is_valid_range(specification: &str) -> bool {
-    let Some((first, last)) = specification.split_once('-') else {
-        return false;
-    };
-
-    if first.parse::<Ipv4Addr>().is_ok() {
-        return last.parse::<Ipv4Addr>().is_ok()
-            || (!last.is_empty()
-                && last.bytes().all(|byte| byte.is_ascii_digit())
-                && last.parse::<u8>().is_ok());
-    }
-    if first.parse::<Ipv6Addr>().is_ok() {
-        return last.parse::<Ipv6Addr>().is_ok()
-            || (!last.is_empty()
-                && last.len() <= 4
-                && last.bytes().all(|byte| byte.is_ascii_hexdigit()));
-    }
-    false
-}
-
-fn is_valid_hostname(specification: &str) -> bool {
-    let hostname = specification.strip_suffix('.').unwrap_or(specification);
-    if hostname.is_empty() || hostname.len() > 253 {
-        return false;
-    }
-
-    let mut labels = hostname.split('.').peekable();
-    while let Some(label) = labels.next() {
-        if label.is_empty()
-            || label.len() > 63
-            || label.starts_with('-')
-            || label.ends_with('-')
-            || !label
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
-            || (labels.peek().is_none() && label.bytes().all(|byte| byte.is_ascii_digit()))
-        {
-            return false;
-        }
-    }
-    true
 }
 
 #[cfg(test)]
@@ -727,147 +573,5 @@ mod tests {
             .err(),
             Some(CreateTargetError::SshPortWithoutCredential)
         );
-    }
-
-    #[test]
-    fn target_host_validation_matches_gvmd_supported_forms() {
-        for specification in [
-            "192.0.2.1",
-            "2001:db8::1",
-            "192.0.2.1/1",
-            "192.0.2.1/30",
-            "2001:db8::1/1",
-            "2001:db8::1/128",
-            "192.0.2.1-25",
-            "192.0.2.1-192.0.2.25",
-            "2001:db8::1-ff",
-            "2001:db8::1-2001:db8::ff",
-            "scanner_1.example",
-            "scanner.example.",
-        ] {
-            assert!(
-                is_valid_host_specification(specification),
-                "expected {specification:?} to be valid"
-            );
-        }
-
-        for specification in [
-            "",
-            "192.0.2.1/0",
-            "192.0.2.1/31",
-            "192.0.2.1/32",
-            "2001:db8::1/0",
-            "2001:db8::1/129",
-            "192.0.2.1/30/1",
-            "2001:db8::1-fffff",
-            "-scanner.example",
-            "scanner-.example",
-            "scanner.123",
-            "scanner..example",
-        ] {
-            assert!(
-                !is_valid_host_specification(specification),
-                "expected {specification:?} to be invalid"
-            );
-        }
-
-        assert!(validate_host_entries(
-            &["scanner.example, 192.0.2.1\n2001:db8::1".into()],
-            TargetHostField::Hosts,
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn create_target_classifies_invalid_host_and_excluded_host_entries() {
-        let hosts_error = create_target(
-            "target",
-            CreateTargetOpts {
-                hosts: vec!["192.0.2.1".into(), "192.0.2.2/31".into()],
-                ..Default::default()
-            },
-        )
-        .err();
-        assert_eq!(
-            hosts_error,
-            Some(CreateTargetError::InvalidHostSpecification(
-                InvalidTargetHost {
-                    field: TargetHostField::Hosts,
-                    index: 1,
-                    specification: "192.0.2.2/31".into(),
-                }
-            ))
-        );
-
-        let excluded_error = create_target(
-            "target",
-            CreateTargetOpts {
-                hosts: vec!["192.0.2.1/30".into()],
-                exclude_hosts: vec!["2001:db8::1/129".into()],
-                ..Default::default()
-            },
-        )
-        .err();
-        assert_eq!(
-            excluded_error,
-            Some(CreateTargetError::InvalidHostSpecification(
-                InvalidTargetHost {
-                    field: TargetHostField::ExcludeHosts,
-                    index: 0,
-                    specification: "2001:db8::1/129".into(),
-                }
-            ))
-        );
-    }
-
-    #[test]
-    fn modify_target_validates_replacements_but_allows_clear_and_omission() {
-        let hosts_error = modify_target(
-            &id("t1"),
-            ModifyTargetOpts {
-                hosts: CollectionUpdate::replace(["192.0.2.1/32".into()]),
-                ..Default::default()
-            },
-        )
-        .err();
-        assert_eq!(
-            hosts_error,
-            Some(ModifyTargetError::InvalidHostSpecification(
-                InvalidTargetHost {
-                    field: TargetHostField::Hosts,
-                    index: 0,
-                    specification: "192.0.2.1/32".into(),
-                }
-            ))
-        );
-
-        let excluded_error = modify_target(
-            &id("t1"),
-            ModifyTargetOpts {
-                exclude_hosts: CollectionUpdate::replace(["bad host".into()]),
-                ..Default::default()
-            },
-        )
-        .err();
-        assert_eq!(
-            excluded_error,
-            Some(ModifyTargetError::InvalidHostSpecification(
-                InvalidTargetHost {
-                    field: TargetHostField::ExcludeHosts,
-                    index: 0,
-                    specification: "bad host".into(),
-                }
-            ))
-        );
-
-        assert!(modify_target(
-            &id("t1"),
-            ModifyTargetOpts {
-                hosts: CollectionUpdate::Clear,
-                exclude_hosts: CollectionUpdate::Omitted,
-                ..Default::default()
-            }
-        )
-        .is_ok());
     }
 }

--- a/crates/gvm-gmp/src/lib.rs
+++ b/crates/gvm-gmp/src/lib.rs
@@ -18,6 +18,8 @@ pub mod filtering;
 pub mod responses;
 /// Typed schedule recurrence and iCalendar helpers.
 pub mod schedule;
+/// Validated target-host specifications.
+pub mod target;
 /// Shared GMP identifier and version types.
 pub mod types;
 
@@ -30,6 +32,11 @@ pub use schedule::{
     ScheduleDefinition, ScheduleIcalendarError, ScheduleInput, ScheduleObservation,
     ScheduleRecurrence, ScheduleRecurrenceObservation, ScheduleStartObservation, ScheduleTimestamp,
     ScheduleTimestampError, ScheduleTimezone, ScheduleTimezoneError,
+};
+/// Re-exported validated target-host values.
+pub use target::{
+    TargetHost, TargetHostError, TargetHostErrorKind, TargetHostKind, TargetHosts,
+    TargetHostsError, TargetPortRange, TargetPortRangeError, TargetPortSelection,
 };
 /// Re-exported shared GMP types.
 pub use types::{

--- a/crates/gvm-gmp/src/target.rs
+++ b/crates/gvm-gmp/src/target.rs
@@ -1,0 +1,1002 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Validated target-host specifications.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+/// A validated host specification accepted by gvmd target commands.
+///
+/// A target host may be an IPv4 or IPv6 address, a CIDR network, a full or
+/// abbreviated address range, or an ASCII hostname. Surrounding whitespace and
+/// IPv4 leading zeroes are normalized like gvmd before GMP serialization.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TargetHost {
+    value: String,
+    kind: TargetHostKind,
+    identity: TargetHostIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TargetHostIdentity {
+    Ip(IpAddr),
+    Network { start: IpAddr, end: IpAddr },
+    Range { start: IpAddr, end: IpAddr },
+    Hostname(String),
+}
+
+/// A validated target host selection.
+///
+/// gvmd treats included and excluded hosts as one value: included hosts must
+/// be non-empty, and modifications replace both lists atomically. This type
+/// makes those request-shape invariants impossible to represent incorrectly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetHosts {
+    included: Vec<TargetHost>,
+    excluded: Vec<TargetHost>,
+}
+
+impl TargetHosts {
+    /// Build a target host selection from included and excluded hosts.
+    ///
+    /// Canonically identical specifications are de-duplicated while retaining
+    /// the order of their first occurrence.
+    ///
+    /// # Errors
+    /// Returns [`TargetHostsError::EmptyIncludedHosts`] when no included host
+    /// remains, or [`TargetHostsError::EmptyEffectiveHosts`] when exclusions
+    /// statically cover the entire included selection.
+    pub fn new(
+        included: impl IntoIterator<Item = TargetHost>,
+        excluded: impl IntoIterator<Item = TargetHost>,
+    ) -> Result<Self, TargetHostsError> {
+        let included = deduplicate_hosts(included);
+        if included.is_empty() {
+            return Err(TargetHostsError::EmptyIncludedHosts);
+        }
+        let hosts = Self {
+            included,
+            excluded: deduplicate_hosts(excluded),
+        };
+        if !hosts.has_effective_hosts() {
+            return Err(TargetHostsError::EmptyEffectiveHosts);
+        }
+        Ok(hosts)
+    }
+
+    /// Borrow the non-empty included-host list.
+    #[must_use]
+    pub fn included(&self) -> &[TargetHost] {
+        &self.included
+    }
+
+    /// Borrow the excluded-host list.
+    #[must_use]
+    pub fn excluded(&self) -> &[TargetHost] {
+        &self.excluded
+    }
+
+    /// Return whether at least one included host remains after exclusions.
+    ///
+    /// Address, network, and range coverage is evaluated without expanding
+    /// large networks. Hostnames use their canonical ASCII identity; DNS
+    /// resolution and deployment-specific maximum-host limits remain gvmd
+    /// responsibilities.
+    #[must_use]
+    pub fn has_effective_hosts(&self) -> bool {
+        self.included
+            .iter()
+            .any(|included| !identity_is_covered(&included.identity, &self.excluded))
+    }
+}
+
+/// Errors raised while constructing a [`TargetHosts`] selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TargetHostsError {
+    /// A manual target must contain at least one included host specification.
+    #[error("a target host selection requires at least one included host")]
+    EmptyIncludedHosts,
+    /// Every included host is covered by the exclusion list.
+    #[error("a target host selection must contain at least one effective host")]
+    EmptyEffectiveHosts,
+}
+
+/// The required port source for a newly created target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetPortSelection {
+    /// Reuse an existing gvmd port list.
+    PortList(crate::types::EntityId),
+    /// Ask gvmd to create a target-specific port list from a validated range.
+    PortRange(TargetPortRange),
+}
+
+/// A validated GMP port-range list such as `T:22, U:53, T:80-443`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TargetPortRange(String);
+
+impl TargetPortRange {
+    /// Parse and normalize a GMP port-range list.
+    ///
+    /// # Errors
+    /// Returns [`TargetPortRangeError`] for an empty expression, an invalid
+    /// protocol/range shape, ports outside `1..=65535`, or a descending range.
+    pub fn new(value: impl AsRef<str>) -> Result<Self, TargetPortRangeError> {
+        let input = value.as_ref();
+        let mut normalized = Vec::new();
+        let mut protocol = 'T';
+        for item in input.split([',', '\n']) {
+            let item = item.trim();
+            if item.is_empty() {
+                continue;
+            }
+            let ports = match item.chars().next() {
+                Some(candidate @ ('T' | 'U')) => {
+                    let remainder = item[candidate.len_utf8()..].trim_start();
+                    let Some(remainder) = remainder.strip_prefix(':') else {
+                        return Err(TargetPortRangeError::InvalidSyntax);
+                    };
+                    protocol = candidate;
+                    remainder.trim()
+                }
+                _ => item,
+            };
+            if ports.is_empty() {
+                continue;
+            }
+            if ports.contains(':') {
+                return Err(TargetPortRangeError::InvalidSyntax);
+            }
+            let ports = ports
+                .chars()
+                .filter(|character| !character.is_whitespace())
+                .collect::<String>();
+            let (start, end) = match ports.split_once('-') {
+                Some((start, end)) if !end.contains('-') => {
+                    (parse_target_port(start)?, Some(parse_target_port(end)?))
+                }
+                Some(_) => return Err(TargetPortRangeError::InvalidSyntax),
+                None => (parse_target_port(&ports)?, None),
+            };
+            if end.is_some_and(|end| start > end) {
+                return Err(TargetPortRangeError::DescendingRange);
+            }
+            normalized.push(match end {
+                Some(end) => format!("{protocol}:{start}-{end}"),
+                None => format!("{protocol}:{start}"),
+            });
+        }
+        if normalized.is_empty() {
+            return Err(TargetPortRangeError::InvalidSyntax);
+        }
+        Ok(Self(normalized.join(", ")))
+    }
+
+    /// Borrow the normalized GMP wire representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TargetPortRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TargetPortRange {
+    type Err = TargetPortRangeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+/// Errors raised while validating a target port-range list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TargetPortRangeError {
+    /// The list does not match GMP's port-range syntax.
+    #[error("invalid GMP port-range syntax")]
+    InvalidSyntax,
+    /// A port is zero, larger than 65535, or not decimal.
+    #[error("target ports must be decimal values in 1..=65535")]
+    InvalidPort,
+    /// A range's first port is larger than its last port.
+    #[error("a target port range must not descend")]
+    DescendingRange,
+}
+
+fn parse_target_port(value: &str) -> Result<u16, TargetPortRangeError> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(TargetPortRangeError::InvalidPort);
+    }
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| TargetPortRangeError::InvalidPort)?;
+    (port != 0)
+        .then_some(port)
+        .ok_or(TargetPortRangeError::InvalidPort)
+}
+
+fn deduplicate_hosts(hosts: impl IntoIterator<Item = TargetHost>) -> Vec<TargetHost> {
+    let mut seen = HashSet::new();
+    hosts
+        .into_iter()
+        .filter(|host| seen.insert(host.identity.clone()))
+        .collect()
+}
+
+fn identity_is_covered(identity: &TargetHostIdentity, excluded: &[TargetHost]) -> bool {
+    match identity {
+        TargetHostIdentity::Hostname(hostname) => excluded.iter().any(|excluded| {
+            matches!(&excluded.identity, TargetHostIdentity::Hostname(value) if value == hostname)
+        }),
+        TargetHostIdentity::Ip(address) => {
+            let interval = IpInterval::from_address(*address);
+            interval_is_covered(interval, excluded)
+        }
+        TargetHostIdentity::Network { start, end }
+        | TargetHostIdentity::Range { start, end } => {
+            let interval = IpInterval::from_bounds(*start, *end);
+            interval_is_covered(interval, excluded)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct IpInterval {
+    version: u8,
+    start: u128,
+    end: u128,
+}
+
+impl IpInterval {
+    fn from_address(address: IpAddr) -> Self {
+        Self::from_bounds(address, address)
+    }
+
+    fn from_bounds(start: IpAddr, end: IpAddr) -> Self {
+        match (start, end) {
+            (IpAddr::V4(start), IpAddr::V4(end)) => Self {
+                version: 4,
+                start: u128::from(u32::from(start)),
+                end: u128::from(u32::from(end)),
+            },
+            (IpAddr::V6(start), IpAddr::V6(end)) => Self {
+                version: 6,
+                start: u128::from(start),
+                end: u128::from(end),
+            },
+            _ => unreachable!("validated interval bounds use one IP version"),
+        }
+    }
+}
+
+fn interval_is_covered(included: IpInterval, excluded: &[TargetHost]) -> bool {
+    let mut intervals = excluded
+        .iter()
+        .filter_map(|host| match &host.identity {
+            TargetHostIdentity::Ip(address) => Some(IpInterval::from_address(*address)),
+            TargetHostIdentity::Network { start, end }
+            | TargetHostIdentity::Range { start, end } => {
+                Some(IpInterval::from_bounds(*start, *end))
+            }
+            TargetHostIdentity::Hostname(_) => None,
+        })
+        .filter(|interval| {
+            interval.version == included.version
+                && interval.end >= included.start
+                && interval.start <= included.end
+        })
+        .collect::<Vec<_>>();
+    intervals.sort_unstable_by_key(|interval| interval.start);
+
+    let mut cursor = included.start;
+    for excluded in intervals {
+        if excluded.start > cursor {
+            return false;
+        }
+        if excluded.end >= included.end {
+            return true;
+        }
+        cursor = cursor.max(excluded.end.saturating_add(1));
+    }
+    false
+}
+
+impl TargetHost {
+    /// Parse and validate a target-host specification.
+    ///
+    /// # Errors
+    /// Returns [`TargetHostError`] when `value` is not one complete host
+    /// specification accepted by gvmd.
+    pub fn new(value: impl Into<String>) -> Result<Self, TargetHostError> {
+        let input = value.into();
+        let value = input.trim();
+        if value.is_empty() {
+            return Err(TargetHostError::new(input, TargetHostErrorKind::Empty));
+        }
+        if value.contains([',', '\n', '\r']) {
+            return Err(TargetHostError::new(
+                input,
+                TargetHostErrorKind::MultipleSpecifications,
+            ));
+        }
+        let value = normalize_ipv4_specification(value).unwrap_or_else(|| value.to_string());
+
+        let kind = classify(&value).map_err(|kind| TargetHostError::new(input, kind))?;
+        let identity = target_host_identity(&value, kind);
+        Ok(Self {
+            value,
+            kind,
+            identity,
+        })
+    }
+
+    /// Borrow the validated wire representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+
+    /// Return the host-specification category.
+    #[must_use]
+    pub const fn kind(&self) -> TargetHostKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for TargetHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TargetHost {
+    type Err = TargetHostError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for TargetHost {
+    type Error = TargetHostError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for TargetHost {
+    type Error = TargetHostError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for TargetHost {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TargetHost {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The syntax category of a validated [`TargetHost`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetHostKind {
+    /// A single IPv4 or IPv6 address.
+    IpAddress,
+    /// An IPv4 or IPv6 CIDR network.
+    Network,
+    /// A full or abbreviated IPv4 or IPv6 address range.
+    Range,
+    /// A DNS-style hostname accepted by gvmd.
+    Hostname,
+}
+
+/// Errors raised while validating a [`TargetHost`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid target host specification {input:?}: {kind}")]
+pub struct TargetHostError {
+    input: String,
+    kind: TargetHostErrorKind,
+}
+
+impl TargetHostError {
+    fn new(input: String, kind: TargetHostErrorKind) -> Self {
+        Self { input, kind }
+    }
+
+    /// Return the rejected input.
+    #[must_use]
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+
+    /// Return the validation failure category.
+    #[must_use]
+    pub const fn kind(&self) -> TargetHostErrorKind {
+        self.kind
+    }
+}
+
+/// Classification of a target-host validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum TargetHostErrorKind {
+    /// The specification is empty after trimming surrounding whitespace.
+    #[error("the specification is empty")]
+    Empty,
+    /// A single value contains a GMP host-list separator.
+    #[error("expected one specification, not a comma or newline separated list")]
+    MultipleSpecifications,
+    /// A CIDR address or prefix is invalid for its IP version.
+    #[error("invalid CIDR network")]
+    InvalidNetwork,
+    /// An address range is malformed, mixes IP versions, or is reversed.
+    #[error("invalid address range")]
+    InvalidRange,
+    /// The value does not match any host form accepted by gvmd.
+    #[error("unsupported host syntax")]
+    InvalidSyntax,
+}
+
+fn classify(value: &str) -> Result<TargetHostKind, TargetHostErrorKind> {
+    if value.parse::<IpAddr>().is_ok() {
+        return Ok(TargetHostKind::IpAddress);
+    }
+    if value.contains('/') {
+        return validate_network(value).map(|()| TargetHostKind::Network);
+    }
+    if let Some(result) = classify_range(value) {
+        return result.map(|()| TargetHostKind::Range);
+    }
+    if is_valid_hostname(value) {
+        return Ok(TargetHostKind::Hostname);
+    }
+    Err(TargetHostErrorKind::InvalidSyntax)
+}
+
+fn target_host_identity(value: &str, kind: TargetHostKind) -> TargetHostIdentity {
+    match kind {
+        TargetHostKind::IpAddress => TargetHostIdentity::Ip(
+            value
+                .parse()
+                .expect("validated IP address must remain parseable"),
+        ),
+        TargetHostKind::Network => {
+            let (address, prefix) = value
+                .split_once('/')
+                .expect("validated network must contain a prefix");
+            let address = address
+                .parse()
+                .expect("validated network address must remain parseable");
+            let prefix = prefix
+                .parse()
+                .expect("validated network prefix must remain parseable");
+            let (start, end) = network_bounds(address, prefix);
+            TargetHostIdentity::Network { start, end }
+        }
+        TargetHostKind::Range => {
+            let (start, end) = range_bounds(value);
+            TargetHostIdentity::Range { start, end }
+        }
+        TargetHostKind::Hostname => TargetHostIdentity::Hostname(value.to_ascii_lowercase()),
+    }
+}
+
+fn network_bounds(address: IpAddr, prefix: u16) -> (IpAddr, IpAddr) {
+    match address {
+        IpAddr::V4(address) => {
+            let prefix = u32::from(prefix);
+            let mask = u32::MAX << (32 - prefix);
+            let network = u32::from(address) & mask;
+            let broadcast = network | !mask;
+            (
+                IpAddr::V4(Ipv4Addr::from(network + 1)),
+                IpAddr::V4(Ipv4Addr::from(broadcast - 1)),
+            )
+        }
+        IpAddr::V6(address) => {
+            let prefix = u32::from(prefix);
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u128::MAX << (128 - prefix)
+            };
+            let network = u128::from(address) & mask;
+            let last = network | !mask;
+            let (start, end) = if prefix >= 127 {
+                (network, last)
+            } else {
+                (network + 1, last - 1)
+            };
+            (
+                IpAddr::V6(Ipv6Addr::from(start)),
+                IpAddr::V6(Ipv6Addr::from(end)),
+            )
+        }
+    }
+}
+
+fn range_bounds(value: &str) -> (IpAddr, IpAddr) {
+    let (start, end) = value
+        .split_once('-')
+        .expect("validated range must contain a separator");
+    let start: IpAddr = start
+        .parse()
+        .expect("validated range start must remain parseable");
+    if let Ok(end) = end.parse() {
+        return (start, end);
+    }
+    match start {
+        IpAddr::V4(start) => {
+            let mut octets = start.octets();
+            octets[3] = end
+                .parse()
+                .expect("validated short IPv4 range must remain parseable");
+            (IpAddr::V4(start), IpAddr::V4(Ipv4Addr::from(octets)))
+        }
+        IpAddr::V6(start) => {
+            let mut segments = start.segments();
+            segments[7] = u16::from_str_radix(end, 16)
+                .expect("validated short IPv6 range must remain parseable");
+            (IpAddr::V6(start), IpAddr::V6(Ipv6Addr::from(segments)))
+        }
+    }
+}
+
+fn normalize_ipv4_specification(value: &str) -> Option<String> {
+    if let Some((address, prefix)) = value.split_once('/') {
+        if prefix.is_empty()
+            || prefix.contains(['/', '-'])
+            || !prefix.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return None;
+        }
+        return Some(format!(
+            "{}/{}",
+            normalize_ipv4_address(address)?,
+            normalize_decimal(prefix)
+        ));
+    }
+    if let Some((start, end)) = value.split_once('-') {
+        if end.is_empty()
+            || end.contains(['/', '-'])
+            || !end
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || byte == b'.')
+        {
+            return None;
+        }
+        let start = normalize_ipv4_address(start)?;
+        let end = if end.contains('.') {
+            normalize_ipv4_address(end)?
+        } else {
+            normalize_decimal(end)
+        };
+        return Some(format!("{start}-{end}"));
+    }
+    normalize_ipv4_address(value)
+}
+
+fn normalize_ipv4_address(value: &str) -> Option<String> {
+    let components = value.split('.').collect::<Vec<_>>();
+    if components.len() != 4
+        || components.iter().any(|component| {
+            component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_digit())
+        })
+    {
+        return None;
+    }
+    Some(
+        components
+            .into_iter()
+            .map(normalize_decimal)
+            .collect::<Vec<_>>()
+            .join("."),
+    )
+}
+
+fn normalize_decimal(value: &str) -> String {
+    let value = value.trim_start_matches('0');
+    if value.is_empty() {
+        "0".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn validate_network(value: &str) -> Result<(), TargetHostErrorKind> {
+    let (address, prefix) = value
+        .split_once('/')
+        .filter(|(_, prefix)| !prefix.contains('/'))
+        .ok_or(TargetHostErrorKind::InvalidNetwork)?;
+    let address = address
+        .parse::<IpAddr>()
+        .map_err(|_| TargetHostErrorKind::InvalidNetwork)?;
+    if prefix.is_empty() || !prefix.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(TargetHostErrorKind::InvalidNetwork);
+    }
+    let prefix = prefix
+        .parse::<u16>()
+        .map_err(|_| TargetHostErrorKind::InvalidNetwork)?;
+    let valid = match address {
+        IpAddr::V4(_) => (1..=30).contains(&prefix),
+        IpAddr::V6(_) => (1..=128).contains(&prefix),
+    };
+    valid
+        .then_some(())
+        .ok_or(TargetHostErrorKind::InvalidNetwork)
+}
+
+fn classify_range(value: &str) -> Option<Result<(), TargetHostErrorKind>> {
+    let (start, end) = value.split_once('-')?;
+    let start = start.parse::<IpAddr>().ok()?;
+    if let Ok(end) = end.parse::<IpAddr>() {
+        return Some(match (start, end) {
+            (IpAddr::V4(start), IpAddr::V4(end)) if start <= end => Ok(()),
+            (IpAddr::V6(start), IpAddr::V6(end)) if start <= end => Ok(()),
+            _ => Err(TargetHostErrorKind::InvalidRange),
+        });
+    }
+
+    match start {
+        IpAddr::V4(start) => classify_short_ipv4_range(start, end),
+        IpAddr::V6(start) => classify_short_ipv6_range(start, end),
+    }
+}
+
+fn classify_short_ipv4_range(
+    start: Ipv4Addr,
+    end: &str,
+) -> Option<Result<(), TargetHostErrorKind>> {
+    if end.is_empty() || !end.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let end = end.parse::<u8>().ok()?;
+    Some(
+        (start.octets()[3] <= end)
+            .then_some(())
+            .ok_or(TargetHostErrorKind::InvalidRange),
+    )
+}
+
+fn classify_short_ipv6_range(
+    start: Ipv6Addr,
+    end: &str,
+) -> Option<Result<(), TargetHostErrorKind>> {
+    if end.is_empty() || end.len() > 4 || !end.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let end = u16::from_str_radix(end, 16).ok()?;
+    Some(
+        (start.segments()[7] <= end)
+            .then_some(())
+            .ok_or(TargetHostErrorKind::InvalidRange),
+    )
+}
+
+fn is_valid_hostname(value: &str) -> bool {
+    let value = value.strip_suffix('.').unwrap_or(value);
+    if value.is_empty() || value.len() > 253 {
+        return false;
+    }
+    let mut labels = value.split('.').peekable();
+    while let Some(label) = labels.next() {
+        if label.is_empty()
+            || label.len() > 63
+            || label.starts_with('-')
+            || label.ends_with('-')
+            || !label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return false;
+        }
+        if labels.peek().is_none() && label.bytes().all(|byte| byte.is_ascii_digit()) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host(value: &str) -> TargetHost {
+        value.parse().expect("valid target host")
+    }
+
+    #[test]
+    fn target_hosts_requires_included_hosts_and_deduplicates_canonically() {
+        assert_eq!(
+            TargetHosts::new([], []).expect_err("empty included hosts"),
+            TargetHostsError::EmptyIncludedHosts
+        );
+
+        let hosts = TargetHosts::new(
+            [
+                host("001.002.003.004"),
+                host("1.2.3.4"),
+                host("2001:0db8:0:0:0:0:0:1"),
+                host("2001:db8::1"),
+                host("2001:db8:1::1/64"),
+                host("2001:0db8:0001::ffff/64"),
+                host("2001:db8::10-001f"),
+                host("2001:0db8:0:0:0:0:0:10-2001:db8::1f"),
+                host("Scanner.Example."),
+                host("scanner.example."),
+                host("scanner.example"),
+            ],
+            [host("2001:0db8::2"), host("2001:db8::2")],
+        )
+        .expect("valid target hosts");
+        assert_eq!(
+            hosts
+                .included()
+                .iter()
+                .map(TargetHost::as_str)
+                .collect::<Vec<_>>(),
+            [
+                "1.2.3.4",
+                "2001:0db8:0:0:0:0:0:1",
+                "2001:db8:1::1/64",
+                "2001:db8::10-001f",
+                "Scanner.Example.",
+                "scanner.example",
+            ]
+        );
+        assert_eq!(hosts.excluded(), [host("2001:0db8::2")]);
+    }
+
+    #[test]
+    fn target_hosts_rejects_empty_effective_address_sets_without_expansion() {
+        for (included, excluded) in [
+            (&["192.0.2.1"][..], &["192.0.2.1"][..]),
+            (&["192.0.2.0/30"][..], &["192.0.2.1-192.0.2.2"][..]),
+            (&["2001:db8::/126"][..], &["2001:db8::1", "2001:db8::2"][..]),
+            (&["Scanner.Example."][..], &["scanner.example."][..]),
+            (&["2001:db8::/127"][..], &["2001:db8::-0001"][..]),
+            (&["2001:db8::1/128"][..], &["2001:db8::1"][..]),
+        ] {
+            let error = TargetHosts::new(
+                included.iter().map(|value| host(value)),
+                excluded.iter().map(|value| host(value)),
+            )
+            .expect_err("fully excluded target hosts");
+            assert_eq!(
+                error,
+                TargetHostsError::EmptyEffectiveHosts,
+                "{included:?} - {excluded:?}"
+            );
+        }
+
+        let hosts = TargetHosts::new([host("192.0.2.0/30")], [host("192.0.2.1")])
+            .expect("valid target hosts");
+        assert!(hosts.has_effective_hosts());
+
+        let hosts = TargetHosts::new([host("Scanner.Example.")], [host("scanner.example")])
+            .expect("valid target hosts");
+        assert!(hosts.has_effective_hosts());
+    }
+
+    #[test]
+    fn target_port_ranges_validate_and_normalize_gmp_syntax() {
+        assert_eq!(
+            TargetPortRange::new(" T:00022, U:53, T:80-00443 ")
+                .expect("valid port range")
+                .as_str(),
+            "T:22, U:53, T:80-443"
+        );
+        assert_eq!(
+            TargetPortRange::new(" T  : 1 -5, 7,9,\nU:1-3, 5,,\n,7,9 ")
+                .expect("gvmd-compatible port range")
+                .as_str(),
+            "T:1-5, T:7, T:9, U:1-3, U:5, U:7, U:9"
+        );
+        assert_eq!(
+            TargetPortRange::new("6-9,7,7,10-20,20")
+                .expect("implicit TCP port range")
+                .as_str(),
+            "T:6-9, T:7, T:7, T:10-20, T:20"
+        );
+
+        for (value, error) in [
+            ("", TargetPortRangeError::InvalidSyntax),
+            ("U:,T:", TargetPortRangeError::InvalidSyntax),
+            ("tcp:22", TargetPortRangeError::InvalidSyntax),
+            ("T,U", TargetPortRangeError::InvalidSyntax),
+            ("T:0", TargetPortRangeError::InvalidPort),
+            ("U:65536", TargetPortRangeError::InvalidPort),
+            ("T:443-80", TargetPortRangeError::DescendingRange),
+            ("T:1-2-3", TargetPortRangeError::InvalidSyntax),
+        ] {
+            assert_eq!(TargetPortRange::new(value), Err(error), "{value}");
+        }
+    }
+
+    #[test]
+    fn classifies_supported_host_forms() {
+        for (value, kind) in [
+            ("192.0.2.1", TargetHostKind::IpAddress),
+            ("2001:db8::1", TargetHostKind::IpAddress),
+            ("192.0.2.0/30", TargetHostKind::Network),
+            ("2001:db8::/64", TargetHostKind::Network),
+            ("192.0.2.1-20", TargetHostKind::Range),
+            ("192.0.2.1-192.0.3.20", TargetHostKind::Range),
+            ("2001:db8::1-00ff", TargetHostKind::Range),
+            ("2001:db8::1-2001:db8::ff", TargetHostKind::Range),
+            ("scanner_example.test.", TargetHostKind::Hostname),
+        ] {
+            assert_eq!(host(value).kind(), kind, "{value}");
+        }
+    }
+
+    #[test]
+    fn enforces_ip_version_specific_cidr_limits() {
+        for value in [
+            "192.0.2.0/1",
+            "192.0.2.0/30",
+            "2001:db8::/1",
+            "2001:db8::/127",
+            "2001:db8::1/128",
+        ] {
+            assert_eq!(host(value).kind(), TargetHostKind::Network, "{value}");
+        }
+        for value in [
+            "192.0.2.0/0",
+            "192.0.2.0/31",
+            "192.0.2.0/32",
+            "192.0.2.0/+24",
+            "2001:db8::/0",
+            "2001:db8::/+64",
+            "2001:db8::/129",
+        ] {
+            assert_eq!(
+                value
+                    .parse::<TargetHost>()
+                    .expect_err("invalid network")
+                    .kind(),
+                TargetHostErrorKind::InvalidNetwork,
+                "{value}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_ranges_and_syntax() {
+        for value in [
+            "192.0.2.20-1",
+            "192.0.2.20-192.0.2.1",
+            "192.0.2.1-2001:db8::1",
+            "2001:db8::20-0001",
+            "2001:db8::20-2001:db8::1",
+        ] {
+            assert_eq!(
+                value
+                    .parse::<TargetHost>()
+                    .expect_err("invalid range")
+                    .kind(),
+                TargetHostErrorKind::InvalidRange,
+                "{value}"
+            );
+        }
+        for value in [
+            "",
+            "   ",
+            "bad host",
+            "-host.example",
+            "host-.example",
+            "example.123",
+            "192.0.2.1-+20",
+            "ſ.example",
+            "K.example",
+        ] {
+            assert!(value.parse::<TargetHost>().is_err(), "{value:?}");
+        }
+        assert_eq!(
+            "192.0.2.1,192.0.2.2"
+                .parse::<TargetHost>()
+                .expect_err("multiple specifications")
+                .kind(),
+            TargetHostErrorKind::MultipleSpecifications
+        );
+    }
+
+    #[test]
+    fn trims_and_preserves_supported_wire_spelling() {
+        let host = host("  Scanner_One.Example.  ");
+        assert_eq!(host.as_str(), "Scanner_One.Example.");
+        assert_eq!(host.to_string(), "Scanner_One.Example.");
+    }
+
+    #[test]
+    fn normalizes_ipv4_leading_zeroes_like_gvmd() {
+        for (input, normalized, kind) in [
+            ("000.001.002.003", "0.1.2.3", TargetHostKind::IpAddress),
+            ("000.001.002.003/024", "0.1.2.3/24", TargetHostKind::Network),
+            ("000.001.002.003-004", "0.1.2.3-4", TargetHostKind::Range),
+            (
+                "000.001.002.003-000.001.002.004",
+                "0.1.2.3-0.1.2.4",
+                TargetHostKind::Range,
+            ),
+            (
+                "000000000000000000192.000168.000001.000001",
+                "192.168.1.1",
+                TargetHostKind::IpAddress,
+            ),
+        ] {
+            let host = host(input);
+            assert_eq!(host.as_str(), normalized, "{input}");
+            assert_eq!(host.kind(), kind, "{input}");
+        }
+
+        for input in [
+            "000.001.002.999",
+            "000.001.002.003/000",
+            "000.001.002.003/031",
+        ] {
+            assert!(input.parse::<TargetHost>().is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn ip_prefixed_hostname_falls_through_range_classification() {
+        let host = host("192.0.2.1-example.com");
+        assert_eq!(host.kind(), TargetHostKind::Hostname);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_uses_validated_string_representation() {
+        let host = host("192.0.2.0/30");
+        assert_eq!(
+            serde_json::to_string(&host).expect("serialize host"),
+            "\"192.0.2.0/30\""
+        );
+        assert_eq!(
+            serde_json::from_str::<TargetHost>("\"2001:db8::1/128\"")
+                .expect("deserialize valid host")
+                .as_str(),
+            "2001:db8::1/128"
+        );
+        assert!(serde_json::from_str::<TargetHost>("\"192.0.2.0/31\"").is_err());
+        assert_eq!(
+            serde_json::from_str::<TargetHost>("\"000.001.002.003/030\"")
+                .expect("deserialize normalized host")
+                .as_str(),
+            "0.1.2.3/30"
+        );
+        for value in [
+            "\"192.0.2.0/+24\"",
+            "\"2001:db8::/+64\"",
+            "\"192.0.2.1-+20\"",
+        ] {
+            assert!(
+                serde_json::from_str::<TargetHost>(value).is_err(),
+                "{value}"
+            );
+        }
+    }
+}

--- a/crates/gvm-gmp/src/target.rs
+++ b/crates/gvm-gmp/src/target.rs
@@ -970,31 +970,45 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_uses_validated_string_representation() {
+        #[derive(Debug, serde::Deserialize, serde::Serialize)]
+        #[serde(rename = "target")]
+        struct TargetHostWire {
+            host: TargetHost,
+        }
+
         let host = host("192.0.2.0/30");
         assert_eq!(
-            serde_json::to_string(&host).expect("serialize host"),
-            "\"192.0.2.0/30\""
+            quick_xml::se::to_string(&TargetHostWire { host }).expect("serialize host"),
+            "<target><host>192.0.2.0/30</host></target>"
         );
         assert_eq!(
-            serde_json::from_str::<TargetHost>("\"2001:db8::1/128\"")
-                .expect("deserialize valid host")
-                .as_str(),
+            quick_xml::de::from_str::<TargetHostWire>(
+                "<target><host>2001:db8::1/128</host></target>",
+            )
+            .expect("deserialize valid host")
+            .host
+            .as_str(),
             "2001:db8::1/128"
         );
-        assert!(serde_json::from_str::<TargetHost>("\"192.0.2.0/31\"").is_err());
+        assert!(quick_xml::de::from_str::<TargetHostWire>(
+            "<target><host>192.0.2.0/31</host></target>",
+        )
+        .is_err());
         assert_eq!(
-            serde_json::from_str::<TargetHost>("\"000.001.002.003/030\"")
-                .expect("deserialize normalized host")
-                .as_str(),
+            quick_xml::de::from_str::<TargetHostWire>(
+                "<target><host>000.001.002.003/030</host></target>",
+            )
+            .expect("deserialize normalized host")
+            .host
+            .as_str(),
             "0.1.2.3/30"
         );
-        for value in [
-            "\"192.0.2.0/+24\"",
-            "\"2001:db8::/+64\"",
-            "\"192.0.2.1-+20\"",
-        ] {
+        for value in ["192.0.2.0/+24", "2001:db8::/+64", "192.0.2.1-+20"] {
             assert!(
-                serde_json::from_str::<TargetHost>(value).is_err(),
+                quick_xml::de::from_str::<TargetHostWire>(&format!(
+                    "<target><host>{value}</host></target>"
+                ))
+                .is_err(),
                 "{value}"
             );
         }

--- a/crates/gvm-gmp/tests/test_targets.rs
+++ b/crates/gvm-gmp/tests/test_targets.rs
@@ -7,13 +7,33 @@ mod common;
 
 use common::{id, xml};
 use gvm_gmp::commands::targets::*;
-use gvm_gmp::{AliveTest, ScalarUpdate, ServicePort};
+use gvm_gmp::{AliveTest, ScalarUpdate, ServicePort, TargetHost, TargetHosts, TargetPortSelection};
+
+fn host(value: &str) -> TargetHost {
+    value.parse().expect("valid target host")
+}
+
+fn hosts(included: &[&str], excluded: &[&str]) -> TargetHosts {
+    TargetHosts::new(
+        included.iter().map(|value| host(value)),
+        excluded.iter().map(|value| host(value)),
+    )
+    .expect("valid target hosts")
+}
+
+fn direct_ports() -> TargetPortSelection {
+    TargetPortSelection::PortRange("T:1-65535".parse().expect("valid port range"))
+}
 
 #[test]
 fn test_create_target_basic() {
     assert_eq!(
-        xml(create_target("target", Default::default()).expect("valid target")),
-        "<create_target><name>target</name></create_target>"
+        xml(create_target(
+            "target",
+            CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports()),
+        )
+        .expect("valid target")),
+        "<create_target><name>target</name><hosts>192.0.2.1</hosts><exclude_hosts></exclude_hosts><port_range>T:1-65535</port_range></create_target>"
     );
 }
 
@@ -25,13 +45,12 @@ fn test_create_target_with_optionals() {
                 "target",
                 CreateTargetOpts {
                 comment: Some("c".into()),
-                hosts: vec!["1.1.1.1".into(), "2.2.2.2".into()],
-                exclude_hosts: vec!["3.3.3.3".into()],
+                hosts: hosts(&["1.1.1.1", "2.2.2.2"], &["3.3.3.3"]),
                 alive_test: Some(AliveTest::IcmpAndArpPing),
-                port_list_id: Some(id("pl1")),
+                ports: TargetPortSelection::PortList(id("pl1")),
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
-                ..Default::default()
+                ..CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports())
                 },
             )
             .expect("valid target"),
@@ -64,14 +83,14 @@ fn test_target_ssh_credential_port_is_nested_in_credential() {
             create_target(
                 "target",
                 CreateTargetOpts {
-                ssh_credential_id: Some(id("ssh1")),
-                ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
-                ..Default::default()
+                    ssh_credential_id: Some(id("ssh1")),
+                    ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
+                    ..CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports())
                 },
             )
             .expect("valid target"),
         ),
-        "<create_target><name>target</name><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></create_target>"
+        "<create_target><name>target</name><hosts>192.0.2.1</hosts><exclude_hosts></exclude_hosts><port_range>T:1-65535</port_range><ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential></create_target>"
     );
 
     assert_eq!(

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -13,7 +13,7 @@ use base64::Engine as _;
 use gvm_gmp::schedule::{
     parse_icalendar_with_timezone, ScheduleStartObservation, ScheduleTimestamp,
 };
-use gvm_gmp::AliveTest;
+use gvm_gmp::{AliveTest, TargetHost, TargetHosts, TargetPortRange};
 use uuid::Uuid;
 
 use crate::command_parser::{parse_command, parse_element_text, ParsedCommand, ParsedElement};
@@ -67,6 +67,202 @@ fn asset_sort_value<'a>(resource: &'a Resource, field: &str) -> &'a str {
         "comment" => &resource.comment,
         "type" => resource.asset_type().unwrap_or_default(),
         _ => resource.attr(field).unwrap_or_default(),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AssetFilterRelation {
+    Equal,
+    Contains,
+    Keyword,
+    Greater,
+    Less,
+}
+
+struct FilteredAssets {
+    resources: Vec<Resource>,
+    filtered: usize,
+}
+
+fn filter_assets(
+    mut resources: Vec<Resource>,
+    filter: Option<&str>,
+    paginate: bool,
+) -> Result<FilteredAssets, String> {
+    let mut first = 1usize;
+    let mut rows = None;
+    let mut sort_field = "name".to_string();
+    let mut reverse = false;
+
+    if let Some(filter) = filter {
+        for predicate in tokenize_asset_filter(filter)? {
+            let (key, relation, value) = parse_asset_filter_predicate(&predicate)?;
+            match key {
+                "first" => {
+                    require_equal_filter_relation(relation, key)?;
+                    first = value
+                        .parse::<isize>()
+                        .map_err(|_| format!("Invalid asset filter value for '{key}'"))?
+                        .max(0) as usize;
+                }
+                "rows" => {
+                    require_equal_filter_relation(relation, key)?;
+                    let value = value
+                        .parse::<isize>()
+                        .map_err(|_| format!("Invalid asset filter value for '{key}'"))?;
+                    rows = (value > 0).then_some(value as usize);
+                }
+                "sort" => {
+                    require_equal_filter_relation(relation, key)?;
+                    sort_field = value.to_string();
+                    reverse = false;
+                }
+                "sort-reverse" => {
+                    require_equal_filter_relation(relation, key)?;
+                    sort_field = value.to_string();
+                    reverse = true;
+                }
+                "permission" | "min_qod" => {
+                    return Err(format!("Unsupported asset filter field '{key}'"));
+                }
+                "uuid" | "id" => resources.retain(|resource| {
+                    asset_filter_matches(&resource.id.to_string(), relation, value)
+                }),
+                _ => resources.retain(|resource| {
+                    asset_filter_value(resource, key)
+                        .is_some_and(|candidate| asset_filter_matches(candidate, relation, value))
+                }),
+            }
+        }
+    }
+
+    resources.sort_by(|left, right| {
+        let left = asset_sort_value(left, &sort_field);
+        let right = asset_sort_value(right, &sort_field);
+        if reverse {
+            right.cmp(left)
+        } else {
+            left.cmp(right)
+        }
+    });
+    let filtered = resources.len();
+    if paginate {
+        let start = first.saturating_sub(1).min(resources.len());
+        let end = rows.map_or(resources.len(), |rows| {
+            start.saturating_add(rows).min(resources.len())
+        });
+        resources = resources[start..end].to_vec();
+    }
+    Ok(FilteredAssets {
+        resources,
+        filtered,
+    })
+}
+
+fn tokenize_asset_filter(filter: &str) -> Result<Vec<String>, String> {
+    let mut predicates = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    for character in filter.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+            continue;
+        }
+        if character == '\\' && quote.is_some() {
+            escaped = true;
+            continue;
+        }
+        if matches!(character, '\'' | '"') {
+            if quote == Some(character) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(character);
+            } else {
+                current.push(character);
+            }
+            continue;
+        }
+        if character.is_whitespace() && quote.is_none() {
+            if !current.is_empty() {
+                predicates.push(std::mem::take(&mut current));
+            }
+        } else {
+            current.push(character);
+        }
+    }
+    if quote.is_some() || escaped {
+        return Err("Malformed quoted asset filter".to_string());
+    }
+    if !current.is_empty() {
+        predicates.push(current);
+    }
+    Ok(predicates)
+}
+
+fn parse_asset_filter_predicate(
+    predicate: &str,
+) -> Result<(&str, AssetFilterRelation, &str), String> {
+    let Some((index, operator)) = predicate
+        .char_indices()
+        .find(|(_, character)| matches!(character, '=' | '~' | ':' | '>' | '<'))
+    else {
+        return Err(format!("Malformed asset filter predicate '{predicate}'"));
+    };
+    let key = &predicate[..index];
+    let value = &predicate[index + operator.len_utf8()..];
+    if key.is_empty() || value.is_empty() {
+        return Err(format!("Malformed asset filter predicate '{predicate}'"));
+    }
+    let relation = match operator {
+        '=' => AssetFilterRelation::Equal,
+        '~' => AssetFilterRelation::Contains,
+        ':' => AssetFilterRelation::Keyword,
+        '>' => AssetFilterRelation::Greater,
+        '<' => AssetFilterRelation::Less,
+        _ => unreachable!("matched filter operator"),
+    };
+    Ok((key, relation, value))
+}
+
+fn require_equal_filter_relation(relation: AssetFilterRelation, key: &str) -> Result<(), String> {
+    if matches!(relation, AssetFilterRelation::Equal) {
+        Ok(())
+    } else {
+        Err(format!("Invalid relation for asset filter field '{key}'"))
+    }
+}
+
+fn asset_filter_value<'a>(resource: &'a Resource, key: &str) -> Option<&'a str> {
+    match key {
+        "name" => Some(&resource.name),
+        "comment" => Some(&resource.comment),
+        "type" => resource.asset_type(),
+        "owner" => Some("admin"),
+        _ => resource.attr(key),
+    }
+}
+
+fn asset_filter_matches(candidate: &str, relation: AssetFilterRelation, value: &str) -> bool {
+    match relation {
+        AssetFilterRelation::Equal => candidate == value,
+        AssetFilterRelation::Contains | AssetFilterRelation::Keyword => candidate
+            .to_ascii_lowercase()
+            .contains(&value.to_ascii_lowercase()),
+        AssetFilterRelation::Greater | AssetFilterRelation::Less => {
+            let ordering = match (candidate.parse::<f64>(), value.parse::<f64>()) {
+                (Ok(candidate), Ok(value)) => candidate.partial_cmp(&value),
+                _ => Some(candidate.cmp(value)),
+            };
+            matches!(
+                (relation, ordering),
+                (
+                    AssetFilterRelation::Greater,
+                    Some(std::cmp::Ordering::Greater)
+                ) | (AssetFilterRelation::Less, Some(std::cmp::Ordering::Less))
+            )
+        }
     }
 }
 
@@ -461,64 +657,13 @@ impl SessionHandler {
             .into_bytes();
         }
 
-        let mut first = 1usize;
-        let mut rows = None;
-        let mut sort_field = "name";
-        let mut reverse = false;
-        if let Some(filter) = cmd.attr("filter") {
-            for predicate in filter.split_whitespace() {
-                let Some((key, value)) = predicate.split_once('=') else {
-                    continue;
-                };
-                match key {
-                    "first" => {
-                        first = value
-                            .parse::<isize>()
-                            .ok()
-                            .map_or(1, |value| value.max(0) as usize);
-                    }
-                    "rows" => {
-                        rows = value
-                            .parse::<isize>()
-                            .ok()
-                            .and_then(|value| (value > 0).then_some(value as usize));
-                    }
-                    "sort" => sort_field = value,
-                    "sort-reverse" => {
-                        sort_field = value;
-                        reverse = true;
-                    }
-                    "permission" | "owner" | "min_qod" => {}
-                    "name" => resources.retain(|resource| resource.name == value),
-                    "comment" => resources.retain(|resource| resource.comment == value),
-                    "uuid" | "id" => {
-                        resources.retain(|resource| resource.id.to_string() == value);
-                    }
-                    "type" => {
-                        resources.retain(|resource| resource.asset_type() == Some(value));
-                    }
-                    _ => resources.retain(|resource| resource.attr(key) == Some(value)),
-                }
-            }
-        }
-        resources.sort_by(|left, right| {
-            let left = asset_sort_value(left, sort_field);
-            let right = asset_sort_value(right, sort_field);
-            if reverse {
-                right.cmp(left)
-            } else {
-                left.cmp(right)
-            }
-        });
-
-        let filtered = resources.len();
-        if !matches!(cmd.attr("ignore_pagination"), Some("1" | "true")) {
-            let start = first.saturating_sub(1).min(resources.len());
-            let end = rows.map_or(resources.len(), |rows| {
-                start.saturating_add(rows).min(resources.len())
-            });
-            resources = resources[start..end].to_vec();
-        }
+        let paginate = !matches!(cmd.attr("ignore_pagination"), Some("1" | "true"));
+        let filtered_assets = match filter_assets(resources, cmd.attr("filter"), paginate) {
+            Ok(filtered_assets) => filtered_assets,
+            Err(message) => return error_response(&cmd.name, 400, &message),
+        };
+        resources = filtered_assets.resources;
+        let filtered = filtered_assets.filtered;
 
         let page = resources.len();
         let items: String = resources.iter().map(Resource::to_asset_xml).collect();
@@ -695,19 +840,37 @@ impl SessionHandler {
 
         let mut resource = Resource::new(resource_type, &name);
 
-        let target_port_list_id = if resource_type == "target" {
+        let (target_port_list_id, target_port_range) = if resource_type == "target" {
             let port_list_id = match optional_child_uuid(cmd, "port_list") {
                 Ok(port_list_id) => port_list_id,
                 Err(message) => return error_response(&cmd.name, 400, message),
+            };
+            let port_range = element_text_including_empty(cmd, raw_xml, "port_range");
+            let port_range = match port_range {
+                Some(port_range) => {
+                    let Ok(port_range) = TargetPortRange::new(port_range) else {
+                        return error_response(&cmd.name, 400, "Error in port range");
+                    };
+                    Some(port_range.to_string())
+                }
+                None => None,
             };
             if let Some(port_list_id) = port_list_id {
                 if store.get_typed(&port_list_id, "port_list").is_none() {
                     return error_response(&cmd.name, 404, "Port list not found");
                 }
+                (Some(port_list_id), None)
+            } else if let Some(port_range) = port_range {
+                (None, Some(port_range))
+            } else {
+                return error_response(
+                    &cmd.name,
+                    400,
+                    "One of PORT_LIST and PORT_RANGE is required",
+                );
             }
-            port_list_id
         } else {
-            None
+            (None, None)
         };
         let target_ssh_credential = if resource_type == "target" {
             match target_credential_update(cmd, store, "ssh_credential") {
@@ -950,14 +1113,38 @@ impl SessionHandler {
 
         // Target-specific
         if resource_type == "target" {
-            if let Some(hosts) = parse_element_text(raw_xml, "hosts") {
-                resource.set_attr("hosts", &hosts);
-            }
-            if let Some(exclude_hosts) = parse_element_text(raw_xml, "exclude_hosts") {
-                resource.set_attr("exclude_hosts", &exclude_hosts);
-            }
+            let asset_hosts_filter = cmd.child_attr("asset_hosts", "filter");
+            let hosts = if let Some(filter) = asset_hosts_filter {
+                match resolve_asset_target_hosts(store, filter) {
+                    Ok(hosts) => hosts,
+                    Err(message) => return error_response(&cmd.name, 400, &message),
+                }
+            } else {
+                let Some(hosts) = element_text_including_empty(cmd, raw_xml, "hosts") else {
+                    return error_response(&cmd.name, 400, "A host is required");
+                };
+                hosts
+            };
+            let exclude_hosts =
+                element_text_including_empty(cmd, raw_xml, "exclude_hosts").unwrap_or_default();
+            let (hosts, exclude_hosts) = match normalize_target_host_pair(&hosts, &exclude_hosts) {
+                Ok(hosts) => hosts,
+                Err(()) => {
+                    return error_response(&cmd.name, 400, "Error in host specification");
+                }
+            };
+            resource.set_attr("hosts", &hosts);
+            resource.set_attr("exclude_hosts", &exclude_hosts);
             if let Some(port_list_id) = target_port_list_id {
                 resource.set_attr("port_list_id", &port_list_id.to_string());
+            }
+            if let Some(port_range) = target_port_range {
+                let mut port_list = Resource::new("port_list", &name);
+                port_list.comment = format!("Autogenerated for target {name}.");
+                port_list.set_attr("port_range", &port_range);
+                let port_list_id = store.create(port_list);
+                resource.set_attr("port_list_id", &port_list_id.to_string());
+                resource.set_attr("port_range", &port_range);
             }
             apply_target_credential_update(&mut resource, "ssh_credential", &target_ssh_credential);
             apply_target_credential_update(&mut resource, "smb_credential", &target_smb_credential);
@@ -1097,6 +1284,8 @@ impl SessionHandler {
                 }
                 let xml = if cmd.name == "get_integration_configs" {
                     resource.to_integration_config_xml(cmd.attr("details") == Some("1"))
+                } else if cmd.name == "get_targets" {
+                    resource.to_xml_with_details(cmd.attr("details") == Some("1"))
                 } else {
                     resource.to_xml()
                 };
@@ -1159,6 +1348,12 @@ impl SessionHandler {
             resources
                 .iter()
                 .map(|resource| resource.to_integration_config_xml(details))
+                .collect()
+        } else if cmd.name == "get_targets" {
+            let details = cmd.attr("details") == Some("1");
+            resources
+                .iter()
+                .map(|resource| resource.to_xml_with_details(details))
                 .collect()
         } else {
             resources.iter().map(|resource| resource.to_xml()).collect()
@@ -1244,8 +1439,27 @@ impl SessionHandler {
         let new_text = parse_element_text(raw_xml, "text");
         let new_comment = parse_element_text(raw_xml, "comment");
         let new_host = parse_element_text(raw_xml, "host");
-        let new_hosts = parse_element_text(raw_xml, "hosts");
-        let new_exclude_hosts = parse_element_text(raw_xml, "exclude_hosts");
+        let (new_hosts, new_exclude_hosts) = if resource_type == "target" {
+            let hosts = element_text_including_empty(cmd, raw_xml, "hosts");
+            let exclude_hosts = element_text_including_empty(cmd, raw_xml, "exclude_hosts");
+            match (hosts, exclude_hosts) {
+                (None, None) => (None, None),
+                (Some(hosts), Some(exclude_hosts)) => {
+                    match normalize_target_host_pair(&hosts, &exclude_hosts) {
+                        Ok((hosts, exclude_hosts)) => (Some(hosts), Some(exclude_hosts)),
+                        Err(()) => {
+                            return error_response(&cmd.name, 400, "Error in host specification");
+                        }
+                    }
+                }
+                _ => return error_response(&cmd.name, 400, "Error in host specification"),
+            }
+        } else {
+            (
+                parse_element_text(raw_xml, "hosts"),
+                parse_element_text(raw_xml, "exclude_hosts"),
+            )
+        };
         let new_image_references = parse_element_text(raw_xml, "image_references");
         let new_urls = parse_element_text(raw_xml, "urls");
         let new_exclude_urls = parse_element_text(raw_xml, "exclude_urls");
@@ -1595,6 +1809,15 @@ impl SessionHandler {
 
         if resource_type == "task" {
             return match store.modify_task(&uuid, task_reference_updates, update_resource) {
+                Ok(()) => format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name)
+                    .into_bytes(),
+                Err(error) => store_error_response(&cmd.name, error),
+            };
+        }
+
+        if resource_type == "target" {
+            let changes_hosts = new_hosts.is_some();
+            return match store.modify_target(&uuid, changes_hosts, update_resource) {
                 Ok(()) => format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name)
                     .into_bytes(),
                 Err(error) => store_error_response(&cmd.name, error),
@@ -4132,6 +4355,70 @@ fn apply_target_credential_update(
     }
 }
 
+fn element_text_including_empty(cmd: &ParsedCommand, raw_xml: &[u8], name: &str) -> Option<String> {
+    parse_element_text(raw_xml, name).or_else(|| {
+        cmd.children
+            .iter()
+            .any(|child| child.name == name)
+            .then(String::new)
+    })
+}
+
+fn resolve_asset_target_hosts(store: &ResourceStore, filter: &str) -> Result<String, String> {
+    let assets = store
+        .list("asset")
+        .into_iter()
+        .filter(|resource| resource.asset_type() == Some("host"))
+        .collect::<Vec<_>>();
+    let assets = filter_assets(assets, Some(filter), true)?.resources;
+    Ok(assets
+        .into_iter()
+        .map(|asset| asset.name)
+        .collect::<Vec<_>>()
+        .join(", "))
+}
+
+fn normalize_target_host_pair(included: &str, excluded: &str) -> Result<(String, String), ()> {
+    let included = clean_target_host_list(included);
+    let excluded = clean_target_host_list(excluded);
+    let hosts = TargetHosts::new(
+        parse_clean_target_hosts(&included)?,
+        parse_clean_target_hosts(&excluded)?,
+    )
+    .map_err(|_| ())?;
+    if !hosts.has_effective_hosts() {
+        return Err(());
+    }
+    Ok((included.join(", "), excluded.join(", ")))
+}
+
+#[cfg(test)]
+fn normalize_target_host_list(value: &str) -> Result<String, ()> {
+    let hosts = clean_target_host_list(value);
+    parse_clean_target_hosts(&hosts)?;
+    Ok(hosts.join(", "))
+}
+
+fn clean_target_host_list(value: &str) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    value
+        .split([',', '\n'])
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| seen.insert((*value).to_string()))
+        .map(str::to_string)
+        .collect()
+}
+
+fn parse_clean_target_hosts(values: &[String]) -> Result<Vec<TargetHost>, ()> {
+    values
+        .iter()
+        .cloned()
+        .map(TargetHost::new)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ())
+}
+
 fn credential_kdcs(cmd: &ParsedCommand) -> Option<Vec<String>> {
     cmd.children
         .iter()
@@ -4294,6 +4581,19 @@ mod tests {
                 Err("Invalid alive test")
             );
         }
+    }
+
+    #[test]
+    fn target_host_lists_clean_separators_duplicates_and_empty_items() {
+        assert_eq!(
+            normalize_target_host_list(
+                " 000.001.002.003/030, ,2001:db8::1/128\n192.0.2.1-002, 2001:db8::1/128 "
+            )
+            .expect("valid host list"),
+            "000.001.002.003/030, 2001:db8::1/128, 192.0.2.1-002"
+        );
+        assert_eq!(normalize_target_host_list(" , \n "), Ok(String::new()));
+        assert!(normalize_target_host_list("192.0.2.1/31").is_err());
     }
 
     #[test]

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -313,6 +313,11 @@ impl Resource {
 
     /// Generate XML representation for get responses.
     pub fn to_xml(&self) -> String {
+        self.to_xml_with_details(false)
+    }
+
+    /// Generate XML representation for get responses with command detail semantics.
+    pub(crate) fn to_xml_with_details(&self, details: bool) -> String {
         // Notes and overrides use <text> instead of <name>
         let name_tag = if self.resource_type == "note" || self.resource_type == "override" {
             "text"
@@ -421,6 +426,14 @@ impl Resource {
                     xml_escape_attr(port_list_id),
                 ));
             }
+            if details {
+                if let Some(port_range) = self.attr("port_range") {
+                    xml.push_str(&format!(
+                        "<port_range>{}</port_range>",
+                        xml_escape(port_range),
+                    ));
+                }
+            }
             if let Some(id) = self.attr("ssh_credential_id") {
                 xml.push_str(&format!(
                     "<ssh_credential id=\"{}\"><name></name>",
@@ -518,6 +531,8 @@ impl Resource {
                     k.as_str(),
                     "port_list_id"
                         | "alive_test"
+                        | "port_range"
+                        | "asset_hosts_filter"
                         | "ssh_credential_id"
                         | "ssh_credential_port"
                         | "smb_credential_id"
@@ -945,6 +960,39 @@ impl ResourceStore {
         f(resource);
         resource.modification_time = now_iso();
         true
+    }
+
+    pub(crate) fn modify_target<F>(
+        &self,
+        id: &Uuid,
+        changes_hosts: bool,
+        f: F,
+    ) -> Result<(), StoreError>
+    where
+        F: FnOnce(&mut Resource),
+    {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        active_typed_resource(&inner, id, "target")?;
+
+        if changes_hosts {
+            let id_text = id.to_string();
+            let referenced = inner.resources.values().any(|candidate| {
+                candidate.resource_type == "task"
+                    && !candidate.trashed
+                    && candidate.attr("target_id") == Some(id_text.as_str())
+            });
+            if referenced {
+                return Err(StoreError::InUse("target"));
+            }
+        }
+
+        let target = inner
+            .resources
+            .get_mut(id)
+            .expect("validated target should remain present while locked");
+        f(target);
+        target.modification_time = now_iso();
+        Ok(())
     }
 
     pub(crate) fn modify_task<F>(

--- a/crates/gvm-mock-server/tests/connections.rs
+++ b/crates/gvm-mock-server/tests/connections.rs
@@ -230,7 +230,7 @@ async fn stateful_session_isolation() {
 
     let target_resp = send_recv(
         &mut client_a,
-        b"<create_target><name>Shared Target</name><hosts>127.0.0.1</hosts></create_target>",
+        b"<create_target><name>Shared Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>",
     )
     .await;
     let target_id = target_resp.id().expect("target should have id");

--- a/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
+++ b/crates/gvm-mock-server/tests/stateful_asset_conformance.rs
@@ -328,8 +328,14 @@ async fn legacy_asset_errors_trash_filters_and_sorting_are_deterministic() {
     let trashed = send_recv(&mut stream, b"<get_assets type=\"host\" trash=\"1\"/>").await;
     assert!(response_text(&trashed).contains(&trashed_id.to_string()));
 
+    let response = send_recv(
+        &mut stream,
+        b"<get_assets type=\"host\" filter=\"ignored-token sort-reverse=comment\"/>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+
     for filter in [
-        "ignored-token sort-reverse=comment",
         "sort=type",
         "sort=severity",
         &format!("uuid={first_id}"),

--- a/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
+++ b/crates/gvm-mock-server/tests/stateful_command_surface_gaps.rs
@@ -88,7 +88,7 @@ async fn create_task(stream: &mut UnixStream, name: &str, usage_type: &str) -> S
     let target = send_recv(
         stream,
         format!(
-            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>"
         )
         .as_bytes(),
     )

--- a/crates/gvm-mock-server/tests/stateful_filtering.rs
+++ b/crates/gvm-mock-server/tests/stateful_filtering.rs
@@ -58,7 +58,7 @@ async fn create_task(stream: &mut UnixStream, name: &str) -> Response {
     let target = send_recv(
         stream,
         format!(
-            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>"
         )
         .as_bytes(),
     )

--- a/crates/gvm-mock-server/tests/stateful_mode.rs
+++ b/crates/gvm-mock-server/tests/stateful_mode.rs
@@ -57,7 +57,7 @@ async fn create_task(stream: &mut UnixStream, name: &str) -> Response {
     let target = send_recv(
         stream,
         format!(
-            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>"
         )
         .as_bytes(),
     )
@@ -173,7 +173,7 @@ async fn stateful_create_task() {
 
     let target = send_recv(
         &mut stream,
-        b"<create_target><name>Test Target</name><hosts>127.0.0.1</hosts></create_target>",
+        b"<create_target><name>Test Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>",
     )
     .await;
     let target_id = target.id().expect("target should have id");

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -108,7 +108,7 @@ async fn matrix_targets_create_get_delete() {
     let target_id = create_and_get_id(
         &mut stream,
         format!(
-            "<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts><ssh_credential id=\"{credential_id}\"><port>2222</port></ssh_credential></create_target>"
+            "<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{credential_id}\"><port>2222</port></ssh_credential></create_target>"
         )
         .as_bytes(),
         "create_target",
@@ -188,7 +188,7 @@ async fn matrix_targets_create_get_delete() {
     let default_target_id = create_and_get_id(
         &mut stream,
         format!(
-            "<create_target><name>Default SSH Port</name><hosts>127.0.0.2</hosts><ssh_credential id=\"{credential_id}\"/></create_target>"
+            "<create_target><name>Default SSH Port</name><hosts>127.0.0.2</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{credential_id}\"/></create_target>"
         )
         .as_bytes(),
         "create_target",
@@ -207,7 +207,7 @@ async fn matrix_targets_create_get_delete() {
     let smb_port_resp = send_recv(
         &mut stream,
         format!(
-            "<create_target><name>Invalid SMB Port</name><hosts>127.0.0.3</hosts><smb_credential id=\"{smb_credential_id}\"><port>445</port></smb_credential></create_target>"
+            "<create_target><name>Invalid SMB Port</name><hosts>127.0.0.3</hosts><port_range>T:1-65535</port_range><smb_credential id=\"{smb_credential_id}\"><port>445</port></smb_credential></create_target>"
         )
         .as_bytes(),
     )
@@ -216,7 +216,7 @@ async fn matrix_targets_create_get_delete() {
 
     let create_detach_resp = send_recv(
         &mut stream,
-        b"<create_target><name>Invalid Detach</name><hosts>127.0.0.4</hosts><ssh_credential id=\"0\"/></create_target>",
+        b"<create_target><name>Invalid Detach</name><hosts>127.0.0.4</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"0\"/></create_target>",
     )
     .await;
     assert_eq!(create_detach_resp.status_code(), Some(400));
@@ -225,7 +225,7 @@ async fn matrix_targets_create_get_delete() {
         let invalid_type_resp = send_recv(
             &mut stream,
             format!(
-                "<create_target><name>Invalid Type {credential_element}</name><hosts>127.0.0.5</hosts><{credential_element} id=\"{invalid_credential_id}\"/></create_target>"
+                "<create_target><name>Invalid Type {credential_element}</name><hosts>127.0.0.5</hosts><port_range>T:1-65535</port_range><{credential_element} id=\"{invalid_credential_id}\"/></create_target>"
             )
             .as_bytes(),
         )

--- a/crates/gvm-mock-server/tests/stateful_target_host_validation.rs
+++ b/crates/gvm-mock-server/tests/stateful_target_host_validation.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Stateful target host-specification validation against raw GMP requests.
+
+#![cfg(feature = "unix-socket-tests")]
+#![allow(clippy::unwrap_used, missing_docs)]
+
+use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
+use gvm_protocol::Response;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+async fn stateful_server() -> Option<MockGmpServer> {
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(GmpVersion::V22_5)
+        .credentials("admin", "admin")
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => None,
+        Err(error) => panic!("server start failed: {error}"),
+    }
+}
+
+async fn connect(server: &MockGmpServer) -> UnixStream {
+    UnixStream::connect(server.socket_path().expect("Unix socket path"))
+        .await
+        .expect("connect to mock server")
+}
+
+async fn send_recv(stream: &mut UnixStream, xml: impl AsRef<[u8]>) -> Response {
+    stream.write_all(xml.as_ref()).await.expect("write request");
+    let mut buffer = vec![0_u8; 64 * 1024];
+    let length = stream.read(&mut buffer).await.expect("read response");
+    buffer.truncate(length);
+    Response::new(buffer)
+}
+
+async fn authenticate(stream: &mut UnixStream) {
+    let response = send_recv(
+        stream,
+        b"<authenticate><credentials><username>admin</username><password>admin</password></credentials></authenticate>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+}
+
+fn response_id(response: &Response) -> String {
+    response.id().expect("created resource id")
+}
+
+async fn get_target_xml(stream: &mut UnixStream, target_id: &str, details: bool) -> String {
+    let details = if details { " details=\"1\"" } else { "" };
+    let response = send_recv(
+        stream,
+        format!("<get_targets target_id=\"{target_id}\"{details}/>"),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+    response.as_str().expect("UTF-8 response").to_string()
+}
+
+#[tokio::test]
+async fn raw_target_create_validates_and_cleans_host_lists() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate(&mut stream).await;
+
+    for body in [
+        "<create_target><name>No ports</name><hosts>192.0.2.1</hosts></create_target>",
+        "<create_target><name>Empty ports</name><hosts>192.0.2.1</hosts><port_range/></create_target>",
+        "<create_target><name>Bad ports</name><hosts>192.0.2.1</hosts><port_range>T:0</port_range></create_target>",
+    ] {
+        let response = send_recv(&mut stream, body).await;
+        assert_eq!(response.status_code(), Some(400), "{body}");
+    }
+
+    for body in [
+        "<create_target><name>Missing</name><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Empty</name><hosts></hosts><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Empty</name><hosts>, ,</hosts><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Excluded</name><hosts>192.0.2.1</hosts><exclude_hosts>192.0.2.1</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Covered</name><hosts>192.0.2.0/30</hosts><exclude_hosts>192.0.2.1-192.0.2.2</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    ] {
+        let response = send_recv(&mut stream, body).await;
+        assert_eq!(response.status_code(), Some(400), "{body}");
+    }
+
+    for (element, value) in [
+        ("hosts", "192.0.2.1/0"),
+        ("hosts", "192.0.2.1/31"),
+        ("hosts", "192.0.2.1/32"),
+        ("exclude_hosts", "2001:db8::/0"),
+        ("exclude_hosts", "2001:db8::/129"),
+    ] {
+        let included = if element == "exclude_hosts" {
+            "<hosts>192.0.2.1</hosts>"
+        } else {
+            ""
+        };
+        let response = send_recv(
+            &mut stream,
+            format!(
+                "<create_target><name>Invalid</name>{included}<{element}>{value}</{element}><port_range>T:1-65535</port_range></create_target>"
+            ),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(400), "{element}={value}");
+        assert_eq!(
+            response.status_text().as_deref(),
+            Some("Error in host specification")
+        );
+    }
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Cleaned</name><hosts>000.001.002.003/030, ,2001:db8::1/128,2001:db8::1/128,2001:0db8:0:0:0:0:0:1/128&#10;192.0.2.1-002</hosts><exclude_hosts>192.0.2.0/1,2001:db8::/127</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+
+    for body in [
+        format!(
+            "<modify_target target_id=\"{target_id}\"><hosts>192.0.2.8</hosts></modify_target>"
+        ),
+        format!(
+            "<modify_target target_id=\"{target_id}\"><exclude_hosts>192.0.2.8</exclude_hosts></modify_target>"
+        ),
+        format!(
+            "<modify_target target_id=\"{target_id}\"><hosts></hosts><exclude_hosts></exclude_hosts></modify_target>"
+        ),
+        format!(
+            "<modify_target target_id=\"{target_id}\"><hosts>, ,</hosts><exclude_hosts></exclude_hosts></modify_target>"
+        ),
+    ] {
+        let response = send_recv(&mut stream, body).await;
+        assert_eq!(response.status_code(), Some(400));
+    }
+
+    let xml = get_target_xml(&mut stream, &target_id, false).await;
+    assert!(xml.contains("<hosts>000.001.002.003/030, 2001:db8::1/128, 2001:0db8:0:0:0:0:0:1/128, 192.0.2.1-002</hosts>"));
+    assert!(xml.contains("<exclude_hosts>192.0.2.0/1, 2001:db8::/127</exclude_hosts>"));
+    assert!(!xml.contains("<port_range>"));
+
+    let xml = get_target_xml(&mut stream, &target_id, true).await;
+    assert_eq!(xml.matches("<port_range>T:1-65535</port_range>").count(), 1);
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Partial</name><hosts>192.0.2.0/30</hosts><exclude_hosts>192.0.2.1</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Distinct hostname</name><hosts>Scanner.Example.</hosts><exclude_hosts>scanner.example</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn raw_target_create_accepts_port_list_and_range_with_port_list_precedence() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate(&mut stream).await;
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_port_list><name>Explicit ports</name></create_port_list>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let port_list_id = response_id(&response);
+
+    let response = send_recv(
+        &mut stream,
+        format!(
+            "<create_target><name>Both ports</name><hosts>192.0.2.1</hosts><port_range>T:22</port_range><port_list id=\"{port_list_id}\"/></create_target>"
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\" details=\"1\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains(&format!("<port_list id=\"{port_list_id}\">")));
+    assert!(!xml.contains("<port_range>"));
+
+    let response = send_recv(
+        &mut stream,
+        format!(
+            "<create_target><name>Invalid range</name><hosts>192.0.2.1</hosts><port_range>T:0</port_range><port_list id=\"{port_list_id}\"/></create_target>"
+        ),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(400));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn raw_target_modify_blocks_host_changes_while_target_is_in_use() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate(&mut stream).await;
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>In use</name><hosts>192.0.2.1</hosts><exclude_hosts>192.0.2.2</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+
+    let response = send_recv(
+        &mut stream,
+        format!("<create_task><name>Uses target</name><target id=\"{target_id}\"/></create_task>"),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+
+    let response = send_recv(
+        &mut stream,
+        format!("<modify_target target_id=\"{target_id}\"><hosts>198.51.100.1</hosts><exclude_hosts></exclude_hosts><comment>must not apply</comment></modify_target>"),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(409));
+
+    let response = send_recv(
+        &mut stream,
+        format!("<modify_target target_id=\"{target_id}\"><comment>metadata allowed</comment></modify_target>"),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains("<hosts>192.0.2.1</hosts>"));
+    assert!(xml.contains("<exclude_hosts>192.0.2.2</exclude_hosts>"));
+    assert!(xml.contains("<comment>metadata allowed</comment>"));
+    assert!(!xml.contains("must not apply"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn raw_target_modify_rejects_invalid_lists_without_mutating_state() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate(&mut stream).await;
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Stable</name><hosts>192.0.2.1</hosts><exclude_hosts>192.0.2.2</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+
+    for (element, value) in [
+        ("hosts", "192.0.2.1/31"),
+        ("exclude_hosts", "2001:db8::/129"),
+    ] {
+        let response = send_recv(
+            &mut stream,
+            format!("<modify_target target_id=\"{target_id}\"><{element}>{value}</{element}></modify_target>"),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(400), "{element}={value}");
+    }
+
+    for (hosts, excluded) in [
+        ("192.0.2.1", "192.0.2.1"),
+        ("192.0.2.0/30", "192.0.2.1-192.0.2.2"),
+        ("2001:db8::/126", "2001:db8::1-0002"),
+    ] {
+        let response = send_recv(
+            &mut stream,
+            format!(
+                "<modify_target target_id=\"{target_id}\"><hosts>{hosts}</hosts><exclude_hosts>{excluded}</exclude_hosts></modify_target>"
+            ),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(400), "{hosts} - {excluded}");
+    }
+
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains("<hosts>192.0.2.1</hosts>"));
+    assert!(xml.contains("<exclude_hosts>192.0.2.2</exclude_hosts>"));
+
+    let response = send_recv(
+        &mut stream,
+        format!("<modify_target target_id=\"{target_id}\"><hosts>000.001.002.003-004</hosts><exclude_hosts></exclude_hosts></modify_target>"),
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(200));
+
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains("<hosts>000.001.002.003-004</hosts>"));
+    assert!(xml.contains("<exclude_hosts></exclude_hosts>"));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn raw_target_create_supports_asset_host_filters_with_gvmd_precedence() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    authenticate(&mut stream).await;
+
+    for (name, comment) in [
+        ("192.0.2.10", "edge"),
+        ("192.0.2.11", "other"),
+        ("192.0.2.12", "edge site"),
+    ] {
+        let response = send_recv(
+            &mut stream,
+            format!(
+                "<create_asset><asset><type>host</type><name>{name}</name><comment>{comment}</comment></asset></create_asset>"
+            ),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(201));
+    }
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Filtered</name><asset_hosts filter=\"comment=edge\"/><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains("<hosts>192.0.2.10</hosts>"));
+    assert!(!xml.contains("asset_hosts_filter"));
+
+    let response = send_recv(
+        &mut stream,
+        b"<create_target><name>Precedence</name><hosts>198.51.100.1</hosts><asset_hosts filter=\"comment=other\"/><port_range>T:1-65535</port_range></create_target>",
+    )
+    .await;
+    assert_eq!(response.status_code(), Some(201));
+    let target_id = response_id(&response);
+    let response = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>"),
+    )
+    .await;
+    let xml = response.as_str().expect("UTF-8 response");
+    assert!(xml.contains("<hosts>192.0.2.11</hosts>"));
+    assert!(!xml.contains("198.51.100.1"));
+
+    for (filter, expected) in [
+        ("comment=&quot;edge site&quot;", "192.0.2.12"),
+        ("comment~EDGE sort-reverse=name rows=1", "192.0.2.12"),
+        ("name&gt;192.0.2.10 sort=name rows=1", "192.0.2.11"),
+    ] {
+        let response = send_recv(
+            &mut stream,
+            format!(
+                "<create_target><name>Filter operators</name><asset_hosts filter=\"{filter}\"/><port_range>T:1-65535</port_range></create_target>"
+            ),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(201), "{filter}");
+        let target_id = response_id(&response);
+        let response = send_recv(
+            &mut stream,
+            format!("<get_targets target_id=\"{target_id}\"/>"),
+        )
+        .await;
+        assert!(
+            response
+                .as_str()
+                .expect("UTF-8 response")
+                .contains(&format!("<hosts>{expected}</hosts>")),
+            "{filter}"
+        );
+    }
+
+    for body in [
+        "<create_target><name>No Match</name><asset_hosts filter=\"comment=missing\"/><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>All Excluded</name><asset_hosts filter=\"comment=edge\"/><exclude_hosts>192.0.2.10</exclude_hosts><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Malformed</name><asset_hosts filter=\"comment\"/><port_range>T:1-65535</port_range></create_target>",
+        "<create_target><name>Unsupported</name><asset_hosts filter=\"permission=read\"/><port_range>T:1-65535</port_range></create_target>",
+    ] {
+        let response = send_recv(&mut stream, body).await;
+        assert_eq!(response.status_code(), Some(400), "{body}");
+    }
+
+    server.shutdown().await;
+}

--- a/crates/gvm-mock-server/tests/stateful_task_graph.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_graph.rs
@@ -84,7 +84,7 @@ fn report_id(response: &Response) -> String {
 async fn create_target(stream: &mut UnixStream, name: &str) -> String {
     let response = send_recv(
         stream,
-        format!("<create_target><name>{name}</name><hosts>127.0.0.1</hosts></create_target>")
+        format!("<create_target><name>{name}</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>")
             .as_bytes(),
     )
     .await;

--- a/crates/gvm-mock-server/tests/stateful_task_lifecycle.rs
+++ b/crates/gvm-mock-server/tests/stateful_task_lifecycle.rs
@@ -61,7 +61,7 @@ async fn create_task_id(stream: &mut UnixStream, name: &str) -> String {
     let target_id = create_and_get_id(
         stream,
         format!(
-            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts></create_target>"
+            "<create_target><name>{name} Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range></create_target>"
         )
         .as_bytes(),
         "create_target",

--- a/crates/gvm-mock-server/tests/version_gating.rs
+++ b/crates/gvm-mock-server/tests/version_gating.rs
@@ -31,7 +31,7 @@ use gvm_gmp::commands::tasks::{create_web_application_task, CreateWebApplication
 use gvm_gmp::commands::web_application_targets::{
     create_web_application_target, get_web_application_targets, CreateWebApplicationTargetOpts,
 };
-use gvm_gmp::CredentialStoreCredentialType;
+use gvm_gmp::{CredentialStoreCredentialType, TargetHost};
 use gvm_mock_server::{GmpVersion, MockGmpServer, ServerMode};
 use gvm_protocol::{Request, Response, XmlCommand};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -191,8 +191,21 @@ async fn base_commands_work_on_all_versions() {
             create_target(
                 &format!("Base Target {}", version.as_str()),
                 CreateTargetOpts {
-                    hosts: vec!["127.0.0.1".to_string()],
-                    ..CreateTargetOpts::default()
+                    hosts: gvm_gmp::TargetHosts::new(
+                        [TargetHost::new("127.0.0.1").expect("valid target host")],
+                        [],
+                    )
+                    .expect("valid target hosts"),
+                    ..CreateTargetOpts::new(
+                        gvm_gmp::TargetHosts::new(
+                            [TargetHost::new("127.0.0.1").expect("valid target host")],
+                            [],
+                        )
+                        .expect("valid target hosts"),
+                        gvm_gmp::TargetPortSelection::PortRange(
+                            "T:1-65535".parse().expect("valid port range"),
+                        ),
+                    )
                 },
             )
             .expect("valid target"),

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -28,6 +28,25 @@ rules from one-time schedules; raw iCalendar remains available for compatibility
 Raw create follows gvmd's default-timezone behavior, and raw modify requires an
 iCalendar payload.
 
+Target create and modify inputs use validated `TargetHost` values inside a
+non-empty `TargetHosts` aggregate. The aggregate de-duplicates canonical values
+across alternate address/network/range spellings and makes included/excluded
+modify updates atomic. It can test whether exclusions cover every included
+specification without expanding networks, using gvmd's usable-address treatment
+for CIDRs; trailing-dot hostnames remain distinct from undotted hostnames.
+IPv4 and IPv6 addresses, CIDR networks, address ranges, and ASCII hostnames are
+rejected locally when malformed; IPv4 leading zeroes are normalized like gvmd,
+and CIDR prefixes follow gvmd's `/1` through `/30` restriction. Unicode hostname
+case-fold lookalikes are intentionally outside the typed API's accepted hostname
+policy. DNS resolution and deployment policy, including gvmd's configured maximum
+IP count, remain server-side. Typed creation models manual hosts; the stateful raw
+mock also resolves gvmd-style `asset_hosts` filters, with filter precedence over a
+supplied manual host list.
+The same strict filter evaluator drives `get_assets` and target resolution,
+including quoted values, relations, sorting, and pagination. Raw mock target
+storage applies gvmd-style trimming, separator cleanup, and exact textual
+de-duplication without rewriting otherwise valid host spellings.
+
 ---
 
 ## gvm-protocol
@@ -318,8 +337,12 @@ representation for detaching an existing port list. Consequently,
 `ScalarUpdate::Clear` is rejected locally with
 `ModifyTargetError::UnsupportedPortListClear`; no GMP request is sent.
 
-`CreateTargetOpts::port_list_id` remains `Option<EntityId>` because target
-creation only needs to distinguish including a port list from leaving it out.
+`CreateTargetOpts` requires a `TargetPortSelection`, enforcing a typed one-of
+choice between an existing `<port_list>` and a validated direct `<port_range>`.
+Raw GMP also permits both, with gvmd validating the range before giving the port
+list precedence. Direct ranges support gvmd's implicit TCP and protocol
+carry-forward grammar, and validate the `1..=65535` port domain and ascending
+range bounds before canonical serialization.
 
 ### Target Credential Service Ports
 
@@ -360,7 +383,7 @@ AlertEvent, AlertCondition, AlertMethod, AliveTest, AggregateStatistic, Credenti
 
 ### Tests
 
-`cargo test -p gvm-gmp --all-features -- --list` currently discovers 640 tests.
+`cargo test -p gvm-gmp --all-features -- --list` currently discovers 650 tests.
 The categories below are a tracked subset of that complete inventory.
 
 | Tracked category | Count |

--- a/docs/response-models-rfc.md
+++ b/docs/response-models-rfc.md
@@ -155,16 +155,16 @@ Each domain follows a consistent structure:
 // target/request.rs
 
 use crate::enums::AliveTest;
-use crate::types::EntityId;
+use crate::target::{TargetHosts, TargetPortSelection};
+use crate::types::{EntityId, ScalarUpdate};
 
 /// Options for creating a target.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CreateTargetOpts {
     pub comment: Option<String>,
-    pub hosts: Vec<String>,
-    pub exclude_hosts: Vec<String>,
+    pub hosts: TargetHosts,
     pub alive_test: Option<AliveTest>,
-    pub port_list_id: Option<EntityId>,
+    pub ports: TargetPortSelection,
     pub reverse_lookup_only: Option<bool>,
     pub reverse_lookup_unify: Option<bool>,
 }
@@ -183,12 +183,17 @@ pub struct GetTargetsOpts {
 pub struct ModifyTargetOpts {
     pub name: Option<String>,
     pub comment: Option<String>,
-    pub hosts: Vec<String>,
-    pub exclude_hosts: Vec<String>,
+    pub hosts: Option<TargetHosts>,
     pub alive_test: Option<AliveTest>,
-    pub port_list_id: Option<EntityId>,
+    pub port_list_id: ScalarUpdate<EntityId>,
 }
 ```
+
+`CreateTargetOpts` intentionally models manual-host target creation. The raw GMP
+surface remains available for gvmd's alternative `<asset_hosts filter="..."/>`
+form. `TargetHosts` uses semantic IP/network/range identities for deterministic
+deduplication and exposes effective-set coverage without applying gvmd's
+deployment-configured maximum-host limit.
 
 ### response.rs — Output Types
 ```rust
@@ -382,16 +387,16 @@ pub enum ParseError {
 
 ### Consumer Code (After)
 ```rust
-use gvm_gmp::target::{CreateTargetOpts, create_target, CreateTargetResponse};
+use gvm_gmp::commands::targets::{create_target, CreateTargetOpts};
+use gvm_gmp::responses::CreateTargetResponse;
+use gvm_gmp::{TargetHost, TargetHosts, TargetPortSelection};
 use gvm_gmp::scanner::{get_scanners, GetScannersOpts, Scanner};
 use gvm_gmp::task::{Task, get_tasks, GetTasksOpts};
 
 // Create a target
-let opts = CreateTargetOpts {
-    hosts: vec!["192.168.1.0/24".to_string()],
-    port_list_id: Some(port_list_id),
-    ..Default::default()
-};
+let hosts = TargetHosts::new(["192.168.1.0/24".parse::<TargetHost>()?], [])?;
+let ports = TargetPortSelection::PortList(port_list_id);
+let opts = CreateTargetOpts::new(hosts, ports);
 let response = client.call(create_target("My Target", opts)).await?;
 let result = CreateTargetResponse::from_response(&response)?;
 println!("Created target: {}", result.id);

--- a/tests/integration/test_python_gvm.py
+++ b/tests/integration/test_python_gvm.py
@@ -137,6 +137,7 @@ def main() -> int:
                                 gmp.create_target(
                                     name="Python Target",
                                     hosts=["192.168.1.10"],
+                                    port_range="T:1-65535",
                                 )
                             ),
                         ),


### PR DESCRIPTION
## Summary

- Replace target host string collections with `TargetHost` and `TargetHosts`, validating gvmd-supported addresses, CIDRs, ranges, and hostnames at construction, deduplicating canonical identities, and rejecting empty or fully excluded selections.
- Require an explicit `TargetPortSelection` for typed target creation, validate and canonicalize direct port ranges, and make included/excluded host updates atomic.
- Align stateful raw GMP behavior with gvmd for host cleanup, asset-host filters, port-list precedence, detailed response rendering, and in-use target mutation checks.
- Migrate typed and raw call sites, compile-check the README workflow, and update status and response-model documentation for the source-level API change.
- Add unit, property, and stateful conformance coverage for parsing, coverage detection, serialization, filtering, and mutation atomicity.

Fixes #480