### PR TITLE
fix(release): publish canonical artifacts

### DIFF
--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -1,5 +1,4 @@
-# Orchestrated Release — triggered by clawosiris/release-orchestrator
-# Do NOT trigger manually — use the orchestrator instead.
+# Orchestrated Release — dispatch with an explicit version and release type.
 #
 # This workflow:
 # 1. Creates the release via pontos (changelog, tag, GitHub release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/clawosiris/gvm-mock-server
+          images: ghcr.io/${{ github.repository_owner }}/gvm-mock-server
           tags: |
             type=raw,value=${{ github.ref_name }}
           labels: |
             org.opencontainers.image.title=gvm-mock-server
             org.opencontainers.image.description=Programmable mock GMP server for testing
-            org.opencontainers.image.vendor=clawosiris
+            org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
@@ -177,6 +177,10 @@ jobs:
     name: Generate SBOM
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
@@ -242,6 +246,11 @@ jobs:
           cd ..
           sha256sum rust-gvm-sbom.tar.gz > rust-gvm-sbom.tar.gz.sha256
 
+      - name: Generate SBOM provenance attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: rust-gvm-sbom.tar.gz
+
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -254,7 +263,7 @@ jobs:
   # Upload artifacts to the GitHub Release created by pontos
   upload-assets:
     name: Upload release assets
-    needs: [build, sbom, container]
+    needs: [build, sbom]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -287,5 +296,5 @@ jobs:
           gh release upload "${{ github.ref_name }}" \
             --repo "${{ github.repository }}" \
             --clobber \
-            artifacts/*.tar.gz artifacts/*.sha256
+            artifacts/*.tar.gz artifacts/*.sha256 artifacts/sbomqs-results.json
           echo "✅ Assets uploaded to release ${{ github.ref_name }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.3"
 edition = "2021"
 rust-version = "1.86.0"
 license = "AGPL-3.0-or-later"
-repository = "https://github.com/clawosiris/rust-gvm"
+repository = "https://github.com/greenbone-hive/rust-gvm"
 keywords = ["greenbone", "gvm", "gmp", "vulnerability", "security"]
 categories = ["network-programming", "api-bindings"]
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,14 @@
 # Releasing rust-gvm
 
-All releases are managed via [clawosiris/release-orchestrator](https://github.com/clawosiris/release-orchestrator).
+Releases are managed via the repository's
+[Orchestrated Release workflow](https://github.com/greenbone-hive/rust-gvm/actions/workflows/release-orchestrated.yml).
 
 ## How It Works
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                        release-orchestrator                              │
-│  (workflow_dispatch)                                                     │
+│                  rust-gvm Orchestrated Release                           │
+│  (workflow_dispatch with an explicit version)                            │
 └─────────────────────┬───────────────────────────────────────────────────┘
                       │ triggers via greenbone/actions/trigger-workflow
                       ▼
@@ -41,7 +42,7 @@ All releases are managed via [clawosiris/release-orchestrator](https://github.co
 
 ## Do NOT
 
-- **Do NOT** trigger `release-orchestrated.yml` manually — it's designed for orchestrator use
+- Trigger `release-orchestrated.yml` with the intended version and release type
 - **Do NOT** push version tags manually — let pontos handle it
 - **Do NOT** create GitHub releases manually — pontos + release.yml handle everything
 
@@ -50,12 +51,12 @@ All releases are managed via [clawosiris/release-orchestrator](https://github.co
 Each release includes:
 
 - **Binaries**: `gvm-mock-server` for Linux (amd64, arm64, musl), macOS (amd64, arm64)
-- **Docker image**: `ghcr.io/clawosiris/gvm-mock-server:<version>`
+- **Docker image**: `ghcr.io/greenbone-hive/gvm-mock-server:<version>`
 - **SBOM**: CycloneDX JSON/XML with quality scoring
 - **Attestations**: Sigstore build provenance for all artifacts
 
 ## Verifying Artifacts
 
 ```bash
-gh attestation verify gvm-mock-server-linux-amd64.tar.gz --owner clawosiris
+gh attestation verify gvm-mock-server-linux-amd64.tar.gz --owner greenbone-hive
 ```


### PR DESCRIPTION
## Summary

- publish the mock-server image under `ghcr.io/greenbone-hive`
- allow binary and SBOM assets to upload independently of the container lane
- attest the SBOM archive and publish `sbomqs-results.json`
- correct canonical repository and release documentation metadata

## Why

The failed `v0.5.0` run attempted to push the image to the historical `clawosiris` namespace. Because release-asset upload depended on that container job, the image failure also prevented binaries and SBOMs from reaching the GitHub release. This repair is required before releasing `v0.5.1` from current `main`.

## Validation

- Prettier `--debug-check` for both release workflows and `RELEASING.md`
- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
