### PR TITLE
fix(gmp): model task observer updates

### DIFF
--- a/crates/gvm-client/src/error.rs
+++ b/crates/gvm-client/src/error.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use gvm_connection::ConnectionError;
 use gvm_gmp::commands::targets::{CreateTargetError, ModifyTargetError};
+use gvm_gmp::commands::tasks::ModifyTaskError;
 use gvm_gmp::responses::ParseError;
 use gvm_gmp::types::GmpVersion;
 use thiserror::Error;
@@ -29,6 +30,10 @@ pub enum GvmError {
     /// A typed `modify_target` update cannot be represented by gvmd.
     #[error("modify_target request error: {0}")]
     ModifyTarget(#[from] ModifyTargetError),
+
+    /// A typed `modify_task` update cannot be represented safely by gvmd.
+    #[error("modify_task request error: {0}")]
+    ModifyTask(#[from] ModifyTaskError),
 
     /// Response or version XML could not be parsed.
     #[error("XML parse error: {0}")]

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -882,7 +882,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         task_id: &EntityId,
         opts: ModifyTaskOpts,
     ) -> Result<ModifyTaskResponse, GvmError> {
-        let response = self.send(modify_task(task_id, opts)).await?;
+        let request = modify_task(task_id, opts)?;
+        let response = self.send(request).await?;
         ModifyTaskResponse::from_response(&response).map_err(GvmError::Parse)
     }
 

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -4590,6 +4590,81 @@ async fn full_crud_lifecycle_succeeds() {
 }
 
 #[tokio::test]
+async fn typed_task_observers_round_trip_create_and_modify() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let connection = unix_connection(&server);
+    let mut client = GmpClient::connect(connection)
+        .await
+        .expect("client should connect");
+    client
+        .authenticate("admin", "admin")
+        .await
+        .expect("authenticate should succeed");
+
+    let target = client
+        .create_target(
+            "Observer Target",
+            CreateTargetOpts::new(target_hosts(&["127.0.0.1"], &[]), target_ports()),
+        )
+        .await
+        .expect("target create should succeed");
+    let config_id = EntityId::new("daba56c8-73ec-11df-a475-002264764cea").expect("config id");
+    let scanner_id = EntityId::new("08b69003-5fc2-4037-a479-93b440211c73").expect("scanner id");
+    let task = client
+        .create_task(
+            "Observer Task",
+            &config_id,
+            &target.id,
+            &scanner_id,
+            CreateTaskOpts {
+                observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![EntityId::new("group-1").expect("group id")],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("task create should succeed");
+
+    let created = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("created task should be observable")
+        .items
+        .into_iter()
+        .find(|candidate| candidate.meta.id == task.id)
+        .expect("created task should be returned");
+    let created_observers = created.observers.expect("created observers");
+    assert_eq!(created_observers.users, ["alice", "bob"]);
+    assert_eq!(created_observers.groups[0].id.as_str(), "group-1");
+
+    client
+        .modify_task(
+            &task.id,
+            ModifyTaskOpts {
+                observers: vec!["carol".into(), "dave".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("observer replacement should succeed");
+    let modified = client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("modified task should be observable")
+        .items
+        .into_iter()
+        .find(|candidate| candidate.meta.id == task.id)
+        .expect("modified task should be returned");
+    let modified_observers = modified.observers.expect("modified observers");
+    assert_eq!(modified_observers.users, ["carol", "dave"]);
+    assert_eq!(modified_observers.groups[0].id.as_str(), "group-1");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_create_import_task_uses_import_task_shape() {
     let Some(server) = stateful_server().await else {
         return;

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -59,12 +59,13 @@ use gvm_gmp::commands::targets::{
 };
 use gvm_gmp::commands::tasks::{
     create_task, delete_task, get_task, start_task, stop_task, CreateTaskOpts, GetTasksOpts,
-    ModifyTaskOpts,
+    ModifyTaskError, ModifyTaskOpts,
 };
 use gvm_gmp::commands::tickets::{
     CreateTicketOpts, GetTicketsOpts, ModifyTicketOpts, TicketOpenNote,
 };
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
+use gvm_gmp::responses::task::TaskObservers;
 use gvm_gmp::responses::{
     Asset, ConfigUsageKind, CreateScanConfigResponse, CredentialKind, GetConfigsResponse,
     GetPermissionsResponse, GetScanConfigsResponse, GetScanReportResponse, ParseError, Permission,
@@ -4589,6 +4590,22 @@ async fn full_crud_lifecycle_succeeds() {
     server.shutdown().await;
 }
 
+async fn observed_task_observers(
+    client: &mut GmpClient<UnixSocketConnection>,
+    task_id: &EntityId,
+) -> TaskObservers {
+    client
+        .get_tasks(GetTasksOpts::default())
+        .await
+        .expect("task should be observable")
+        .items
+        .into_iter()
+        .find(|candidate| candidate.meta.id == *task_id)
+        .expect("task should be returned")
+        .observers
+        .expect("observer container should be observable")
+}
+
 #[tokio::test]
 async fn typed_task_observers_round_trip_create_and_modify() {
     let Some(server) = stateful_server().await else {
@@ -4627,39 +4644,74 @@ async fn typed_task_observers_round_trip_create_and_modify() {
         .await
         .expect("task create should succeed");
 
-    let created = client
-        .get_tasks(GetTasksOpts::default())
-        .await
-        .expect("created task should be observable")
-        .items
-        .into_iter()
-        .find(|candidate| candidate.meta.id == task.id)
-        .expect("created task should be returned");
-    let created_observers = created.observers.expect("created observers");
+    let created_observers = observed_task_observers(&mut client, &task.id).await;
     assert_eq!(created_observers.users, ["alice", "bob"]);
     assert_eq!(created_observers.groups[0].id.as_str(), "group-1");
+
+    let history_len = server.command_history().len();
+    let error = client
+        .modify_task(
+            &task.id,
+            ModifyTaskOpts {
+                observer_group_ids: CollectionUpdate::replace([
+                    EntityId::new("group-2").expect("group id")
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("group-only update must be rejected before sending");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTask(ModifyTaskError::ObserverGroupsWithoutUserUpdate)
+    ));
+    assert_eq!(server.command_history().len(), history_len);
 
     client
         .modify_task(
             &task.id,
             ModifyTaskOpts {
-                observers: vec!["carol".into(), "dave".into()],
+                observers: CollectionUpdate::replace(["carol".into(), "dave".into()]),
+                observer_group_ids: CollectionUpdate::replace([
+                    EntityId::new("group-2").expect("group id")
+                ]),
                 ..Default::default()
             },
         )
         .await
         .expect("observer replacement should succeed");
-    let modified = client
-        .get_tasks(GetTasksOpts::default())
-        .await
-        .expect("modified task should be observable")
-        .items
-        .into_iter()
-        .find(|candidate| candidate.meta.id == task.id)
-        .expect("modified task should be returned");
-    let modified_observers = modified.observers.expect("modified observers");
+    let modified_observers = observed_task_observers(&mut client, &task.id).await;
     assert_eq!(modified_observers.users, ["carol", "dave"]);
-    assert_eq!(modified_observers.groups[0].id.as_str(), "group-1");
+    assert_eq!(modified_observers.groups[0].id.as_str(), "group-2");
+
+    client
+        .modify_task(
+            &task.id,
+            ModifyTaskOpts {
+                observers: CollectionUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("observer-user clear should succeed");
+    let users_cleared = observed_task_observers(&mut client, &task.id).await;
+    assert!(users_cleared.users.is_empty());
+    assert_eq!(users_cleared.groups[0].id.as_str(), "group-2");
+
+    client
+        .modify_task(
+            &task.id,
+            ModifyTaskOpts {
+                observers: CollectionUpdate::Clear,
+                observer_group_ids: CollectionUpdate::Clear,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("all-observer clear should succeed");
+    let all_cleared = observed_task_observers(&mut client, &task.id).await;
+    assert!(all_cleared.users.is_empty());
+    assert!(all_cleared.groups.is_empty());
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -11,7 +11,7 @@ use crate::common::{
     add_scalar_id_update, add_text_element, bool_str, set_optional_bool_attr,
 };
 use crate::enums::HostsOrdering;
-use crate::types::{EntityId, ScalarUpdate};
+use crate::types::{CollectionUpdate, EntityId, ScalarUpdate};
 
 /// Optional fields for `create_task` requests.
 #[derive(Debug, Clone, Default)]
@@ -139,10 +139,31 @@ pub struct ModifyTaskOpts {
     pub scanner_id: Option<EntityId>,
     /// Alert identifiers associated with the request.
     pub alert_ids: Option<Vec<EntityId>>,
-    /// Observer names associated with the task.
-    pub observers: Vec<String>,
+    /// Observer-user update: omit, replace, or clear.
+    ///
+    /// An explicit clear emits an empty `<observers>` element, which gvmd
+    /// interprets as removing every user observer.
+    pub observers: CollectionUpdate<String>,
+    /// Observer-group update: omit, replace, or clear.
+    ///
+    /// gvmd accepts group children on `modify_task` even though the published
+    /// GMP grammar documents only observer-user text. Because opening the
+    /// shared `<observers>` container also updates the user list, a group
+    /// update requires [`Self::observers`] to explicitly replace or clear the
+    /// users. Clearing groups is encoded with gvmd's `group id="0"` sentinel.
+    pub observer_group_ids: CollectionUpdate<EntityId>,
     /// Preference key/value pairs to include.
     pub preferences: Vec<(String, String)>,
+}
+
+/// Errors raised while building a `modify_task` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ModifyTaskError {
+    /// A group update would otherwise clear users implicitly on gvmd.
+    #[error(
+        "updating task observer groups requires explicitly replacing or clearing observer users"
+    )]
+    ObserverGroupsWithoutUserUpdate,
 }
 
 /// Build a clone request for an existing task.
@@ -370,8 +391,14 @@ pub fn get_task(task_id: &EntityId) -> impl Request {
 }
 
 /// Build a `modify_task` request.
-#[must_use]
-pub fn modify_task(task_id: &EntityId, opts: ModifyTaskOpts) -> impl Request {
+///
+/// # Errors
+/// Returns [`ModifyTaskError::ObserverGroupsWithoutUserUpdate`] when observer
+/// groups are updated without an explicit observer-user replacement or clear.
+pub fn modify_task(
+    task_id: &EntityId,
+    opts: ModifyTaskOpts,
+) -> Result<impl Request, ModifyTaskError> {
     modify_task_with_usage(task_id, opts, None)
 }
 
@@ -379,7 +406,7 @@ fn modify_task_with_usage(
     task_id: &EntityId,
     opts: ModifyTaskOpts,
     usage_type: Option<UsageType>,
-) -> XmlCommand {
+) -> Result<XmlCommand, ModifyTaskError> {
     let mut cmd = XmlCommand::new("modify_task").attribute("task_id", task_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -408,9 +435,9 @@ fn modify_task_with_usage(
             }
         }
     }
-    add_task_observers(&mut cmd, &opts.observers, &[]);
+    add_task_observer_update(&mut cmd, &opts.observers, &opts.observer_group_ids)?;
     add_preferences(&mut cmd, &opts.preferences);
-    cmd
+    Ok(cmd)
 }
 
 fn add_task_observers(cmd: &mut XmlCommand, observers: &[String], observer_group_ids: &[EntityId]) {
@@ -426,6 +453,44 @@ fn add_task_observers(cmd: &mut XmlCommand, observers: &[String], observer_group
             .add_child("group")
             .set_attribute("id", group_id.as_str());
     }
+}
+
+fn add_task_observer_update(
+    cmd: &mut XmlCommand,
+    observers: &CollectionUpdate<String>,
+    observer_group_ids: &CollectionUpdate<EntityId>,
+) -> Result<(), ModifyTaskError> {
+    if !matches!(observer_group_ids, CollectionUpdate::Omitted)
+        && matches!(observers, CollectionUpdate::Omitted)
+    {
+        return Err(ModifyTaskError::ObserverGroupsWithoutUserUpdate);
+    }
+    if matches!(observers, CollectionUpdate::Omitted)
+        && matches!(observer_group_ids, CollectionUpdate::Omitted)
+    {
+        return Ok(());
+    }
+
+    let element = cmd.add_element("observers");
+    if let CollectionUpdate::Replace(observers) = observers {
+        if !observers.is_empty() {
+            element.set_text(&observers.join(" "));
+        }
+    }
+    match observer_group_ids {
+        CollectionUpdate::Omitted => {}
+        CollectionUpdate::Replace(group_ids) if !group_ids.is_empty() => {
+            for group_id in group_ids {
+                element
+                    .add_child("group")
+                    .set_attribute("id", group_id.as_str());
+            }
+        }
+        CollectionUpdate::Replace(_) | CollectionUpdate::Clear => {
+            element.add_child("group").set_attribute("id", "0");
+        }
+    }
+    Ok(())
 }
 
 /// Build a `move_task` request.
@@ -515,8 +580,14 @@ pub fn resume_audit(task_id: &EntityId) -> impl Request {
 }
 
 /// Build a `modify_task` request scoped to audits.
-#[must_use]
-pub fn modify_audit(task_id: &EntityId, opts: ModifyTaskOpts) -> impl Request {
+///
+/// # Errors
+/// Returns [`ModifyTaskError::ObserverGroupsWithoutUserUpdate`] when observer
+/// groups are updated without an explicit observer-user replacement or clear.
+pub fn modify_audit(
+    task_id: &EntityId,
+    opts: ModifyTaskOpts,
+) -> Result<impl Request, ModifyTaskError> {
     modify_task_with_usage(task_id, opts, Some(UsageType::Audit))
 }
 
@@ -632,7 +703,8 @@ mod tests {
                 alert_ids: Some(Vec::new()),
                 ..Default::default()
             },
-        ));
+        )
+        .expect("valid task update"));
         assert_eq!(
             rendered,
             "<modify_task task_id=\"t1\"><name>foo</name><alert id=\"0\"/></modify_task>"
@@ -652,18 +724,81 @@ mod tests {
             xml(modify_task(
                 &id("t1"),
                 ModifyTaskOpts {
-                    observers: vec!["alice".into(), "bob".into()],
+                    observers: CollectionUpdate::replace(["alice".into(), "bob".into(),]),
                     ..Default::default()
                 },
-            )),
+            )
+            .expect("valid observer update"),),
             "<modify_task task_id=\"t1\"><observers>alice bob</observers></modify_task>"
+        );
+    }
+
+    #[test]
+    fn modify_task_distinguishes_omitted_replaced_and_cleared_observers() {
+        assert_eq!(
+            xml(modify_task(&id("t1"), ModifyTaskOpts::default()).expect("valid omission")),
+            "<modify_task task_id=\"t1\"/>"
+        );
+        assert_eq!(
+            xml(
+                modify_task(
+                    &id("t1"),
+                    ModifyTaskOpts {
+                        observers: CollectionUpdate::replace(["alice".into()]),
+                        observer_group_ids: CollectionUpdate::replace([id("group-1")]),
+                        ..Default::default()
+                    },
+                )
+                .expect("valid observer replacement"),
+            ),
+            "<modify_task task_id=\"t1\"><observers>alice<group id=\"group-1\"/></observers></modify_task>"
+        );
+        assert_eq!(
+            xml(modify_task(
+                &id("t1"),
+                ModifyTaskOpts {
+                    observers: CollectionUpdate::Clear,
+                    ..Default::default()
+                },
+            )
+            .expect("valid observer clear"),),
+            "<modify_task task_id=\"t1\"><observers/></modify_task>"
+        );
+        assert_eq!(
+            xml(
+                modify_task(
+                    &id("t1"),
+                    ModifyTaskOpts {
+                        observers: CollectionUpdate::replace(["alice".into()]),
+                        observer_group_ids: CollectionUpdate::Clear,
+                        ..Default::default()
+                    },
+                )
+                .expect("valid observer-group clear"),
+            ),
+            "<modify_task task_id=\"t1\"><observers>alice<group id=\"0\"/></observers></modify_task>"
+        );
+    }
+
+    #[test]
+    fn modify_task_rejects_group_update_without_explicit_users() {
+        assert_eq!(
+            modify_task(
+                &id("t1"),
+                ModifyTaskOpts {
+                    observer_group_ids: CollectionUpdate::replace([id("group-1")]),
+                    ..Default::default()
+                },
+            )
+            .err(),
+            Some(ModifyTaskError::ObserverGroupsWithoutUserUpdate)
         );
     }
 
     #[test]
     fn modify_task_distinguishes_omitted_set_and_cleared_schedule() {
         assert_eq!(
-            xml(modify_task(&id("t1"), ModifyTaskOpts::default())),
+            xml(modify_task(&id("t1"), ModifyTaskOpts::default()).expect("valid omission")),
             "<modify_task task_id=\"t1\"/>"
         );
         assert_eq!(
@@ -672,8 +807,9 @@ mod tests {
                 ModifyTaskOpts {
                     schedule_id: ScalarUpdate::set(id("schedule-1")),
                     ..Default::default()
-                }
-            )),
+                },
+            )
+            .expect("valid schedule update"),),
             "<modify_task task_id=\"t1\"><schedule id=\"schedule-1\"/></modify_task>"
         );
         assert_eq!(
@@ -682,8 +818,9 @@ mod tests {
                 ModifyTaskOpts {
                     schedule_id: ScalarUpdate::Clear,
                     ..Default::default()
-                }
-            )),
+                },
+            )
+            .expect("valid schedule clear"),),
             "<modify_task task_id=\"t1\"><schedule id=\"0\"/></modify_task>"
         );
     }
@@ -730,13 +867,16 @@ mod tests {
             "<get_tasks details=\"1\" task_id=\"a1\" usage_type=\"audit\"/>"
         );
         assert_eq!(
-            xml(modify_audit(
-                &id("a1"),
-                ModifyTaskOpts {
-                    comment: Some("updated".into()),
-                    ..Default::default()
-                }
-            )),
+            xml(
+                modify_audit(
+                    &id("a1"),
+                    ModifyTaskOpts {
+                        comment: Some("updated".into()),
+                        ..Default::default()
+                    },
+                )
+                .expect("valid audit update"),
+            ),
             "<modify_task task_id=\"a1\"><comment>updated</comment><usage_type>audit</usage_type></modify_task>"
         );
         assert_eq!(xml(start_audit(&id("a1"))), "<start_task task_id=\"a1\"/>");

--- a/crates/gvm-gmp/src/commands/tasks.rs
+++ b/crates/gvm-gmp/src/commands/tasks.rs
@@ -8,7 +8,7 @@ use gvm_protocol::{Request, XmlCommand};
 use crate::commands::usage_type::UsageType;
 use crate::common::{
     add_filter_attrs, add_id_element, add_optional_id_element, add_preferences,
-    add_scalar_id_update, add_string_list, add_text_element, bool_str, set_optional_bool_attr,
+    add_scalar_id_update, add_text_element, bool_str, set_optional_bool_attr,
 };
 use crate::enums::HostsOrdering;
 use crate::types::{EntityId, ScalarUpdate};
@@ -30,6 +30,8 @@ pub struct CreateTaskOpts {
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
+    /// Observer group identifiers associated with the task.
+    pub observer_group_ids: Vec<EntityId>,
     /// Preference key/value pairs to include.
     pub preferences: Vec<(String, String)>,
 }
@@ -49,6 +51,8 @@ pub struct CreateAgentGroupTaskOpts {
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
+    /// Observer group identifiers associated with the task.
+    pub observer_group_ids: Vec<EntityId>,
     /// Preference key/value pairs to include.
     pub preferences: Vec<(String, String)>,
 }
@@ -68,6 +72,8 @@ pub struct CreateOciImageTargetTaskOpts {
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
+    /// Observer group identifiers associated with the task.
+    pub observer_group_ids: Vec<EntityId>,
     /// Preference key/value pairs to include.
     pub preferences: Vec<(String, String)>,
 }
@@ -87,6 +93,8 @@ pub struct CreateWebApplicationTaskOpts {
     pub schedule_periods: Option<u32>,
     /// Observer names associated with the task.
     pub observers: Vec<String>,
+    /// Observer group identifiers associated with the task.
+    pub observer_group_ids: Vec<EntityId>,
     /// Preference key/value pairs to include.
     pub preferences: Vec<(String, String)>,
 }
@@ -187,7 +195,7 @@ pub fn create_agent_group_task(
             cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
         }
     }
-    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_task_observers(&mut cmd, &opts.observers, &opts.observer_group_ids);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
 }
@@ -218,7 +226,7 @@ pub fn create_oci_image_target_task(
             cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
         }
     }
