### PR TITLE
docs(journal): add 2026-08-29 update

### DIFF
--- a/journal/2026-08-29.md
+++ b/journal/2026-08-29.md
@@ -1,0 +1,12 @@
+# 2026-08-29 — Release Lands as GMP Scope Moves to Asynchronous Exports
+
+## Release and Supply Chain
+- Release [v0.5.1](https://github.com/greenbone-hive/rust-gvm/releases/tag/v0.5.1) was published after fixes made the release workflow watch tag-triggered runs and publish canonical artifacts.
+- Pull request [#510](https://github.com/greenbone-hive/rust-gvm/pull/510) hardened supply-chain controls, and the pending security dependency refreshes from pull requests [#506](https://github.com/greenbone-hive/rust-gvm/pull/506) and [#507](https://github.com/greenbone-hive/rust-gvm/pull/507) merged along with subsequent dependency updates.
+
+## GMP Direction
+- Pull request [#521](https://github.com/greenbone-hive/rust-gvm/pull/521) merged the decision to freeze further GMP ticket support, aligning the crate with the product boundary adopted by `rust-gvm-api`.
+- Issues [#519](https://github.com/greenbone-hive/rust-gvm/issues/519), [#523](https://github.com/greenbone-hive/rust-gvm/issues/523), and [#524](https://github.com/greenbone-hive/rust-gvm/issues/524) opened work for asynchronous scan-report export, Rust-native typed request/response execution, and SSH session/exec channel mode. Pull request [#522](https://github.com/greenbone-hive/rust-gvm/pull/522) now implements the asynchronous export path and awaits review.
+
+## CI State
+- Mainline Security and OpenSSF Scorecard workflows are green, but aggregate CI is failing because downstream live E2E validation cannot find `gvm-community-e2e` on the runner. Recovery remains dependent on the runner-image repair tracked in `rust-gvm-e2e-tests` pull request [#133](https://github.com/clawosiris/rust-gvm-e2e-tests/pull/133).


### PR DESCRIPTION
## Summary

- record the v0.5.1 release and supply-chain hardening
- document the GMP ticket boundary and asynchronous export direction
- capture the actionable mainline E2E blocker
