### PR TITLE
feat(client): add Phase 0 typed GMP execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,26 @@ let response = client.call(targets::get_targets(Default::default())).await?;
 println!("Raw XML: {} bytes", response.data().len());
 ```
 
+#### Statically associated typed execution
+
+The `next` Technology Preview lane also exposes semantic request values whose
+response type is selected at compile time. The first representative slice covers
+version negotiation, authentication, target CRUD, and asynchronous scan-report
+export:
+
+```rust
+use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};
+
+let targets = client
+    .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
+    .await?;
+```
+
+Existing convenience methods, builders, `send`, and `call` remain supported
+while command families migrate incrementally. See
+[Typed request/response execution](docs/typed-execution.md) for the compatibility
+contract, raw escape hatch, and command-authoring guidance.
+
 #### Version-aware client
 
 Use `GmpVersioned` when you need to branch on the server's GMP version:

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -57,7 +57,7 @@ use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
 use gvm_gmp::commands::tasks::create_oci_image_target_task as build_oci_image_target_task;
 use gvm_gmp::commands::tasks::create_web_application_task;
-use gvm_gmp::commands::version::get_version;
+use gvm_gmp::commands::version::GetVersionRequest;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
     get_web_application_target, get_web_application_targets, modify_web_application_target,
@@ -109,6 +109,7 @@ pub use gvm_gmp::commands::web_application_targets::{
     CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
 };
 pub use gvm_gmp::enums::{CredentialStoreCredentialType, FeedType};
+pub use gvm_gmp::{GmpRequest, GmpResponse};
 pub use version::{
     command_supported, map_supported_version, minimum_version_for_command, parse_version_text,
     required_version_label,
@@ -207,7 +208,12 @@ impl<C: GvmConnection> GmpClient<C> {
     ) -> Result<Self, GvmError> {
         connection.connect().await?;
 
-        let response = Self::send_on(&mut connection, get_version(), wire_trace.as_deref()).await?;
+        let response = Self::send_on(
+            &mut connection,
+            GetVersionRequest::new(),
+            wire_trace.as_deref(),
+        )
+        .await?;
         let response = Self::raise_for_status(response)?;
         let version_text = response.child_text("version").ok_or_else(|| {
             GvmError::XmlParse("missing <version> in get_version response".to_string())
@@ -304,6 +310,37 @@ impl<C: GvmConnection> GmpClient<C> {
             self.wire_trace.as_deref(),
         )
         .await
+    }
+
+    /// Execute a semantic request and decode its statically associated response.
+    ///
+    /// This uses [`Self::send`] so command/version/help-discovery checks,
+    /// redacted wire tracing, transport behavior, and typed response errors are
+    /// identical to the compatibility convenience methods.
+    ///
+    /// The request's associated response type is enforced at compile time:
+    ///
+    /// ```compile_fail
+    /// use gvm_client::{GmpClient, GvmError};
+    /// use gvm_connection::GvmConnection;
+    /// use gvm_gmp::commands::version::GetVersionRequest;
+    /// use gvm_gmp::responses::AuthenticateResponse;
+    ///
+    /// async fn mismatched_response<C: GvmConnection>(
+    ///     client: &mut GmpClient<C>,
+    /// ) -> Result<(), GvmError> {
+    ///     let _: AuthenticateResponse = client.execute(GetVersionRequest::new()).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an error if request transmission, command support checks, or
+    /// typed response decoding fails.
+    pub async fn execute<R: GmpRequest>(&mut self, request: R) -> Result<R::Response, GvmError> {
+        let version = self.version;
+        let response = self.send(request).await?;
+        R::Response::decode(&response, version).map_err(GvmError::Parse)
     }
 
     /// Send a request and raise a server error on non-2xx responses.
@@ -1583,6 +1620,15 @@ impl<C: GvmConnection> GmpVersioned<C> {
         self.inner_mut()
             .export_scan_report_raw(report_id, opts)
             .await
+    }
+
+    /// Execute a semantic request and decode its statically associated response.
+    ///
+    /// # Errors
+    /// Returns an error if request transmission, command support checks, or
+    /// typed response decoding fails.
+    pub async fn execute<R: GmpRequest>(&mut self, request: R) -> Result<R::Response, GvmError> {
+        self.inner_mut().execute(request).await
     }
 
     /// Send a request and return the raw parsed response.

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -18,7 +18,7 @@ use gvm_gmp::commands::assets::{
     create_asset, delete_asset, get_assets, modify_asset, AssetType, CreateAssetOpts,
     DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
 };