-    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_task_observers(&mut cmd, &opts.observers, &opts.observer_group_ids);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
 }
@@ -284,7 +292,7 @@ fn create_task_with_usage(
     for alert_id in &opts.alert_ids {
         add_id_element(&mut cmd, "alert", alert_id);
     }
-    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_task_observers(&mut cmd, &opts.observers, &opts.observer_group_ids);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
 }
@@ -319,7 +327,7 @@ pub fn create_web_application_task(
             cmd.add_element_with_text("schedule_periods", &schedule_periods.to_string());
         }
     }
-    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_task_observers(&mut cmd, &opts.observers, &opts.observer_group_ids);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
 }
@@ -400,9 +408,24 @@ fn modify_task_with_usage(
             }
         }
     }
-    add_string_list(&mut cmd, "observers", "observer", &opts.observers);
+    add_task_observers(&mut cmd, &opts.observers, &[]);
     add_preferences(&mut cmd, &opts.preferences);
     cmd
+}
+
+fn add_task_observers(cmd: &mut XmlCommand, observers: &[String], observer_group_ids: &[EntityId]) {
+    if observers.is_empty() && observer_group_ids.is_empty() {
+        return;
+    }
+    let element = cmd.add_element("observers");
+    if !observers.is_empty() {
+        element.set_text(&observers.join(" "));
+    }
+    for group_id in observer_group_ids {
+        element
+            .add_child("group")
+            .set_attribute("id", group_id.as_str());
+    }
 }
 
 /// Build a `move_task` request.
