### PR TITLE
feat(gmp): expose alert active state

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -1236,6 +1236,90 @@ async fn typed_alert_data_maps_and_rename_round_trip() {
 }
 
 #[tokio::test]
+async fn typed_alert_active_round_trip() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let created = client
+        .create_alert(
+            "Inactive Alert",
+            AlertOpts {
+                active: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_alert should succeed");
+    let fetched = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts should succeed");
+    assert!(!only_alert(&fetched).active);
+
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                active: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("enabling alert should succeed");
+    let enabled = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after enabling should succeed");
+    assert!(only_alert(&enabled).active);
+
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                comment: Some("active omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("partial modify_alert should succeed");
+    let preserved = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after partial modify should succeed");
+    assert!(
+        only_alert(&preserved).active,
+        "omitting active must preserve its current state"
+    );
+
+    client
+        .modify_alert(
+            &created.id,
+            AlertOpts {
+                active: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("disabling alert should succeed");
+    let disabled = client
+        .get_alerts(GetAlertsOpts::default())
+        .await
+        .expect("get_alerts after disabling should succeed");
+    assert!(!only_alert(&disabled).active);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_ticket_create_read_and_reassign_round_trip() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-gmp/src/commands/alerts.rs
+++ b/crates/gvm-gmp/src/commands/alerts.rs
@@ -48,7 +48,15 @@ pub struct AlertOpts {
     /// Data entries applied when `method` is present.
     pub method_data: Vec<AlertData>,
     /// Optional saved filter identifier.
+    ///
+    /// When modifying an alert, gvmd clears the current filter binding if this
+    /// field is omitted. Pass the existing filter ID to preserve the binding.
     pub filter_id: Option<EntityId>,
+    /// Whether the alert is enabled.
+    ///
+    /// When modifying an alert, omitting this field preserves its current
+    /// active state.
+    pub active: Option<bool>,
 }
 
 /// Options for `get_alerts` requests.
@@ -184,6 +192,9 @@ fn add_alert_body(cmd: &mut XmlCommand, opts: &AlertOpts) {
     if let Some(filter_id) = opts.filter_id.as_ref() {
         cmd.add_element("filter")
             .set_attribute("id", filter_id.as_str());
+    }
+    if let Some(active) = opts.active {
+        cmd.add_element_with_text("active", bool_str(active));
     }
 }
 

--- a/crates/gvm-gmp/src/responses/alert.rs
+++ b/crates/gvm-gmp/src/responses/alert.rs
@@ -26,6 +26,7 @@ pub struct Alert {
     pub method: Option<String>,
     pub method_data: HashMap<String, String>,
     pub filter: Option<NamedEntity>,
+    /// Whether the alert is enabled.
     pub active: bool,
 }
 

--- a/crates/gvm-gmp/tests/test_alerts.rs
+++ b/crates/gvm-gmp/tests/test_alerts.rs
@@ -31,10 +31,11 @@ fn test_create_alert_with_all_optionals() {
                 method: Some(AlertMethod::Email),
                 method_data: vec![AlertData::new("to_address", "ops@example.com")],
                 filter_id: Some(id("f1")),
+                active: Some(false),
                 ..Default::default()
             }
         )),
-        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed<data>Done<name>status</name></data></event><condition>Severity at least<data>5.5<name>severity</name></data></condition><method>Email<data>ops@example.com<name>to_address</name></data></method><filter id=\"f1\"/></create_alert>"
+        "<create_alert><name>a</name><comment>c</comment><event>Task run status changed<data>Done<name>status</name></data></event><condition>Severity at least<data>5.5<name>severity</name></data></condition><method>Email<data>ops@example.com<name>to_address</name></data></method><filter id=\"f1\"/><active>0</active></create_alert>"
     );
 }
 
@@ -57,10 +58,11 @@ fn test_alert_get_modify_delete_and_test() {
                 event_data: vec![AlertData::new("status", "Done")],
                 condition: Some(AlertCondition::Always),
                 method: Some(AlertMethod::SysLog),
+                active: Some(true),
                 ..Default::default()
             }
         )),
-        "<modify_alert alert_id=\"a1\"><name>renamed</name><event>Task run status changed<data>Done<name>status</name></data></event><condition>Always</condition><method>Syslog</method></modify_alert>"
+        "<modify_alert alert_id=\"a1\"><name>renamed</name><event>Task run status changed<data>Done<name>status</name></data></event><condition>Always</condition><method>Syslog</method><active>1</active></modify_alert>"
     );
     assert_eq!(
         xml(delete_alert(&id("a1"), false)),

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -4141,6 +4141,9 @@ fn set_alert_fields(resource: &mut Resource, cmd: &ParsedCommand) {
     if let Some(filter_id) = cmd.child_attr("filter", "id") {
         resource.set_attr("filter_id", filter_id);
     }
+    if let Some(active) = cmd.child_text("active") {
+        resource.set_attr("active", active);
+    }
 }
 
 fn nested_child_attr(cmd: &ParsedCommand, path: &[&str], attr: &str) -> Option<String> {


### PR DESCRIPTION
## What Problem This Solves

Alert clients could read an alert's active state but could not send the gvmd
`active` field when creating or modifying an alert. Disabling an alert therefore
required destructive workarounds instead of a normal state transition.

## Why This Change Was Made

- Add `active: Option<bool>` to `AlertOpts` and serialize explicit values as
  `<active>1</active>` or `<active>0</active>`.
- Preserve omission semantics: a modify request without `active` leaves the
  server-side state unchanged.
- Persist the field in the stateful mock for both create and modify flows.
- Document that omitting `filter_id` during modification is different and clears
  the gvmd filter binding.
- Retain the existing typed `Alert.active` parser and add end-to-end lifecycle
  coverage around it.

## User Impact

Callers can now enable and disable alerts without deleting their configuration
or breaking task associations. Existing callers remain source-compatible
because the new field is optional and defaults to omission.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test -p gvm-gmp --test test_alerts` (4 passed)
- `cargo test -p gvm-gmp responses::alert::tests` (7 passed)
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_alert_active_round_trip -- --exact` (1 passed)
- `cargo clippy -p gvm-gmp -p gvm-mock-server -p gvm-client --all-targets --all-features -- -D warnings`
- Commit signature verified for `clawosiris@gmail.com`.

Fixes greenbone-hive/rust-gvm#494

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
