### PR TITLE
refactor(client): type scanner lifecycle

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -89,8 +89,8 @@ use gvm_gmp::commands::scan_configs::{
     modify_scan_config_set_name, sync_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::{
-    clone_scanner, create_scanner, delete_scanner, get_scanner, get_scanners, modify_scanner,
-    verify_scanner, GetScannersOpts, ScannerOpts,
+    CloneScannerRequest, CreateScannerRequest, DeleteScannerRequest, GetScannerRequest,
+    GetScannersOpts, GetScannersRequest, ModifyScannerRequest, ScannerOpts, VerifyScannerRequest,
 };
 use gvm_gmp::commands::schedules::{
     create_schedule, create_typed_schedule, delete_schedule, get_schedules, modify_schedule,
@@ -687,8 +687,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetScannersOpts,
     ) -> Result<GetScannersResponse, GvmError> {
-        let response = self.send(get_scanners(opts)).await?;
-        GetScannersResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetScannersRequest::new(opts)).await
     }
 
     /// Send a `create_scanner` request and return a typed [`CreateScannerResponse`].
@@ -700,8 +699,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         name: &str,
         opts: ScannerOpts,
     ) -> Result<CreateScannerResponse, GvmError> {
-        let response = self.send(create_scanner(name, opts)).await?;
-        CreateScannerResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateScannerRequest::new(name, opts)).await
     }
 
     /// Send a `get_scanner` request and return a typed [`GetScannersResponse`].
@@ -712,8 +710,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         scanner_id: &EntityId,
     ) -> Result<GetScannersResponse, GvmError> {
-        let response = self.send(get_scanner(scanner_id)).await?;
-        GetScannersResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetScannerRequest::new(scanner_id.clone()))
+            .await
     }
 
     /// Send a `modify_scanner` request and return a typed [`ModifyScannerResponse`].
@@ -725,8 +723,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         scanner_id: &EntityId,
         opts: ScannerOpts,
     ) -> Result<ModifyScannerResponse, GvmError> {
-        let response = self.send(modify_scanner(scanner_id, opts)).await?;
-        ModifyScannerResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyScannerRequest::new(scanner_id.clone(), opts))
+            .await
     }
 
     /// Send a `delete_scanner` request and return a typed [`DeleteScannerResponse`].
@@ -738,8 +736,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         scanner_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteScannerResponse, GvmError> {
-        let response = self.send(delete_scanner(scanner_id, ultimate)).await?;
-        DeleteScannerResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteScannerRequest::new(scanner_id.clone(), ultimate))
+            .await
     }
 
     /// Send a `verify_scanner` request and return a typed [`VerifyScannerResponse`].
@@ -750,8 +748,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         scanner_id: &EntityId,
     ) -> Result<VerifyScannerResponse, GvmError> {
-        let response = self.send(verify_scanner(scanner_id)).await?;
-        VerifyScannerResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(VerifyScannerRequest::new(scanner_id.clone()))
+            .await
     }
 
     /// Send a `clone_scanner` request and return a typed [`CreateScannerResponse`].
