### PR TITLE
feat(gmp): support asynchronous scan report exports

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -18,6 +18,7 @@ mod typed;
 mod version;
 mod wire_trace;
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -35,6 +36,7 @@ use gvm_gmp::commands::credentials::{
     get_credential_stores_with_opts, modify_credential_store_credential, verify_credential_store,
 };
 use gvm_gmp::commands::features::get_features;
+use gvm_gmp::commands::help::help_with_mode;
 use gvm_gmp::commands::integration_configs::{
     get_integration_config, get_integration_configs, modify_integration_config,
 };
@@ -47,9 +49,9 @@ use gvm_gmp::commands::report_configs::{
     modify_report_config,
 };
 use gvm_gmp::commands::reports::{
-    get_report_applications, get_report_closed_cves, get_report_cves, get_report_errors,
-    get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
-    get_report_vulns, get_scan_report,
+    export_scan_report, get_report_applications, get_report_closed_cves, get_report_cves,
+    get_report_errors, get_report_hosts, get_report_operating_systems, get_report_ports,
+    get_report_tls_certificates, get_report_vulns, get_scan_report,
 };
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
@@ -63,7 +65,7 @@ use gvm_gmp::commands::web_application_targets::{
 use gvm_gmp::responses::{
     CloneAgentGroupResponse, CreateAgentGroupResponse, DeleteAgentGroupResponse,
     DeleteAgentResponse, GetAgentGroupsResponse, GetAgentInstallerInstructionResponse,
-    GetAgentSupportBundleResponse, GetAgentsResponse, GetScanReportResponse,
+    GetAgentSupportBundleResponse, GetAgentsResponse, GetScanReportResponse, HelpResponse,
     ModifyAgentControlScanConfigResponse, ModifyAgentGroupResponse, ModifyAgentResponse,
     SyncAgentsResponse,
 };
@@ -95,8 +97,8 @@ pub use gvm_gmp::commands::oci_image_targets::{
 };
 pub use gvm_gmp::commands::report_configs::ModifyReportConfigOpts;
 pub use gvm_gmp::commands::reports::{
-    GetAuditReportHostsOpts, GetAuditReportOpts, GetReportDetailsOpts, GetReportExportOpts,
-    GetScanReportOpts, ImportReportOpts,
+    ExportScanReportOpts, GetAuditReportHostsOpts, GetAuditReportOpts, GetReportDetailsOpts,
+    GetReportExportOpts, GetScanReportOpts, ImportReportOpts,
 };
 pub use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 pub use gvm_gmp::commands::tasks::CreateAgentGroupTaskOpts;
@@ -117,6 +119,7 @@ pub struct GmpClient<C: GvmConnection> {
     connection: C,
     version: GmpVersion,
     wire_trace: Option<Arc<dyn WireTrace>>,
+    discovered_commands: Option<BTreeSet<String>>,
 }
 
 impl<C: GvmConnection + fmt::Debug> fmt::Debug for GmpClient<C> {
@@ -215,6 +218,7 @@ impl<C: GvmConnection> GmpClient<C> {
             connection,
             version,
             wire_trace,
+            discovered_commands: None,
         })
     }
 