@@ -536,6 +559,7 @@ mod tests {
                 comment: Some("bar".into()),
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             },
         ));
@@ -544,7 +568,7 @@ mod tests {
         assert!(rendered.contains("<hosts_ordering>random</hosts_ordering>"));
         assert!(rendered.contains("<schedule id=\"sched1\"/>"));
         assert!(rendered.contains("<alert id=\"a1\"/>"));
-        assert!(rendered.contains("<observer>alice</observer>"));
+        assert!(rendered.contains("<observers>alice bob<group id=\"group-1\"/></observers>"));
         assert!(rendered.contains("<scanner_name>k</scanner_name><value>v</value>"));
     }
 
@@ -561,12 +585,13 @@ mod tests {
                 comment: Some("scan web app".into()),
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             },
         ));
         assert_eq!(
             rendered,
-            "<create_task><name>web task</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>scan web app</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+            "<create_task><name>web task</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>scan web app</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers>alice bob<group id=\"group-1\"/></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
         );
     }
 
@@ -619,6 +644,20 @@ mod tests {
         assert_eq!(xml(start_task(&id("a1"))), "<start_task task_id=\"a1\"/>");
         assert_eq!(xml(resume_task(&id("a1"))), "<resume_task task_id=\"a1\"/>");
         assert_eq!(xml(stop_task(&id("a1"))), "<stop_task task_id=\"a1\"/>");
+    }
+
+    #[test]
+    fn modify_task_builds_observer_user_list_text() {
+        assert_eq!(
+            xml(modify_task(
+                &id("t1"),
+                ModifyTaskOpts {
+                    observers: vec!["alice".into(), "bob".into()],
+                    ..Default::default()
+                },
+            )),
+            "<modify_task task_id=\"t1\"><observers>alice bob</observers></modify_task>"
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/src/common.rs
+++ b/crates/gvm-gmp/src/common.rs
@@ -72,16 +72,6 @@ pub(crate) fn add_preferences(cmd: &mut XmlCommand, preferences: &[(String, Stri
     }
 }
 
-pub(crate) fn add_string_list(cmd: &mut XmlCommand, parent: &str, child: &str, values: &[String]) {
-    if values.is_empty() {
-        return;
-    }
-    let root = cmd.add_element(parent);
-    for value in values {
-        root.add_child_with_text(child, value);
-    }
-}
-
 pub(crate) fn validate_single_xml_document(
     xml: &str,
     field: &str,

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -33,10 +33,11 @@ fn test_create_task_with_optionals() {
                 comment: Some("bar".into()),
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             }
         )),
-        "<create_task><name>foo</name><usage_type>scan</usage_type><config id=\"c1\"/><target id=\"t1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><hosts_ordering>random</hosts_ordering><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><alert id=\"a1\"/><alert id=\"a2\"/><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+        "<create_task><name>foo</name><usage_type>scan</usage_type><config id=\"c1\"/><target id=\"t1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><hosts_ordering>random</hosts_ordering><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><alert id=\"a1\"/><alert id=\"a2\"/><observers>alice bob<group id=\"group-1\"/></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
     );
 }
 
