### PR TITLE
docs(journal): add 2026-08-17 update

### DIFF
--- a/journal/2026-08-17.md
+++ b/journal/2026-08-17.md
@@ -1,0 +1,13 @@
+# 2026-08-17 — Dependency Queues Refreshed with a Vetting Blocker
+
+## Pull Request Activity
+- Dependabot opened [#503](https://github.com/greenbone-hive/rust-gvm/pull/503) to update six GitHub Actions dependencies, including `harden-runner`, `rust-cache`, Greenbone workflow helpers, and the CodeQL SARIF uploader.
+- Pull request #503 is mergeable and its CI and Security workflows pass, leaving it ready for normal review.
+- Dependabot refreshed cargo update [#484](https://github.com/greenbone-hive/rust-gvm/pull/484) with six patch-level dependency upgrades. Its functional CI passes, but the Security workflow now fails at Cargo Vet.
+
+## Action Required
+- Pull request #484 needs vetting coverage for eight updated packages: `async-trait`, `clap`, `clap_builder`, `russh`, `rustls`, `thiserror`, `thiserror-impl`, and `tokio-stream`.
+- The reported audit backlog is 2,671 lines; the PR remains blocked until the required `safe-to-deploy` and `safe-to-run` attestations are recorded or imported.
+
+## Mainline State
+- No new default-branch commit, release, tag, or non-journal issue change accompanied the dependency activity.


### PR DESCRIPTION
## Summary

- record the newly opened, green GitHub Actions dependency update
- record the refreshed cargo dependency PR and its actionable Cargo Vet blocker
- note that mainline itself did not change

## Journal policy

Targets `journal-main`; no changes are proposed for `main`.
