### PR TITLE
docs(journal): add 2026-08-18 update

### DIFF
--- a/journal/2026-08-18.md
+++ b/journal/2026-08-18.md
@@ -1,0 +1,12 @@
+# 2026-08-18 — Persistent SSH Trust Landed on Main
+
+## Mainline Features
+- Pull request [#488](https://github.com/greenbone-hive/rust-gvm/pull/488) merged persistent SSH trust-on-first-use host-key handling into `main`.
+- The implementation adds atomic known-host updates, serialization for concurrent writers, and changed-key rejection, closing [#453](https://github.com/greenbone-hive/rust-gvm/issues/453) and advancing python-gvm connection-policy parity.
+
+## Dependency Automation
+- Pull request [#503](https://github.com/greenbone-hive/rust-gvm/pull/503) merged six refreshed immutable GitHub Actions pins across CI, release, Scorecard, and security workflows.
+- Both merged pull requests passed their required functional and security checks before merge.
+
+## Integration State
+- Mainline CI completed its local test matrix successfully but the downstream E2E trigger failed on both new commits because the previously recorded `gvm-community-e2e` runner-image blocker remains unresolved.


### PR DESCRIPTION
Records the persistent SSH TOFU merge, refreshed Actions pins, and current downstream E2E integration state.