@@ -67,10 +68,11 @@ fn test_create_agent_group_task_with_optionals() {
                 alert_ids: vec![id("a1"), id("a2")],
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             }
         )),
-        "<create_task><name>foo</name><usage_type>scan</usage_type><agent_group id=\"ag1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+        "<create_task><name>foo</name><usage_type>scan</usage_type><agent_group id=\"ag1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers>alice bob<group id=\"group-1\"/></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
     );
 }
 
@@ -126,10 +128,11 @@ fn test_create_oci_image_target_task_with_optionals() {
                 alert_ids: vec![id("a1"), id("a2")],
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             }
         )),
-        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+        "<create_task><name>foo</name><usage_type>scan</usage_type><oci_image_target id=\"oci1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers>alice bob<group id=\"group-1\"/></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
     );
 }
 
@@ -176,10 +179,11 @@ fn test_create_web_application_task_with_optionals() {
                 comment: Some("bar".into()),
                 schedule_periods: Some(5),
                 observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
                 preferences: vec![("k".into(), "v".into())],
             }
         )),
-        "<create_task><name>foo</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers><observer>alice</observer><observer>bob</observer></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
+        "<create_task><name>foo</name><usage_type>scan</usage_type><web_application_target id=\"wt1\"/><scanner id=\"s1\"/><comment>bar</comment><alterable>1</alterable><alert id=\"a1\"/><alert id=\"a2\"/><schedule id=\"sched1\"/><schedule_periods>5</schedule_periods><observers>alice bob<group id=\"group-1\"/></observers><preferences><preference><scanner_name>k</scanner_name><value>v</value></preference></preferences></create_task>"
     );
 }
 
