### PR TITLE
docs(journal): add 2026-08-31 entry

### DIFF
--- a/journal/2026-08-31.md
+++ b/journal/2026-08-31.md
@@ -1,0 +1,8 @@
+# 2026-08-31 — Dependency Update Queue Exposes a Cargo Vet Gap
+
+## Dependency Maintenance
+- Dependabot opened pull requests [#532](https://github.com/greenbone-hive/rust-gvm/pull/532), [#533](https://github.com/greenbone-hive/rust-gvm/pull/533), and [#534](https://github.com/greenbone-hive/rust-gvm/pull/534) for UUID 1.26, the Rust 1.98 Bookworm image, and four CI action updates.
+- The Rust image and Actions updates are mergeable and green across their reported checks.
+
+## Action Required
+- Pull request #532 is mergeable and passes the functional test matrix, but Cargo Vet fails and makes the aggregate Security check fail. The new UUID release needs the vet policy updated or reviewed before the dependency bump can merge cleanly.


### PR DESCRIPTION
Documents the new dependency update queue and the actionable Cargo Vet failure on the UUID bump.