### PR TITLE
docs: remove prototype disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # rust-gvm
 
-> **⚠️ Prototype / Experimental**
-> This project is purely a prototype to experiment with the concepts of GVM + Rust and agentic engineering. It is **not** production-ready, **not** endorsed by Greenbone, and **not** intended as a replacement for [python-gvm](https://github.com/greenbone/python-gvm). APIs, architecture, and scope may change without notice.
-
 Rust client and protocol ecosystem for the [Greenbone Management Protocol (GMP)](https://docs.greenbone.net/API/GMP/gmp-22.5.html) and [Greenbone Vulnerability Manager (gvmd)](https://github.com/greenbone/gvmd), with type safety, async-first design, version-aware command builders, and a programmable mock server for testing.
 
 [![CI](https://github.com/clawosiris/rust-gvm/actions/workflows/ci.yml/badge.svg)](https://github.com/clawosiris/rust-gvm/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

- remove the obsolete prototype / experimental disclaimer from the README
- leave the current project description and remaining documentation unchanged

## Validation

- `git diff --check origin/main..HEAD`
- confirmed the removed disclaimer no longer appears in `README.md`
- Rust tests not run because this is a documentation-only change with no checked examples

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