-use gvm_gmp::commands::authentication::authenticate;
+use gvm_gmp::commands::authentication::AuthenticateRequest;
 use gvm_gmp::commands::configs::{
     clone_config as clone_config_cmd, create_config as create_config_cmd,
     delete_config as delete_config_cmd, get_config as get_config_cmd, get_configs,
@@ -72,12 +72,12 @@ use gvm_gmp::commands::report_formats::{
     GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    export_scan_report, get_audit_report, get_audit_report_hosts, get_report_applications,
-    get_report_closed_cves, get_report_cves, get_report_errors, get_report_export,
-    get_report_export_with_opts, get_report_hosts, get_report_operating_systems, get_report_ports,
-    get_report_tls_certificates, get_report_vulnerabilities, get_report_vulns, get_reports,
-    import_report, ExportScanReportOpts, GetAuditReportHostsOpts, GetAuditReportOpts,
-    GetReportDetailsOpts, GetReportExportOpts, GetReportsOpts, ImportReportOpts,
+    get_audit_report, get_audit_report_hosts, get_report_applications, get_report_closed_cves,
+    get_report_cves, get_report_errors, get_report_export, get_report_export_with_opts,
+    get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
+    get_report_vulnerabilities, get_report_vulns, get_reports, import_report, ExportScanReportOpts,
+    ExportScanReportRequest, GetAuditReportHostsOpts, GetAuditReportOpts, GetReportDetailsOpts,
+    GetReportExportOpts, GetReportsOpts, ImportReportOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -107,8 +107,8 @@ use gvm_gmp::commands::system::{
 use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
 use gvm_gmp::commands::tags::{create_tag, get_tags, GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{
-    create_target, delete_target, get_target as get_target_cmd, get_targets, modify_target,
-    CreateTargetOpts, GetTargetsOpts, ModifyTargetOpts,
+    CreateTargetOpts, CreateTargetRequest, DeleteTargetRequest, GetTargetRequest, GetTargetsOpts,
+    GetTargetsRequest, ModifyTargetOpts, ModifyTargetRequest,
 };
 use gvm_gmp::commands::tasks::{
     create_import_task, create_task, delete_task, get_tasks, modify_task, resume_task, start_task,
@@ -124,7 +124,7 @@ use gvm_gmp::commands::trashcan::{empty_trashcan, restore_from_trashcan};
 use gvm_gmp::commands::users::{
     create_user, get_users, modify_user, GetUsersOpts, ModifyUserOpts, UserOpts,
 };
-use gvm_gmp::commands::version::get_version;
+use gvm_gmp::commands::version::GetVersionRequest;
 use gvm_gmp::commands::web_application_targets::{
     clone_web_application_target, create_web_application_target, delete_web_application_target,
     get_web_application_target, get_web_application_targets, modify_web_application_target,
@@ -179,8 +179,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_version(&mut self) -> Result<GetVersionResponse, GvmError> {
-        let response = self.send(get_version()).await?;
-        GetVersionResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetVersionRequest::new()).await
     }
 
     /// Send an `authenticate` request and return a typed [`AuthenticateResponse`].
@@ -192,8 +191,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         username: &str,
         password: &str,
     ) -> Result<AuthenticateResponse, GvmError> {
-        let response = self.send(authenticate(username, password)).await?;
-        AuthenticateResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(AuthenticateRequest::new(username, password))
+            .await
     }
 
     // ── Targets ───────────────────────────────────────────────────────────────
@@ -206,8 +205,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetTargetsOpts,
     ) -> Result<GetTargetsResponse, GvmError> {
-        let response = self.send(get_targets(opts)).await?;
-        GetTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetTargetsRequest::new(opts)).await
     }
 
     /// Send a detailed `get_targets` request for one target and return a typed
@@ -219,8 +217,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         target_id: &EntityId,
     ) -> Result<GetTargetsResponse, GvmError> {
-        let response = self.send(get_target_cmd(target_id)).await?;
-        GetTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetTargetRequest::new(target_id.clone())).await
     }
 
     /// Send a `create_target` request and return a typed [`CreateTargetResponse`].
@@ -232,9 +229,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         name: &str,
         opts: CreateTargetOpts,
     ) -> Result<CreateTargetResponse, GvmError> {
-        let request = create_target(name, opts)?;
-        let response = self.send(request).await?;
-        CreateTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        let request = CreateTargetRequest::new(name, opts)?;
+        self.execute(request).await
     }
 
     /// Send a `modify_target` request and return a typed [`ModifyTargetResponse`].
@@ -246,9 +242,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         target_id: &EntityId,
         opts: ModifyTargetOpts,
     ) -> Result<ModifyTargetResponse, GvmError> {
-        let request = modify_target(target_id, opts)?;
-        let response = self.send(request).await?;
-        ModifyTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        let request = ModifyTargetRequest::new(target_id.clone(), opts)?;
+        self.execute(request).await
     }
 
     /// Send a `delete_target` request and return a typed [`DeleteTargetResponse`].
@@ -260,8 +255,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         target_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteTargetResponse, GvmError> {
-        let response = self.send(delete_target(target_id, ultimate)).await?;
-        DeleteTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteTargetRequest::new(target_id.clone(), ultimate))
+            .await
     }
 
     /// Send a `create_oci_image_target` request and return a typed
