### PR TITLE
feat: support extended target credential settings

### DIFF
--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3537,7 +3537,6 @@ async fn typed_target_extended_credentials_and_simultaneous_ips_round_trip() {
             "Extended Credential Target",
             CreateTargetOpts {
                 ssh_credential_id: Some(ssh.clone()),
-                ssh_elevate_credential_id: Some(elevate.clone()),
                 allow_simultaneous_ips: Some(true),
                 ..CreateTargetOpts::new(target_hosts(&["192.0.2.20"], &[]), target_ports())
             },
@@ -3549,15 +3548,32 @@ async fn typed_target_extended_credentials_and_simultaneous_ips_round_trip() {
         target.ssh_credential.as_ref().map(|value| &value.id),
         Some(&ssh)
     );
+    assert_eq!(target.ssh_elevate_credential, None);
+    assert_eq!(target.krb5_credential, None);
+    assert!(target.allow_simultaneous_ips);
+
+    client
+        .modify_target(
+            &created.id,
+            ModifyTargetOpts {
+                ssh_elevate_credential_id: ScalarUpdate::set(elevate.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("elevation should be added while the existing SSH binding is preserved");
+    let elevated = target_by_id(&mut client, &created.id).await;
     assert_eq!(
-        target
+        elevated.ssh_credential.as_ref().map(|value| &value.id),
+        Some(&ssh)
+    );
+    assert_eq!(
+        elevated
             .ssh_elevate_credential
             .as_ref()
             .map(|value| &value.id),
         Some(&elevate)
     );
-    assert_eq!(target.krb5_credential, None);
-    assert!(target.allow_simultaneous_ips);
 
     client
         .modify_target(
@@ -3739,21 +3755,6 @@ async fn typed_target_credential_invariants_fail_before_send() {
         )
         .await
         .expect_err("elevation with SSH detach should fail locally");
-    assert!(matches!(
-        error,
-        GvmError::ModifyTarget(ModifyTargetError::SshElevateWithoutSshCredential)
-    ));
-
-    let error = client
-        .modify_target(
-            &target_id,
-            ModifyTargetOpts {
-                ssh_elevate_credential_id: ScalarUpdate::set(id("elevate")),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect_err("elevation without an explicit SSH binding should fail locally");
     assert!(matches!(
         error,
         GvmError::ModifyTarget(ModifyTargetError::SshElevateWithoutSshCredential)

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3537,7 +3537,6 @@ async fn typed_target_extended_credentials_and_simultaneous_ips_round_trip() {
             "Extended Credential Target",
             CreateTargetOpts {
                 ssh_credential_id: Some(ssh.clone()),
-                allow_simultaneous_ips: Some(true),
                 ..CreateTargetOpts::new(target_hosts(&["192.0.2.20"], &[]), target_ports())
             },
         )

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -3507,6 +3507,126 @@ async fn typed_target_credentials_round_trip_in_stateful_mode() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn typed_target_extended_credentials_and_simultaneous_ips_round_trip() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let ssh = create_test_credential(&mut client, "Extended SSH").await;
+    let elevate = create_test_smb_credential(&mut client, "Extended Elevation").await;
+    let smb = create_test_smb_credential(&mut client, "Extended SMB").await;
+    let krb5 = client
+        .create_credential(
+            "Extended Kerberos",
+            CredentialOpts {
+                credential_type: Some(CredentialType::Kerberos5),
+                login: Some("principal".into()),
+                password: Some("secret".into()),
+                kdcs: vec!["kdc.example".into()],
+                realm: Some("EXAMPLE.COM".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Kerberos credential should be created")
+        .id;
+
+    let created = client
+        .create_target(
+            "Extended Credential Target",
+            CreateTargetOpts {
+                ssh_credential_id: Some(ssh.clone()),
+                ssh_elevate_credential_id: Some(elevate.clone()),
+                allow_simultaneous_ips: Some(true),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.20"], &[]), target_ports())
+            },
+        )
+        .await
+        .expect("target should be created");
+    let target = target_by_id(&mut client, &created.id).await;
+    assert_eq!(
+        target.ssh_credential.as_ref().map(|value| &value.id),
+        Some(&ssh)
+    );
+    assert_eq!(
+        target
+            .ssh_elevate_credential
+            .as_ref()
+            .map(|value| &value.id),
+        Some(&elevate)
+    );
+    assert_eq!(target.krb5_credential, None);
+    assert!(target.allow_simultaneous_ips);
+
+    client
+        .modify_target(
+            &created.id,
+            ModifyTargetOpts {
+                comment: Some("new fields omitted".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("omitted fields should be preserved");
+    let preserved = target_by_id(&mut client, &created.id).await;
+    assert_eq!(
+        preserved
+            .ssh_elevate_credential
+            .as_ref()
+            .map(|value| &value.id),
+        Some(&elevate)
+    );
+    assert!(preserved.allow_simultaneous_ips);
+
+    client
+        .modify_target(
+            &created.id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::Clear,
+                ssh_elevate_credential_id: ScalarUpdate::Clear,
+                krb5_credential_id: ScalarUpdate::set(krb5.clone()),
+                allow_simultaneous_ips: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SSH credentials should detach while Kerberos is set");
+    let kerberos_target = target_by_id(&mut client, &created.id).await;
+    assert_eq!(kerberos_target.ssh_credential, None);
+    assert_eq!(kerberos_target.ssh_elevate_credential, None);
+    assert_eq!(
+        kerberos_target
+            .krb5_credential
+            .as_ref()
+            .map(|value| &value.id),
+        Some(&krb5)
+    );
+    assert!(!kerberos_target.allow_simultaneous_ips);
+
+    client
+        .modify_target(
+            &created.id,
+            ModifyTargetOpts {
+                krb5_credential_id: ScalarUpdate::Clear,
+                smb_credential_id: ScalarUpdate::set(smb.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Kerberos should detach while SMB is set");
+    let smb_target = target_by_id(&mut client, &created.id).await;
+    assert_eq!(smb_target.krb5_credential, None);
+    assert_eq!(
+        smb_target.smb_credential.as_ref().map(|value| &value.id),
+        Some(&smb)
+    );
+    assert!(!smb_target.allow_simultaneous_ips);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
     let Some(server) = stateful_server().await else {
         return;
@@ -3540,6 +3660,138 @@ async fn typed_target_create_rejects_an_orphaned_ssh_port_before_send() {
         .count();
     assert_eq!(create_count_after, create_count_before);
 
+    server.shutdown().await;
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn typed_target_credential_invariants_fail_before_send() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut client = authenticated_client(&server).await;
+    let id = |value| EntityId::new(value).expect("valid credential ID");
+    let command_count = || {
+        server
+            .command_history()
+            .iter()
+            .filter(|record| matches!(record.command_name(), "create_target" | "modify_target"))
+            .count()
+    };
+    let before = command_count();
+
+    let error = client
+        .create_target(
+            "Missing SSH",
+            CreateTargetOpts {
+                ssh_elevate_credential_id: Some(id("elevate")),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.12"], &[]), target_ports())
+            },
+        )
+        .await
+        .expect_err("elevation without SSH should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::CreateTarget(CreateTargetError::SshElevateWithoutSshCredential)
+    ));
+
+    let error = client
+        .create_target(
+            "Same SSH",
+            CreateTargetOpts {
+                ssh_credential_id: Some(id("same")),
+                ssh_elevate_credential_id: Some(id("same")),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.13"], &[]), target_ports())
+            },
+        )
+        .await
+        .expect_err("matching SSH credentials should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::CreateTarget(CreateTargetError::SshElevateMatchesSshCredential)
+    ));
+
+    let error = client
+        .create_target(
+            "SMB and Kerberos",
+            CreateTargetOpts {
+                smb_credential_id: Some(id("smb")),
+                krb5_credential_id: Some(id("krb5")),
+                ..CreateTargetOpts::new(target_hosts(&["192.0.2.14"], &[]), target_ports())
+            },
+        )
+        .await
+        .expect_err("SMB and Kerberos should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::CreateTarget(CreateTargetError::SmbAndKrb5Credentials)
+    ));
+
+    let target_id = id("target");
+    let error = client
+        .modify_target(
+            &target_id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::Clear,
+                ssh_elevate_credential_id: ScalarUpdate::set(id("elevate")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("elevation with SSH detach should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTarget(ModifyTargetError::SshElevateWithoutSshCredential)
+    ));
+
+    let error = client
+        .modify_target(
+            &target_id,
+            ModifyTargetOpts {
+                ssh_elevate_credential_id: ScalarUpdate::set(id("elevate")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("elevation without an explicit SSH binding should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTarget(ModifyTargetError::SshElevateWithoutSshCredential)
+    ));
+
+    let error = client
+        .modify_target(
+            &target_id,
+            ModifyTargetOpts {
+                ssh_credential_id: ScalarUpdate::set(id("same")),
+                ssh_elevate_credential_id: ScalarUpdate::set(id("same")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("matching SSH credentials should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTarget(ModifyTargetError::SshElevateMatchesSshCredential)
+    ));
+
+    let error = client
+        .modify_target(
+            &target_id,
+            ModifyTargetOpts {
+                smb_credential_id: ScalarUpdate::set(id("smb")),
+                krb5_credential_id: ScalarUpdate::set(id("krb5")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("SMB and Kerberos should fail locally");
+    assert!(matches!(
+        error,
+        GvmError::ModifyTarget(ModifyTargetError::SmbAndKrb5Credentials)
+    ));
+
+    assert_eq!(command_count(), before);
     server.shutdown().await;
 }
 

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -193,6 +193,8 @@ pub fn create_target(
     {
         return Err(CreateTargetError::SshElevateMatchesSshCredential);
     }
+    // gvmd enforces this in the GMP create-target handler in gmp.c, before
+    // dispatching to the SQL-layer create_target implementation.
     if opts.smb_credential_id.is_some() && opts.krb5_credential_id.is_some() {
         return Err(CreateTargetError::SmbAndKrb5Credentials);
     }

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -28,8 +28,12 @@ pub struct CreateTargetOpts {
     pub ssh_credential_id: Option<EntityId>,
     /// Optional SSH service port nested below the SSH credential.
     pub ssh_credential_port: Option<ServicePort>,
+    /// Optional SSH privilege-escalation credential identifier.
+    pub ssh_elevate_credential_id: Option<EntityId>,
     /// Optional SMB credential identifier.
     pub smb_credential_id: Option<EntityId>,
+    /// Optional Kerberos 5 credential identifier.
+    pub krb5_credential_id: Option<EntityId>,
     /// Optional `ESXi` credential identifier.
     pub esxi_credential_id: Option<EntityId>,
     /// Optional SNMP credential identifier.
@@ -38,6 +42,8 @@ pub struct CreateTargetOpts {
     pub reverse_lookup_only: Option<bool>,
     /// Whether reverse-lookup unification should be enabled.
     pub reverse_lookup_unify: Option<bool>,
+    /// Whether multiple IP addresses of one host may be scanned simultaneously.
+    pub allow_simultaneous_ips: Option<bool>,
 }
 
 impl CreateTargetOpts {
@@ -51,11 +57,14 @@ impl CreateTargetOpts {
             ports,
             ssh_credential_id: None,
             ssh_credential_port: None,
+            ssh_elevate_credential_id: None,
             smb_credential_id: None,
+            krb5_credential_id: None,
             esxi_credential_id: None,
             snmp_credential_id: None,
             reverse_lookup_only: None,
             reverse_lookup_unify: None,
+            allow_simultaneous_ips: None,
         }
     }
 }
@@ -100,8 +109,12 @@ pub struct ModifyTargetOpts {
     /// credential is set and this update is omitted, gvmd selects its default
     /// SSH port (22); omitting both updates preserves the existing binding.
     pub ssh_credential_port: ScalarUpdate<ServicePort>,
+    /// SSH privilege-escalation credential relationship update: omit, set, or detach.
+    pub ssh_elevate_credential_id: ScalarUpdate<EntityId>,
     /// SMB credential relationship update: omit, set, or detach.
     pub smb_credential_id: ScalarUpdate<EntityId>,
+    /// Kerberos 5 credential relationship update: omit, set, or detach.
+    pub krb5_credential_id: ScalarUpdate<EntityId>,
     /// `ESXi` credential relationship update: omit, set, or detach.
     pub esxi_credential_id: ScalarUpdate<EntityId>,
     /// SNMP credential relationship update: omit, set, or detach.
@@ -110,6 +123,8 @@ pub struct ModifyTargetOpts {
     pub reverse_lookup_only: Option<bool>,
     /// Whether reverse-lookup unification should be enabled.
     pub reverse_lookup_unify: Option<bool>,
+    /// Whether multiple IP addresses of one host may be scanned simultaneously.
+    pub allow_simultaneous_ips: Option<bool>,
 }
 
 /// Errors raised while building a `create_target` request.
@@ -118,6 +133,15 @@ pub enum CreateTargetError {
     /// A service port cannot be encoded without an SSH credential identifier.
     #[error("setting an SSH credential port requires an SSH credential identifier")]
     SshPortWithoutCredential,
+    /// An SSH elevation credential requires a separate SSH login credential.
+    #[error("setting an SSH elevation credential requires an SSH credential")]
+    SshElevateWithoutSshCredential,
+    /// The SSH login and elevation credentials must be different.
+    #[error("the SSH elevation credential must differ from the SSH credential")]
+    SshElevateMatchesSshCredential,
+    /// gvmd does not allow SMB and Kerberos credentials on the same target.
+    #[error("SMB and Kerberos credentials are mutually exclusive")]
+    SmbAndKrb5Credentials,
 }
 
 /// Errors raised while building a `modify_target` request.
@@ -132,6 +156,15 @@ pub enum ModifyTargetError {
     /// A service-port update is incompatible with detaching the credential.
     #[error("an SSH credential port cannot be updated while detaching the SSH credential")]
     SshPortWithCredentialClear,
+    /// A newly bound elevation credential cannot accompany SSH credential detachment.
+    #[error("setting an SSH elevation credential requires an SSH credential")]
+    SshElevateWithoutSshCredential,
+    /// The SSH login and elevation credentials must be different.
+    #[error("the SSH elevation credential must differ from the SSH credential")]
+    SshElevateMatchesSshCredential,
+    /// gvmd does not allow SMB and Kerberos credentials to be set together.
+    #[error("SMB and Kerberos credentials are mutually exclusive")]
+    SmbAndKrb5Credentials,
 }
 
 /// Build a clone request for an existing target.
@@ -151,6 +184,17 @@ pub fn create_target(
 ) -> Result<impl Request, CreateTargetError> {
     if opts.ssh_credential_port.is_some() && opts.ssh_credential_id.is_none() {
         return Err(CreateTargetError::SshPortWithoutCredential);
+    }
+    if opts.ssh_elevate_credential_id.is_some() && opts.ssh_credential_id.is_none() {
+        return Err(CreateTargetError::SshElevateWithoutSshCredential);
+    }
+    if opts.ssh_elevate_credential_id == opts.ssh_credential_id
+        && opts.ssh_elevate_credential_id.is_some()
+    {
+        return Err(CreateTargetError::SshElevateMatchesSshCredential);
+    }
+    if opts.smb_credential_id.is_some() && opts.krb5_credential_id.is_some() {
+        return Err(CreateTargetError::SmbAndKrb5Credentials);
     }
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
@@ -174,6 +218,9 @@ pub fn create_target(
     }
     if let Some(value) = opts.reverse_lookup_unify {
         cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
+    }
+    if let Some(value) = opts.allow_simultaneous_ips {
+        cmd.add_element_with_text("allow_simultaneous_ips", bool_str(value));
     }
     Ok(cmd)
 }
@@ -222,6 +269,23 @@ pub fn modify_target(
         }
         _ => {}
     }
+    if matches!(opts.ssh_elevate_credential_id, ScalarUpdate::Set(_))
+        && !matches!(opts.ssh_credential_id, ScalarUpdate::Set(_))
+    {
+        return Err(ModifyTargetError::SshElevateWithoutSshCredential);
+    }
+    if let (ScalarUpdate::Set(ssh), ScalarUpdate::Set(elevate)) =
+        (&opts.ssh_credential_id, &opts.ssh_elevate_credential_id)
+    {
+        if ssh == elevate {
+            return Err(ModifyTargetError::SshElevateMatchesSshCredential);
+        }
+    }
+    if matches!(opts.smb_credential_id, ScalarUpdate::Set(_))
+        && matches!(opts.krb5_credential_id, ScalarUpdate::Set(_))
+    {
+        return Err(ModifyTargetError::SmbAndKrb5Credentials);
+    }
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -242,6 +306,9 @@ pub fn modify_target(
     if let Some(value) = opts.reverse_lookup_unify {
         cmd.add_element_with_text("reverse_lookup_unify", bool_str(value));
     }
+    if let Some(value) = opts.allow_simultaneous_ips {
+        cmd.add_element_with_text("allow_simultaneous_ips", bool_str(value));
+    }
     Ok(cmd)
 }
 
@@ -259,7 +326,13 @@ fn add_create_target_credentials(cmd: &mut XmlCommand, opts: &CreateTargetOpts) 
         opts.ssh_credential_id.as_ref(),
         opts.ssh_credential_port,
     );
+    add_optional_id_element(
+        cmd,
+        "ssh_elevate_credential",
+        opts.ssh_elevate_credential_id.as_ref(),
+    );
     add_optional_id_element(cmd, "smb_credential", opts.smb_credential_id.as_ref());
+    add_optional_id_element(cmd, "krb5_credential", opts.krb5_credential_id.as_ref());
     add_optional_id_element(cmd, "esxi_credential", opts.esxi_credential_id.as_ref());
     add_optional_id_element(cmd, "snmp_credential", opts.snmp_credential_id.as_ref());
 }
@@ -284,7 +357,13 @@ fn add_modify_target_credentials(cmd: &mut XmlCommand, opts: &ModifyTargetOpts) 
             add_scalar_id_update(cmd, "ssh_credential", &ScalarUpdate::<EntityId>::Clear);
         }
     }
+    add_scalar_id_update(
+        cmd,
+        "ssh_elevate_credential",
+        &opts.ssh_elevate_credential_id,
+    );
     add_scalar_id_update(cmd, "smb_credential", &opts.smb_credential_id);
+    add_scalar_id_update(cmd, "krb5_credential", &opts.krb5_credential_id);
     add_scalar_id_update(cmd, "esxi_credential", &opts.esxi_credential_id);
     add_scalar_id_update(cmd, "snmp_credential", &opts.snmp_credential_id);
 }
@@ -353,11 +432,14 @@ mod tests {
                 ports: TargetPortSelection::PortList(id("pl1")),
                 ssh_credential_id: Some(id("ssh1")),
                 ssh_credential_port: Some(ServicePort::new(2222).expect("valid port")),
+                ssh_elevate_credential_id: Some(id("elevate1")),
                 smb_credential_id: Some(id("smb1")),
+                krb5_credential_id: None,
                 esxi_credential_id: Some(id("esxi1")),
                 snmp_credential_id: Some(id("snmp1")),
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
+                allow_simultaneous_ips: Some(true),
             },
         )
         .expect("valid target"));
@@ -366,9 +448,11 @@ mod tests {
         assert!(rendered.contains("<alive_tests>ICMP Ping</alive_tests>"));
         assert!(rendered.contains("<port_list id=\"pl1\"/>"));
         assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
+        assert!(rendered.contains("<ssh_elevate_credential id=\"elevate1\"/>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
+        assert!(rendered.contains("<allow_simultaneous_ips>1</allow_simultaneous_ips>"));
         assert_eq!(
             xml(clone_target(&id("t1"))),
             "<create_target><copy>t1</copy></create_target>"
@@ -396,11 +480,13 @@ mod tests {
                 alive_test: Some(AliveTest::IcmpAndArpPing),
                 ssh_credential_id: ScalarUpdate::set(id("ssh1")),
                 ssh_credential_port: ScalarUpdate::set(ServicePort::new(2222).expect("valid port")),
+                ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
                 smb_credential_id: ScalarUpdate::set(id("smb1")),
                 esxi_credential_id: ScalarUpdate::set(id("esxi1")),
                 snmp_credential_id: ScalarUpdate::set(id("snmp1")),
                 reverse_lookup_only: Some(true),
                 reverse_lookup_unify: Some(false),
+                allow_simultaneous_ips: Some(false),
                 ..Default::default()
             },
         )
@@ -408,11 +494,13 @@ mod tests {
         assert!(rendered.contains("<name>n</name>"));
         assert!(rendered.contains("<alive_tests>ICMP &amp; ARP Ping</alive_tests>"));
         assert!(rendered.contains("<ssh_credential id=\"ssh1\"><port>2222</port></ssh_credential>"));
+        assert!(rendered.contains("<ssh_elevate_credential id=\"elevate1\"/>"));
         assert!(rendered.contains("<smb_credential id=\"smb1\"/>"));
         assert!(rendered.contains("<esxi_credential id=\"esxi1\"/>"));
         assert!(rendered.contains("<snmp_credential id=\"snmp1\"/>"));
         assert!(rendered.contains("<reverse_lookup_only>1</reverse_lookup_only>"));
         assert!(rendered.contains("<reverse_lookup_unify>0</reverse_lookup_unify>"));
+        assert!(rendered.contains("<allow_simultaneous_ips>0</allow_simultaneous_ips>"));
         assert_eq!(
             xml(delete_target(&id("t1"), false)),
             "<delete_target target_id=\"t1\" ultimate=\"0\"/>"
@@ -476,13 +564,15 @@ mod tests {
                 &id("t1"),
                 ModifyTargetOpts {
                     ssh_credential_id: ScalarUpdate::Clear,
+                    ssh_elevate_credential_id: ScalarUpdate::Clear,
                     smb_credential_id: ScalarUpdate::Clear,
+                    krb5_credential_id: ScalarUpdate::Clear,
                     esxi_credential_id: ScalarUpdate::Clear,
                     snmp_credential_id: ScalarUpdate::Clear,
                     ..Default::default()
                 }
             ).expect("valid update")),
-            "<modify_target target_id=\"t1\"><ssh_credential id=\"0\"/><smb_credential id=\"0\"/><esxi_credential id=\"0\"/><snmp_credential id=\"0\"/></modify_target>"
+            "<modify_target target_id=\"t1\"><ssh_credential id=\"0\"/><ssh_elevate_credential id=\"0\"/><smb_credential id=\"0\"/><krb5_credential id=\"0\"/><esxi_credential id=\"0\"/><snmp_credential id=\"0\"/></modify_target>"
         );
     }
 
@@ -572,6 +662,136 @@ mod tests {
             )
             .err(),
             Some(CreateTargetError::SshPortWithoutCredential)
+        );
+    }
+
+    #[test]
+    fn target_new_fields_have_exact_wire_shapes() {
+        assert_eq!(
+            xml(create_target(
+                "target",
+                CreateTargetOpts {
+                    ssh_credential_id: Some(id("ssh1")),
+                    ssh_elevate_credential_id: Some(id("elevate1")),
+                    allow_simultaneous_ips: Some(true),
+                    ..CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports())
+                }
+            )
+            .expect("valid elevation target")),
+            "<create_target><name>target</name><hosts>192.0.2.1</hosts><exclude_hosts></exclude_hosts><port_range>T:1-65535</port_range><ssh_credential id=\"ssh1\"/><ssh_elevate_credential id=\"elevate1\"/><allow_simultaneous_ips>1</allow_simultaneous_ips></create_target>"
+        );
+        assert_eq!(
+            xml(create_target(
+                "target",
+                CreateTargetOpts {
+                    krb5_credential_id: Some(id("krb1")),
+                    allow_simultaneous_ips: Some(false),
+                    ..CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports())
+                }
+            )
+            .expect("valid Kerberos target")),
+            "<create_target><name>target</name><hosts>192.0.2.1</hosts><exclude_hosts></exclude_hosts><port_range>T:1-65535</port_range><krb5_credential id=\"krb1\"/><allow_simultaneous_ips>0</allow_simultaneous_ips></create_target>"
+        );
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_id: ScalarUpdate::set(id("ssh1")),
+                    ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
+                    krb5_credential_id: ScalarUpdate::set(id("krb1")),
+                    allow_simultaneous_ips: Some(true),
+                    ..Default::default()
+                }
+            )
+            .expect("valid target update")),
+            "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"/><ssh_elevate_credential id=\"elevate1\"/><krb5_credential id=\"krb1\"/><allow_simultaneous_ips>1</allow_simultaneous_ips></modify_target>"
+        );
+    }
+
+    #[test]
+    fn target_new_credential_invariants_are_typed_errors() {
+        let base = || CreateTargetOpts::new(hosts(&["192.0.2.1"], &[]), direct_ports());
+        assert_eq!(
+            create_target(
+                "target",
+                CreateTargetOpts {
+                    ssh_elevate_credential_id: Some(id("elevate1")),
+                    ..base()
+                }
+            )
+            .err(),
+            Some(CreateTargetError::SshElevateWithoutSshCredential)
+        );
+        assert_eq!(
+            create_target(
+                "target",
+                CreateTargetOpts {
+                    ssh_credential_id: Some(id("same")),
+                    ssh_elevate_credential_id: Some(id("same")),
+                    ..base()
+                }
+            )
+            .err(),
+            Some(CreateTargetError::SshElevateMatchesSshCredential)
+        );
+        assert_eq!(
+            create_target(
+                "target",
+                CreateTargetOpts {
+                    smb_credential_id: Some(id("smb1")),
+                    krb5_credential_id: Some(id("krb1")),
+                    ..base()
+                }
+            )
+            .err(),
+            Some(CreateTargetError::SmbAndKrb5Credentials)
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_id: ScalarUpdate::Clear,
+                    ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SshElevateWithoutSshCredential)
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SshElevateWithoutSshCredential)
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_credential_id: ScalarUpdate::set(id("same")),
+                    ssh_elevate_credential_id: ScalarUpdate::set(id("same")),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SshElevateMatchesSshCredential)
+        );
+        assert_eq!(
+            modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    smb_credential_id: ScalarUpdate::set(id("smb1")),
+                    krb5_credential_id: ScalarUpdate::set(id("krb1")),
+                    ..Default::default()
+                }
+            )
+            .err(),
+            Some(ModifyTargetError::SmbAndKrb5Credentials)
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -270,7 +270,7 @@ pub fn modify_target(
         _ => {}
     }
     if matches!(opts.ssh_elevate_credential_id, ScalarUpdate::Set(_))
-        && !matches!(opts.ssh_credential_id, ScalarUpdate::Set(_))
+        && matches!(opts.ssh_credential_id, ScalarUpdate::Clear)
     {
         return Err(ModifyTargetError::SshElevateWithoutSshCredential);
     }
@@ -706,6 +706,17 @@ mod tests {
             .expect("valid target update")),
             "<modify_target target_id=\"t1\"><ssh_credential id=\"ssh1\"/><ssh_elevate_credential id=\"elevate1\"/><krb5_credential id=\"krb1\"/><allow_simultaneous_ips>1</allow_simultaneous_ips></modify_target>"
         );
+        assert_eq!(
+            xml(modify_target(
+                &id("t1"),
+                ModifyTargetOpts {
+                    ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
+                    ..Default::default()
+                }
+            )
+            .expect("existing SSH credential may be preserved")),
+            "<modify_target target_id=\"t1\"><ssh_elevate_credential id=\"elevate1\"/></modify_target>"
+        );
     }
 
     #[test]
@@ -751,17 +762,6 @@ mod tests {
                 &id("t1"),
                 ModifyTargetOpts {
                     ssh_credential_id: ScalarUpdate::Clear,
-                    ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
-                    ..Default::default()
-                }
-            )
-            .err(),
-            Some(ModifyTargetError::SshElevateWithoutSshCredential)
-        );
-        assert_eq!(
-            modify_target(
-                &id("t1"),
-                ModifyTargetOpts {
                     ssh_elevate_credential_id: ScalarUpdate::set(id("elevate1")),
                     ..Default::default()
                 }

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -113,7 +113,7 @@ impl Target {
                 .optional_child_text("allow_simultaneous_ips")
                 .map(|value| crate::responses::common::parse_bool(&value, "allow_simultaneous_ips"))
                 .transpose()?
-                .unwrap_or(false),
+                .unwrap_or(true),
             max_hosts: optional_u32(node, "max_hosts", "max_hosts")?,
         })
     }
@@ -342,7 +342,7 @@ mod tests {
         assert_eq!(target.krb5_credential, None);
         assert_eq!(target.esxi_credential, None);
         assert_eq!(target.snmp_credential, None);
-        assert!(!target.allow_simultaneous_ips);
+        assert!(target.allow_simultaneous_ips);
         assert!(!target.meta.in_use);
         assert!(!target.meta.writable);
     }

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -25,9 +25,12 @@ pub struct Target {
     pub port_list: Option<NamedEntity>,
     pub ssh_credential: Option<NamedEntity>,
     pub ssh_credential_port: Option<ServicePort>,
+    pub ssh_elevate_credential: Option<NamedEntity>,
     pub smb_credential: Option<NamedEntity>,
+    pub krb5_credential: Option<NamedEntity>,
     pub esxi_credential: Option<NamedEntity>,
     pub snmp_credential: Option<NamedEntity>,
+    pub allow_simultaneous_ips: bool,
     pub max_hosts: Option<u32>,
 }
 
@@ -101,9 +104,16 @@ impl Target {
             port_list: parse_named_entity(node, "port_list")?,
             ssh_credential,
             ssh_credential_port,
+            ssh_elevate_credential: parse_named_entity(node, "ssh_elevate_credential")?,
             smb_credential: parse_named_entity(node, "smb_credential")?,
+            krb5_credential: parse_named_entity(node, "krb5_credential")?,
             esxi_credential: parse_named_entity(node, "esxi_credential")?,
             snmp_credential: parse_named_entity(node, "snmp_credential")?,
+            allow_simultaneous_ips: node
+                .optional_child_text("allow_simultaneous_ips")
+                .map(|value| crate::responses::common::parse_bool(&value, "allow_simultaneous_ips"))
+                .transpose()?
+                .unwrap_or(false),
             max_hosts: optional_u32(node, "max_hosts", "max_hosts")?,
         })
     }
@@ -153,6 +163,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn parses_multiple_targets() {
         let response = Response::from(
             r#"<get_targets_response status="200" status_text="OK">
@@ -171,9 +182,12 @@ mod tests {
                     <reverse_lookup_unify>1</reverse_lookup_unify>
                     <port_list id="pl-1"><name>All TCP</name></port_list>
                     <ssh_credential id="cred-ssh"><name>SSH Cred</name><port>2222</port></ssh_credential>
+                    <ssh_elevate_credential id="cred-elevate"><name>Elevation Cred</name></ssh_elevate_credential>
                     <smb_credential id="cred-smb"><name>SMB Cred</name></smb_credential>
+                    <krb5_credential id="cred-krb5"><name>Kerberos Cred</name></krb5_credential>
                     <esxi_credential id="cred-esxi"><name>ESXi Cred</name></esxi_credential>
                     <snmp_credential id="cred-snmp"><name>SNMP Cred</name></snmp_credential>
+                    <allow_simultaneous_ips>1</allow_simultaneous_ips>
                     <max_hosts>4096</max_hosts>
                 </target>
                 <target id="t-2">
@@ -219,10 +233,24 @@ mod tests {
         );
         assert_eq!(
             parsed.items[0]
+                .ssh_elevate_credential
+                .as_ref()
+                .map(|credential| credential.name.as_str()),
+            Some("Elevation Cred")
+        );
+        assert_eq!(
+            parsed.items[0]
                 .smb_credential
                 .as_ref()
                 .map(|credential| credential.name.as_str()),
             Some("SMB Cred")
+        );
+        assert_eq!(
+            parsed.items[0]
+                .krb5_credential
+                .as_ref()
+                .map(|credential| credential.name.as_str()),
+            Some("Kerberos Cred")
         );
         assert_eq!(
             parsed.items[0]
@@ -247,6 +275,7 @@ mod tests {
             vec!["192.168.1.5".to_string(), "192.168.1.6".to_string()]
         );
         assert!(parsed.items[0].reverse_lookup_unify);
+        assert!(parsed.items[0].allow_simultaneous_ips);
         assert!(parsed.items[1].meta.in_use);
     }
 
@@ -308,9 +337,12 @@ mod tests {
         assert_eq!(target.port_list, None);
         assert_eq!(target.ssh_credential, None);
         assert_eq!(target.ssh_credential_port, None);
+        assert_eq!(target.ssh_elevate_credential, None);
         assert_eq!(target.smb_credential, None);
+        assert_eq!(target.krb5_credential, None);
         assert_eq!(target.esxi_credential, None);
         assert_eq!(target.snmp_credential, None);
+        assert!(!target.allow_simultaneous_ips);
         assert!(!target.meta.in_use);
         assert!(!target.meta.writable);
     }

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -944,7 +944,9 @@ impl SessionHandler {
                         );
                     }
                 },
-                None => None,
+                // gvmd stores this as enabled unless the request explicitly
+                // supplies a literal false value.
+                None => Some(true),
             }
         } else {
             None

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -889,6 +889,66 @@ impl SessionHandler {
         } else {
             TargetCredentialUpdate::Omitted
         };
+        let target_ssh_elevate_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "ssh_elevate_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let target_krb5_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "krb5_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let target_esxi_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "esxi_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let target_snmp_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "snmp_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        if resource_type == "target" {
+            if let Err(message) = validate_target_credential_combination(
+                None,
+                &target_ssh_credential,
+                &target_ssh_elevate_credential,
+                &target_smb_credential,
+                &target_krb5_credential,
+            ) {
+                return error_response(&cmd.name, 400, message);
+            }
+        }
+        let target_allow_simultaneous_ips = if resource_type == "target" {
+            match cmd.child_text("allow_simultaneous_ips") {
+                Some(value) => match parse_filter_bool(value.trim()) {
+                    Some(value) => Some(value),
+                    None => {
+                        return error_response(
+                            &cmd.name,
+                            400,
+                            "Invalid allow_simultaneous_ips value",
+                        );
+                    }
+                },
+                None => None,
+            }
+        } else {
+            None
+        };
         let target_alive_test = if resource_type == "target" {
             match target_alive_test_update(cmd) {
                 Ok(update) => update,
@@ -1148,7 +1208,30 @@ impl SessionHandler {
                 resource.set_attr("port_range", &port_range);
             }
             apply_target_credential_update(&mut resource, "ssh_credential", &target_ssh_credential);
+            apply_target_credential_update(
+                &mut resource,
+                "ssh_elevate_credential",
+                &target_ssh_elevate_credential,
+            );
             apply_target_credential_update(&mut resource, "smb_credential", &target_smb_credential);
+            apply_target_credential_update(
+                &mut resource,
+                "krb5_credential",
+                &target_krb5_credential,
+            );
+            apply_target_credential_update(
+                &mut resource,
+                "esxi_credential",
+                &target_esxi_credential,
+            );
+            apply_target_credential_update(
+                &mut resource,
+                "snmp_credential",
+                &target_snmp_credential,
+            );
+            if let Some(value) = target_allow_simultaneous_ips {
+                resource.set_attr("allow_simultaneous_ips", if value { "1" } else { "0" });
+            }
             if let Some(alive_test) = target_alive_test {
                 resource.set_attr("alive_test", alive_test.as_target_name());
             }
@@ -1424,6 +1507,68 @@ impl SessionHandler {
         } else {
             TargetCredentialUpdate::Omitted
         };
+        let new_target_ssh_elevate_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "ssh_elevate_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let new_target_krb5_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "krb5_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let new_target_esxi_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "esxi_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let new_target_snmp_credential = if resource_type == "target" {
+            match target_credential_update(cmd, store, "snmp_credential") {
+                Ok(update) => update,
+                Err((status, message)) => return error_response(&cmd.name, status, message),
+            }
+        } else {
+            TargetCredentialUpdate::Omitted
+        };
+        let new_target_allow_simultaneous_ips = if resource_type == "target" {
+            match cmd.child_text("allow_simultaneous_ips") {
+                Some(value) => match parse_filter_bool(value.trim()) {
+                    Some(value) => Some(value),
+                    None => {
+                        return error_response(
+                            &cmd.name,
+                            400,
+                            "Invalid allow_simultaneous_ips value",
+                        );
+                    }
+                },
+                None => None,
+            }
+        } else {
+            None
+        };
+        if resource_type == "target" {
+            if let Some(existing) = store.get_typed(&uuid, "target") {
+                if let Err(message) = validate_target_credential_combination(
+                    Some(&existing),
+                    &new_target_ssh_credential,
+                    &new_target_ssh_elevate_credential,
+                    &new_target_smb_credential,
+                    &new_target_krb5_credential,
+                ) {
+                    return error_response(&cmd.name, 400, message);
+                }
+            }
+        }
         let new_target_alive_test = if resource_type == "target" {
             match target_alive_test_update(cmd) {
                 Ok(update) => update,
@@ -1656,7 +1801,18 @@ impl SessionHandler {
                 r.set_attr("port_list_id", &port_list_id.to_string());
             }
             apply_target_credential_update(r, "ssh_credential", &new_target_ssh_credential);
+            apply_target_credential_update(
+                r,
+                "ssh_elevate_credential",
+                &new_target_ssh_elevate_credential,
+            );
             apply_target_credential_update(r, "smb_credential", &new_target_smb_credential);
+            apply_target_credential_update(r, "krb5_credential", &new_target_krb5_credential);
+            apply_target_credential_update(r, "esxi_credential", &new_target_esxi_credential);
+            apply_target_credential_update(r, "snmp_credential", &new_target_snmp_credential);
+            if let Some(value) = new_target_allow_simultaneous_ips {
+                r.set_attr("allow_simultaneous_ips", if value { "1" } else { "0" });
+            }
             if let Some(alive_test) = new_target_alive_test {
                 r.set_attr("alive_test", alive_test.as_target_name());
             }
@@ -1820,8 +1976,19 @@ impl SessionHandler {
         }
 
         if resource_type == "target" {
-            let changes_hosts = new_hosts.is_some();
-            return match store.modify_target(&uuid, changes_hosts, update_resource) {
+            let changes_scan_settings = new_hosts.is_some()
+                || new_target_port_list_id.is_some()
+                || !matches!(new_target_ssh_credential, TargetCredentialUpdate::Omitted)
+                || !matches!(
+                    new_target_ssh_elevate_credential,
+                    TargetCredentialUpdate::Omitted
+                )
+                || !matches!(new_target_smb_credential, TargetCredentialUpdate::Omitted)
+                || !matches!(new_target_krb5_credential, TargetCredentialUpdate::Omitted)
+                || !matches!(new_target_esxi_credential, TargetCredentialUpdate::Omitted)
+                || !matches!(new_target_snmp_credential, TargetCredentialUpdate::Omitted)
+                || new_target_allow_simultaneous_ips.is_some();
+            return match store.modify_target(&uuid, changes_scan_settings, update_resource) {
                 Ok(()) => format!("<{}_response status=\"200\" status_text=\"OK\"/>", cmd.name)
                     .into_bytes(),
                 Err(error) => store_error_response(&cmd.name, error),
@@ -4200,7 +4367,11 @@ fn target_credential_update(
     let credential_type = credential.attr("type").unwrap_or("usk");
     let type_supported = match element {
         "ssh_credential" => matches!(credential_type, "up" | "usk" | "cs_up" | "cs_usk"),
+        "ssh_elevate_credential" => matches!(credential_type, "up" | "cs_up"),
         "smb_credential" => matches!(credential_type, "up" | "cs_up"),
+        "krb5_credential" => credential_type == "krb5",
+        "esxi_credential" => matches!(credential_type, "up" | "cs_up"),
+        "snmp_credential" => credential_type == "snmp",
         _ => true,
     };
     if !type_supported {
@@ -4253,6 +4424,45 @@ fn apply_target_credential_update(
             }
         }
     }
+}
+
+fn effective_target_credential_id(
+    existing: Option<&Resource>,
+    prefix: &str,
+    update: &TargetCredentialUpdate,
+) -> Option<Uuid> {
+    match update {
+        TargetCredentialUpdate::Omitted => existing
+            .and_then(|resource| resource.attr(&format!("{prefix}_id")))
+            .and_then(|id| Uuid::parse_str(id).ok()),
+        TargetCredentialUpdate::Clear => None,
+        TargetCredentialUpdate::Set { id, .. } => Some(*id),
+    }
+}
+
+fn validate_target_credential_combination(
+    existing: Option<&Resource>,
+    ssh: &TargetCredentialUpdate,
+    ssh_elevate: &TargetCredentialUpdate,
+    smb: &TargetCredentialUpdate,
+    krb5: &TargetCredentialUpdate,
+) -> Result<(), &'static str> {
+    let ssh = effective_target_credential_id(existing, "ssh_credential", ssh);
+    let ssh_elevate =
+        effective_target_credential_id(existing, "ssh_elevate_credential", ssh_elevate);
+    let smb = effective_target_credential_id(existing, "smb_credential", smb);
+    let krb5 = effective_target_credential_id(existing, "krb5_credential", krb5);
+
+    if ssh_elevate.is_some() && ssh.is_none() {
+        return Err("SSH elevate credential requires an SSH credential");
+    }
+    if ssh_elevate.is_some() && ssh_elevate == ssh {
+        return Err("SSH elevate credential must differ from SSH credential");
+    }
+    if smb.is_some() && krb5.is_some() {
+        return Err("SMB and Kerberos credentials are mutually exclusive");
+    }
+    Ok(())
 }
 
 fn element_text_including_empty(cmd: &ParsedCommand, raw_xml: &[u8], name: &str) -> Option<String> {

--- a/crates/gvm-mock-server/src/store.rs
+++ b/crates/gvm-mock-server/src/store.rs
@@ -570,6 +570,21 @@ impl Resource {
             } else {
                 xml.push_str("<smb_credential id=\"\"><name></name></smb_credential>");
             }
+            for (attribute, element) in [
+                ("ssh_elevate_credential_id", "ssh_elevate_credential"),
+                ("krb5_credential_id", "krb5_credential"),
+                ("esxi_credential_id", "esxi_credential"),
+                ("snmp_credential_id", "snmp_credential"),
+            ] {
+                if let Some(id) = self.attr(attribute) {
+                    xml.push_str(&format!(
+                        "<{element} id=\"{}\"><name></name></{element}>",
+                        xml_escape_attr(id),
+                    ));
+                } else {
+                    xml.push_str(&format!("<{element} id=\"\"><name></name></{element}>"));
+                }
+            }
         }
         // Add type-specific attributes
         if self.resource_type == "alert" {
@@ -652,6 +667,10 @@ impl Resource {
                         | "ssh_credential_id"
                         | "ssh_credential_port"
                         | "smb_credential_id"
+                        | "ssh_elevate_credential_id"
+                        | "krb5_credential_id"
+                        | "esxi_credential_id"
+                        | "snmp_credential_id"
                 )
             {
                 continue;
@@ -1284,7 +1303,7 @@ impl ResourceStore {
     pub(crate) fn modify_target<F>(
         &self,
         id: &Uuid,
-        changes_hosts: bool,
+        changes_scan_settings: bool,
         f: F,
     ) -> Result<(), StoreError>
     where
@@ -1293,7 +1312,7 @@ impl ResourceStore {
         let mut inner = self.inner.write().expect("store lock poisoned");
         active_typed_resource(&inner, id, "target")?;
 
-        if changes_hosts {
+        if changes_scan_settings {
             let id_text = id.to_string();
             let referenced = inner.resources.values().any(|candidate| {
                 candidate.resource_type == "task"

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -104,11 +104,17 @@ async fn matrix_targets_create_get_delete() {
         "create_credential",
     )
     .await;
+    let snmp_credential_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Matrix SNMP</name><type>snmp</type></create_credential>",
+        "create_credential",
+    )
+    .await;
 
     let target_id = create_and_get_id(
         &mut stream,
         format!(
-            "<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{credential_id}\"><port>2222</port></ssh_credential></create_target>"
+            "<create_target><name>Matrix Target</name><hosts>127.0.0.1</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{credential_id}\"><port>2222</port></ssh_credential><esxi_credential id=\"{smb_credential_id}\"/><snmp_credential id=\"{snmp_credential_id}\"/></create_target>"
         )
         .as_bytes(),
         "create_target",
@@ -126,6 +132,12 @@ async fn matrix_targets_create_get_delete() {
     assert!(get_text.contains("Matrix Target"));
     assert!(get_text.contains(&format!(
         "<ssh_credential id=\"{credential_id}\"><name></name><port>2222</port></ssh_credential>"
+    )));
+    assert!(get_text.contains(&format!(
+        "<esxi_credential id=\"{smb_credential_id}\"><name></name></esxi_credential>"
+    )));
+    assert!(get_text.contains(&format!(
+        "<snmp_credential id=\"{snmp_credential_id}\"><name></name></snmp_credential>"
     )));
 
     let modify_resp = send_recv(
@@ -256,6 +268,235 @@ async fn matrix_targets_create_get_delete() {
     )
     .await;
     assert_eq!(missing_resp.status_code(), Some(404));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn target_scan_settings_are_immutable_while_in_use() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let ssh_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>In-use SSH</name><type>usk</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let elevate_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>In-use Elevation</name><type>up</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let krb5_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>In-use Kerberos</name><type>krb5</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let snmp_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>In-use SNMP</name><type>snmp</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let target_id = create_and_get_id(
+        &mut stream,
+        format!(
+            "<create_target><name>In-use Extended Target</name><hosts>192.0.2.30</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{ssh_id}\"/><ssh_elevate_credential id=\"{elevate_id}\"/><allow_simultaneous_ips>1</allow_simultaneous_ips></create_target>"
+        )
+        .as_bytes(),
+        "create_target",
+    )
+    .await;
+    create_and_get_id(
+        &mut stream,
+        format!(
+            "<create_task><name>Uses extended target</name><target id=\"{target_id}\"/></create_task>"
+        )
+        .as_bytes(),
+        "create_task",
+    )
+    .await;
+
+    let rejected = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"0\"/><ssh_elevate_credential id=\"0\"/><krb5_credential id=\"{krb5_id}\"/><allow_simultaneous_ips>0</allow_simultaneous_ips><comment>must not apply</comment></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(rejected.status_code(), Some(409));
+
+    for update in [
+        "<ssh_elevate_credential id=\"0\"/>".to_string(),
+        format!("<smb_credential id=\"{elevate_id}\"/>"),
+        format!("<krb5_credential id=\"{krb5_id}\"/>"),
+        format!("<esxi_credential id=\"{elevate_id}\"/>"),
+        format!("<snmp_credential id=\"{snmp_id}\"/>"),
+        "<allow_simultaneous_ips>0</allow_simultaneous_ips>".to_string(),
+    ] {
+        let rejected = send_recv(
+            &mut stream,
+            format!("<modify_target target_id=\"{target_id}\">{update}</modify_target>").as_bytes(),
+        )
+        .await;
+        assert_eq!(rejected.status_code(), Some(409), "{update}");
+    }
+
+    let fetched = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    let xml = fetched.as_str().expect("target response should be UTF-8");
+    assert!(xml.contains(&format!("<ssh_credential id=\"{ssh_id}\"")));
+    assert!(xml.contains(&format!("<ssh_elevate_credential id=\"{elevate_id}\"")));
+    assert!(xml.contains("<krb5_credential id=\"\">"));
+    assert!(xml.contains("<allow_simultaneous_ips>1</allow_simultaneous_ips>"));
+    assert!(!xml.contains("must not apply"));
+
+    let metadata = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><comment>metadata allowed</comment></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(metadata.status_code(), Some(200));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn target_extended_credential_combinations_are_atomic() {
+    let Some(server) = stateful_server().await else {
+        return;
+    };
+    let mut stream = connect(&server).await;
+    auth_admin(&mut stream).await;
+
+    let ssh_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Combination SSH</name><type>usk</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let elevate_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Combination Elevation</name><type>up</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let smb_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Combination SMB</name><type>up</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+    let krb5_id = create_and_get_id(
+        &mut stream,
+        b"<create_credential><name>Combination Kerberos</name><type>krb5</type></create_credential>",
+        "create_credential",
+    )
+    .await;
+
+    for xml in [
+        format!(
+            "<create_target><name>Missing SSH</name><hosts>192.0.2.31</hosts><port_range>T:1-65535</port_range><ssh_elevate_credential id=\"{elevate_id}\"/></create_target>"
+        ),
+        format!(
+            "<create_target><name>Same SSH</name><hosts>192.0.2.32</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{elevate_id}\"/><ssh_elevate_credential id=\"{elevate_id}\"/></create_target>"
+        ),
+        format!(
+            "<create_target><name>SMB and Kerberos</name><hosts>192.0.2.33</hosts><port_range>T:1-65535</port_range><smb_credential id=\"{smb_id}\"/><krb5_credential id=\"{krb5_id}\"/></create_target>"
+        ),
+        format!(
+            "<create_target><name>Wrong Elevation Type</name><hosts>192.0.2.34</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{ssh_id}\"/><ssh_elevate_credential id=\"{ssh_id}\"/></create_target>"
+        ),
+        format!(
+            "<create_target><name>Wrong Kerberos Type</name><hosts>192.0.2.35</hosts><port_range>T:1-65535</port_range><krb5_credential id=\"{smb_id}\"/></create_target>"
+        ),
+    ] {
+        assert_eq!(send_recv(&mut stream, xml.as_bytes()).await.status_code(), Some(400));
+    }
+
+    let target_id = create_and_get_id(
+        &mut stream,
+        format!(
+            "<create_target><name>Combination Target</name><hosts>192.0.2.40</hosts><port_range>T:1-65535</port_range><ssh_credential id=\"{ssh_id}\"/><ssh_elevate_credential id=\"{elevate_id}\"/></create_target>"
+        )
+        .as_bytes(),
+        "create_target",
+    )
+    .await;
+
+    for update in [
+        "<ssh_credential id=\"0\"/>".to_string(),
+        format!("<ssh_elevate_credential id=\"{ssh_id}\"/>"),
+    ] {
+        let rejected = send_recv(
+            &mut stream,
+            format!(
+                "<modify_target target_id=\"{target_id}\">{update}<comment>invalid</comment></modify_target>"
+            )
+            .as_bytes(),
+        )
+        .await;
+        assert_eq!(rejected.status_code(), Some(400));
+    }
+    let unchanged = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    let unchanged = unchanged.as_str().expect("target response should be UTF-8");
+    assert!(unchanged.contains(&format!("<ssh_credential id=\"{ssh_id}\"")));
+    assert!(unchanged.contains(&format!("<ssh_elevate_credential id=\"{elevate_id}\"")));
+    assert!(!unchanged.contains("invalid"));
+
+    let smb_update = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><ssh_credential id=\"0\"/><ssh_elevate_credential id=\"0\"/><smb_credential id=\"{smb_id}\"/></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(smb_update.status_code(), Some(200));
+    let invalid_krb5 = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><krb5_credential id=\"{krb5_id}\"/></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(invalid_krb5.status_code(), Some(400));
+    let krb5_update = send_recv(
+        &mut stream,
+        format!(
+            "<modify_target target_id=\"{target_id}\"><smb_credential id=\"0\"/><krb5_credential id=\"{krb5_id}\"/></modify_target>"
+        )
+        .as_bytes(),
+    )
+    .await;
+    assert_eq!(krb5_update.status_code(), Some(200));
+    let fetched = send_recv(
+        &mut stream,
+        format!("<get_targets target_id=\"{target_id}\"/>").as_bytes(),
+    )
+    .await;
+    let fetched = fetched.as_str().expect("target response should be UTF-8");
+    assert!(fetched.contains("<smb_credential id=\"\">"));
+    assert!(fetched.contains(&format!("<krb5_credential id=\"{krb5_id}\"")));
 
     server.shutdown().await;
 }

--- a/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
+++ b/crates/gvm-mock-server/tests/stateful_resource_matrix.rs
@@ -139,6 +139,7 @@ async fn matrix_targets_create_get_delete() {
     assert!(get_text.contains(&format!(
         "<snmp_credential id=\"{snmp_credential_id}\"><name></name></snmp_credential>"
     )));
+    assert!(get_text.contains("<allow_simultaneous_ips>1</allow_simultaneous_ips>"));
 
     let modify_resp = send_recv(
         &mut stream,


### PR DESCRIPTION
## What Problem This Solves

Target commands and typed responses could not configure or observe Kerberos credentials, SSH privilege-escalation credentials, or simultaneous-IP scanning. Callers were forced outside the typed API, while invalid credential combinations surfaced only as opaque server errors.

## Why This Change Was Made

- Add `ssh_elevate_credential_id`, `krb5_credential_id`, and `allow_simultaneous_ips` to typed create/modify target options.
- Preserve omit/set/detach semantics with `ScalarUpdate<EntityId>` and gvmd's `0` detach sentinel.
- Reject only credential combinations provably invalid from the request: elevation with an explicit SSH detach, identical explicitly supplied SSH/elevation IDs, and SMB/Kerberos conflicts.
- Allow elevation-only modify requests to preserve an existing SSH binding, matching gvmd's stored-state validation.
- Parse the new target observations and make the stateful mock validate, persist, render, and atomically update all target credential bindings.
- Default omitted `allow_simultaneous_ips` to enabled in the stateful mock and response fallback, matching gvmd create semantics.
- Apply gvmd-compatible in-use protection to port-list, credential, host, and simultaneous-IP scan-setting changes while leaving metadata edits available.

## User Impact

Typed clients can now configure and round-trip enterprise SSH elevation and Kerberos target authentication, control multi-homed host scanning, deliberately detach credential relationships, and receive actionable local errors for invalid combinations. Existing target host and port-selection behavior is preserved.

## Evidence

- Full `gvm-gmp` all-feature suite passed: 460 unit tests plus integration and schema suites.
- Full `gvm-mock-server` all-feature suite passed: 129 unit tests plus all integration suites.
- Full `gvm-client` all-feature suite passed: 31 unit tests, 74 client integration tests, and auxiliary typed-facade suites.
- Focused regressions passed for elevation-only modify and omitted simultaneous-IP create/read behavior.
- Strict all-target/all-feature Clippy passed for `gvm-gmp`, `gvm-mock-server`, and `gvm-client` with warnings denied.
- Formatting and whitespace checks passed.

Fixes greenbone-hive/rust-gvm#495

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
