### PR TITLE
docs(journal): 2026-08-13 project update

### DIFF
--- a/journal/2026-08-13.md
+++ b/journal/2026-08-13.md
@@ -1,0 +1,12 @@
+# 2026-08-13 — Target and Report Contracts Advanced
+
+## Mainline Movement
+- [#491](https://github.com/greenbone-hive/rust-gvm/pull/491) merged typed, validated target hosts and explicit port selections, including canonicalization and gvmd-aligned stateful behavior.
+- [#490](https://github.com/greenbone-hive/rust-gvm/pull/490) merged lifecycle-aware task report history, GVMD-compatible report metadata, stale-pointer recovery, and consistent deletion behavior.
+
+## New Contract Work
+- Four follow-up gaps were filed and immediately moved into green, mergeable pull requests: port-list replacement semantics ([#493](https://github.com/greenbone-hive/rust-gvm/issues/493), [#496](https://github.com/greenbone-hive/rust-gvm/pull/496)); alert active-state exposure ([#494](https://github.com/greenbone-hive/rust-gvm/issues/494), [#497](https://github.com/greenbone-hive/rust-gvm/pull/497)); correct task-observer serialization ([#492](https://github.com/greenbone-hive/rust-gvm/issues/492), [#498](https://github.com/greenbone-hive/rust-gvm/pull/498)); and extended target credential settings ([#495](https://github.com/greenbone-hive/rust-gvm/issues/495), [#499](https://github.com/greenbone-hive/rust-gvm/pull/499)).
+- The open changes cover API correctness where gvmd can otherwise ignore malformed or unsupported fields, plus Kerberos, SSH elevation, and simultaneous-IP target configuration. Their reported CI and Security checks are green.
+
+## Validation State
+- Both new `main` commits passed Security and OpenSSF Scorecard checks. Main CI remains red at the previously identified downstream E2E dispatch blocker, so this is not a new regression.


### PR DESCRIPTION
## Summary

- record the two post-journal mainline merges for target validation and task-report history
- capture four newly opened GMP contract gaps and their green implementation PRs
- distinguish the unchanged downstream E2E blocker from new CI regressions
