### PR TITLE
refactor(client): type core credential lifecycle

### DIFF
--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -7,9 +7,10 @@
 //! response parser, eliminating the need for callers to import response types
 //! and call `from_response()` manually.
 //!
-//! All methods use [`GmpClient::send`] internally so that
-//! [`gvm_gmp::responses::ParseError`] owns all response validation (including
-//! non-2xx status detection), which is then converted to [`GvmError::Parse`].
+//! Migrated command families delegate to [`GmpClient::execute`], while
+//! not-yet-migrated helpers continue to use [`GmpClient::send`] directly. Both
+//! paths preserve [`gvm_gmp::responses::ParseError`] ownership of response
+//! validation, including non-2xx status detection.
 
 use gvm_connection::GvmConnection;
 use gvm_gmp::commands::aggregates::{get_aggregates_request, GetAggregatesRequestOpts};
@@ -26,11 +27,11 @@ use gvm_gmp::commands::configs::{
     GetConfigOpts, GetConfigsOpts, ModifyConfigOpts,
 };
 use gvm_gmp::commands::credentials::{
-    create_credential, create_credential_store_credential, delete_credential, get_credential_store,
-    get_credential_stores, get_credential_stores_with_opts, get_credentials, modify_credential,
-    modify_credential_store_credential, verify_credential_store, CredentialOpts,
-    CredentialStoreCredentialOpts, GetCredentialStoresOpts, GetCredentialsOpts,
-    ModifyCredentialOpts, ModifyCredentialStoreCredentialOpts,
+    create_credential_store_credential, get_credential_store, get_credential_stores,
+    get_credential_stores_with_opts, modify_credential_store_credential, verify_credential_store,
+    CreateCredentialRequest, CredentialOpts, CredentialStoreCredentialOpts,
+    DeleteCredentialRequest, GetCredentialStoresOpts, GetCredentialsOpts, GetCredentialsRequest,
+    ModifyCredentialOpts, ModifyCredentialRequest, ModifyCredentialStoreCredentialOpts,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::feed::{get_feed, get_feeds};
@@ -1496,8 +1497,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetCredentialsOpts,
     ) -> Result<GetCredentialsResponse, GvmError> {
-        let response = self.send(get_credentials(opts)).await?;
-        GetCredentialsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetCredentialsRequest::new(opts)).await
     }
 
     /// Send a `create_credential` request and return a typed [`CreateCredentialResponse`].
@@ -1509,8 +1509,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         name: &str,
         opts: CredentialOpts,
     ) -> Result<CreateCredentialResponse, GvmError> {
-        let response = self.send(create_credential(name, opts)).await?;
-        CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateCredentialRequest::new(name, opts)).await
     }
 
     /// Send a `modify_credential` request and return a typed
@@ -1523,8 +1522,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         credential_id: &EntityId,
         opts: ModifyCredentialOpts,
     ) -> Result<ModifyCredentialResponse, GvmError> {
-        let response = self.send(modify_credential(credential_id, opts)).await?;
-        ModifyCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyCredentialRequest::new(credential_id.clone(), opts))
+            .await
     }
 
     /// Send a `delete_credential` request and return a typed
