### PR TITLE
docs(journal): add 2026-08-30 entry

### DIFF
--- a/journal/2026-08-30.md
+++ b/journal/2026-08-30.md
@@ -1,0 +1,8 @@
+# 2026-08-30 — Asynchronous Report Export Reaches Main
+
+## GMP Delivery
+- Pull request [#522](https://github.com/greenbone-hive/rust-gvm/pull/522) merged asynchronous scan-report export support, completing issue [#519](https://github.com/greenbone-hive/rust-gvm/issues/519).
+- The implementation adds start and poll commands for gvmd's asynchronous export flow, so clients can request large report exports without holding a single synchronous GMP exchange open.
+
+## Repository Ownership
+- Pull request [#528](https://github.com/greenbone-hive/rust-gvm/pull/528) added Daniel Hornung as a repository co-owner, expanding the project's explicit review and ownership coverage.


### PR DESCRIPTION
## Summary

- record the merge of asynchronous scan-report exports
- note the expanded repository ownership coverage

