### PR TITLE
docs: journal update for 2026-08-24

### DIFF
--- a/journal/2026-08-24.md
+++ b/journal/2026-08-24.md
@@ -1,0 +1,12 @@
+# 2026-08-24 — Security Dependency Refresh Awaits Vetting
+
+## Dependency Security
+- Dependabot opened pull request [#506](https://github.com/greenbone-hive/rust-gvm/pull/506) to update seven Rust dependencies, including `russh` 0.62.4 to 0.62.7.
+- The `russh` update incorporates fixes for GHSA-m65r-rprj-r5rg and GHSA-g6xm-f9xp-qq35, covering invalid-channel callback handling and enforcement of server-side authentication-attempt limits.
+
+## Action Required
+- The functional CI matrix, Cargo Audit, Cargo Deny, SBOM, Geiger, and Semgrep checks pass, but Cargo Vet rejects the refreshed dependency set and blocks the aggregate Security check.
+- Pull request [#506](https://github.com/greenbone-hive/rust-gvm/pull/506) therefore needs updated vet audits or exemptions before the security fixes can land.
+
+## Workflow Dependencies
+- Pull request [#507](https://github.com/greenbone-hive/rust-gvm/pull/507) separately refreshes four pinned GitHub Actions and currently passes its complete CI and security checks.


### PR DESCRIPTION
Documents the new security-relevant dependency refresh, its Cargo Vet blocker, and the independently passing GitHub Actions pin update.
