### PR TITLE
docs(journal): add 2026-08-27 update

### DIFF
--- a/journal/2026-08-27.md
+++ b/journal/2026-08-27.md
@@ -1,0 +1,14 @@
+# 2026-08-27 — v0.5.1 Ships as Mainline E2E Remains Broken
+
+## Release
+- Release [v0.5.1](https://github.com/greenbone-hive/rust-gvm/releases/tag/v0.5.1) published canonical artifacts after pull requests [#516](https://github.com/greenbone-hive/rust-gvm/pull/516), [#517](https://github.com/greenbone-hive/rust-gvm/pull/517), and [#518](https://github.com/greenbone-hive/rust-gvm/pull/518) repaired the release path and tag-triggered workflow handling.
+
+## Security and Dependencies
+- Pull request [#510](https://github.com/greenbone-hive/rust-gvm/pull/510) hardened supply-chain controls, and the previously blocked dependency refreshes [#506](https://github.com/greenbone-hive/rust-gvm/pull/506) and [#507](https://github.com/greenbone-hive/rust-gvm/pull/507) merged after validation.
+- Additional updates to Rust, coverage tooling, `quick-xml`, `russh`, and pinned Actions also landed; mainline Security and OpenSSF Scorecard workflows are green.
+
+## New Capability Gap
+- Issue [#519](https://github.com/greenbone-hive/rust-gvm/issues/519) records the only detected drift from current gvmd: the new asynchronous `export_scan_report` GMP command requires a typed builder, response handling, capability discovery, mock support, and schema evidence refresh.
+
+## Action Required
+- Mainline CI is failing because the downstream E2E runner image still cannot execute `gvm-community-e2e`. The release workflow itself succeeded, but every current mainline E2E dispatch ends at the missing runner executable.


### PR DESCRIPTION
Records the v0.5.1 release, merged security and dependency work, the new GMP capability gap, and the actionable downstream E2E failure.