@@ -987,8 +982,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: ExportScanReportOpts,
     ) -> Result<ExportScanReportResponse, GvmError> {
-        let response = self.send(export_scan_report(report_id, opts)).await?;
-        ExportScanReportResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ExportScanReportRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_vulns` request and return a typed [`GetReportVulnsResponse`].

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -29,7 +29,7 @@ use gvm_gmp::commands::scanners::GetScannersOpts;
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::GetSecInfoOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
-use gvm_gmp::commands::targets::{GetTargetsOpts, ModifyTargetOpts};
+use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest, ModifyTargetOpts};
 use gvm_gmp::commands::tasks::{GetTasksOpts, ModifyTaskOpts};
 use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, TicketOpenNote};
 use gvm_gmp::commands::tls_certificates::{GetTlsCertificatesOpts, TlsCertificateOpts};
@@ -104,6 +104,30 @@ macro_rules! create_response {
             r#" status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#
         )
     };
+}
+
+#[tokio::test]
+async fn generic_execute_decodes_the_requests_associated_response() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_7,
+        &[(
+            "get_targets",
+            r#"<get_targets_response status="200" status_text="OK"/>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+
+    let response = client
+        .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
+        .await
+        .expect("associated response should decode");
+
+    assert_eq!(response.status, 200);
+    assert!(response.items.is_empty());
 }
 
 const MUTATION_SUCCESS_OVERRIDES: &[(&str, &str)] = &[

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -19,6 +19,7 @@ use gvm_gmp::commands::agents::get_agents;
 use gvm_gmp::commands::credentials::{create_credential, verify_credential_store, CredentialOpts};
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::commands::reports::{get_scan_report, GetScanReportOpts};
+use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 
@@ -772,6 +773,31 @@ async fn versioned_scan_report_export_requires_then_uses_help_discovery() {
         .expect_err("missing report should reach the mock");
     assert!(matches!(error, GvmError::Server { status: 404, .. }));
 
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn versioned_execute_forwards_and_decodes_the_associated_response() {
+    let Some(server) = stateful_server(MockVersion::V22_7).await else {
+        return;
+    };
+    let mut client = GmpVersioned::connect(unix_connection(&server))
+        .await
+        .expect("client should connect");
+
+    client
+        .call(gvm_gmp::commands::authentication::authenticate(
+            "admin", "admin",
+        ))
+        .await
+        .expect("authenticate should succeed");
+    let response = client
+        .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
+        .await
+        .expect("versioned execute should decode targets");
+
+    assert_eq!(response.status, 200);
+    assert!(response.items.is_empty());
     server.shutdown().await;
 }
 

--- a/crates/gvm-gmp/src/commands/authentication.rs
+++ b/crates/gvm-gmp/src/commands/authentication.rs
@@ -3,7 +3,48 @@
 
 //! Authentication command builders.
 
+use std::fmt;
+
 use gvm_protocol::{Request, XmlCommand};
+
+use crate::responses::AuthenticateResponse;
+use crate::GmpRequest;
+
+/// Semantic `authenticate` request.
+#[derive(Clone)]
+pub struct AuthenticateRequest {
+    username: String,
+    password: String,
+}
+
+impl AuthenticateRequest {
+    /// Create an authentication request.
+    #[must_use]
+    pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+impl fmt::Debug for AuthenticateRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthenticateRequest")
+            .field("credentials", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Request for AuthenticateRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        authenticate(&self.username, &self.password).to_bytes()
+    }
+}
+
+impl GmpRequest for AuthenticateRequest {
+    type Response = AuthenticateResponse;
+}
 
 /// Build an `authenticate` request.
 #[must_use]
@@ -26,5 +67,15 @@ mod tests {
             xml(authenticate("admin", "pass")),
             "<authenticate><credentials><username>admin</username><password>pass</password></credentials></authenticate>"
         );
+    }
+
+    #[test]
+    fn semantic_request_matches_builder_bytes_and_redacts_debug() {
+        let request = AuthenticateRequest::new("admin", "pass");
+        assert_eq!(request.to_bytes(), authenticate("admin", "pass").to_bytes());
+        let debug = format!("{request:?}");
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("admin"));
+        assert!(!debug.contains("pass"));
     }
 }

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -10,8 +10,9 @@ use crate::common::{
     add_filter_attrs, add_optional_id_element, bool_str, set_optional_bool_attr,
     validate_single_xml_document,
 };
-use crate::responses::ParseError;
+use crate::responses::{ExportScanReportResponse, ParseError};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for `create_report` requests.
 #[derive(Debug, Clone, Default)]
@@ -112,6 +113,31 @@ pub struct ExportScanReportOpts {
     pub overrides_details: Option<bool>,
     /// Whether result tags are included.
     pub result_tags: Option<bool>,
+}
+
+/// Semantic request for queuing or reusing an asynchronous report export.
+#[derive(Debug, Clone)]
+pub struct ExportScanReportRequest {
+    report_id: EntityId,
+    opts: ExportScanReportOpts,
+}
+
+impl ExportScanReportRequest {
+    /// Create an asynchronous scan-report export request.
+    #[must_use]
+    pub fn new(report_id: EntityId, opts: ExportScanReportOpts) -> Self {
+        Self { report_id, opts }
+    }
+}
+
+impl Request for ExportScanReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        export_scan_report(&self.report_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ExportScanReportRequest {
+    type Response = ExportScanReportResponse;
 }
 
 impl GetReportExportOpts {
@@ -488,6 +514,30 @@ mod tests {
         assert_eq!(
             xml(delete_report(&id("r1"), false)),
             "<delete_report report_id=\"r1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn semantic_scan_report_export_matches_legacy_builder_bytes() {
+        let report_id = id("report-1");
+        let opts = ExportScanReportOpts {
+            format_id: Some(id("format-1")),
+            config_id: Some(id("config-1")),
+            filter_string: Some("severity>5".into()),
+            ignore_pagination: Some(true),
+            lean: Some(false),
+            notes_details: Some(true),
+            overrides_details: Some(false),
+            result_tags: Some(true),
+        };
+
+        let semantic = ExportScanReportRequest::new(report_id.clone(), opts.clone());
+        let legacy = export_scan_report(&report_id, opts);
+
+        assert_eq!(semantic.to_bytes(), legacy.to_bytes());
+        assert_eq!(
+            semantic.to_bytes(),
+            br#"<export_scan_report config_id="config-1" filter="severity&gt;5" format_id="format-1" ignore_pagination="1" lean="0" notes_details="1" overrides_details="0" report_id="report-1" result_tags="1"/>"#
         );
     }
 

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -10,8 +10,12 @@ use crate::common::{
     set_optional_bool_attr,
 };
 use crate::enums::AliveTest;
+use crate::responses::{
+    CreateTargetResponse, DeleteTargetResponse, GetTargetsResponse, ModifyTargetResponse,
+};
 use crate::target::{TargetHost, TargetHosts, TargetPortSelection};
 use crate::types::{EntityId, ScalarUpdate, ServicePort};
+use crate::GmpRequest;
 
 /// Required and optional fields for `create_target` requests.
 #[derive(Debug, Clone)]
@@ -167,6 +171,141 @@ pub enum ModifyTargetError {
     SmbAndKrb5Credentials,
 }
 
+/// Semantic request for listing targets.
+#[derive(Debug, Clone, Default)]
+pub struct GetTargetsRequest {
+    opts: GetTargetsOpts,
+}
+
+impl GetTargetsRequest {
+    /// Create a target-list request.
+    #[must_use]
+    pub fn new(opts: GetTargetsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetTargetsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_targets(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetTargetsRequest {
+    type Response = GetTargetsResponse;
+}
+
+/// Semantic request for one detailed target.
+#[derive(Debug, Clone)]
+pub struct GetTargetRequest {
+    target_id: EntityId,
+}
+
+impl GetTargetRequest {
+    /// Create a detailed single-target request.
+    #[must_use]
+    pub fn new(target_id: EntityId) -> Self {
+        Self { target_id }
+    }
+}
+
+impl Request for GetTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_target(&self.target_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetTargetRequest {
+    type Response = GetTargetsResponse;
+}
+
+/// Semantic request for creating a target.
+#[derive(Debug, Clone)]
+pub struct CreateTargetRequest {
+    name: String,
+    opts: CreateTargetOpts,
+}
+
+impl CreateTargetRequest {
+    /// Validate and create a target-creation request.
+    ///
+    /// # Errors
+    /// Returns the same construction errors as [`create_target`].
+    pub fn new(name: impl Into<String>, opts: CreateTargetOpts) -> Result<Self, CreateTargetError> {
+        validate_create_target_opts(&opts)?;
+        Ok(Self {
+            name: name.into(),
+            opts,
+        })
+    }
+}
+
+impl Request for CreateTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_target_command(&self.name, &self.opts).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateTargetRequest {
+    type Response = CreateTargetResponse;
+}
+
+/// Semantic request for modifying a target.
+#[derive(Debug, Clone)]
+pub struct ModifyTargetRequest {
+    target_id: EntityId,
+    opts: ModifyTargetOpts,
+}
+
+impl ModifyTargetRequest {
+    /// Validate and create a target-modification request.
+    ///
+    /// # Errors
+    /// Returns the same construction errors as [`modify_target`].
+    pub fn new(target_id: EntityId, opts: ModifyTargetOpts) -> Result<Self, ModifyTargetError> {
+        validate_modify_target_opts(&opts)?;
+        Ok(Self { target_id, opts })
+    }
+}
+
+impl Request for ModifyTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_target_command(&self.target_id, &self.opts).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyTargetRequest {
+    type Response = ModifyTargetResponse;
+}
+
+/// Semantic request for deleting a target.
+#[derive(Debug, Clone)]
+pub struct DeleteTargetRequest {
+    target_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteTargetRequest {
+    /// Create a target-deletion request.
+    #[must_use]
+    pub fn new(target_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            target_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_target(&self.target_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteTargetRequest {
+    type Response = DeleteTargetResponse;
+}
+
 /// Build a clone request for an existing target.
 #[must_use]
 pub fn clone_target(target_id: &EntityId) -> impl Request {
@@ -182,6 +321,11 @@ pub fn create_target(
     name: &str,
     opts: CreateTargetOpts,
 ) -> Result<impl Request, CreateTargetError> {
+    validate_create_target_opts(&opts)?;
+    Ok(create_target_command(name, &opts))
+}
+
+fn validate_create_target_opts(opts: &CreateTargetOpts) -> Result<(), CreateTargetError> {
     if opts.ssh_credential_port.is_some() && opts.ssh_credential_id.is_none() {
         return Err(CreateTargetError::SshPortWithoutCredential);
     }
@@ -198,6 +342,10 @@ pub fn create_target(
     if opts.smb_credential_id.is_some() && opts.krb5_credential_id.is_some() {
         return Err(CreateTargetError::SmbAndKrb5Credentials);
     }
+    Ok(())
+}
+
+fn create_target_command(name: &str, opts: &CreateTargetOpts) -> XmlCommand {
     let mut cmd = XmlCommand::new("create_target");
     cmd.add_element_with_text("name", name);
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -214,7 +362,7 @@ pub fn create_target(
             cmd.add_element_with_text("port_range", port_range.as_str());
         }
     }
-    add_create_target_credentials(&mut cmd, &opts);
+    add_create_target_credentials(&mut cmd, opts);
     if let Some(value) = opts.reverse_lookup_only {
         cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
     }
@@ -224,7 +372,7 @@ pub fn create_target(
     if let Some(value) = opts.allow_simultaneous_ips {
         cmd.add_element_with_text("allow_simultaneous_ips", bool_str(value));
     }
-    Ok(cmd)
+    cmd
 }
 
 /// Build a `get_targets` request.
@@ -259,6 +407,11 @@ pub fn modify_target(
     target_id: &EntityId,
     opts: ModifyTargetOpts,
 ) -> Result<impl Request, ModifyTargetError> {
+    validate_modify_target_opts(&opts)?;
+    Ok(modify_target_command(target_id, &opts))
+}
+
+fn validate_modify_target_opts(opts: &ModifyTargetOpts) -> Result<(), ModifyTargetError> {
     if matches!(opts.port_list_id, ScalarUpdate::Clear) {
         return Err(ModifyTargetError::UnsupportedPortListClear);
     }
@@ -288,6 +441,10 @@ pub fn modify_target(
     {
         return Err(ModifyTargetError::SmbAndKrb5Credentials);
     }
+    Ok(())
+}
+
+fn modify_target_command(target_id: &EntityId, opts: &ModifyTargetOpts) -> XmlCommand {
     let mut cmd = XmlCommand::new("modify_target").attribute("target_id", target_id.as_str());
     add_text_element(&mut cmd, "name", opts.name.as_deref());
     add_text_element(&mut cmd, "comment", opts.comment.as_deref());
@@ -301,7 +458,7 @@ pub fn modify_target(
     if let ScalarUpdate::Set(port_list_id) = &opts.port_list_id {
         add_optional_id_element(&mut cmd, "port_list", Some(port_list_id));
     }
-    add_modify_target_credentials(&mut cmd, &opts);
+    add_modify_target_credentials(&mut cmd, opts);
     if let Some(value) = opts.reverse_lookup_only {
         cmd.add_element_with_text("reverse_lookup_only", bool_str(value));
     }
@@ -311,7 +468,7 @@ pub fn modify_target(
     if let Some(value) = opts.allow_simultaneous_ips {
         cmd.add_element_with_text("allow_simultaneous_ips", bool_str(value));
     }
-    Ok(cmd)
+    cmd
 }
 
 /// Build a `delete_target` request.
@@ -506,6 +663,55 @@ mod tests {
         assert_eq!(
             xml(delete_target(&id("t1"), false)),
             "<delete_target target_id=\"t1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn semantic_target_requests_match_legacy_builder_bytes() {
+        let list_opts = GetTargetsOpts {
+            filter_string: Some("name=production".into()),
+            details: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(
+            GetTargetsRequest::new(list_opts.clone()).to_bytes(),
+            get_targets(list_opts).to_bytes()
+        );
+
+        let target_id = id("target-1");
+        assert_eq!(
+            GetTargetRequest::new(target_id.clone()).to_bytes(),
+            get_target(&target_id).to_bytes()
+        );
+
+        let create_opts =
+            CreateTargetOpts::new(hosts(&["192.0.2.1"], &["192.0.2.2"]), direct_ports());
+        assert_eq!(
+            CreateTargetRequest::new("production", create_opts.clone())
+                .expect("valid semantic create request")
+                .to_bytes(),
+            create_target("production", create_opts)
+                .expect("valid legacy create request")
+                .to_bytes()
+        );
+
+        let modify_opts = ModifyTargetOpts {
+            name: Some("renamed".into()),
+            allow_simultaneous_ips: Some(false),
+            ..Default::default()
+        };
+        assert_eq!(
+            ModifyTargetRequest::new(target_id.clone(), modify_opts.clone())
+                .expect("valid semantic modify request")
+                .to_bytes(),
+            modify_target(&target_id, modify_opts)
+                .expect("valid legacy modify request")
+                .to_bytes()
+        );
+
+        assert_eq!(
+            DeleteTargetRequest::new(target_id.clone(), true).to_bytes(),
+            delete_target(&target_id, true).to_bytes()
         );
     }
 

--- a/crates/gvm-gmp/src/commands/version.rs
+++ b/crates/gvm-gmp/src/commands/version.rs
@@ -5,6 +5,31 @@
 
 use gvm_protocol::{Request, XmlCommand};
 
+use crate::responses::GetVersionResponse;
+use crate::GmpRequest;
+
+/// Semantic `get_version` request.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetVersionRequest;
+
+impl GetVersionRequest {
+    /// Create a version request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for GetVersionRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_version().to_bytes()
+    }
+}
+
+impl GmpRequest for GetVersionRequest {
+    type Response = GetVersionResponse;
+}
+
 /// Build a `get_version` command.
 #[must_use]
 pub fn get_version() -> impl Request {
@@ -19,5 +44,13 @@ mod tests {
     #[test]
     fn get_version_builds_xml() {
         assert_eq!(xml(get_version()), "<get_version/>");
+    }
+
+    #[test]
+    fn semantic_request_matches_builder_bytes() {
+        assert_eq!(
+            GetVersionRequest::new().to_bytes(),
+            get_version().to_bytes()
+        );
     }
 }

--- a/crates/gvm-gmp/src/execution.rs
+++ b/crates/gvm-gmp/src/execution.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+//! Statically associated GMP request and response contracts.
+
+use gvm_protocol::{Request, Response};
+
+use crate::{responses::ParseError, GmpVersion};
+
+/// A semantic GMP request whose response type is known at compile time.
+///
+/// Encoding remains the responsibility of [`Request`], so typed execution and
+/// the raw/custom request escape hatch share the same XML command machinery.
+///
+/// A request cannot be associated with an unrelated response type:
+///
+/// ```compile_fail
+/// use gvm_gmp::commands::version::GetVersionRequest;
+/// use gvm_gmp::responses::AuthenticateResponse;
+/// use gvm_gmp::GmpRequest;
+///
+/// fn require_authentication<R: GmpRequest<Response = AuthenticateResponse>>(_: R) {}
+/// require_authentication(GetVersionRequest::new());
+/// ```
+pub trait GmpRequest: Request {
+    /// The only typed response produced by this request.
+    type Response: GmpResponse;
+}
+
+/// A typed GMP response that can decode the protocol response envelope.
+pub trait GmpResponse: Sized {
+    /// Decode a typed value from a raw GMP response.
+    ///
+    /// The negotiated `version` is available to response models whose wire
+    /// shape varies by GMP version. Models that are version-independent may
+    /// ignore it.
+    ///
+    /// # Errors
+    /// Returns the response model's existing parse or server-status error.
+    fn decode(response: &Response, version: GmpVersion) -> Result<Self, ParseError>;
+}

--- a/crates/gvm-gmp/src/lib.rs
+++ b/crates/gvm-gmp/src/lib.rs
@@ -12,6 +12,8 @@ pub mod commands;
 mod common;
 /// GMP enums and wire-format helpers.
 pub mod enums;
+/// Statically associated semantic request and response contracts.
+pub mod execution;
 /// Shared gvmd filter composition helpers.
 pub mod filtering;
 /// Typed GMP response models.
@@ -25,6 +27,8 @@ pub mod types;
 
 /// Re-exported GMP enums.
 pub use enums::*;
+/// Re-exported typed execution contracts.
+pub use execution::{GmpRequest, GmpResponse};
 /// Re-exported gvmd filter helpers.
 pub use filtering::{FilterFragment, FilterFragmentError, PaginatedFilter, Pagination};
 /// Re-exported typed schedule values.

--- a/crates/gvm-gmp/src/responses/auth.rs
+++ b/crates/gvm-gmp/src/responses/auth.rs
@@ -6,6 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{parse_document, status_from_response, ParseError};
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -23,6 +24,12 @@ impl AuthenticateResponse {
             status,
             status_text,
         })
