### PR TITLE
docs(journal): 2026-08-14 project update

### DIFF
--- a/journal/2026-08-14.md
+++ b/journal/2026-08-14.md
@@ -1,0 +1,13 @@
+# 2026-08-14 — Source Review Exposed Contract Gaps
+
+## Review Findings
+- Source-level review of [#499](https://github.com/greenbone-hive/rust-gvm/pull/499) found a blocking modify-target bug: the typed builder rejects setting an SSH elevation credential unless the same request also sets the SSH credential, even though gvmd correctly resolves an omitted SSH credential from the target's stored state.
+- The same review identified a mock divergence for `allow_simultaneous_ips`: gvmd defaults an omitted value to enabled, while the stateful mock currently reports it as disabled.
+- Review of [#498](https://github.com/greenbone-hive/rust-gvm/pull/498) confirmed the observer wire-format fix but recorded two follow-up capability gaps: typed modify requests cannot clear all observers and cannot update observer groups, despite gvmd supporting both operations.
+
+## Required Follow-up
+- [#499](https://github.com/greenbone-hive/rust-gvm/pull/499) needs its local validation narrowed to reject only provably invalid credential combinations, plus a regression for elevation-only modification and correction of the mock default.
+- [#498](https://github.com/greenbone-hive/rust-gvm/pull/498) remains mergeable, but observer replacement semantics will need a tri-state collection update before the planned REST replace endpoint can revoke the final observer.
+
+## Validation State
+- Both pull requests remain open with green CI and Security checks; the newly documented concerns are semantic contract issues not detected by the existing suites.


### PR DESCRIPTION
Records new source-review findings on target credential modification, simultaneous-IP defaults, and observer replacement semantics.