@@ -762,8 +760,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         scanner_id: &EntityId,
     ) -> Result<CreateScannerResponse, GvmError> {
-        let response = self.send(clone_scanner(scanner_id)).await?;
-        CreateScannerResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CloneScannerRequest::new(scanner_id.clone()))
+            .await
     }
 
     // ── Port Lists ────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -29,7 +29,10 @@ use gvm_gmp::commands::reports::GetReportsOpts;
 use gvm_gmp::commands::results::GetResultsOpts;
 use gvm_gmp::commands::roles::{GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::GetScanConfigsOpts;
-use gvm_gmp::commands::scanners::GetScannersOpts;
+use gvm_gmp::commands::scanners::{
+    CloneScannerRequest, CreateScannerRequest, DeleteScannerRequest, GetScannerRequest,
+    GetScannersOpts, GetScannersRequest, ModifyScannerRequest, ScannerOpts, VerifyScannerRequest,
+};
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::GetSecInfoOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
@@ -96,6 +99,29 @@ const CREDENTIAL_LIFECYCLE_OVERRIDES: &[(&str, &str)] = &[
     (
         "delete_credential",
         r#"<delete_credential_response status="200" status_text="OK"/>"#,
+    ),
+];
+
+const SCANNER_LIFECYCLE_OVERRIDES: &[(&str, &str)] = &[
+    (
+        "get_scanners",
+        r#"<get_scanners_response status="200" status_text="OK"><scanner_count>0<filtered>0</filtered></scanner_count></get_scanners_response>"#,
+    ),
+    (
+        "create_scanner",
+        r#"<create_scanner_response status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#,
+    ),
+    (
+        "modify_scanner",
+        r#"<modify_scanner_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "delete_scanner",
+        r#"<delete_scanner_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "verify_scanner",
+        r#"<verify_scanner_response status="200" status_text="OK"/>"#,
     ),
 ];
 
@@ -441,6 +467,118 @@ async fn standard_credential_execute_preserves_status_and_parse_context() {
 
     let parse_error = client
         .execute(CloneCredentialRequest::new(id("credential-1")))
+        .await
+        .expect_err("missing clone id should fail");
+    assert!(matches!(
+        parse_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "id"
+    ));
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn scanner_requests_execute_on_the_oldest_supported_version() {
+    let Some(server) = fixture_server(MockVersion::V22_4, SCANNER_LIFECYCLE_OVERRIDES).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+    let scanner_id = id("scanner-1");
+
+    let listed = client
+        .execute(GetScannersRequest::default())
+        .await
+        .expect("scanner listing should be supported");
+    assert_eq!(listed.status, 200);
+    let detailed = client
+        .execute(GetScannerRequest::new(scanner_id.clone()))
+        .await
+        .expect("detailed scanner get should be supported");
+    assert_eq!(detailed.status, 200);
+
+    let created = client
+        .execute(CreateScannerRequest::new("scanner", ScannerOpts::default()))
+        .await
+        .expect("scanner creation should be supported");
+    assert_eq!(created.status, 201);
+    let cloned = client
+        .execute(CloneScannerRequest::new(scanner_id.clone()))
+        .await
+        .expect("scanner cloning should be supported");
+    assert_eq!(cloned.status, 201);
+
+    let modified = client
+        .execute(ModifyScannerRequest::new(
+            scanner_id.clone(),
+            ScannerOpts::default(),
+        ))
+        .await
+        .expect("scanner modification should be supported");
+    assert_eq!(modified.status, 200);
+    let deleted = client
+        .execute(DeleteScannerRequest::new(scanner_id.clone(), false))
+        .await
+        .expect("scanner deletion should be supported");
+    assert_eq!(deleted.status, 200);
+    let verified = client
+        .execute(VerifyScannerRequest::new(scanner_id))
+        .await
+        .expect("scanner verification should be supported");
+    assert_eq!(verified.status, 200);
+
+    let commands = server
+        .command_history()
+        .iter()
+        .map(|record| record.command_name().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands,
+        [
+            "get_scanners",
+            "get_scanners",
+            "create_scanner",
+            "create_scanner",
+            "modify_scanner",
+            "delete_scanner",
+            "verify_scanner",
+        ]
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn scanner_execute_preserves_status_and_parse_context() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_4,
+        &[
+            (
+                "get_scanners",
+                r#"<get_scanners_response status="409" status_text="scanner conflict"/>"#,
+            ),
+            (
+                "create_scanner",
+                r#"<create_scanner_response status="201" status_text="OK"/>"#,
+            ),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+
+    let status_error = client
+        .execute(GetScannerRequest::new(id("scanner-1")))
+        .await
+        .expect_err("non-success scanner response should fail");
+    assert!(matches!(
+        status_error,
+        GvmError::Parse(ParseError::ServerError { status: 409, message })
+            if message == "scanner conflict"
+    ));
+
+    let parse_error = client
+        .execute(CloneScannerRequest::new(id("scanner-1")))
         .await
         .expect_err("missing clone id should fail");
     assert!(matches!(

--- a/crates/gvm-gmp/src/commands/scanners.rs
+++ b/crates/gvm-gmp/src/commands/scanners.rs
@@ -7,7 +7,12 @@ use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
 use crate::enums::ScannerType;
+use crate::responses::{
+    CreateScannerResponse, DeleteScannerResponse, GetScannersResponse, ModifyScannerResponse,
+    VerifyScannerResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields shared by scanner create and modify requests.
 ///
@@ -42,6 +47,194 @@ pub struct GetScannersOpts {
     pub trash: Option<bool>,
     /// Whether to request detailed output.
     pub details: Option<bool>,
+}
+
+/// Semantic request for listing scanners.
+///
+/// The associated response is fixed at compile time:
+///
+/// ```compile_fail
+/// use gvm_gmp::commands::scanners::{GetScannersOpts, GetScannersRequest};
+/// use gvm_gmp::responses::CreateScannerResponse;
+/// use gvm_gmp::GmpRequest;
+///
+/// fn require_create<R: GmpRequest<Response = CreateScannerResponse>>(_: R) {}
+/// require_create(GetScannersRequest::new(GetScannersOpts::default()));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct GetScannersRequest {
+    opts: GetScannersOpts,
+}
+
+impl GetScannersRequest {
+    /// Create a scanner list request.
+    #[must_use]
+    pub fn new(opts: GetScannersOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetScannersRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scanners(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScannersRequest {
+    type Response = GetScannersResponse;
+}
+
+/// Semantic request for one detailed scanner.
+#[derive(Debug, Clone)]
+pub struct GetScannerRequest {
+    scanner_id: EntityId,
+}
+
+impl GetScannerRequest {
+    /// Create a detailed single-scanner request.
+    #[must_use]
+    pub fn new(scanner_id: EntityId) -> Self {
+        Self { scanner_id }
+    }
+}
+
+impl Request for GetScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scanner(&self.scanner_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScannerRequest {
+    type Response = GetScannersResponse;
+}
+
+/// Semantic request for creating a scanner.
+#[derive(Debug, Clone)]
+pub struct CreateScannerRequest {
+    name: String,
+    opts: ScannerOpts,
+}
+
+impl CreateScannerRequest {
+    /// Create a scanner creation request.
+    #[must_use]
+    pub fn new(name: impl Into<String>, opts: ScannerOpts) -> Self {
+        Self {
+            name: name.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for CreateScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_scanner(&self.name, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateScannerRequest {
+    type Response = CreateScannerResponse;
+}
+
+/// Semantic request for cloning a scanner.
+#[derive(Debug, Clone)]
+pub struct CloneScannerRequest {
+    scanner_id: EntityId,
+}
+
+impl CloneScannerRequest {
+    /// Create a scanner clone request.
+    #[must_use]
+    pub fn new(scanner_id: EntityId) -> Self {
+        Self { scanner_id }
+    }
+}
+
+impl Request for CloneScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_scanner(&self.scanner_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneScannerRequest {
+    type Response = CreateScannerResponse;
+}
+
+/// Semantic request for modifying a scanner.
+#[derive(Debug, Clone)]
+pub struct ModifyScannerRequest {
+    scanner_id: EntityId,
+    opts: ScannerOpts,
+}
+
+impl ModifyScannerRequest {
+    /// Create a scanner modification request.
+    #[must_use]
+    pub fn new(scanner_id: EntityId, opts: ScannerOpts) -> Self {
+        Self { scanner_id, opts }
+    }
+}
+
+impl Request for ModifyScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_scanner(&self.scanner_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyScannerRequest {
+    type Response = ModifyScannerResponse;
+}
+
+/// Semantic request for deleting a scanner.
+#[derive(Debug, Clone)]
+pub struct DeleteScannerRequest {
+    scanner_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteScannerRequest {
+    /// Create a scanner deletion request.
+    #[must_use]
+    pub fn new(scanner_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            scanner_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_scanner(&self.scanner_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteScannerRequest {
+    type Response = DeleteScannerResponse;
+}
+
+/// Semantic request for verifying a scanner.
+#[derive(Debug, Clone)]
+pub struct VerifyScannerRequest {
+    scanner_id: EntityId,
+}
+
+impl VerifyScannerRequest {
+    /// Create a scanner verification request.
+    #[must_use]
+    pub fn new(scanner_id: EntityId) -> Self {
+        Self { scanner_id }
+    }
+}
+
+impl Request for VerifyScannerRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        verify_scanner(&self.scanner_id).to_bytes()
+    }
+}
+
+impl GmpRequest for VerifyScannerRequest {
+    type Response = VerifyScannerResponse;
 }
 
 /// Build a clone request for an existing scanner.
@@ -199,5 +392,82 @@ mod tests {
             xml(verify_scanner(&id("s1"))),
             "<verify_scanner scanner_id=\"s1\"/>"
         );
+    }
+
+    #[test]
+    fn semantic_scanner_requests_match_existing_builders() {
+        let scanner_id = id("s1");
+        let get_opts = GetScannersOpts {
+            filter_string: Some("name=scanner".into()),
+            filter_id: Some(id("filter-1")),
+            trash: Some(false),
+            details: Some(true),
+        };
+        let scanner_opts = ScannerOpts {
+            name: Some("renamed".into()),
+            comment: Some("updated".into()),
+            host: Some("scanner.example".into()),
+            port: Some(9390),
+            scanner_type: Some(ScannerType::OpenVasScanner),
+            ca_pub: Some("CA certificate".into()),
+            credential_id: Some(id("cred-1")),
+        };
+
+        assert_eq!(
+            GetScannersRequest::new(get_opts.clone()).to_bytes(),
+            get_scanners(get_opts).to_bytes()
+        );
+        assert_eq!(
+            GetScannerRequest::new(scanner_id.clone()).to_bytes(),
+            get_scanner(&scanner_id).to_bytes()
+        );
+        assert_eq!(
+            CreateScannerRequest::new("scanner", scanner_opts.clone()).to_bytes(),
+            create_scanner("scanner", scanner_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            CloneScannerRequest::new(scanner_id.clone()).to_bytes(),
+            clone_scanner(&scanner_id).to_bytes()
+        );
+        assert_eq!(
+            ModifyScannerRequest::new(scanner_id.clone(), scanner_opts.clone()).to_bytes(),
+            modify_scanner(&scanner_id, scanner_opts).to_bytes()
+        );
+        assert_eq!(
+            DeleteScannerRequest::new(scanner_id.clone(), true).to_bytes(),
+            delete_scanner(&scanner_id, true).to_bytes()
+        );
+        assert_eq!(
+            VerifyScannerRequest::new(scanner_id.clone()).to_bytes(),
+            verify_scanner(&scanner_id).to_bytes()
+        );
+    }
+
+    #[test]
+    fn semantic_scanner_requests_have_the_expected_response_associations() {
+        fn assert_response<R, T>(_: &R)
+        where
+            R: GmpRequest<Response = T>,
+            T: crate::GmpResponse,
+        {
+        }
+
+        let scanner_id = id("scanner-1");
+        assert_response::<_, GetScannersResponse>(&GetScannersRequest::default());
+        assert_response::<_, GetScannersResponse>(&GetScannerRequest::new(scanner_id.clone()));
+        assert_response::<_, CreateScannerResponse>(&CreateScannerRequest::new(
+            "scanner",
+            ScannerOpts::default(),
+        ));
+        assert_response::<_, CreateScannerResponse>(&CloneScannerRequest::new(scanner_id.clone()));
+        assert_response::<_, ModifyScannerResponse>(&ModifyScannerRequest::new(
+            scanner_id.clone(),
+            ScannerOpts::default(),
+        ));
+        assert_response::<_, DeleteScannerResponse>(&DeleteScannerRequest::new(
+            scanner_id.clone(),
+            false,
+        ));
+        assert_response::<_, VerifyScannerResponse>(&VerifyScannerRequest::new(scanner_id));
     }
 }

--- a/crates/gvm-gmp/src/responses/scanner.rs
+++ b/crates/gvm-gmp/src/responses/scanner.rs
@@ -5,10 +5,13 @@
 
 use gvm_protocol::Response;
 
-use crate::responses::common::{
-    count_info, optional_u16, parse_document, parse_entity_id, parse_entity_meta,
-    parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
-    ParseError,
+use crate::{
+    responses::common::{
+        count_info, optional_u16, parse_document, parse_entity_id, parse_entity_meta,
+        parse_named_entity, status_from_response, ActionResponse, CountInfo, EntityMeta,
+        NamedEntity, ParseError,
+    },
+    GmpResponse, GmpVersion,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,6 +75,12 @@ impl GetScannersResponse {
     }
 }
 
+impl GmpResponse for GetScannersResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateScannerResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -86,6 +95,12 @@ impl CreateScannerResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateScannerResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ contract before family-by-family migration. See
 [typed-execution guide](typed-execution.md).
 
 The first focused Phase 2 batch, tracked by
-[`#539`](https://github.com/greenbone-hive/rust-gvm/issues/539), migrates the
+[`#539`](https://github.com/greenbone-hive/rust-gvm/issues/539), migrated the
 standard scan-task list/get/create/clone/modify/delete/start/stop/resume
 lifecycle to the same typed execution contract. It intentionally leaves import,
 agent-group, OCI/container-image, web-application, move, and audit task shapes
@@ -34,6 +34,14 @@ credential convenience methods remain source-compatible wrappers over generic
 typed execution. Credential-store operations stay separate because their
 vault, preference, semantic-alias, and version-policy shapes require a focused
 follow-up.
+
+The scanner-focused Phase 2 batch, tracked by
+[`#542`](https://github.com/greenbone-hive/rust-gvm/issues/542), migrates the
+scanner list/get/create/clone/modify/delete/verify lifecycle. Scanner builders
+remain the single byte-compatible encoders, and the existing convenience
+methods remain additive wrappers over generic typed execution. Scan
+configurations remain a separate later batch because they include larger and
+more specialized command surfaces.
 
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|


### PR DESCRIPTION
## What Problem This Solves

Phase 2 of #523 requires standard GMP command families to adopt the statically associated request/response execution contract without changing the established public compatibility or wire surfaces. Scanner list/get/create/clone/modify/delete/verify still paired builders and response parsers manually in `gvm-client`.

## Why This Change Was Made

- Adds seven concrete scanner request types in the owning `gvm-gmp` module.
- Associates each request with exactly one existing response type through `GmpRequest`.
- Delegates every request encoder to the existing scanner builder, preserving one byte-compatible wire path.
- Implements `GmpResponse` for scanner list and create responses; action aliases reuse the shared action codec.
- Converts all seven existing scanner convenience methods into thin `execute` wrappers without signature changes.
- Keeps credentials and scan configurations in separate later batches because their command surfaces are substantially larger and more specialized.

## User Impact

Callers may execute scanner operations directly with compile-time response association or continue using the unchanged builders, typed convenience methods, raw `send`, and raw `call` APIs. There is no transport, framing, version-policy, mock-state, response-shape, dependency, or wire-format change.

## Evidence

- Exact base: `2c73f4cfe682085d7aab8b5816d0b90bb32f2db6` (`next`).
- Exact head: `a9a9f0deca6d7bf650f0f8d0ae80b5d22231e7bc`, signed locally and GitHub-verified.
- Scanner byte-equivalence and compile-time response-association tests pass.
- Direct generic execution covers all seven operations on GMP 22.4, command history, non-2xx mapping, and parse-field context.
- Typed-facade inventory, command-surface parity, and stateful scanner lifecycle tests pass.
- Stable default/all-feature workspace tests and Rust 1.86 test/check gates pass.
- Strict all-target/all-feature Clippy, warning-free docs, formatting, and diff checks pass.
- Cargo Deny, Audit, Vet, and Machete pass with only existing allowed warnings.
- Coverage passes at 96.33% lines, 94.40% regions, and 93.83% functions.
- Semver checks against both `origin/next` and `v0.6.0` pass for all five crates with no required version update.
- Pinned Python-gvm Unix, TLS, and mTLS interoperability tests pass.

Fixes #542
Part of #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
