### PR TITLE
docs(journal): add 2026-08-28 update

### DIFF
--- a/journal/2026-08-28.md
+++ b/journal/2026-08-28.md
@@ -1,0 +1,14 @@
+# 2026-08-28 — v0.5.1 Ships as GMP Scope Narrows
+
+## Release
+- Release [v0.5.1](https://github.com/greenbone-hive/rust-gvm/releases/tag/v0.5.1) published with the canonical artifact workflow repaired by pull requests [#516](https://github.com/greenbone-hive/rust-gvm/pull/516), [#517](https://github.com/greenbone-hive/rust-gvm/pull/517), and [#518](https://github.com/greenbone-hive/rust-gvm/pull/518).
+- The release also includes the previously blocked dependency refresh from pull request [#506](https://github.com/greenbone-hive/rust-gvm/pull/506); Cargo Vet and the aggregate Security workflow now pass.
+
+## Project Direction
+- Pull request [#521](https://github.com/greenbone-hive/rust-gvm/pull/521) froze further GMP ticket support, narrowing future protocol expansion to concrete compatibility needs.
+- Issue [#519](https://github.com/greenbone-hive/rust-gvm/issues/519) and green pull request [#522](https://github.com/greenbone-hive/rust-gvm/pull/522) cover one such need: asynchronous `export_scan_report` support for gvmd 26.36.
+- New issues [#523](https://github.com/greenbone-hive/rust-gvm/issues/523) and [#524](https://github.com/greenbone-hive/rust-gvm/issues/524) propose a Rust-native typed execution model and SSH session/exec channel support.
+
+## CI State
+- Supply-chain hardening from pull request [#510](https://github.com/greenbone-hive/rust-gvm/pull/510) landed, and Security plus OpenSSF Scorecard checks are green.
+- Mainline functional CI remains blocked by the downstream live E2E runner failure: `gvm-community-e2e` is still missing from the runner image `PATH`.


### PR DESCRIPTION
## Summary

- record the v0.5.1 release and repaired canonical artifact flow
- capture the GMP scope decision and newly proposed compatibility work
- note the hardened security posture and remaining downstream E2E blocker
