### PR TITLE
release: prepare v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "gvm-connection",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-connection"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "getrandom 0.4.3",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-gmp"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-mock-server"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "gvm-protocol"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.86.0"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the workspace version from `0.5.1` to `0.6.0`
- update all five workspace package entries in `Cargo.lock`

## Version rationale

`main` adds the public asynchronous scan-report export capability since `v0.5.1`, so this is an additive minor release.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