+    }
+}
+
+impl GmpResponse for AuthenticateResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/common.rs
+++ b/crates/gvm-gmp/src/responses/common.rs
@@ -10,7 +10,7 @@ use gvm_protocol::Response;
 use quick_xml::events::Event;
 use quick_xml::{Reader, XmlVersion};
 
-use crate::EntityId;
+use crate::{EntityId, GmpResponse, GmpVersion};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
@@ -75,6 +75,12 @@ impl ActionResponse {
             status,
             status_text,
         })
+    }
+}
+
+impl GmpResponse for ActionResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -13,6 +13,7 @@ use crate::responses::common::{
     parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
     ParseError,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
@@ -408,6 +409,12 @@ impl ExportScanReportResponse {
             id,
             export_status: root.attr("export_status").map(ToString::to_string),
         })
+    }
+}
+
+impl GmpResponse for ExportScanReportResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/target.rs
+++ b/crates/gvm-gmp/src/responses/target.rs
@@ -10,7 +10,7 @@ use crate::responses::common::{
     parse_named_entity, parse_u16, status_from_response, ActionResponse, CountInfo, EntityMeta,
     NamedEntity, ParseError,
 };
-use crate::ServicePort;
+use crate::{GmpResponse, GmpVersion, ServicePort};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -136,6 +136,12 @@ impl GetTargetsResponse {
     }
 }
 
