### PR TITLE
fix(ci): restore journal auto-merge

### DIFF
--- a/.github/workflows/journal-pr-automation.yml
+++ b/.github/workflows/journal-pr-automation.yml
@@ -5,17 +5,18 @@ on:
     branches: [journal-main]
     types: [opened, reopened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all
 
 jobs:
-  journal-auto-merge-gate:
-    name: Journal Auto-Merge Gate
+  validate-journal-pr:
+    name: Validate Journal PR
     if: >-
       github.event.pull_request.draft == false &&
       startsWith(github.head_ref, 'journal/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Validate changed files are journal entries only
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -37,16 +38,45 @@ jobs:
               core.setFailed(`Non-journal files present: ${invalid.map(file => file.filename).join(', ')}`);
               return;
             }
+
+  journal-auto-merge-gate:
+    name: Journal Auto-Merge Gate
+    needs: validate-journal-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
       - name: Enable squash auto-merge
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;
+            const result = await github.graphql(
+              `query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    id
+                    autoMergeRequest { enabledAt }
+                  }
+                }
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: pr.number,
+              },
+            );
+            const pullRequest = result.repository.pullRequest;
+            if (pullRequest.autoMergeRequest) {
+              core.info(`Auto-merge already enabled at ${pullRequest.autoMergeRequest.enabledAt}`);
+              return;
+            }
             await github.graphql(
               `mutation($pullRequestId:ID!) {
                 enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: SQUASH}) {
                   pullRequest { number autoMergeRequest { enabledAt } }
                 }
               }`,
-              { pullRequestId: pr.node_id },
+              { pullRequestId: pullRequest.id },
             );


### PR DESCRIPTION
## Summary

- split journal-only validation from the auto-merge mutation
- keep validation read-only and grant write authority only to the dependent final job
- preserve the required `Journal Auto-Merge Gate` check name
- make auto-merge enablement idempotent when it was already enabled manually

## Why

This repairs the regression blocking journal PR #520. Security-hardening PR #510 changed the workflow's top-level `contents` permission from `write` to `read`, after which GitHub rejected `enablePullRequestAutoMerge` with `FORBIDDEN: Resource not accessible by integration`.

Restoring top-level write permission would reopen the OpenSSF Token-Permissions finding. Instead, this change follows the repository's existing Scorecard-compatible release pattern: top-level permissions remain read-only, and only the job that performs the write receives job-level `contents: write`.

The `pull_request_target` workflow still does not check out or execute pull-request content. The write-enabled job cannot run until the read-only job has verified that every changed path is a dated journal entry.

## Validation

- checksum-verified `actionlint` 1.7.12 passes
- the exact GraphQL query succeeds against PR #520 and detects its existing `autoMergeRequest`
- `git diff --check` passes
- current Scorecard v5.5.0 evidence gives Token-Permissions 10 while accepting an existing job-level `contents: write` in `release.yml`

The Rust suite was not run because this changes only GitHub Actions orchestration and no Rust source or checked example.

Unblocks #520.

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
