### PR TITLE
release: prepare v0.5.1

### DIFF
--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -1,8 +1,9 @@
 # Orchestrated Release — dispatch with an explicit version and release type.
 #
 # This workflow:
-# 1. Creates the release via pontos (changelog, tag, GitHub release)
-# 2. Waits for release.yml (triggered by tag push) to build and upload artifacts
+# 1. Validates the version already merged through the protected branch
+# 2. Creates the release via pontos (changelog, tag, GitHub release)
+# 3. Waits for release.yml (triggered by tag push) to build and upload artifacts
 #
 # The orchestrator waits for this workflow to complete before proceeding to
 # downstream repos (rust-gvm-api, gvm-rools, etc.).
@@ -51,13 +52,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Relax main branch protection for release push
+      - name: Verify workspace release version
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          gh api repos/${{ github.repository }}/branches/main/protection > "$RUNNER_TEMP/main-protection.json"
-          gh api --method DELETE repos/${{ github.repository }}/branches/main/protection/required_status_checks || true
-          gh api --method DELETE repos/${{ github.repository }}/branches/main/protection/required_pull_request_reviews || true
+          CURRENT_VERSION="$(awk '
+            $0 == "[workspace.package]" { in_workspace = 1; next }
+            /^\[/ { in_workspace = 0 }
+            in_workspace && $1 == "version" {
+              gsub(/"/, "", $3)
+              print $3
+              exit
+            }
+          ' Cargo.toml)"
+          if [[ "$CURRENT_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "Expected workspace version $RELEASE_VERSION, found $CURRENT_VERSION" >&2
+            exit 1
+          fi
 
       - name: Create release with pontos
         env:
@@ -69,24 +80,13 @@ jobs:
           ARGS="$ARGS --project-types cargo"
           ARGS="$ARGS --git-tag-prefix v"
           ARGS="$ARGS --no-next-version"
+          ARGS="$ARGS --no-update-project"
 
           if [[ "${{ inputs.version }}" == *"-"* ]]; then
             ARGS="$ARGS --github-pre-release"
           fi
 
           pontos-release create $ARGS --repository ${{ github.repository }}
-
-      - name: Regenerate Cargo.lock
-        run: |
-          cargo generate-lockfile
-          if ! git diff --quiet Cargo.lock 2>/dev/null; then
-            git add Cargo.lock
-            git commit --amend --no-edit
-            git push --force-with-lease
-            TAG="v${{ inputs.version }}"
-            git tag -f "$TAG"
-            git push origin "$TAG" --force
-          fi
 
       - name: Trigger release.yml and wait for completion
         uses: greenbone/actions/trigger-workflow@cdaf49a9913e2944bfb5ebc1e333acadaeb3d16d # v3.36.15
@@ -97,14 +97,3 @@ jobs:
           ref: v${{ inputs.version }}
           wait-for-completion-timeout: "1800"
           wait-for-completion-interval: "30"
-
-      - name: Restore main branch protection
-        if: ${{ always() }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          gh api \
-            --method PUT \
-            -H 'Accept: application/vnd.github+json' \
-            repos/${{ github.repository }}/branches/main/protection \
-            --input "$RUNNER_TEMP/main-protection.json"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-client"
-version = "0.3.3"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "gvm-connection",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-connection"
-version = "0.3.3"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "getrandom 0.4.3",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-gmp"
-version = "0.3.3"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-mock-server"
-version = "0.3.3"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-protocol"
-version = "0.3.3"
+version = "0.5.1"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.86.0"
 license = "AGPL-3.0-or-later"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,11 @@ Releases are managed via the repository's
 
 ## How It Works
 
+First, update `[workspace.package].version` and `Cargo.lock` in a normal pull
+request. Merge that pull request through the protected `main` branch after all
+required review and checks pass. Then dispatch the release workflow with that
+exact version.
+
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                  rust-gvm Orchestrated Release                           │
@@ -14,8 +19,8 @@ Releases are managed via the repository's
                       ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                    release-orchestrated.yml                              │
-│  1. Creates release via pontos (changelog, version bump, GitHub release) │
-│  2. Pushes tag v<version>                                                │
+│  1. Validates the version already merged through protected main          │
+│  2. Creates the changelog, tag, and GitHub release via pontos            │
 │  3. Waits for release.yml to complete                                    │
 └─────────────────────┬───────────────────────────────────────────────────┘
                       │ tag push triggers


### PR DESCRIPTION
## Summary

- bump the protected workspace version to `0.5.1`
- make release orchestration verify the version already merged to `main`
- invoke Pontos with `--no-update-project`, avoiding its virtual-workspace Cargo updater bug
- keep `main` branch protection enabled throughout the release
- update the release documentation to match the protected-PR workflow

## Why

The first `0.5.1` orchestration attempt failed before creating a tag or release because Pontos requires a root `[package].name` while this repository is a virtual Cargo workspace. Its failure-recovery path also could not restore the raw branch-protection response with GitHub's update API. Protection was restored immediately and verified.

This change moves the version mutation into the normal reviewed PR path. Release automation then creates only the changelog, tag, and GitHub release from the already-versioned commit, without relaxing protection or force-updating `main`.

Failed run: https://github.com/greenbone-hive/rust-gvm/actions/runs/33030412681

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- Prettier 3.6.2 `--debug-check` on the workflow and release documentation
- exact workflow version extraction returns `0.5.1`
- `git diff --check`
- only the five workspace package versions changed in `Cargo.lock`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
