### PR TITLE
test(client): lock typed execution foundation

### DIFF
--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -2284,7 +2284,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connect_with_wire_trace_emits_redacted_typed_helper_events() {
+    async fn execute_redacts_wire_bytes_before_trace_observation() {
         let connection =
             ScriptedConnection::new([version_response("22.7"), auth_response().to_string()]);
         let sent = connection.sent();
@@ -2298,7 +2298,10 @@ mod tests {
         .expect("client connects");
 
         client
-            .authenticate("admin", "secret-password")
+            .execute(gvm_gmp::commands::authentication::AuthenticateRequest::new(
+                "admin",
+                "secret-password",
+            ))
             .await
             .expect("authenticate succeeds");
 

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -34,11 +34,29 @@ use gvm_gmp::commands::tasks::{GetTasksOpts, ModifyTaskOpts};
 use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, TicketOpenNote};
 use gvm_gmp::commands::tls_certificates::{GetTlsCertificatesOpts, TlsCertificateOpts};
 use gvm_gmp::commands::users::{GetUsersOpts, UserOpts};
-use gvm_gmp::responses::ParseError;
+use gvm_gmp::responses::{ActionResponse, ParseError};
 use gvm_gmp::types::{EntityId, GmpVersion, ScalarUpdate};
+use gvm_gmp::GmpRequest;
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
+use gvm_protocol::Request;
 
 const CREATED_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+struct SemanticAliasRequest;
+
+impl Request for SemanticAliasRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        b"<get_reports/>".to_vec()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some("get_report_export")
+    }
+}
+
+impl GmpRequest for SemanticAliasRequest {
+    type Response = ActionResponse;
+}
 
 fn id(value: &str) -> EntityId {
     EntityId::new(value).expect("test entity id")
@@ -128,6 +146,31 @@ async fn generic_execute_decodes_the_requests_associated_response() {
 
     assert_eq!(response.status, 200);
     assert!(response.items.is_empty());
+}
+
+#[tokio::test]
+async fn generic_execute_preserves_semantic_alias_version_checks() {
+    let Some(server) = fixture_server(MockVersion::V22_7, &[]).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+
+    let error = client
+        .execute(SemanticAliasRequest)
+        .await
+        .expect_err("semantic alias should be checked before sending the wire command");
+
+    assert!(matches!(
+        error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "get_report_export"
+    ));
+    assert!(server.command_history().is_empty());
+    server.shutdown().await;
 }
 
 const MUTATION_SUCCESS_OVERRIDES: &[(&str, &str)] = &[
@@ -724,7 +767,7 @@ async fn asynchronous_scan_report_export_rejects_negative_help_discovery_on_22_8
 }
 
 #[tokio::test]
-async fn typed_facade_maps_server_status_and_malformed_payload_errors() {
+async fn generic_execute_preserves_server_status_and_parse_error_context() {
     let Some(status_server) = fixture_server(
         MockVersion::V22_8,
         &[(
@@ -738,7 +781,7 @@ async fn typed_facade_maps_server_status_and_malformed_payload_errors() {
     };
     let mut status_client = client(&status_server).await;
     let status_error = status_client
-        .get_targets(GetTargetsOpts::default())
+        .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
         .await
         .expect_err("server status should fail");
     assert!(matches!(
@@ -763,7 +806,7 @@ async fn typed_facade_maps_server_status_and_malformed_payload_errors() {
     };
     let mut malformed_client = client(&malformed_server).await;
     let malformed_error = malformed_client
-        .get_targets(GetTargetsOpts::default())
+        .execute(GetTargetsRequest::new(GetTargetsOpts::default()))
         .await
         .expect_err("malformed typed payload should fail");
     assert!(matches!(

--- a/crates/gvm-gmp/src/execution.rs
+++ b/crates/gvm-gmp/src/execution.rs
@@ -11,6 +11,55 @@ use crate::{responses::ParseError, GmpVersion};
 ///
 /// Encoding remains the responsibility of [`Request`], so typed execution and
 /// the raw/custom request escape hatch share the same XML command machinery.
+/// Implementations may delegate to a public builder or provide an explicit
+/// codec for irregular/custom XML. [`Request::semantic_command_name`] remains
+/// authoritative when the wire root and capability name differ.
+///
+/// A downstream custom codec uses the same public contracts:
+///
+/// ```
+/// use gvm_gmp::responses::ParseError;
+/// use gvm_gmp::{GmpRequest, GmpResponse, GmpVersion};
+/// use gvm_protocol::{Request, Response};
+///
+/// struct CustomRequest;
+///
+/// impl Request for CustomRequest {
+///     fn to_bytes(&self) -> Vec<u8> {
+///         b"<custom_command/>".to_vec()
+///     }
+/// }
+///
+/// #[derive(Debug, PartialEq, Eq)]
+/// struct CustomResponse(u16);
+///
+/// impl GmpResponse for CustomResponse {
+///     fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+///         let status = response
+///             .status_code()
+///             .ok_or_else(|| ParseError::MissingElement("status".into()))?;
+///         let message = response
+///             .status_text()
+///             .ok_or_else(|| ParseError::MissingElement("status_text".into()))?;
+///         if !(200..300).contains(&status) {
+///             return Err(ParseError::ServerError { status, message });
+///         }
+///         Ok(Self(status))
+///     }
+/// }
+///
+/// impl GmpRequest for CustomRequest {
+///     type Response = CustomResponse;
+/// }
+///
+/// fn require_custom_response<R: GmpRequest<Response = CustomResponse>>(_: R) {}
+/// require_custom_response(CustomRequest);
+/// let raw = Response::new(
+///     br#"<custom_command_response status="200" status_text="OK"/>"#.to_vec(),
+/// );
+/// assert_eq!(CustomResponse::decode(&raw, GmpVersion(22, 8))?, CustomResponse(200));
+/// # Ok::<(), ParseError>(())
+/// ```
 ///
 /// A request cannot be associated with an unrelated response type:
 ///
@@ -28,6 +77,11 @@ pub trait GmpRequest: Request {
 }
 
 /// A typed GMP response that can decode the protocol response envelope.
+///
+/// Implementations must preserve the typed response contract: non-2xx GMP
+/// statuses are returned as [`ParseError::ServerError`], and structural parse
+/// errors retain enough field context to identify the malformed value. This is
+/// the extension point for irregular or application-owned response codecs.
 pub trait GmpResponse: Sized {
     /// Decode a typed value from a raw GMP response.
     ///

--- a/docs/adr/0001-typed-request-response-execution.md
+++ b/docs/adr/0001-typed-request-response-execution.md
@@ -1,6 +1,6 @@
 # ADR 0001: Typed request/response execution
 
-- Status: Accepted for the `next` Technology Preview lane
+- Status: Accepted; Phase 1 names and ownership stabilized for the `next` lane
 - Date: 2026-08-31
 - Tracking issue: [#523](https://github.com/greenbone-hive/rust-gvm/issues/523)
 
@@ -88,8 +88,9 @@ duplication between semantic request structs and builder function signatures,
 but no duplicated XML encoder.
 
 This ADR does not authorize a repository-wide conversion or removal of old
-APIs. Trait naming and details remain Technology Preview until more standard and
-version-irregular families have exercised the contract.
+APIs. Phase 1 stabilizes the public `GmpRequest`, `GmpResponse`, and
+`GmpClient::execute` names and the ownership boundaries above. The set of
+migrated command families remains intentionally incomplete until later phases.
 
 ## Validation
 

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -41,6 +41,67 @@ let raw = client
 typed-facade behavior and report non-2xx statuses through
 `GvmError::Parse(ParseError::ServerError { .. })`.
 
+The Phase 1 public contract is owned by `gvm-gmp` (`GmpRequest` and
+`GmpResponse`) and `gvm-client` (`GmpClient::execute`). `gvm-client` re-exports
+the two traits for ergonomic imports. These names and ownership boundaries are
+stable within the additive `next` migration; later phases add command families
+without changing this execution shape.
+
+## Custom codecs
+
+Custom and irregular commands have two supported paths. If raw bytes are the
+right abstraction, implement `gvm_protocol::Request` (or pass `Vec<u8>`/a byte
+slice) and use `send` or `call`. If the command should participate in typed
+execution, implement `Request` plus `GmpRequest` on the request type and
+`GmpResponse` on its associated response type:
+
+```rust
+use gvm_gmp::{GmpRequest, GmpResponse, GmpVersion};
+use gvm_gmp::responses::ParseError;
+use gvm_protocol::{Request, Response};
+
+struct CustomRequest;
+
+impl Request for CustomRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        b"<custom_command/>".to_vec()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some("custom_command")
+    }
+}
+
+struct CustomResponse(Response);
+
+impl GmpResponse for CustomResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        let status = response
+            .status_code()
+            .ok_or_else(|| ParseError::MissingElement("status".into()))?;
+        let message = response
+            .status_text()
+            .ok_or_else(|| ParseError::MissingElement("status_text".into()))?;
+        if !(200..300).contains(&status) {
+            return Err(ParseError::ServerError { status, message });
+        }
+        Ok(Self(response.clone()))
+    }
+}
+
+impl GmpRequest for CustomRequest {
+    type Response = CustomResponse;
+}
+```
+
+Custom response codecs must reject non-2xx statuses as
+`ParseError::ServerError` and retain structural field context in other parse
+errors. `execute` still applies negotiated-version/help checks to registered
+commands and declared semantic aliases, while unknown custom names retain the
+raw path's forward compatibility. It also redacts wire bytes before invoking a
+trace observer. A semantic alias supplied by `Request::semantic_command_name`
+is checked before the XML root command.
+
 ## Authoring a migrated command
 
 1. Define a semantic request struct in the owning `gvm-gmp` command module.


### PR DESCRIPTION
## Summary

Complete the production-foundation guarantees in Phase 1 of #523 without migrating any Phase 2 command families.

- stabilize the public `gvm_gmp::{GmpRequest, GmpResponse}` and `gvm_client::{GmpClient, GmpVersioned}::execute` naming/ownership decision for the `next` migration lane
- document the raw `send` / `call` escape hatch and downstream custom request/response codec path, backed by a Rust 1.86-compatible doctest
- directly enforce generic `execute` behavior for semantic aliases, pre-send version rejection, non-2xx mapping, parse-field context, and redaction before trace observation
- retain the existing compile-fail response-association proof and all builders, raw APIs, and typed convenience wrappers

## Gap audit

Phase 0 already delivered the semantic request/response traits, direct and versioned execution, representative request families, byte-equivalence tests, compatibility wrappers, version/help checks, typed errors, and structural wire redaction. The remaining concrete Phase 1 gaps were:

1. ADR 0001 still said the trait names/details remained unstable.
2. The typed custom-codec path had no compilable downstream example or explicit error contract.
3. Generic `execute` inherited semantic-alias checks, error behavior, and redaction through `send`, but those guarantees were only tested indirectly through compatibility helpers.

This PR addresses only those gaps. It adds no command family, transport, dependency, or wire-format change.

## Validation

- `cargo fmt --all -- --check`
- default and all-feature workspace tests
- focused direct/versioned `execute` tests and compile/compile-fail doctests
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- Rust 1.86 workspace tests and all-feature checks
- `cargo deny check`, `cargo audit`, `cargo vet`, and `cargo machete`
- coverage policy: 96.29% lines, 94.32% regions (94.00% floor)
- `cargo-semver-checks` against both `origin/next` and `v0.6.0`: all five crates pass 196 checks each, with 58 non-applicable checks skipped

The installed `cargo-geiger` binary could not run locally because it requires GLIBC 2.38/2.39. This patch adds no unsafe code, and each workspace crate continues to forbid unsafe code; protected Security CI remains authoritative for that environment-specific gate.

Phase 1 only; #523 remains open for later phases.

Exact base: `4854d293c223c1f9aa9815d14ff00815949b3c3d`
Exact head: `6cc1cd5027a1e1fb3b70b5166b618cb50a574fc6`

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
