### PR TITLE
fix(release): watch tag-triggered workflow

### DIFF
--- a/.github/workflows/release-orchestrated.yml
+++ b/.github/workflows/release-orchestrated.yml
@@ -1,4 +1,4 @@
-# Orchestrated Release — dispatch with an explicit version and release type.
+# Orchestrated Release — dispatch with an explicit version.
 #
 # This workflow:
 # 1. Validates the version already merged through the protected branch
@@ -17,11 +17,6 @@ on:
         description: "Release version (without 'v' prefix)"
         required: true
         type: string
-      release-type:
-        description: "Release type (alpha, beta, release-candidate, patch, minor, major)"
-        required: false
-        type: string
-        default: "patch"
 
 permissions:
   contents: read
@@ -72,7 +67,7 @@ jobs:
 
       - name: Create release with pontos
         env:
-          GITHUB_USER: ${{ vars.RELEASE_USER || 'clawosiris' }}
+          GITHUB_USER: ${{ vars.RELEASE_USER || github.actor }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           ARGS="--release-version ${{ inputs.version }}"
@@ -88,12 +83,35 @@ jobs:
 
           pontos-release create $ARGS --repository ${{ github.repository }}
 
-      - name: Trigger release.yml and wait for completion
-        uses: greenbone/actions/trigger-workflow@cdaf49a9913e2944bfb5ebc1e333acadaeb3d16d # v3.36.15
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          repository: ${{ github.repository }}
-          workflow: release.yml
-          ref: v${{ inputs.version }}
-          wait-for-completion-timeout: "1800"
-          wait-for-completion-interval: "30"
+      - name: Wait for release.yml triggered by tag push
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          RUN_ID=""
+          for attempt in $(seq 1 30); do
+            RUN_ID="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow release.yml \
+              --event push \
+              --branch "v${RELEASE_VERSION}" \
+              --limit 20 \
+              --json databaseId,headSha \
+              --jq '.[] | select(.headSha == env.RELEASE_SHA) | .databaseId' \
+              | head -n 1)"
+            if [[ -n "$RUN_ID" ]]; then
+              break
+            fi
+            sleep 10
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "release.yml did not start for v${RELEASE_VERSION} at ${RELEASE_SHA}" >&2
+            exit 1
+          fi
+
+          gh run watch "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --interval 30 \
+            --exit-status

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,10 +12,10 @@ exact version.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                  rust-gvm Orchestrated Release                           │
-│  (workflow_dispatch with an explicit version)                            │
+│                        Protected main                                    │
+│  Version and Cargo.lock update merged through a reviewed pull request    │
 └─────────────────────┬───────────────────────────────────────────────────┘
-                      │ triggers via greenbone/actions/trigger-workflow
+                      │ workflow_dispatch with the exact merged version
                       ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                    release-orchestrated.yml                              │
@@ -35,19 +35,15 @@ exact version.
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Release Types
+## Versioning
 
-| Type | Command | Example Version |
-|------|---------|-----------------|
-| Patch | `patch` | `0.4.1` |
-| Minor | `minor` | `0.5.0` |
-| Major | `major` | `1.0.0` |
-| Alpha | `alpha: true` | `0.5.0-alpha.1` |
-| Release Candidate | `release-candidate: true` | `0.5.0-rc.1` |
+The workflow accepts the exact semantic version already merged to `main`.
+Versions containing a pre-release suffix, such as `0.6.0-alpha.1` or
+`0.6.0-rc.1`, are published as GitHub pre-releases automatically.
 
 ## Do NOT
 
-- Trigger `release-orchestrated.yml` with the intended version and release type
+- **Do NOT** dispatch a version that is not already merged to `main`
 - **Do NOT** push version tags manually — let pontos handle it
 - **Do NOT** create GitHub releases manually — pontos + release.yml handle everything
 


### PR DESCRIPTION
## Summary

- wait for the `release.yml` run automatically started by the Pontos tag push
- stop trying to dispatch `release.yml`, which intentionally has only a tag-push trigger
- remove the unused `release-type` input
- use the authenticated workflow actor instead of a historical hard-coded identity fallback
- correct the release documentation and flow diagram

## Why

The `v0.5.1` release itself completed successfully, but the orchestrator reported failure after Pontos created the tag and release because it attempted to dispatch the push-only `release.yml` workflow. GitHub correctly returned HTTP 422: `Workflow does not have 'workflow_dispatch' trigger`.

The replacement locates the tag-triggered run by exact commit SHA and waits for its real conclusion. The lookup was validated against the successful `v0.5.1` run (`33031558792`).

Failed orchestrator: https://github.com/greenbone-hive/rust-gvm/actions/runs/33031528399
Successful release pipeline: https://github.com/greenbone-hive/rust-gvm/actions/runs/33031558792

## Validation

- Prettier 3.6.2 `--debug-check`
- `git diff --check`
- exact `gh run list` lookup resolves run `33031558792`
- resolved run conclusion is `success`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
