### PR TITLE
docs: add 2026-08-15 project journal

### DIFF
--- a/journal/2026-08-15.md
+++ b/journal/2026-08-15.md
@@ -1,0 +1,13 @@
+# 2026-08-15 — Reviewed Protocol Fixes Landed on Main
+
+## Mainline Changes
+- Pull requests [#496](https://github.com/greenbone-hive/rust-gvm/pull/496), [#497](https://github.com/greenbone-hive/rust-gvm/pull/497), [#498](https://github.com/greenbone-hive/rust-gvm/pull/498), and [#499](https://github.com/greenbone-hive/rust-gvm/pull/499) merged into `main` as commits `7ebc504b`, `3be87073`, `b2250487`, and `a0b7f639`.
+- The merged work fixes port-list replacement semantics, exposes alert active state, models task observer replacement and clearing, and adds extended target credential and simultaneous-IP settings.
+- Issues [#492](https://github.com/greenbone-hive/rust-gvm/issues/492) through [#495](https://github.com/greenbone-hive/rust-gvm/issues/495) closed with those merges.
+
+## Validation State
+- On final `main` commit `a0b7f639`, the substantive CI jobs, Security workflow, and OpenSSF Scorecard passed.
+- The CI workflow is reported failed only because its downstream E2E dispatch failed. The dispatched `rust-gvm-e2e-tests` run reached gvmd but could not launch `gvm-community-e2e` because that binary is missing from the runner image `PATH`, matching the cross-repository blocker already recorded by the E2E project.
+
+## Follow-up
+- Repair the E2E runner image or launch path so `rust-gvm` mainline validation can complete end to end.


### PR DESCRIPTION
## Summary

- record the merge of protocol fixes #496–#499 into `main`
- capture the final green core CI/security state
- retain the downstream E2E runner binary failure as the actionable follow-up
