### PR TITLE
Fix port list modify replacement semantics

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -799,6 +799,9 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// Send a `modify_port_list` request and return a typed
     /// [`ModifyPortListResponse`].
     ///
+    /// gvmd replaces both the name and comment, clearing either field when its
+    /// option is omitted. Use the port-range commands to change ranges.
+    ///
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn modify_port_list(

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -2262,7 +2262,7 @@ async fn typed_rest_support_gap_helpers_parse_fixture_responses() {
 }
 
 #[tokio::test]
-async fn typed_port_list_and_user_renames_round_trip() {
+async fn typed_port_list_replacement_round_trip() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -2285,7 +2285,6 @@ async fn typed_port_list_and_user_renames_round_trip() {
             ModifyPortListOpts {
                 name: Some("Renamed Port List".into()),
                 comment: Some("renamed through typed client".into()),
-                ..Default::default()
             },
         )
         .await
@@ -2304,6 +2303,56 @@ async fn typed_port_list_and_user_renames_round_trip() {
         renamed_port_list.meta.comment.as_deref(),
         Some("renamed through typed client")
     );
+
+    server.clear_history();
+    client
+        .modify_port_list(
+            &port_list.id,
+            ModifyPortListOpts {
+                name: Some("Name Only".into()),
+                comment: None,
+            },
+        )
+        .await
+        .expect("port list replacement should succeed");
+    let port_lists = client
+        .get_port_lists(GetPortListsOpts::default())
+        .await
+        .expect("port list read-back should succeed");
+    let replaced_port_list = port_lists
+        .items
+        .iter()
+        .find(|item| item.meta.id == port_list.id)
+        .expect("replaced port list should be present");
+    assert_eq!(replaced_port_list.meta.name, "Name Only");
+    assert_eq!(replaced_port_list.meta.comment, None);
+    let history = server.command_history();
+    assert_eq!(history[0].command_name(), "modify_port_list");
+    assert_eq!(
+        history[0].raw_xml(),
+        format!(
+            "<modify_port_list port_list_id=\"{}\"><name>Name Only</name></modify_port_list>",
+            port_list.id
+        )
+        .as_bytes()
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn typed_user_rename_round_trip() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authentication should succeed");
 
     let user = client
         .create_user("old-user", UserOpts::default())

--- a/crates/gvm-gmp/src/commands/port_lists.rs
+++ b/crates/gvm-gmp/src/commands/port_lists.rs
@@ -9,7 +9,7 @@ use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_b
 use crate::enums::PortRangeType;
 use crate::types::EntityId;
 
-/// Optional fields for port-list create and modify requests.
+/// Optional fields for port-list create requests.
 #[derive(Debug, Clone, Default)]
 pub struct PortListOpts {
     /// Optional comment text included in the request.
@@ -18,25 +18,17 @@ pub struct PortListOpts {
     pub port_range: Option<String>,
 }
 
-/// Optional fields for port-list modify requests.
+/// Replacement fields for port-list modify requests.
+///
+/// `modify_port_list` uses replacement semantics: gvmd stores an empty string
+/// for each omitted field. Port ranges are changed separately with
+/// [`create_port_range`] and [`delete_port_range`].
 #[derive(Debug, Clone, Default)]
 pub struct ModifyPortListOpts {
-    /// Optional replacement name.
+    /// Replacement name. Omission clears the current name.
     pub name: Option<String>,
-    /// Optional comment text included in the request.
+    /// Replacement comment. Omission clears the current comment.
     pub comment: Option<String>,
-    /// Optional port range expression.
-    pub port_range: Option<String>,
-}
-
-impl From<PortListOpts> for ModifyPortListOpts {
-    fn from(opts: PortListOpts) -> Self {
-        Self {
-            name: None,
-            comment: opts.comment,
-            port_range: opts.port_range,
-        }
-    }
 }
 
 /// Options for `get_port_lists` requests.
@@ -106,17 +98,16 @@ pub fn get_port_list(port_list_id: &EntityId) -> impl Request {
 }
 
 /// Build a `modify_port_list` request.
+///
+/// This is a full replacement of the port list's name and comment: gvmd
+/// clears either field when its element is omitted. Port ranges must instead
+/// be changed with [`create_port_range`] or [`delete_port_range`].
 #[must_use]
-pub fn modify_port_list(
-    port_list_id: &EntityId,
-    opts: impl Into<ModifyPortListOpts>,
-) -> impl Request {
-    let opts = opts.into();
+pub fn modify_port_list(port_list_id: &EntityId, opts: ModifyPortListOpts) -> impl Request {
     let mut cmd =
         XmlCommand::new("modify_port_list").attribute("port_list_id", port_list_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
-    add_text_element(&mut cmd, "port_range", opts.port_range.as_deref());
     cmd
 }
 
@@ -179,7 +170,6 @@ mod tests {
             ModifyPortListOpts {
                 name: Some("Renamed ports".into()),
                 comment: Some("updated".into()),
-                ..Default::default()
             },
         ));
         assert_eq!(

--- a/crates/gvm-gmp/tests/test_port_lists.rs
+++ b/crates/gvm-gmp/tests/test_port_lists.rs
@@ -44,3 +44,21 @@ fn test_port_list_get_delete_commands() {
         "<delete_port_range port_range_id=\"pr1\"/>"
     );
 }
+
+#[test]
+fn test_modify_port_list_uses_only_gvmd_supported_replacement_fields() {
+    assert_eq!(
+        xml(modify_port_list(
+            &id("pl1"),
+            ModifyPortListOpts {
+                name: Some("renamed".into()),
+                comment: Some("replacement comment".into()),
+            },
+        )),
+        "<modify_port_list port_list_id=\"pl1\"><name>renamed</name><comment>replacement comment</comment></modify_port_list>"
+    );
+    assert_eq!(
+        xml(modify_port_list(&id("pl1"), ModifyPortListOpts::default())),
+        "<modify_port_list port_list_id=\"pl1\"/>"
+    );
+}

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -1637,10 +1637,14 @@ impl SessionHandler {
                 if let Some(ref text) = new_text {
                     r.name.clone_from(text);
                 }
+            } else if resource_type == "port_list" {
+                r.name = new_name.clone().unwrap_or_default();
             } else if let Some(ref name) = new_name {
                 r.name.clone_from(name);
             }
-            if let Some(ref comment) = new_comment {
+            if resource_type == "port_list" {
+                r.comment = new_comment.clone().unwrap_or_default();
+            } else if let Some(ref comment) = new_comment {
                 r.comment.clone_from(comment);
             }
             if let Some(ref host) = new_host {

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix_more.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix_more.rs
@@ -226,7 +226,7 @@ async fn matrix_tickets_create_delete_ultimate() {
 }
 
 #[tokio::test]
-async fn matrix_port_lists_create_list() {
+async fn matrix_port_lists_modify_replaces_and_blanks_omitted_fields() {
     let Some(server) = stateful_server().await else {
         return;
     };
@@ -245,6 +245,46 @@ async fn matrix_port_lists_create_list() {
     let list_text = list_resp.as_str().expect("valid utf8");
     assert!(list_text.contains(&port_list_id));
     assert!(list_text.contains("Matrix Port List"));
+
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_port_list port_list_id=\"{port_list_id}\"><comment>replacement</comment></modify_port_list>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_port_lists port_list_id=\"{port_list_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+    let get_text = get_resp.as_str().expect("valid utf8");
+    assert!(get_text.contains("<name></name>"));
+    assert!(get_text.contains("<comment>replacement</comment>"));
+
+    let modify_resp = send_recv(
+        &mut stream,
+        format!(
+            "<modify_port_list port_list_id=\"{port_list_id}\"><name>Replacement Name</name></modify_port_list>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(modify_resp.status_code(), Some(200));
+
+    let get_resp = send_recv(
+        &mut stream,
+        format!("<get_port_lists port_list_id=\"{port_list_id}\"/>").as_bytes(),
+    )
+    .await;
+    assert_eq!(get_resp.status_code(), Some(200));
+    let get_text = get_resp.as_str().expect("valid utf8");
+    assert!(get_text.contains("<name>Replacement Name</name>"));
+    assert!(get_text.contains("<comment></comment>"));
 
     server.shutdown().await;
 }


### PR DESCRIPTION
## What Problem This Solves

`modify_port_list` exposed a `port_range` field that gvmd ignores, while the
`PortListOpts` conversion silently omitted the existing name. Because gvmd
treats this command as a full replacement, callers could receive success while
either failing to change ranges or erasing port-list metadata.

## Why This Change Was Made

- Remove `port_range` from `ModifyPortListOpts`; ranges remain managed through
  `create_port_range` and `delete_port_range`.
- Remove the lossy `PortListOpts` conversion so modify callers construct the
  replacement fields explicitly.
- Document the replace-not-merge contract on both command and typed client APIs.
- Make the stateful mock blank omitted names and comments like gvmd.

## User Impact

Unsupported range modifications are no longer expressible through this API,
and accidental metadata loss through the create-to-modify conversion is
prevented at compile time. Mock-backed consumers can now test gvmd's destructive
omission behavior before deployment.

## Evidence

- `cargo test -p gvm-gmp --test test_port_lists`
- `cargo test -p gvm-mock-server --features unix-socket-tests --test stateful_resource_matrix_more matrix_port_lists_modify_replaces_and_blanks_omitted_fields`
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_port_list_replacement_round_trip`
- `cargo clippy -p gvm-gmp -p gvm-mock-server -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Fixes greenbone-hive/rust-gvm#493

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
