### PR TITLE
chore: add repository co-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for repository changes.
-* @g-w
+* @g-w @daniel-grnbn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for repository changes.
-* @g-w @daniel-grnbn
+* @g-w @daniel-grnbn @clawosiris


### PR DESCRIPTION
## Summary

- add `@daniel-grnbn` and the shared agent identity `@clawosiris` as default code owners alongside `@g-w`
- allow either listed owner to satisfy code-owner review requirements for repository changes

## Validation

- `git diff --check origin/main...HEAD`
- verified the outbound commit has a good SSH signature for `clawosiris@gmail.com`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