+impl GmpResponse for GetTargetsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateTargetResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -150,6 +156,12 @@ impl CreateTargetResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateTargetResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/version.rs
+++ b/crates/gvm-gmp/src/responses/version.rs
@@ -6,6 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{parse_document, status_from_response, ParseError};
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -25,6 +26,12 @@ impl GetVersionResponse {
             status_text,
             version: root.required_child_text("version")?,
         })
+    }
+}
+
+impl GmpResponse for GetVersionResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-08-10
+Last updated: 2026-08-31
 
 ## Support Direction
 
@@ -9,6 +9,15 @@ rust-gvm is intended to track current GMP/GVMD behavior directly. python-gvm com
 See [ROADMAP.md](ROADMAP.md) for the version support stance, compatibility policy, known coverage gaps, and follow-up work.
 
 ## Crate Status
+
+The `next` Technology Preview lane now includes the first statically associated
+typed-execution slice. `GmpRequest` binds a semantic request to one
+`GmpResponse`, and `GmpClient::execute` preserves existing command gates,
+redacted tracing, parsing, and compatibility APIs. Version/authentication,
+target list/get/create/modify/delete, and asynchronous report export prove the
+contract before family-by-family migration. See
+[ADR 0001](adr/0001-typed-request-response-execution.md) and the
+[typed-execution guide](typed-execution.md).
 
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|