@@ -222,6 +226,51 @@ impl<C: GvmConnection> GmpClient<C> {
     #[must_use]
     pub fn version(&self) -> GmpVersion {
         self.version
+    }
+
+    /// Query the server's XML `help` command listing and cache the advertised
+    /// command names.
+    ///
+    /// This is required before invoking commands whose availability cannot be
+    /// proven by the negotiated GMP version, including `export_scan_report`.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails, the response cannot be parsed,
+    /// or the server does not return a structured command listing.
+    pub async fn discover_commands(&mut self) -> Result<HelpResponse, GvmError> {
+        let response = self.call(help_with_mode(HelpMode::BriefXml)).await?;
+        let parsed = HelpResponse::from_response(&response).map_err(GvmError::Parse)?;
+        let schema = parsed.schema.as_ref().ok_or_else(|| {
+            GvmError::XmlParse("help response did not include an XML command listing".to_string())
+        })?;
+        self.discovered_commands = Some(
+            schema
+                .commands
+                .iter()
+                .map(|command| command.name.clone())
+                .collect(),
+        );
+        Ok(parsed)
+    }
+
+    /// Return the client's current knowledge of a known command's support.
+    ///
+    /// Version-qualified commands return `Some` immediately. Commands marked
+    /// for help discovery return `None` until [`Self::discover_commands`] has
+    /// succeeded.
+    #[must_use]
+    pub fn supports_command(&self, command_name: &str) -> Option<bool> {
+        let capability = gvm_gmp::capabilities::command_capability(command_name)?;
+        if capability.requires_help_discovery {
+            if !capability.permitted_in(self.version) {
+                return Some(false);
+            }
+            return self
+                .discovered_commands
+                .as_ref()
+                .map(|commands| commands.contains(command_name));
+        }
+        Some(capability.available_in(self.version))
     }
 
     /// Enable redacted GMP wire tracing on this client.
@@ -326,14 +375,13 @@ impl<C: GvmConnection> GmpClient<C> {
         let semantic_command_name = semantic_command_name
             .or_else(|| next_only_semantic_command(command_name, request_bytes));
         let unsupported_semantic =
-            semantic_command_name.filter(|name| !version::command_supported(name, self.version));
-        if unsupported_semantic.is_none() && version::command_supported(command_name, self.version)
-        {
+            semantic_command_name.filter(|name| !self.command_supported_with_discovery(name));
+        if unsupported_semantic.is_none() && self.command_supported_with_discovery(command_name) {
             return Ok(());
         }
 
         let command = unsupported_semantic.unwrap_or(command_name);
-        let required = version::required_version_label(command).unwrap_or("a newer GMP version");
+        let required = self.command_requirement(command);
 
         Err(GvmError::UnsupportedCommand {
             command: command.to_string(),
@@ -346,16 +394,40 @@ impl<C: GvmConnection> GmpClient<C> {
         &self,
         command_name: &str,
     ) -> Result<(), GvmError> {
-        if version::command_supported(command_name, self.version) {
+        if self.command_supported_with_discovery(command_name) {
             return Ok(());
         }
 
         Err(GvmError::UnsupportedCommand {
             command: command_name.to_string(),
             version: self.version,
-            required: version::required_version_label(command_name)
-                .unwrap_or("a newer GMP version"),
+            required: self.command_requirement(command_name),
         })
+    }
+
+    fn command_supported_with_discovery(&self, command_name: &str) -> bool {
+        let Some(capability) = gvm_gmp::capabilities::command_capability(command_name) else {
+            return version::command_supported(command_name, self.version);
+        };
+        if !capability.permitted_in(self.version) {
+            return false;
+        }
+        if capability.requires_help_discovery {
+            return self
+                .discovered_commands
+                .as_ref()
+                .is_some_and(|commands| commands.contains(command_name));
+        }
+        true
+    }
+
+    fn command_requirement(&self, command_name: &str) -> &'static str {
+        if let Some(capability) = gvm_gmp::capabilities::command_capability(command_name) {
+            if capability.requires_help_discovery && capability.permitted_in(self.version) {
+                return "positive XML help discovery";
+            }
+        }
+        version::required_version_label(command_name).unwrap_or("a newer GMP version")
     }
 
     /// Get a single integration configuration.
@@ -799,6 +871,24 @@ impl<C: GvmConnection> GmpClient<C> {
         opts: GetScanReportOpts,
     ) -> Result<Response, GvmError> {
         self.call(get_scan_report(scan_report_id, opts)).await
+    }
+
+    /// Queue or reuse an asynchronous scan-report export and return the raw
+    /// response.
+    ///
+    /// Call [`Self::discover_commands`] first. The negotiated GMP version is
+    /// not sufficient evidence that the server implements this command.
+    ///
+    /// # Errors
+    /// Returns an error if positive help discovery is missing, the server does
+    /// not advertise the command, or request transmission or response handling
+    /// fails.
+    pub async fn export_scan_report_raw(
+        &mut self,
+        report_id: &EntityId,
+        opts: ExportScanReportOpts,
+    ) -> Result<Response, GvmError> {
+        self.call(export_scan_report(report_id, opts)).await
     }
 
     /// Get host summaries for a report.
@@ -1460,6 +1550,39 @@ impl<C: GvmConnection> GmpVersioned<C> {
     #[must_use]
     pub fn version(&self) -> GmpVersion {
         self.inner().version()
+    }
+
+    /// Query and cache the server's XML command listing.
+    ///
+    /// # Errors
+    /// Returns an error if help discovery or response parsing fails.
+    pub async fn discover_commands(&mut self) -> Result<HelpResponse, GvmError> {
+        self.inner_mut().discover_commands().await
+    }
+
+    /// Return the versioned client's current knowledge of a known command's
+    /// support.
+    #[must_use]
+    pub fn supports_command(&self, command_name: &str) -> Option<bool> {
+        self.inner().supports_command(command_name)
+    }
+
+    /// Queue or reuse an asynchronous scan-report export.
+    ///
+    /// Call [`Self::discover_commands`] first because GMP 22.7 or 22.8 alone
+    /// does not prove that the server implements this command.
+    ///
+    /// # Errors
+    /// Returns an error if positive help discovery is missing, the command is
+    /// unavailable, or request transmission or response handling fails.
+    pub async fn export_scan_report(
+        &mut self,
+        report_id: &EntityId,
+        opts: ExportScanReportOpts,
+    ) -> Result<Response, GvmError> {
+        self.inner_mut()
+            .export_scan_report_raw(report_id, opts)
+            .await
     }
 
     /// Send a request and return the raw parsed response.
@@ -2272,6 +2395,7 @@ mod tests {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
             version: GmpVersion(22, 7),
             wire_trace: None,
+            discovered_commands: None,
         };
         let error = client
             .ensure_command_supported(
@@ -2293,6 +2417,7 @@ mod tests {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
             version: GmpVersion(22, 8),
             wire_trace: None,
+            discovered_commands: None,
         };
         client
             .ensure_command_supported(
@@ -2311,6 +2436,7 @@ mod tests {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
             version: GmpVersion(22, 7),
             wire_trace: None,
+            discovered_commands: None,
         };
         let error = client
             .ensure_command_supported(
@@ -2347,6 +2473,7 @@ mod tests {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
             version: GmpVersion(22, 8),
             wire_trace: None,
+            discovered_commands: None,
         };
         client
             .ensure_command_supported(
@@ -2369,6 +2496,7 @@ mod tests {
             connection,
             version: GmpVersion(22, 8),
             wire_trace: None,
+            discovered_commands: None,
         });
 
         let response = client
@@ -2395,6 +2523,7 @@ mod tests {
             connection,
             version: GmpVersion(22, 8),
             wire_trace: None,
+            discovered_commands: None,
         });
 
         let response = client

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -72,12 +72,12 @@ use gvm_gmp::commands::report_formats::{
     GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    get_audit_report, get_audit_report_hosts, get_report_applications, get_report_closed_cves,
-    get_report_cves, get_report_errors, get_report_export, get_report_export_with_opts,
-    get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
-    get_report_vulnerabilities, get_report_vulns, get_reports, import_report,
-    GetAuditReportHostsOpts, GetAuditReportOpts, GetReportDetailsOpts, GetReportExportOpts,
-    GetReportsOpts, ImportReportOpts,
+    export_scan_report, get_audit_report, get_audit_report_hosts, get_report_applications,
+    get_report_closed_cves, get_report_cves, get_report_errors, get_report_export,
+    get_report_export_with_opts, get_report_hosts, get_report_operating_systems, get_report_ports,
+    get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns, get_reports,
+    import_report, ExportScanReportOpts, GetAuditReportHostsOpts, GetAuditReportOpts,
+    GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts, ImportReportOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -142,12 +142,12 @@ use gvm_gmp::responses::{
     DeleteCredentialResponse, DeleteOciImageTargetResponse, DeleteScanConfigResponse,
     DeleteScannerResponse, DeleteScheduleResponse, DeleteTargetResponse, DeleteTaskResponse,
     DeleteWebApplicationTargetResponse, DescribeAuthResponse, EmptyTrashcanResponse,
-    GetAggregatesResponse, GetAlertsResponse, GetAssetsResponse, GetAuditReportHostsResponse,
-    GetAuditReportResponse, GetCertBundAdvisoriesResponse, GetConfigsResponse, GetCpesResponse,
-    GetCredentialStoresResponse, GetCredentialsResponse, GetCvesResponse,
-    GetDfnCertAdvisoriesResponse, GetFeaturesResponse, GetFeedsResponse, GetFiltersResponse,
-    GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse, GetNotesResponse,
-    GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
+    ExportScanReportResponse, GetAggregatesResponse, GetAlertsResponse, GetAssetsResponse,
+    GetAuditReportHostsResponse, GetAuditReportResponse, GetCertBundAdvisoriesResponse,
+    GetConfigsResponse, GetCpesResponse, GetCredentialStoresResponse, GetCredentialsResponse,
+    GetCvesResponse, GetDfnCertAdvisoriesResponse, GetFeaturesResponse, GetFeedsResponse,
+    GetFiltersResponse, GetGroupsResponse, GetHostsResponse, GetIntegrationConfigsResponse,
+    GetNotesResponse, GetNvtFamiliesResponse, GetNvtsResponse, GetOciImageTargetsResponse,
     GetOperatingSystemAssetsResponse, GetOverridesResponse, GetPermissionsResponse,
     GetPortListsResponse, GetReportApplicationsResponse, GetReportClosedCvesResponse,
     GetReportConfigsResponse, GetReportCvesResponse, GetReportErrorsResponse,
@@ -971,6 +971,24 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     ) -> Result<GetReportsResponse, GvmError> {
         let response = self.send(get_reports(opts)).await?;
         GetReportsResponse::from_response(&response).map_err(GvmError::Parse)
+    }
+
+    /// Queue or reuse an asynchronous scan-report export and return its typed
+    /// identifier and optional processing status.
+    ///
+    /// Call [`GmpClient::discover_commands`] first. The negotiated GMP version
+    /// does not prove that the server implements this command.
+    ///
+    /// # Errors
+    /// Returns an error if positive help discovery is missing, the command is
+    /// unavailable, the request fails, or response parsing fails.
+    pub async fn export_scan_report(
+        &mut self,
+        report_id: &EntityId,
+        opts: ExportScanReportOpts,
+    ) -> Result<ExportScanReportResponse, GvmError> {
+        let response = self.send(export_scan_report(report_id, opts)).await?;
+        ExportScanReportResponse::from_response(&response).map_err(GvmError::Parse)
     }
 
     /// Send a `get_report_vulns` request and return a typed [`GetReportVulnsResponse`].

--- a/crates/gvm-client/src/version.rs
+++ b/crates/gvm-client/src/version.rs
@@ -13,10 +13,18 @@ pub fn minimum_version_for_command(command_name: &str) -> Option<GmpVersion> {
     gvm_gmp::capabilities::minimum_version_for_command(command_name)
 }
 
-/// Return whether a command is supported by the negotiated version.
+/// Return whether the negotiated version alone proves command support.
+///
+/// This returns `false` for commands that require positive XML `help`
+/// discovery even when their version floor is satisfied. Use
+/// [`crate::GmpClient::supports_command`] after discovery for the client's
+/// complete current knowledge.
 #[must_use]
 pub fn command_supported(command_name: &str, version: GmpVersion) -> bool {
-    minimum_version_for_command(command_name).is_none_or(|minimum| version >= minimum)
+    gvm_gmp::capabilities::command_capability(command_name).map_or_else(
+        || minimum_version_for_command(command_name).is_none_or(|minimum| version >= minimum),
+        |capability| capability.available_in(version),
+    )
 }
 
 /// Human-readable minimum version label for a version-gated command.
@@ -255,6 +263,16 @@ mod tests {
             minimum_version_for_command("create_web_application_target"),
             Some(GmpVersion(22, 8))
         );
+    }
+
+    #[test]
+    fn help_discovered_command_is_not_proven_by_version() {
+        assert_eq!(
+            minimum_version_for_command("export_scan_report"),
+            Some(GmpVersion(22, 7))
+        );
+        assert!(!command_supported("export_scan_report", GmpVersion(22, 7)));
+        assert!(!command_supported("export_scan_report", GmpVersion(22, 8)));
     }
 
     #[test]

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -4,7 +4,9 @@
 #![allow(missing_docs)]
 #![cfg(feature = "unix-socket-tests")]
 
-use gvm_client::{GetOciImageTargetsOpts, GetReportExportOpts, GetWebApplicationTargetsOpts};
+use gvm_client::{
+    ExportScanReportOpts, GetOciImageTargetsOpts, GetReportExportOpts, GetWebApplicationTargetsOpts,
+};
 use gvm_client::{GmpClient, GvmError};
 use gvm_connection::UnixSocketConnection;
 use gvm_gmp::commands::alerts::{AlertOpts, GetAlertsOpts};
@@ -614,6 +616,86 @@ async fn report_export_simple_and_options_paths_preserve_distinct_xml() {
     assert!(requests[1].contains(r#"filter="severity&gt;5""#));
     assert!(requests[1].contains(r#"ignore_pagination="0""#));
 
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn asynchronous_scan_report_export_uses_positive_help_discovery() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_8,
+        &[
+            (
+                "help",
+                r#"<help_response status="200" status_text="OK"><schema format="XML"><command><name>export_scan_report</name></command></schema></help_response>"#,
+            ),
+            (
+                "export_scan_report",
+                r#"<export_scan_report_response status="201" status_text="OK, resource created" id="11111111-1111-1111-1111-111111111111"/>"#,
+            ),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+    assert_eq!(client.supports_command("export_scan_report"), None);
+    client
+        .discover_commands()
+        .await
+        .expect("help discovery should parse");
+
+    let response = client
+        .export_scan_report(
+            &id("22222222-2222-2222-2222-222222222222"),
+            ExportScanReportOpts::default(),
+        )
+        .await
+        .expect("asynchronous export should parse");
+
+    assert_eq!(response.status, 201);
+    assert_eq!(response.export_status, None);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn asynchronous_scan_report_export_rejects_negative_help_discovery_on_22_8() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_8,
+        &[(
+            "help",
+            r#"<help_response status="200" status_text="OK"><schema format="XML"><command><name>get_tasks</name></command></schema></help_response>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+    client
+        .discover_commands()
+        .await
+        .expect("negative help discovery should still parse");
+    assert_eq!(client.supports_command("export_scan_report"), Some(false));
+    server.clear_history();
+
+    let error = client
+        .export_scan_report(
+            &id("22222222-2222-2222-2222-222222222222"),
+            ExportScanReportOpts::default(),
+        )
+        .await
+        .expect_err("22.8 alone must not unlock the command");
+
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 8),
+            required: "positive XML help discovery",
+        } if command == "export_scan_report"
+    ));
+    assert!(server.command_history().is_empty());
     server.shutdown().await;
 }
 

--- a/crates/gvm-client/tests/typed_facade_inventory.rs
+++ b/crates/gvm-client/tests/typed_facade_inventory.rs
@@ -76,6 +76,7 @@ const INTEGRATION_COVERED: &[&str] = &[
     "get_report_closed_cves",
     "get_report_export",
     "get_report_export_with_opts",
+    "export_scan_report",
     "get_results",
     "get_feeds",
     "get_feed",

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -8,9 +8,10 @@ use gvm_client::{
     AgentInstallerLanguage, CreateAgentGroupOpts, CreateAgentGroupTaskOpts,
     CreateOciImageTargetOpts, CreateOciImageTargetTaskOpts, CreateWebApplicationTargetOpts,
     CreateWebApplicationTaskOpts, CredentialStoreCredentialOpts, CredentialStoreCredentialType,
-    GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands, GmpNextCommands, GmpVersioned,
-    GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts, ModifyAgentOpts,
-    ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
+    ExportScanReportOpts, GetAgentsOpts, GetCredentialStoresOpts, Gmp226Commands, GmpNextCommands,
+    GmpVersioned, GvmError, ModifyAgentControlScanConfigOpts, ModifyAgentGroupOpts,
+    ModifyAgentOpts, ModifyCredentialStoreCredentialOpts, ModifyOciImageTargetOpts,
+    ModifyWebApplicationTargetOpts,
 };
 use gvm_client::{GmpClient, GmpNext};
 use gvm_connection::{GvmConnection, UnixSocketConnection};
@@ -729,6 +730,47 @@ async fn versioned_client_rejects_get_scan_report_before_next() {
             required: "22.8",
         } if command == "get_scan_report"
     ));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn versioned_scan_report_export_requires_then_uses_help_discovery() {
+    let Some(server) = stateful_server(MockVersion::V22_7).await else {
+        return;
+    };
+    let mut client = GmpVersioned::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+    let report_id = EntityId::new("11111111-1111-1111-1111-111111111111").expect("valid report ID");
+
+    let error = client
+        .export_scan_report(&report_id, ExportScanReportOpts::default())
+        .await
+        .expect_err("undiscovered export should fail");
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            required: "positive XML help discovery",
+            ..
+        } if command == "export_scan_report"
+    ));
+
+    let help = client.discover_commands().await.expect("help discovery");
+    assert_eq!(help.supports_command("export_scan_report"), Some(true));
+    assert_eq!(client.supports_command("export_scan_report"), Some(true));
+    let error = client
+        .export_scan_report(&report_id, ExportScanReportOpts::default())
+        .await
+        .expect_err("missing report should reach the mock");
+    assert!(matches!(error, GvmError::Server { status: 404, .. }));
 
     server.shutdown().await;
 }

--- a/crates/gvm-gmp/src/capabilities.rs
+++ b/crates/gvm-gmp/src/capabilities.rs
@@ -39,18 +39,39 @@ pub struct CommandCapability {
     pub min_version: Option<GmpVersion>,
     /// Public evidence qualification for current gvmd support.
     pub gvmd_evidence: GvmdEvidence,
+    /// Whether callers must confirm availability from the server's `help`
+    /// command listing instead of inferring it from the negotiated GMP version.
+    pub requires_help_discovery: bool,
 }
 
 impl CommandCapability {
     /// Return whether this command is available in the negotiated GMP version.
     #[must_use]
     pub fn available_in(self, version: GmpVersion) -> bool {
+        !self.requires_help_discovery && self.min_version.is_none_or(|minimum| version >= minimum)
+    }
+
+    /// Return whether the negotiated version permits attempting this command.
+    ///
+    /// A `true` result is not proof of availability when
+    /// [`Self::requires_help_discovery`] is set.
+    #[must_use]
+    pub fn permitted_in(self, version: GmpVersion) -> bool {
         self.min_version.is_none_or(|minimum| version >= minimum)
     }
 }
 
+macro_rules! requires_help_discovery {
+    () => {
+        false
+    };
+    (Help) => {
+        true
+    };
+}
+
 macro_rules! command_capabilities {
-    ($(($name:literal, $support:ident, $min_version:expr, $evidence:ident),)+) => {
+    ($(($name:literal, $support:ident, $min_version:expr, $evidence:ident $(, $discovery:ident)?),)+) => {
         /// Authoritative, name-sorted command capability registry.
         pub static COMMAND_CAPABILITIES: &[CommandCapability] = &[
             $(CommandCapability {
@@ -58,6 +79,7 @@ macro_rules! command_capabilities {
                 support: MockSupport::$support,
                 min_version: $min_version,
                 gvmd_evidence: GvmdEvidence::$evidence,
+                requires_help_discovery: requires_help_discovery!($($discovery)?),
             },)+
         ];
 
@@ -123,6 +145,7 @@ command_capabilities! {
     ("delete_web_application_target", Stateful, Some(GmpVersion(22, 8)), PinnedSchema),
     ("describe_auth", EchoOnly, None, PinnedSchema),
     ("empty_trashcan", Stateful, None, PinnedSchema),
+    ("export_scan_report", Stateful, Some(GmpVersion(22, 7)), PinnedSchema, Help),
     ("get_agent_groups", Stateful, Some(GmpVersion(22, 8)), PinnedSchema),
     ("get_agent_installer_instruction", Fixture, Some(GmpVersion(22, 8)), PinnedSchema),
     ("get_agent_support_bundle", Fixture, Some(GmpVersion(22, 8)), PinnedSchema),
@@ -254,6 +277,13 @@ pub fn minimum_version_for_command(name: &str) -> Option<GmpVersion> {
     }
 }
 
+/// Return whether a command needs positive availability confirmation from a
+/// parsed XML `help` command listing.
+#[must_use]
+pub fn command_requires_help_discovery(name: &str) -> bool {
+    command_capability(name).is_some_and(|capability| capability.requires_help_discovery)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,6 +304,12 @@ mod tests {
 
         let reports = command_capability("get_reports").expect("known command");
         assert!(reports.available_in(GmpVersion(22, 4)));
+        let export = command_capability("export_scan_report").expect("known discoverable command");
+        assert!(!export.permitted_in(GmpVersion(22, 6)));
+        assert!(export.permitted_in(GmpVersion(22, 7)));
+        assert!(!export.available_in(GmpVersion(22, 7)));
+        assert!(!export.available_in(GmpVersion(22, 8)));
+        assert!(export.requires_help_discovery);
         let audit_report =
             command_capability("get_audit_report").expect("known structured audit command");
         assert!(!audit_report.available_in(GmpVersion(22, 6)));

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -92,6 +92,28 @@ pub struct GetReportExportOpts {
     pub ignore_pagination: Option<bool>,
 }
 
+/// Options for asynchronous `export_scan_report` requests.
+#[derive(Debug, Clone, Default)]
+pub struct ExportScanReportOpts {
+    /// Optional report format identifier. gvmd defaults to the XML report
+    /// format when this is omitted.
+    pub format_id: Option<EntityId>,
+    /// Optional report configuration identifier.
+    pub config_id: Option<EntityId>,
+    /// Optional inline result filter expression.
+    pub filter_string: Option<String>,
+    /// Whether pagination settings in the filter are ignored.
+    pub ignore_pagination: Option<bool>,
+    /// Whether lean report data is generated.
+    pub lean: Option<bool>,
+    /// Whether note details are included.
+    pub notes_details: Option<bool>,
+    /// Whether override details are included.
+    pub overrides_details: Option<bool>,
+    /// Whether result tags are included.
+    pub result_tags: Option<bool>,
+}
+
 impl GetReportExportOpts {
     /// Create export options for a report format.
     #[must_use]
@@ -283,6 +305,31 @@ pub fn get_report_export_with_opts(
         opts.filter_id.as_ref(),
     );
     ReportExportCommand(cmd)
+}
+
+/// Build an asynchronous `export_scan_report` request.
+///
+/// The command was added without a distinct GMP version. Callers using the
+/// high-level client must first confirm it through the server's XML `help`
+/// command listing.
+#[must_use]
+pub fn export_scan_report(report_id: &EntityId, opts: ExportScanReportOpts) -> impl Request {
+    let mut cmd = XmlCommand::new("export_scan_report").attribute("report_id", report_id.as_str());
+    if let Some(format_id) = opts.format_id {
+        cmd.set_attribute("format_id", format_id.as_str());
+    }
+    if let Some(config_id) = opts.config_id {
+        cmd.set_attribute("config_id", config_id.as_str());
+    }
+    if let Some(filter_string) = opts.filter_string {
+        cmd.set_attribute("filter", &filter_string);
+    }
+    set_optional_bool_attr(&mut cmd, "ignore_pagination", opts.ignore_pagination);
+    set_optional_bool_attr(&mut cmd, "lean", opts.lean);
+    set_optional_bool_attr(&mut cmd, "notes_details", opts.notes_details);
+    set_optional_bool_attr(&mut cmd, "overrides_details", opts.overrides_details);
+    set_optional_bool_attr(&mut cmd, "result_tags", opts.result_tags);
+    cmd
 }
 
 /// Build a `delete_report` request.

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -131,13 +131,13 @@ pub use port_list::{
     CreatePortListResponse, GetPortListsResponse, ModifyPortListResponse, PortList,
 };
 pub use report::{
-    CreateReportResponse, DeleteReportResponse, GetReportApplicationsResponse,
-    GetReportClosedCvesResponse, GetReportCvesResponse, GetReportErrorsResponse,
-    GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
-    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse, Report,
-    ReportApplicationSummary, ReportClosedCve, ReportCveSummary, ReportError, ReportExport,
-    ReportHostSummary, ReportOperatingSystemSummary, ReportPortSummary, ReportTlsCertificate,
-    ReportVulnerability, ResultCount, Severity,
+    CreateReportResponse, DeleteReportResponse, ExportScanReportResponse,
+    GetReportApplicationsResponse, GetReportClosedCvesResponse, GetReportCvesResponse,
+    GetReportErrorsResponse, GetReportHostsResponse, GetReportOperatingSystemsResponse,
+    GetReportPortsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
+    GetReportsResponse, Report, ReportApplicationSummary, ReportClosedCve, ReportCveSummary,
+    ReportError, ReportExport, ReportHostSummary, ReportOperatingSystemSummary, ReportPortSummary,
+    ReportTlsCertificate, ReportVulnerability, ResultCount, Severity,
 };
 pub use report_config::{
     CreateReportConfigResponse, DeleteReportConfigResponse, GetReportConfigsResponse,

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -76,6 +76,19 @@ pub struct CreateReportResponse {
     pub id: crate::EntityId,
 }
 
+/// Response from an asynchronous `export_scan_report` request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ExportScanReportResponse {
+    pub status: u16,
+    pub status_text: String,
+    pub id: crate::EntityId,
+    /// Current processing status for a reused export. Newly created exports
+    /// omit this attribute in current gvmd responses.
+    pub export_status: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -376,6 +389,24 @@ impl CreateReportResponse {
             status,
             status_text,
             id,
+        })
+    }
+}
+
+impl ExportScanReportResponse {
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let id = parse_entity_id(
+            root.attr("id")
+                .ok_or_else(|| ParseError::MissingElement("id".to_string()))?,
+            "id",
+        )?;
+        Ok(Self {
+            status,
+            status_text,
+            id,
+            export_status: root.attr("export_status").map(ToString::to_string),
         })
     }
 }
@@ -1278,6 +1309,46 @@ mod tests {
         assert_eq!(export.bytes, b"Hello PDF");
         assert_eq!(export.content_type.as_deref(), Some("application/pdf"));
         assert_eq!(export.extension.as_deref(), Some("pdf"));
+    }
+
+    #[test]
+    fn parses_created_asynchronous_scan_report_export_without_status() {
+        let response = Response::from(
+            r#"<export_scan_report_response status="201" status_text="OK, resource created" id="e6e2f6e1-daa9-411d-aa5a-1321c9894ab9"/>"#,
+        );
+
+        let parsed = ExportScanReportResponse::from_response(&response).expect("created parse");
+
+        assert_eq!(parsed.status, 201);
+        assert_eq!(parsed.id.as_str(), "e6e2f6e1-daa9-411d-aa5a-1321c9894ab9");
+        assert_eq!(parsed.export_status, None);
+    }
+
+    #[test]
+    fn parses_reused_asynchronous_scan_report_export_with_status() {
+        let response = Response::from(
+            r#"<export_scan_report_response status="200" status_text="OK" id="e6e2f6e1-daa9-411d-aa5a-1321c9894ab9" export_status="pending"/>"#,
+        );
+
+        let parsed = ExportScanReportResponse::from_response(&response).expect("reused parse");
+
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.export_status.as_deref(), Some("pending"));
+    }
+
+    #[test]
+    fn rejects_asynchronous_scan_report_export_error_response() {
+        let response = Response::from(
+            r#"<export_scan_report_response status="400" status_text="Missing or invalid report_id"/>"#,
+        );
+
+        let error = ExportScanReportResponse::from_response(&response).expect_err("server error");
+
+        assert!(matches!(
+            error,
+            ParseError::ServerError { status: 400, message }
+                if message == "Missing or invalid report_id"
+        ));
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/scan_report.rs
+++ b/crates/gvm-gmp/src/responses/scan_report.rs
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn parses_current_gvmd_scan_report_example() {
         // Copied from greenbone/gvmd GMP.xml.in at
-        // 7ac172654b703d9f202481f7a53453964061de2f.
+        // 55e5d4c657c48ce52ee340c2439680418bfe1a4d.
         let parsed = GetScanReportResponse::from_response(&Response::from(include_str!(
             "../../tests/data/get_scan_report.xml"
         )))

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -205,6 +205,20 @@ impl HelpResponse {
             schema,
         })
     }
+
+    /// Return whether an XML command listing advertises `command_name`.
+    ///
+    /// `None` means the response did not include a structured command listing,
+    /// so absence cannot be established from this response.
+    #[must_use]
+    pub fn supports_command(&self, command_name: &str) -> Option<bool> {
+        self.schema.as_ref().map(|schema| {
+            schema
+                .commands
+                .iter()
+                .any(|command| command.name == command_name)
+        })
+    }
 }
 
 fn collect_help_commands(
@@ -379,6 +393,7 @@ mod tests {
             "Available commands: get_tasks, get_alerts"
         );
         assert!(parsed.schema.is_none());
+        assert_eq!(parsed.supports_command("get_tasks"), None);
     }
 
     #[test]
@@ -393,7 +408,7 @@ mod tests {
         );
 
         let parsed = HelpResponse::from_response(&response).expect("brief XML help parse");
-        let schema = parsed.schema.expect("schema");
+        let schema = parsed.schema.as_ref().expect("schema");
 
         assert!(parsed.help_text.is_empty());
         assert_eq!(schema.format.as_deref(), Some("XML"));
@@ -402,6 +417,8 @@ mod tests {
         assert_eq!(schema.commands.len(), 2);
         assert_eq!(schema.commands[0].name, "get_tasks");
         assert_eq!(schema.commands[0].summary.as_deref(), Some("Get tasks"));
+        assert_eq!(parsed.supports_command("get_tasks"), Some(true));
+        assert_eq!(parsed.supports_command("export_scan_report"), Some(false));
     }
 
     #[test]

--- a/crates/gvm-gmp/tests/data/gvmd-gmp-commands-55e5d4c6.txt
+++ b/crates/gvm-gmp/tests/data/gvmd-gmp-commands-55e5d4c6.txt
@@ -1,8 +1,8 @@
 # Extracted top-level GMP commands from public gvmd source.
 # Repository: https://github.com/greenbone/gvmd
-# Commit: 7ac172654b703d9f202481f7a53453964061de2f
+# Commit: 55e5d4c657c48ce52ee340c2439680418bfe1a4d
 # Path: src/schema_formats/XML/GMP.xml.in
-# GMP.xml.in SHA-256: d0f8314fcd0bc15e2e07881a336cef3e5cfa8cc2a9b263abb510fe6aad124b7b
+# GMP.xml.in SHA-256: ee7054ffffbdce859f90086b28cdc876eebb8225a2a53ad0f7e8100084e1e0b0
 authenticate
 create_agent_group
 create_alert
@@ -58,6 +58,7 @@ delete_user
 delete_web_application_target
 describe_auth
 empty_trashcan
+export_scan_report
 get_agent_groups
 get_agent_installer_instruction
 get_agent_support_bundle

--- a/crates/gvm-gmp/tests/gmp_schema_snapshot.rs
+++ b/crates/gvm-gmp/tests/gmp_schema_snapshot.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use gvm_gmp::capabilities::{GvmdEvidence, MockSupport, COMMAND_CAPABILITIES};
 use gvm_gmp::GmpVersion;
 
-const PINNED_COMMANDS: &str = include_str!("data/gvmd-gmp-commands-7ac17265.txt");
+const PINNED_COMMANDS: &str = include_str!("data/gvmd-gmp-commands-55e5d4c6.txt");
 
 fn pinned_commands() -> BTreeSet<&'static str> {
     PINNED_COMMANDS
@@ -39,7 +39,7 @@ fn pinned_schema_matches_qualified_registry() {
         registry_only.is_empty(),
         "commands marked PinnedSchema but absent from pinned GMP.xml.in: {registry_only:?}"
     );
-    assert_eq!(pinned.len(), 154);
+    assert_eq!(pinned.len(), 155);
 }
 
 #[test]

--- a/crates/gvm-gmp/tests/test_reports.rs
+++ b/crates/gvm-gmp/tests/test_reports.rs
@@ -219,6 +219,37 @@ fn test_report_export_with_combined_options() {
 }
 
 #[test]
+fn test_export_scan_report_with_all_current_attributes_and_escaping() {
+    assert_eq!(
+        xml(export_scan_report(
+            &id("11111111-1111-1111-1111-111111111111"),
+            ExportScanReportOpts {
+                format_id: Some(id("22222222-2222-2222-2222-222222222222")),
+                config_id: Some(id("33333333-3333-3333-3333-333333333333")),
+                filter_string: Some("severity>5 & name='quoted'".into()),
+                ignore_pagination: Some(true),
+                lean: Some(false),
+                notes_details: Some(true),
+                overrides_details: Some(false),
+                result_tags: Some(true),
+            },
+        )),
+        "<export_scan_report config_id=\"33333333-3333-3333-3333-333333333333\" filter=\"severity&gt;5 &amp; name=&apos;quoted&apos;\" format_id=\"22222222-2222-2222-2222-222222222222\" ignore_pagination=\"1\" lean=\"0\" notes_details=\"1\" overrides_details=\"0\" report_id=\"11111111-1111-1111-1111-111111111111\" result_tags=\"1\"/>"
+    );
+}
+
+#[test]
+fn test_export_scan_report_allows_source_default_format() {
+    assert_eq!(
+        xml(export_scan_report(
+            &id("11111111-1111-1111-1111-111111111111"),
+            ExportScanReportOpts::default(),
+        )),
+        "<export_scan_report report_id=\"11111111-1111-1111-1111-111111111111\"/>"
+    );
+}
+
+#[test]
 fn test_report_helper_commands() {
     assert_eq!(
         xml(get_report_hosts(

--- a/crates/gvm-mock-server/src/handler.rs
+++ b/crates/gvm-mock-server/src/handler.rs
@@ -45,6 +45,7 @@ pub struct SessionHandler {
     store: Option<ResourceStore>,
     scenario_engine: Option<Mutex<ScenarioEngine>>,
     large_report: Option<LargeReportConfig>,
+    scan_report_exports: Mutex<BTreeMap<String, Uuid>>,
     fault_engine: FaultEngine,
     command_count: AtomicUsize,
 }
@@ -319,6 +320,7 @@ impl SessionHandler {
             scenario_engine: scenario_config
                 .map(|(mode, steps)| Mutex::new(ScenarioEngine::new(mode, steps))),
             large_report,
+            scan_report_exports: Mutex::new(BTreeMap::new()),
             fault_engine,
             command_count: AtomicUsize::new(0),
         }
@@ -491,11 +493,68 @@ impl SessionHandler {
             }
             "restore" => self.handle_restore(cmd, store),
             // Help
-            "help" => render_help_response(cmd),
+            "help" => render_help_response(cmd, self.version),
+            "export_scan_report" => self.handle_export_scan_report(cmd, store),
             "sync_agents" => b"<sync_agents_response status=\"200\" status_text=\"OK\"/>".to_vec(),
             // Everything else
             _ => echo_response(&cmd.name, self.version.as_str()),
         }
+    }
+
+    fn handle_export_scan_report(&self, cmd: &ParsedCommand, store: &ResourceStore) -> Vec<u8> {
+        let Some(report_id) = cmd.attr("report_id") else {
+            return error_response(&cmd.name, 400, "Missing or invalid report_id");
+        };
+        let Ok(report_uuid) = Uuid::parse_str(report_id) else {
+            return error_response(&cmd.name, 400, "Missing or invalid report_id");
+        };
+        let Some(report) = store.get_typed(&report_uuid, "report") else {
+            return error_response(&cmd.name, 404, "Failed to find report");
+        };
+        if report.attr("usage_type") == Some("audit") || report.attr("delta") == Some("1") {
+            return error_response(&cmd.name, 400, "Report is not a scan report");
+        }
+
+        const XML_REPORT_FORMAT_ID: &str = "a994b278-1f62-11e1-96ac-406186ea4fc5";
+        let format_id = cmd.attr("format_id").unwrap_or(XML_REPORT_FORMAT_ID);
+        if Uuid::parse_str(format_id).is_err() {
+            return error_response(&cmd.name, 400, "Invalid format_id");
+        }
+        if let Some(config_id) = cmd.attr("config_id").filter(|value| !value.is_empty()) {
+            if Uuid::parse_str(config_id).is_err() {
+                return error_response(&cmd.name, 400, "Invalid config_id");
+            }
+        }
+
+        let key = [
+            report_id,
+            format_id,
+            cmd.attr("config_id").unwrap_or_default(),
+            cmd.attr("filter").unwrap_or_default(),
+            cmd.attr("ignore_pagination").unwrap_or("0"),
+            cmd.attr("lean").unwrap_or("0"),
+            cmd.attr("notes_details").unwrap_or("0"),
+            cmd.attr("overrides_details").unwrap_or("0"),
+            cmd.attr("result_tags").unwrap_or("0"),
+        ]
+        .join("\u{1f}");
+
+        let Ok(mut exports) = self.scan_report_exports.lock() else {
+            return error_response(&cmd.name, 500, "Report export state lock poisoned");
+        };
+        if let Some(export_id) = exports.get(&key) {
+            return format!(
+                "<export_scan_report_response status=\"200\" status_text=\"OK\" id=\"{export_id}\" export_status=\"pending\"/>"
+            )
+            .into_bytes();
+        }
+
+        let export_id = Uuid::new_v4();
+        exports.insert(key, export_id);
+        format!(
+            "<export_scan_report_response status=\"201\" status_text=\"OK, resource created\" id=\"{export_id}\"/>"
+        )
+        .into_bytes()
     }
 
     fn handle_authenticate(
@@ -3792,8 +3851,12 @@ fn store_error_response(command_name: &str, error: StoreError) -> Vec<u8> {
     }
 }
 
-fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
-    const COMMANDS: [(&str, &str); 6] = [
+fn render_help_response(cmd: &ParsedCommand, version: GmpVersion) -> Vec<u8> {
+    const COMMANDS: [(&str, &str); 7] = [
+        (
+            "export_scan_report",
+            "Create an asynchronous scan report export",
+        ),
         ("get_configs", "Get scan configurations"),
         ("get_feeds", "Get feed information"),
         ("get_info", "Get security information"),
@@ -3813,7 +3876,10 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
 
     if format.as_deref().is_none_or(|value| value == "text") {
         let mut body = String::new();
-        for (name, summary) in COMMANDS {
+        for (name, summary) in COMMANDS
+            .into_iter()
+            .filter(|(name, _)| command_available(name, version))
+        {
             body.push_str(name);
             body.push_str(" - ");
             body.push_str(summary);
@@ -3825,7 +3891,10 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
 
     if help_type == "brief" {
         let mut body = String::new();
-        for (name, summary) in COMMANDS {
+        for (name, summary) in COMMANDS
+            .into_iter()
+            .filter(|(name, _)| command_available(name, version))
+        {
             body.push_str("<command><name>");
             body.push_str(name);
             body.push_str("</name><summary>");
@@ -3841,7 +3910,10 @@ fn render_help_response(cmd: &ParsedCommand) -> Vec<u8> {
     match format.as_deref().unwrap_or_default() {
         "xml" => {
             let mut commands = String::new();
-            for (name, summary) in COMMANDS {
+            for (name, summary) in COMMANDS
+                .into_iter()
+                .filter(|(name, _)| command_available(name, version))
+            {
                 commands.push_str("<command><name>");
                 commands.push_str(name);
                 commands.push_str("</name><summary>");

--- a/crates/gvm-mock-server/src/version.rs
+++ b/crates/gvm-mock-server/src/version.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for GmpVersion {
 #[must_use]
 pub fn command_available(command_name: &str, version: GmpVersion) -> bool {
     gvm_gmp::capabilities::command_capability(command_name)
-        .is_some_and(|capability| capability.available_in(version.into()))
+        .is_some_and(|capability| capability.permitted_in(version.into()))
 }
 
 impl From<GmpVersion> for gvm_gmp::GmpVersion {
@@ -244,5 +244,16 @@ mod tests {
             assert!(command_available(command, GmpVersion::V22_7));
             assert!(command_available(command, GmpVersion::V22_8));
         }
+    }
+
+    #[test]
+    fn help_discovered_export_has_a_version_floor_without_version_proof() {
+        assert!(!command_available("export_scan_report", GmpVersion::V22_6));
+        assert!(command_available("export_scan_report", GmpVersion::V22_7));
+        let capability =
+            gvm_gmp::capabilities::command_capability("export_scan_report").expect("known command");
+        assert!(capability.requires_help_discovery);
+        assert!(!capability.available_in(gvm_gmp::GmpVersion(22, 7)));
+        assert!(!capability.available_in(gvm_gmp::GmpVersion(22, 8)));
     }
 }

--- a/crates/gvm-mock-server/tests/stateful_scan_report_exports.rs
+++ b/crates/gvm-mock-server/tests/stateful_scan_report_exports.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(clippy::print_stderr, clippy::unwrap_used, missing_docs)]
+#![cfg(feature = "unix-socket-tests")]
+
+use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::help::{help_with_mode, HelpMode};
+use gvm_gmp::commands::reports::{export_scan_report, ExportScanReportOpts};
+use gvm_gmp::EntityId;
+use gvm_mock_server::{GmpVersion, MockGmpServer, Resource, ServerMode};
+use gvm_protocol::{Request, Response};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+const REPORT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const AUDIT_REPORT_ID: &str = "22222222-2222-2222-2222-222222222222";
+const DELTA_REPORT_ID: &str = "33333333-3333-3333-3333-333333333333";
+
+async fn stateful_server(version: GmpVersion) -> Option<MockGmpServer> {
+    let report_id = Uuid::parse_str(REPORT_ID).expect("valid UUID");
+    let audit_report_id = Uuid::parse_str(AUDIT_REPORT_ID).expect("valid UUID");
+    let delta_report_id = Uuid::parse_str(DELTA_REPORT_ID).expect("valid UUID");
+    match MockGmpServer::builder()
+        .mode(ServerMode::Stateful)
+        .version(version)
+        .credentials("admin", "admin")
+        .seed(move |store| {
+            store.create(Resource::with_id("report", "Scan report", report_id));
+            let mut audit_report = Resource::with_id("report", "Audit report", audit_report_id);
+            audit_report.set_attr("usage_type", "audit");
+            store.create(audit_report);
+            let mut delta_report = Resource::with_id("report", "Delta report", delta_report_id);
+            delta_report.set_attr("delta", "1");
+            store.create(delta_report);
+        })
+        .unix_socket_auto()
+        .build()
+        .await
+    {
+        Ok(server) => Some(server),
+        Err(error)
+            if error.to_string().contains("Permission denied")
+                || error.to_string().contains("Operation not permitted") =>
+        {
+            eprintln!("Skipping: sandbox restriction");
+            None
+        }
+        Err(error) => panic!("server should start: {error}"),
+    }
+}
+
+async fn send_recv(stream: &mut UnixStream, request: impl Request) -> Response {
+    stream
+        .write_all(&request.to_bytes())
+        .await
+        .expect("request write");
+    let mut bytes = vec![0; 16 * 1024];
+    let size = stream.read(&mut bytes).await.expect("response read");
+    bytes.truncate(size);
+    Response::new(bytes)
+}
+
+async fn assert_created_and_reused(server: &MockGmpServer, stream: &mut UnixStream) {
+    let help = send_recv(stream, help_with_mode(HelpMode::BriefXml)).await;
+    assert_eq!(help.status_code(), Some(200));
+    assert!(help
+        .as_str()
+        .expect("help UTF-8")
+        .contains("<name>export_scan_report</name>"));
+
+    let report_id = EntityId::new(REPORT_ID).expect("valid entity id");
+    let export_options = || ExportScanReportOpts {
+        filter_string: Some("severity>5 & rows=10".into()),
+        notes_details: Some(true),
+        ..Default::default()
+    };
+    let created = send_recv(stream, export_scan_report(&report_id, export_options())).await;
+    assert_eq!(created.status_code(), Some(201));
+    assert!(created
+        .as_str()
+        .expect("created UTF-8")
+        .contains("OK, resource created"));
+    let created_id = created.id().expect("created export id");
+
+    let reused = send_recv(stream, export_scan_report(&report_id, export_options())).await;
+    assert_eq!(reused.status_code(), Some(200));
+    assert_eq!(reused.id().as_deref(), Some(created_id.as_str()));
+    assert!(reused
+        .as_str()
+        .expect("reused UTF-8")
+        .contains("export_status=\"pending\""));
+
+    let request = server
+        .command_history()
+        .into_iter()
+        .rev()
+        .find(|record| record.command_name() == "export_scan_report")
+        .expect("export request");
+    let xml = std::str::from_utf8(request.raw_xml()).expect("request UTF-8");
+    assert!(xml.contains(r#"filter="severity&gt;5 &amp; rows=10""#));
+    assert!(xml.contains(r#"notes_details="1""#));
+}
+
+async fn assert_validation_errors(stream: &mut UnixStream) {
+    let invalid = send_recv(
+        stream,
+        export_scan_report(
+            &EntityId::new("not-a-uuid").expect("valid protocol entity id"),
+            ExportScanReportOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(invalid.status_code(), Some(400));
+    assert_eq!(
+        invalid.status_text().as_deref(),
+        Some("Missing or invalid report_id")
+    );
+
+    let missing = send_recv(
+        stream,
+        export_scan_report(
+            &EntityId::new("44444444-4444-4444-4444-444444444444").expect("valid entity id"),
+            ExportScanReportOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(missing.status_code(), Some(404));
+    assert_eq!(
+        missing.status_text().as_deref(),
+        Some("Failed to find report")
+    );
+
+    for report_id in [AUDIT_REPORT_ID, DELTA_REPORT_ID] {
+        let response = send_recv(
+            stream,
+            export_scan_report(
+                &EntityId::new(report_id).expect("valid entity id"),
+                ExportScanReportOpts::default(),
+            ),
+        )
+        .await;
+        assert_eq!(response.status_code(), Some(400));
+        assert_eq!(
+            response.status_text().as_deref(),
+            Some("Report is not a scan report")
+        );
+    }
+}
+
+async fn assert_pre_22_7_unsupported() {
+    let Some(server) = stateful_server(GmpVersion::V22_6).await else {
+        return;
+    };
+    let mut stream = UnixStream::connect(server.socket_path().expect("socket path"))
+        .await
+        .expect("connect");
+    let _ = send_recv(&mut stream, authenticate("admin", "admin")).await;
+    let unsupported = send_recv(
+        &mut stream,
+        export_scan_report(
+            &EntityId::new(REPORT_ID).expect("valid entity id"),
+            ExportScanReportOpts::default(),
+        ),
+    )
+    .await;
+    assert_eq!(unsupported.status_code(), Some(400));
+    assert!(unsupported
+        .status_text()
+        .expect("status text")
+        .contains("not available in GMP 22.6"));
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn stateful_mock_rejects_invalid_inputs_and_pre_22_7_command_use() {
+    let Some(server) = stateful_server(GmpVersion::V22_7).await else {
+        return;
+    };
+    let mut stream = UnixStream::connect(server.socket_path().expect("socket path"))
+        .await
+        .expect("connect");
+    assert_eq!(
+        send_recv(&mut stream, authenticate("admin", "admin"))
+            .await
+            .status_code(),
+        Some(200)
+    );
+
+    assert_created_and_reused(&server, &mut stream).await;
+    assert_validation_errors(&mut stream).await;
+    server.shutdown().await;
+    assert_pre_22_7_unsupported().await;
+}

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -22,6 +22,14 @@ deliberately permits unknown raw commands for forward compatibility; standard
 mock responses reject commands absent from the registry. Explicit fixture and
 scenario configuration remains programmable by design.
 
+`export_scan_report` is the exception to pure version routing. It requires at
+least GMP 22.7, but it was added without a new GMP version: servers with and
+without the command can advertise 22.7 or 22.8. Call
+`GmpClient::discover_commands` (or the equivalent method on `GmpVersioned`) to
+parse and cache the XML `help` command listing before using its raw, versioned,
+or typed helper. The command is therefore represented in the registry and
+current-schema count but not in any version-only count above.
+
 `get_audit_report` and `get_audit_report_hosts` are gated at 22.7 and exposed
 through `Gmp227Commands` on both `Gmp227` and `GmpNext`. The placement follows
 the reviewed gvmd build contract rather than commit dates: default builds set
@@ -42,14 +50,14 @@ server advertises 22.8.
 
 ## Command and mock qualification
 
-The registry contains 157 wire command names:
+The registry contains 158 wire command names:
 
 | Qualification | Count | Meaning |
 |---|---:|---|
-| Stateful mock behavior | 141 | Bespoke behavior or deterministic generic CRUD |
+| Stateful mock behavior | 142 | Bespoke behavior or deterministic generic CRUD |
 | Fixture mock behavior | 10 | Deterministic built-in fixture response |
 | Echo-only mock behavior | 6 | Intentionally limited to a generic success response |
-| Current pinned `GMP.xml.in` | 154 | Present in the public schema snapshot |
+| Current pinned `GMP.xml.in` | 155 | Present in the public schema snapshot |
 | Public gvmd source only | 2 | Implemented publicly but omitted from that schema |
 | Legacy compatibility | 1 | Retained for public legacy-client compatibility |
 
@@ -73,19 +81,22 @@ The three commands outside the pinned schema are explicitly qualified:
 ## Pinned public evidence and drift audit
 
 The deterministic snapshot is extracted from Greenbone's public gvmd commit
-[`7ac172654b703d9f202481f7a53453964061de2f`](https://github.com/greenbone/gvmd/commit/7ac172654b703d9f202481f7a53453964061de2f),
+[`55e5d4c657c48ce52ee340c2439680418bfe1a4d`](https://github.com/greenbone/gvmd/commit/55e5d4c657c48ce52ee340c2439680418bfe1a4d),
 file
-[`src/schema_formats/XML/GMP.xml.in`](https://github.com/greenbone/gvmd/blob/7ac172654b703d9f202481f7a53453964061de2f/src/schema_formats/XML/GMP.xml.in).
+[`src/schema_formats/XML/GMP.xml.in`](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/src/schema_formats/XML/GMP.xml.in).
 The snapshot records SHA-256
-`d0f8314fcd0bc15e2e07881a336cef3e5cfa8cc2a9b263abb510fe6aad124b7b`
-and its 154 unique top-level commands. The structured audit contracts are
+`ee7054ffffbdce859f90086b28cdc876eebb8225a2a53ad0f7e8100084e1e0b0`
+and its 155 unique top-level commands. The asynchronous export contract is
 backed by the same commit's
-[`get_audit_report`](https://github.com/greenbone/gvmd/blob/7ac172654b703d9f202481f7a53453964061de2f/src/gmp_audit_report.c),
-[`get_audit_report_hosts`](https://github.com/greenbone/gvmd/blob/7ac172654b703d9f202481f7a53453964061de2f/src/gmp_audit_report_hosts.c),
+[`export_scan_report`](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/src/gmp_scan_report_exports.c).
+The structured audit contracts are
+backed by the same commit's
+[`get_audit_report`](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/src/gmp_audit_report.c),
+[`get_audit_report_hosts`](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/src/gmp_audit_report_hosts.c),
 and
-[`GMP_VERSION` selection](https://github.com/greenbone/gvmd/blob/7ac172654b703d9f202481f7a53453964061de2f/CMakeLists.txt).
+[`GMP_VERSION` selection](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/CMakeLists.txt).
 The source-only qualification is backed by the same commit's
-[credential-store implementation](https://github.com/greenbone/gvmd/blob/7ac172654b703d9f202481f7a53453964061de2f/src/gmp_credential_stores.c).
+[credential-store implementation](https://github.com/greenbone/gvmd/blob/55e5d4c657c48ce52ee340c2439680418bfe1a4d/src/gmp_credential_stores.c).
 The legacy qualification is backed by public python-gvm commit
 [`2bb100fd03f02e598f046e2032e12550b5b14751`](https://github.com/greenbone/python-gvm/blob/2bb100fd03f02e598f046e2032e12550b5b14751/gvm/protocols/gmp/requests/v224/_tls_certificates.py).
 


### PR DESCRIPTION
## What Problem This Solves

GMP clients could not start gvmd's asynchronous scan report export workflow or interpret its created/reused responses. They also had no safe way to distinguish servers that expose `export_scan_report` from servers with the same GMP version that do not.

## Why This Change Was Made

- Add schema-faithful request and response types for `export_scan_report`, including source-default formats and all current optional attributes.
- Require positive XML-help discovery before the versioned client exposes the command, because GMP 22.7/22.8 alone does not prove availability.
- Model created (`201`, no `export_status`) and reused (`200`, optional `export_status`) responses.
- Extend the stateful mock with validation, reuse behavior, help advertisement, and unsupported-version handling.
- Refresh the pinned gvmd command snapshot to `55e5d4c657c48ce52ee340c2439680418bfe1a4d` and document the discovery requirement.

## User Impact

Users can initiate asynchronous exports through both raw and typed clients, inspect whether gvmd created or reused an export, and avoid sending the command when XML-help discovery says it is unavailable.

## Evidence

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gvm-gmp --all-features`
- `cargo test -p gvm-client --all-features`
- `cargo test -p gvm-mock-server --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Upstream schema audit: 155 qualified commands matched the pinned gvmd schema
- Pinned schema SHA-256: `ee7054ffffbdce859f90086b28cdc876eebb8225a2a53ad0f7e8100084e1e0b0`

Fixes greenbone-hive/rust-gvm#519

Agent: Codex Subagent
Model: openai/gpt-5.6-sol
Thinking: high