@@ -1537,10 +1536,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         credential_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteCredentialResponse, GvmError> {
-        let response = self
-            .send(delete_credential(credential_id, ultimate))
-            .await?;
-        DeleteCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteCredentialRequest::new(
+            credential_id.clone(),
+            ultimate,
+        ))
+        .await
     }
 
     /// Send a credential-store-backed `create_credential` request and return a

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -10,7 +10,11 @@ use gvm_client::{
 use gvm_client::{GmpClient, GvmError};
 use gvm_connection::UnixSocketConnection;
 use gvm_gmp::commands::alerts::{AlertOpts, GetAlertsOpts};
-use gvm_gmp::commands::credentials::GetCredentialsOpts;
+use gvm_gmp::commands::credentials::{
+    CloneCredentialRequest, CreateCredentialRequest, CredentialOpts, DeleteCredentialRequest,
+    GetCredentialRequest, GetCredentialsOpts, GetCredentialsRequest, ModifyCredentialOpts,
+    ModifyCredentialRequest,
+};
 use gvm_gmp::commands::filters::{FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{GetGroupsOpts, GroupOpts};
 use gvm_gmp::commands::hosts::{GetHostsOpts, HostOpts};
@@ -73,6 +77,25 @@ const TASK_LIFECYCLE_OVERRIDES: &[(&str, &str)] = &[
     (
         "resume_task",
         r#"<resume_task_response status="202" status_text="OK"><report_id>33333333-3333-3333-3333-333333333333</report_id></resume_task_response>"#,
+    ),
+];
+
+const CREDENTIAL_LIFECYCLE_OVERRIDES: &[(&str, &str)] = &[
+    (
+        "get_credentials",
+        r#"<get_credentials_response status="200" status_text="OK"><credential_count>0<filtered>0</filtered></credential_count></get_credentials_response>"#,
+    ),
+    (
+        "create_credential",
+        r#"<create_credential_response status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#,
+    ),
+    (
+        "modify_credential",
+        r#"<modify_credential_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "delete_credential",
+        r#"<delete_credential_response status="200" status_text="OK"/>"#,
     ),
 ];
 
@@ -308,6 +331,116 @@ async fn standard_task_execute_preserves_status_and_parse_context() {
 
     let parse_error = client
         .execute(CloneTaskRequest::new(id("task-1")))
+        .await
+        .expect_err("missing clone id should fail");
+    assert!(matches!(
+        parse_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "id"
+    ));
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn standard_credential_requests_execute_on_the_oldest_supported_version() {
+    let Some(server) = fixture_server(MockVersion::V22_4, CREDENTIAL_LIFECYCLE_OVERRIDES).await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+    let credential_id = id("credential-1");
+
+    let listed = client
+        .execute(GetCredentialsRequest::new(GetCredentialsOpts::default()))
+        .await
+        .expect("credential listing should be supported");
+    assert_eq!(listed.status, 200);
+    let detailed = client
+        .execute(GetCredentialRequest::new(credential_id.clone()))
+        .await
+        .expect("detailed credential get should be supported");
+    assert_eq!(detailed.status, 200);
+
+    let created = client
+        .execute(CreateCredentialRequest::new(
+            "credential",
+            CredentialOpts::default(),
+        ))
+        .await
+        .expect("credential creation should be supported");
+    assert_eq!(created.status, 201);
+    let cloned = client
+        .execute(CloneCredentialRequest::new(credential_id.clone()))
+        .await
+        .expect("credential cloning should be supported");
+    assert_eq!(cloned.status, 201);
+
+    let modified = client
+        .execute(ModifyCredentialRequest::new(
+            credential_id.clone(),
+            ModifyCredentialOpts::default(),
+        ))
+        .await
+        .expect("credential modification should be supported");
+    assert_eq!(modified.status, 200);
+    let deleted = client
+        .execute(DeleteCredentialRequest::new(credential_id, false))
+        .await
+        .expect("credential deletion should be supported");
+    assert_eq!(deleted.status, 200);
+
+    let commands = server
+        .command_history()
+        .iter()
+        .map(|record| record.command_name().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands,
+        [
+            "get_credentials",
+            "get_credentials",
+            "create_credential",
+            "create_credential",
+            "modify_credential",
+            "delete_credential",
+        ]
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn standard_credential_execute_preserves_status_and_parse_context() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_4,
+        &[
+            (
+                "get_credentials",
+                r#"<get_credentials_response status="409" status_text="credential conflict"/>"#,
+            ),
+            (
+                "create_credential",
+                r#"<create_credential_response status="201" status_text="OK"/>"#,
+            ),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+
+    let status_error = client
+        .execute(GetCredentialRequest::new(id("credential-1")))
+        .await
+        .expect_err("non-success credential response should fail");
+    assert!(matches!(
+        status_error,
+        GvmError::Parse(ParseError::ServerError { status: 409, message })
+            if message == "credential conflict"
+    ));
+
+    let parse_error = client
+        .execute(CloneCredentialRequest::new(id("credential-1")))
         .await
         .expect_err("missing clone id should fail");
     assert!(matches!(

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -12,7 +12,12 @@ use crate::enums::{
     CredentialFormat, CredentialStoreCredentialType, CredentialType, SnmpAuthAlgorithm,
     SnmpPrivacyAlgorithm,
 };
+use crate::responses::{
+    CreateCredentialResponse, DeleteCredentialResponse, GetCredentialsResponse,
+    ModifyCredentialResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for credential create requests.
 #[derive(Clone, Default)]
@@ -198,6 +203,173 @@ pub struct GetCredentialsOpts {
     pub trash: Option<bool>,
     /// Whether to request detailed output.
     pub details: Option<bool>,
+}
+
+/// Semantic request for listing credentials.
+///
+/// The associated response is fixed at compile time:
+///
+/// ```compile_fail
+/// use gvm_gmp::commands::credentials::{GetCredentialsOpts, GetCredentialsRequest};
+/// use gvm_gmp::responses::CreateCredentialResponse;
+/// use gvm_gmp::GmpRequest;
+///
+/// fn require_create<R: GmpRequest<Response = CreateCredentialResponse>>(_: R) {}
+/// require_create(GetCredentialsRequest::new(GetCredentialsOpts::default()));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct GetCredentialsRequest {
+    opts: GetCredentialsOpts,
+}
+
+impl GetCredentialsRequest {
+    /// Create a credential list request.
+    #[must_use]
+    pub fn new(opts: GetCredentialsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetCredentialsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_credentials(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetCredentialsRequest {
+    type Response = GetCredentialsResponse;
+}
+
+/// Semantic request for one detailed credential.
+#[derive(Debug, Clone)]
+pub struct GetCredentialRequest {
+    credential_id: EntityId,
+}
+
+impl GetCredentialRequest {
+    /// Create a detailed single-credential request.
+    #[must_use]
+    pub fn new(credential_id: EntityId) -> Self {
+        Self { credential_id }
+    }
+}
+
+impl Request for GetCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_credential(&self.credential_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetCredentialRequest {
+    type Response = GetCredentialsResponse;
+}
+
+/// Semantic request for creating a credential.
+#[derive(Debug, Clone)]
+pub struct CreateCredentialRequest {
+    name: String,
+    opts: CredentialOpts,
+}
+
+impl CreateCredentialRequest {
+    /// Create a credential creation request.
+    #[must_use]
+    pub fn new(name: impl Into<String>, opts: CredentialOpts) -> Self {
+        Self {
+            name: name.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for CreateCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_credential(&self.name, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateCredentialRequest {
+    type Response = CreateCredentialResponse;
+}
+
+/// Semantic request for cloning a credential.
+#[derive(Debug, Clone)]
+pub struct CloneCredentialRequest {
+    credential_id: EntityId,
+}
+
+impl CloneCredentialRequest {
+    /// Create a credential clone request.
+    #[must_use]
+    pub fn new(credential_id: EntityId) -> Self {
+        Self { credential_id }
+    }
+}
+
+impl Request for CloneCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_credential(&self.credential_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneCredentialRequest {
+    type Response = CreateCredentialResponse;
+}
+
+/// Semantic request for modifying a credential.
+#[derive(Debug, Clone)]
+pub struct ModifyCredentialRequest {
+    credential_id: EntityId,
+    opts: ModifyCredentialOpts,
+}
+
+impl ModifyCredentialRequest {
+    /// Create a credential modification request.
+    #[must_use]
+    pub fn new(credential_id: EntityId, opts: impl Into<ModifyCredentialOpts>) -> Self {
+        Self {
+            credential_id,
+            opts: opts.into(),
+        }
+    }
+}
+
+impl Request for ModifyCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_credential(&self.credential_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyCredentialRequest {
+    type Response = ModifyCredentialResponse;
+}
+
+/// Semantic request for deleting a credential.
+#[derive(Debug, Clone)]
+pub struct DeleteCredentialRequest {
+    credential_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteCredentialRequest {
+    /// Create a credential deletion request.
+    #[must_use]
+    pub fn new(credential_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            credential_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_credential(&self.credential_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteCredentialRequest {
+    type Response = DeleteCredentialResponse;
 }
 
 /// Options for `get_credential_stores` requests.
@@ -665,6 +837,88 @@ mod tests {
     }
 
     #[test]
+    fn semantic_credential_requests_match_existing_builders() {
+        let credential_id = id("c1");
+        let get_opts = GetCredentialsOpts {
+            filter_string: Some("name=credential".into()),
+            filter_id: Some(id("filter-1")),
+            trash: Some(false),
+            details: Some(true),
+        };
+        let create_opts = CredentialOpts {
+            comment: Some("created through typed execution".into()),
+            credential_type: Some(CredentialType::UsernamePassword),
+            login: Some("alice".into()),
+            password: Some("create-secret".into()),
+            allow_insecure: Some(false),
+            ..Default::default()
+        };
+        let modify_opts = ModifyCredentialOpts {
+            name: Some("renamed".into()),
+            comment: Some("updated through typed execution".into()),
+            login: Some("bob".into()),
+            password: Some("modify-secret".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            GetCredentialsRequest::new(get_opts.clone()).to_bytes(),
+            get_credentials(get_opts).to_bytes()
+        );
+        assert_eq!(
+            GetCredentialRequest::new(credential_id.clone()).to_bytes(),
+            get_credential(&credential_id).to_bytes()
+        );
+        assert_eq!(
+            CreateCredentialRequest::new("credential", create_opts.clone()).to_bytes(),
+            create_credential("credential", create_opts).to_bytes()
+        );
+        assert_eq!(
+            CloneCredentialRequest::new(credential_id.clone()).to_bytes(),
+            clone_credential(&credential_id).to_bytes()
+        );
+        assert_eq!(
+            ModifyCredentialRequest::new(credential_id.clone(), modify_opts.clone()).to_bytes(),
+            modify_credential(&credential_id, modify_opts).to_bytes()
+        );
+        assert_eq!(
+            DeleteCredentialRequest::new(credential_id.clone(), true).to_bytes(),
+            delete_credential(&credential_id, true).to_bytes()
+        );
+    }
+
+    #[test]
+    fn semantic_credential_requests_have_the_expected_response_associations() {
+        fn assert_response<R, T>(_: &R)
+        where
+            R: GmpRequest<Response = T>,
+            T: crate::GmpResponse,
+        {
+        }
+
+        let credential_id = id("credential-1");
+        assert_response::<_, GetCredentialsResponse>(&GetCredentialsRequest::default());
+        assert_response::<_, GetCredentialsResponse>(&GetCredentialRequest::new(
+            credential_id.clone(),
+        ));
+        assert_response::<_, CreateCredentialResponse>(&CreateCredentialRequest::new(
+            "credential",
+            CredentialOpts::default(),
+        ));
+        assert_response::<_, CreateCredentialResponse>(&CloneCredentialRequest::new(
+            credential_id.clone(),
+        ));
+        assert_response::<_, ModifyCredentialResponse>(&ModifyCredentialRequest::new(
+            credential_id.clone(),
+            ModifyCredentialOpts::default(),
+        ));
+        assert_response::<_, DeleteCredentialResponse>(&DeleteCredentialRequest::new(
+            credential_id,
+            false,
+        ));
+    }
+
+    #[test]
     fn credential_value_variants_match_current_gvmd_shape() {
         assert_eq!(
             xml(create_credential(
@@ -791,21 +1045,23 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn modify_credential_accepts_legacy_create_options() {
-        let rendered = xml(modify_credential(
-            &id("c1"),
-            CredentialOpts {
-                comment: Some("legacy".into()),
-                login: Some("alice".into()),
-                password: Some("secret".into()),
-                credential_type: Some(CredentialType::UsernamePassword),
-                format: Some(CredentialFormat::Pem),
-                ..Default::default()
-            },
-        ));
+        let opts = CredentialOpts {
+            comment: Some("legacy".into()),
+            login: Some("alice".into()),
+            password: Some("secret".into()),
+            credential_type: Some(CredentialType::UsernamePassword),
+            format: Some(CredentialFormat::Pem),
+            ..Default::default()
+        };
+        let rendered = xml(modify_credential(&id("c1"), opts.clone()));
 
         assert_eq!(
             rendered,
             "<modify_credential credential_id=\"c1\"><comment>legacy</comment><login>alice</login><password>secret</password></modify_credential>"
+        );
+        assert_eq!(
+            ModifyCredentialRequest::new(id("c1"), opts).to_bytes(),
+            rendered.into_bytes()
         );
     }
 
@@ -819,7 +1075,19 @@ mod tests {
             privacy_password: Some("privacy-secret".into()),
             ..Default::default()
         };
-        let debug = format!("{opts:?}");
+        let request = CreateCredentialRequest::new("credential", opts.clone());
+        let modify_request = ModifyCredentialRequest::new(
+            id("c1"),
+            ModifyCredentialOpts {
+                password: Some("modify-password-secret".into()),
+                private_key: Some("modify-private-secret".into()),
+                key_phrase: Some("modify-phrase-secret".into()),
+                community: Some("modify-community-secret".into()),
+                privacy_password: Some("modify-privacy-secret".into()),
+                ..Default::default()
+            },
+        );
+        let debug = format!("{opts:?} {request:?} {modify_request:?}");
 
         for secret in [
             "password-secret",
@@ -827,6 +1095,11 @@ mod tests {
             "phrase-secret",
             "community-secret",
             "privacy-secret",
+            "modify-password-secret",
+            "modify-private-secret",
+            "modify-phrase-secret",
+            "modify-community-secret",
+            "modify-privacy-secret",
         ] {
             assert!(!debug.contains(secret));
         }

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -9,7 +9,7 @@ use crate::responses::common::{
     count_info, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
     status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
-use crate::{CredentialStoreCredentialType, CredentialType};
+use crate::{CredentialStoreCredentialType, CredentialType, GmpResponse, GmpVersion};
 
 /// Credential kind observed in a `get_credentials` response.
 ///
@@ -223,6 +223,12 @@ impl GetCredentialsResponse {
     }
 }
 
+impl GmpResponse for GetCredentialsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CredentialStore {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
@@ -264,6 +270,12 @@ impl CreateCredentialResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateCredentialResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -26,6 +26,15 @@ lifecycle to the same typed execution contract. It intentionally leaves import,
 agent-group, OCI/container-image, web-application, move, and audit task shapes
 for later focused batches.
 
+The credential-focused Phase 2 batch, tracked by
+[`#544`](https://github.com/greenbone-hive/rust-gvm/issues/544), migrates the
+core credential list/get/create/clone/modify/delete lifecycle. Existing
+builders remain the single byte-compatible encoders, and the existing core
+credential convenience methods remain source-compatible wrappers over generic
+typed execution. Credential-store operations stay separate because their
+vault, preference, semantic-alias, and version-policy shapes require a focused
+follow-up.
+
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|
 | `gvm-protocol` | ✅ Implemented | ~2,330 | 67 | XML command builder, response parser, streaming reader |


### PR DESCRIPTION
## What Problem This Solves

Phase 2 of #523 needs each standard GMP command family to bind semantic requests to their exact response types without changing the mature builder, transport, validation, or compatibility layers. The core credential lifecycle still paired generic builders and parsers manually in the client facade, and detailed-get/clone callers could choose an unrelated response type through raw execution.

## Why This Change Was Made

This focused batch adds six semantic request types for credential list, detailed get, create, clone, modify, and delete. Each delegates to the existing builder, so the builder remains the single wire encoder, while `GmpRequest` fixes the associated response at compile time. The four existing core credential helpers now call `execute(...)` with unchanged public signatures and return types.

Credential-store operations remain deliberately out of scope because their vault/preference fields, semantic aliases, and version policy form a separate focused batch. Scan configurations, policies, imports, preferences, and synchronization are also unchanged.

## User Impact

- Direct callers can execute the six core credential operations without manually choosing a parser.
- Existing credential builders, typed helpers, raw `send` / `call`, transports, framing, validation, response models, mock behavior, and wire bytes remain supported.
- Secret-bearing request `Debug` output remains redacted, including create and modify requests.
- The migration is additive; no dependency, version floor, or wire-format change is introduced.

## Evidence

- Exact builder-byte equivalence and compile-time association tests cover all six requests.
- Direct generic execution succeeds on the oldest supported GMP 22.4 and preserves command history, non-success status mapping, and parse-field context.
- Existing stateful SSH/SNMP/Kerberos credential lifecycle tests and all five command-surface parity checks pass.
- Default and all-feature workspace suites pass, including 77 client integration, 15 typed-facade, 16 versioned-client, and 475 `gvm-gmp` unit tests.
- Rust 1.86 default workspace tests and all-feature workspace check pass.
- Strict all-target/all-feature Clippy, warning-free docs, formatting, and whitespace checks pass.
- Cargo Deny, Audit, Vet, Machete, and the coverage-policy regression test pass with only the existing documented warnings.
- Full all-feature coverage passes at 96.40% lines (29,362/30,458), 94.48% regions (47,827/50,620), and 93.85% functions (3,436/3,661).
- Additive semver comparisons against both `origin/next` and `v0.6.0` pass for all five crates: 196 applicable checks pass and 58 skip per crate.
- Pinned Python-gvm 27.7.0 Unix, anonymous TLS, and mTLS interoperability passes.
- Signed, GitHub-verified head: `a14a5789b1c6090aba3732a1d9573bf4e2611f82`.
- Exact protected `next` base: `2c73f4cfe682085d7aab8b5816d0b90bb32f2db6`.

Fixes #544.
Part of #523.

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