@@ -232,4 +236,32 @@ fn test_task_mutation_and_actions() {
     assert_eq!(xml(start_task(&id("a1"))), "<start_task task_id=\"a1\"/>");
     assert_eq!(xml(resume_task(&id("a1"))), "<resume_task task_id=\"a1\"/>");
     assert_eq!(xml(stop_task(&id("a1"))), "<stop_task task_id=\"a1\"/>");
+}
+
+#[test]
+fn test_audit_and_modify_task_observers_use_user_list_text() {
+    assert_eq!(
+        xml(create_audit(
+            "audit",
+            &id("c1"),
+            &id("t1"),
+            &id("s1"),
+            CreateTaskOpts {
+                observers: vec!["alice".into(), "bob".into()],
+                observer_group_ids: vec![id("group-1")],
+                ..Default::default()
+            },
+        )),
+        "<create_task><name>audit</name><usage_type>audit</usage_type><config id=\"c1\"/><target id=\"t1\"/><scanner id=\"s1\"/><observers>alice bob<group id=\"group-1\"/></observers></create_task>"
+    );
+    assert_eq!(
+        xml(modify_task(
+            &id("t1"),
+            ModifyTaskOpts {
+                observers: vec!["alice".into(), "bob".into()],
+                ..Default::default()
+            },
+        )),
+        "<modify_task task_id=\"t1\"><observers>alice bob</observers></modify_task>"
+    );
 }