--- a/docs/adr/0001-typed-request-response-execution.md
+++ b/docs/adr/0001-typed-request-response-execution.md
@@ -1,0 +1,104 @@
+# ADR 0001: Typed request/response execution
+
+- Status: Accepted for the `next` Technology Preview lane
+- Date: 2026-08-31
+- Tracking issue: [#523](https://github.com/greenbone-hive/rust-gvm/issues/523)
+
+## Context
+
+`rust-gvm` already separates transports, raw XML framing, GMP command builders,
+and typed response models. The high-level client previously reconnected a
+builder and its parser in command-specific methods, while raw callers could pair
+a request with the wrong response parser. Replacing hundreds of builders in one
+change would create unnecessary compatibility and review risk.
+
+The first production slice must prove one generic contract across version
+negotiation, authentication, target list/get/create/modify/delete, and the
+irregular asynchronous scan-report export command. Existing builders, raw
+requests, convenience methods, transports, mock behavior, redaction, and error
+semantics must remain available.
+
+## Decision
+
+### Ownership
+
+- `gvm-protocol` retains only transport-independent raw `Request`, `Response`,
+  XML construction, parsing, and framing.
+- `gvm-gmp` owns semantic request structs, typed response models,
+  `GmpRequest`, and `GmpResponse` because those contracts name GMP resources and
+  commands.
+- `gvm-client` owns negotiated-version and help-discovery checks, transport,
+  tracing, and `GmpClient::execute` / `GmpVersioned::execute`.
+
+### Request encoding
+
+`GmpRequest` extends the existing `gvm_protocol::Request` contract and has one
+associated `GmpResponse`. Semantic request structs implement `Request` by
+delegating to the existing command builders. The builders therefore remain the
+single wire-encoding implementation and the compatibility oracle during the
+incremental migration.
+
+Validation that can fail occurs in semantic request constructors, just as it
+does in the existing fallible builders. The representative slice has no
+version-dependent request bytes. The client still checks the encoded semantic
+command against the negotiated version and help-discovery state before sending.
+When a later family needs different bytes for different GMP versions, it must
+use distinct semantic request types or introduce a reviewed internal codec
+extension; it must not hide version branching in transport code.
+
+### Response decoding and errors
+
+`GmpResponse::decode` receives both the raw `Response` and negotiated
+`GmpVersion`. Version-independent models delegate to their existing
+`from_response` parser. This leaves room for explicitly version-dependent
+response shapes without moving protocol semantics into the client.
+
+`execute` intentionally follows the existing typed-facade path: it calls
+`send`, then invokes the associated response decoder. It does not call `call`.
+Consequently, non-2xx statuses continue to become
+`GvmError::Parse(ParseError::ServerError { .. })` for typed methods, while raw
+`call` continues to return `GvmError::Server`. Parse-error context and public
+error behavior remain compatible.
+
+Version negotiation is the bootstrap exception. `GmpClient::connect` sends a
+`GetVersionRequest`, but parses and validates the advertised version before a
+negotiated `GmpVersion` exists. Later explicit `get_version` calls use
+`execute` normally.
+
+### Compatibility and security
+
+- Existing command-builder functions and typed convenience methods remain
+  public. Converted convenience methods are thin wrappers over semantic request
+  construction and `execute`.
+- `send` and `call` remain the raw/custom escape hatch for commands that have
+  not migrated or require caller-owned XML.
+- `execute` reuses `send`, preserving version/help gates and redacted wire
+  tracing before bytes reach observers.
+- `AuthenticateRequest` has a custom redacted `Debug` implementation; request
+  bytes still pass through the existing structural wire redactor.
+- Asynchronous report export uses the same typed contract but retains its
+  positive XML-help-discovery requirement.
+
+## Consequences
+
+The compiler now selects the response from the request type, and callers cannot
+ask `execute` to decode an unrelated response. New families can migrate without
+removing their old builders or changing downstream behavior. There is temporary
+duplication between semantic request structs and builder function signatures,
+but no duplicated XML encoder.
+
+This ADR does not authorize a repository-wide conversion or removal of old
+APIs. Trait naming and details remain Technology Preview until more standard and
+version-irregular families have exercised the contract.
+
+## Validation
+
+- Compile-fail documentation proves `GetVersionRequest` cannot satisfy a
+  request bound associated with `AuthenticateResponse`.
+- Exact-byte tests compare every representative semantic request with its
+  existing builder, including target validation and asynchronous report export.
+- Client integration tests exercise `execute`, compatibility wrappers,
+  non-success and malformed responses, command-version/help gates, and wire
+  redaction.
+- Workspace formatting, tests, strict Clippy, documentation, and additive API
+  checks remain required before merge.

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -1,0 +1,66 @@
+# Typed request/response execution
+
+The `next` Technology Preview lane provides an additive typed execution API.
+Each migrated semantic request implements `GmpRequest` and selects exactly one
+`GmpResponse` through an associated type:
+
+```rust
+use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};
+
+let response = client
+    .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
+    .await?;
+```
+
+No response type annotation or manual `from_response` call is required. Passing
+the request to `execute` determines the result type at compile time.
+
+## Compatibility APIs
+
+Existing typed convenience methods remain supported. For migrated commands they
+construct the same semantic request and delegate to `execute`:
+
+```rust
+let response = client.get_targets(GetTargetsOpts::default()).await?;
+```
+
+Existing command builders plus `send` and `call` also remain supported. Use
+them for custom XML, commands that have not migrated, or response details not
+yet represented by a typed model:
+
+```rust
+use gvm_gmp::commands::targets;
+
+let raw = client
+    .call(targets::get_targets(GetTargetsOpts::default()))
+    .await?;
+```
+
+`send` returns any GMP status as a raw response. `call` raises
+`GvmError::Server` for a non-2xx status. Typed decoders preserve the existing
+typed-facade behavior and report non-2xx statuses through
+`GvmError::Parse(ParseError::ServerError { .. })`.
+
+## Authoring a migrated command
+
+1. Define a semantic request struct in the owning `gvm-gmp` command module.
+2. Validate fallible input in its constructor, reusing the legacy builder's
+   validation rather than delaying failures until transport execution.
+3. Implement `Request` by delegating to the existing builder so only one XML
+   encoding path exists. Preserve `semantic_command_name` metadata when the
+   wire root has a different capability name.
+4. Implement `GmpRequest` and associate exactly one response model.
+5. Implement `GmpResponse` on that existing response model. Use the negotiated
+   version only when the response wire shape genuinely differs by version.
+6. Convert the existing convenience method into a thin `execute` wrapper; do
+   not remove the builder or raw path.
+7. Add exact byte-equivalence, response parsing, version/help gating,
+   non-success, malformed-response, and redaction tests as applicable.
+
+Irregular commands are first-class. They may retain explicit XML codecs and do
+not need Serde derives. A request whose encoding genuinely differs by GMP
+version must make that distinction explicit in the GMP layer; transport code is
+not the place for command-specific branching.
+
+See [ADR 0001](adr/0001-typed-request-response-execution.md) for ownership,
+compatibility, error, and security decisions.


### PR DESCRIPTION
## What Problem This Solves

Phase 0 of #523 needs to prove that semantic Rust requests can select their response types at compile time without replacing the mature GMP encoding, transport, compatibility, version-policy, or security paths.

## Why This Change Was Made

This introduces the smallest production-quality vertical slice: `GmpRequest`, `GmpResponse`, and generic execution remain owned by the GMP/client layers, while semantic requests delegate to the existing builders as the single wire encoder. The accompanying ADR records trait placement, error ownership, version policy, encoding strategy, and compatibility decisions before more command families migrate.

## User Impact

- Adds `GmpClient::execute` and `GmpVersioned::execute` with compile-time request/response association.
- Covers version, authentication, target list/get/create/modify/delete, and asynchronous scan-report export.
- Preserves existing builders, convenience methods, `send`, and `call` as compatible APIs and raw escape hatches.
- Preserves version/help gates, response-error behavior, redacted tracing, and request validation.
- Adds usage/authoring guidance and ADR 0001 for incremental follow-on work.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test --workspace` on stable and Rust 1.86.0
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo audit`, `cargo deny check`, `cargo vet`, and `cargo machete`
- Coverage policy regression and all-feature workspace coverage gate: 94.32% lines / 96.29% regions
- Exact request-byte equivalence, mock-server response parsing, compatibility wrappers, version/help gates, error mapping, redaction, and compile-fail association checks
- Signed commit verified for `clawosiris@gmail.com`

Implements Phase 0 of #523. The tracker remains open for later migration phases.

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