--- a/crates/gvm-gmp/tests/test_tasks.rs
+++ b/crates/gvm-gmp/tests/test_tasks.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::{id, xml};
 use gvm_gmp::commands::tasks::*;
-use gvm_gmp::HostsOrdering;
+use gvm_gmp::{CollectionUpdate, HostsOrdering};
 
 #[test]
 fn test_create_task_basic() {
@@ -258,10 +258,11 @@ fn test_audit_and_modify_task_observers_use_user_list_text() {
         xml(modify_task(
             &id("t1"),
             ModifyTaskOpts {
-                observers: vec!["alice".into(), "bob".into()],
+                observers: CollectionUpdate::replace(["alice".into(), "bob".into()]),
                 ..Default::default()
             },
-        )),
+        )
+        .expect("valid observer update"),),
         "<modify_task task_id=\"t1\"><observers>alice bob</observers></modify_task>"
     );
 }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -992,6 +992,15 @@ impl SessionHandler {
                 resource.set_attr("usage_type", &usage_type);
             }
         }
+        if resource_type == "task" {
+            if let Some(observers) = element_text_including_empty(cmd, raw_xml, "observers") {
+                resource.set_attr("observers", &observers);
+            }
+            let observer_group_ids = task_observer_group_ids(cmd);
+            if !observer_group_ids.is_empty() {
+                resource.set_attr("observer_group_ids", &observer_group_ids.join(","));
+            }
+        }
         if resource_type == "credential" {
             if let Some(credential_type) = parse_element_text(raw_xml, "type") {
                 resource.set_attr("type", &credential_type);
@@ -1523,6 +1532,9 @@ impl SessionHandler {
         let new_new_severity = parse_element_text(raw_xml, "new_severity");
         let new_active = parse_element_text(raw_xml, "active");
         let new_usage_type = parse_element_text(raw_xml, "usage_type");
+        let new_task_observers = (resource_type == "task")
+            .then(|| element_text_including_empty(cmd, raw_xml, "observers"))
+            .flatten();
         let new_value = parse_element_text(raw_xml, "value");
         let new_value = if resource_type == "setting" {
             let Some(value) = new_value else {
@@ -1715,6 +1727,9 @@ impl SessionHandler {
             }
             if let Some(ref usage_type) = new_usage_type {
                 r.set_attr("usage_type", usage_type);
+            }
+            if let Some(ref observers) = new_task_observers {
+                r.set_attr("observers", observers);
             }
             if let Some(ref value) = new_value {
                 r.set_attr("value", value);
@@ -4262,6 +4277,19 @@ fn element_text_including_empty(cmd: &ParsedCommand, raw_xml: &[u8], name: &str)
             .any(|child| child.name == name)
             .then(String::new)
     })
+}
+
+fn task_observer_group_ids(cmd: &ParsedCommand) -> Vec<String> {
+    cmd.children
+        .iter()
+        .find(|child| child.name == "observers")
+        .into_iter()
+        .flat_map(|observers| &observers.children)
+        .filter(|child| child.name == "group")
+        .filter_map(|group| group.attributes.get("id"))
+        .filter(|id| !id.is_empty())
+        .cloned()
+        .collect()
 }
 
 fn resolve_asset_target_hosts(store: &ResourceStore, filter: &str) -> Result<String, String> {

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -996,7 +996,10 @@ impl SessionHandler {
             if let Some(observers) = element_text_including_empty(cmd, raw_xml, "observers") {
                 resource.set_attr("observers", &observers);
             }
-            let observer_group_ids = task_observer_group_ids(cmd);
+            let observer_group_ids = task_observer_group_ids(cmd)
+                .into_iter()
+                .filter(|id| id != "0")
+                .collect::<Vec<_>>();
             if !observer_group_ids.is_empty() {
                 resource.set_attr("observer_group_ids", &observer_group_ids.join(","));
             }
@@ -1535,6 +1538,12 @@ impl SessionHandler {
         let new_task_observers = (resource_type == "task")
             .then(|| element_text_including_empty(cmd, raw_xml, "observers"))
             .flatten();
+        let new_task_observer_group_ids = if resource_type == "task" {
+            let group_ids = task_observer_group_ids(cmd);
+            (!group_ids.is_empty()).then_some(group_ids)
+        } else {
+            None
+        };
         let new_value = parse_element_text(raw_xml, "value");
         let new_value = if resource_type == "setting" {
             let Some(value) = new_value else {
@@ -1730,6 +1739,18 @@ impl SessionHandler {
             }
             if let Some(ref observers) = new_task_observers {
                 r.set_attr("observers", observers);
+            }
+            if let Some(ref group_ids) = new_task_observer_group_ids {
+                let group_ids = group_ids
+                    .iter()
+                    .filter(|id| id.as_str() != "0")
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if group_ids.is_empty() {
+                    r.remove_attr("observer_group_ids");
+                } else {
+                    r.set_attr("observer_group_ids", &group_ids.join(","));
+                }
             }
             if let Some(ref value) = new_value {
                 r.set_attr("value", value);

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -483,6 +483,22 @@ impl Resource {
             }
         }
         if self.resource_type == "task" {
+            if self.attr("observers").is_some() || self.attr("observer_group_ids").is_some() {
+                xml.push_str("<observers>");
+                if let Some(observers) = self.attr("observers") {
+                    xml.push_str(&xml_escape(observers));
+                }
+                if let Some(group_ids) = self.attr("observer_group_ids") {
+                    for group_id in group_ids.split(',').filter(|id| !id.is_empty()) {
+                        xml.push_str(&format!(
+                            "<group id=\"{}\"><name>{}</name></group>",
+                            xml_escape_attr(group_id),
+                            xml_escape(group_id),
+                        ));
+                    }
+                }
+                xml.push_str("</observers>");
+            }
             if self.attr("target_id").is_none() {
                 xml.push_str("<target id=\"\"><name></name></target>");
             }

--- a/spec/openspec.md
+++ b/spec/openspec.md
@@ -348,7 +348,10 @@ impl Tasks {
 
     pub fn get_tasks(opts: GetTasksOpts) -> impl Request;
     pub fn get_task(task_id: &EntityId) -> impl Request;
-    pub fn modify_task(task_id: &EntityId, opts: ModifyTaskOpts) -> impl Request;
+    pub fn modify_task(
+        task_id: &EntityId,
+        opts: ModifyTaskOpts,
+    ) -> Result<impl Request, ModifyTaskError>;
     pub fn move_task(task_id: &EntityId, slave_id: Option<&EntityId>) -> impl Request;
     pub fn start_task(task_id: &EntityId) -> impl Request;
     pub fn resume_task(task_id: &EntityId) -> impl Request;
@@ -364,7 +367,15 @@ pub struct CreateTaskOpts {
     pub comment: Option<String>,
     pub schedule_periods: Option<u32>,
     pub observers: Vec<String>,
+    pub observer_group_ids: Vec<EntityId>,
     pub preferences: HashMap<String, String>,
+}
+
+#[derive(Default)]
+pub struct ModifyTaskOpts {
+    // Other optional task fields omitted here.
+    pub observers: CollectionUpdate<String>,
+    pub observer_group_ids: CollectionUpdate<EntityId>,
 }
 
 #[derive(Default)]
@@ -377,6 +388,10 @@ pub struct GetTasksOpts {
     pub ignore_pagination: Option<bool>,
 }
 ```
+
+`ModifyTaskOpts::observers` distinguishes omission, replacement, and clearing.
+Updating `observer_group_ids` requires `observers` to explicitly replace or
+clear the user list; a group-only update returns `ModifyTaskError`.
 
 #### Full GMP Command Coverage
 


### PR DESCRIPTION
## What Problem This Solves

Task create and modify helpers emitted observer users as nested `<observer>` elements. gvmd ignores that non-schema shape, so a successful request could silently remove the task's user observer grants.

The previous patch fixed that wire shape but still could not clear the final user observer or modify observer groups, both of which current gvmd supports.

## Why This Change Was Made

- Serialize observer users as GMP's space-separated `<observers>` text content across scan, audit, agent-group, OCI-image, and web-application task builders.
- Model create-time observer group children on every typed create-task option.
- Model modify-time observer users and groups with independent `CollectionUpdate` values so callers can omit, replace, or clear them without exposing gvmd sentinels.
- Reject group-only modify requests before sending because opening gvmd's shared `<observers>` container would otherwise clear the current users implicitly.
- Encode group clearing with gvmd's `group id="0"` behavior while keeping that protocol detail out of the typed API.
- Persist and render observer-user and observer-group replacements and clears in the stateful mock.
- Document the updated public command contract.

## User Impact

Typed task create and modify calls now preserve the requested observer access grants instead of reporting success after gvmd discarded malformed values. A caller can revoke the last user observer with `CollectionUpdate::Clear`, replace observer groups against a real gvmd, or clear every observer grant explicitly.

`ModifyTaskOpts::observers` is now `CollectionUpdate<String>` and gains `observer_group_ids: CollectionUpdate<EntityId>`. The raw `modify_task` and `modify_audit` builders now return `Result` so an unsafe group-only update is a typed `ModifyTaskError`; `GmpClient::modify_task` maps it to `GvmError::ModifyTask` before any request is sent.

## Evidence

- `cargo test -p gvm-gmp --all-features` (461 unit tests plus all integration/schema tests passed)
- `cargo test -p gvm-mock-server --all-features` (complete unit, integration, transport, and doctest suite passed)
- `cargo test -p gvm-client --features unix-socket-tests --test client_integration typed_task_observers_round_trip_create_and_modify -- --exact`
- `cargo clippy -p gvm-gmp -p gvm-mock-server -p gvm-client --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes greenbone-hive/rust-gvm#492

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
