### PR TITLE
refactor(client): type irregular report execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ println!("Raw XML: {} bytes", response.data().len());
 #### Statically associated typed execution
 
 The `next` Technology Preview lane also exposes semantic request values whose
-response type is selected at compile time. The first representative slice covers
-version negotiation, authentication, target CRUD, and asynchronous scan-report
-export:
+response type is selected at compile time. Migrated families cover version
+negotiation, authentication, target/task/credential/scanner lifecycles, and
+irregular report retrieval, drill-down, and export operations:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -51,7 +51,7 @@ use gvm_gmp::commands::report_configs::{
 use gvm_gmp::commands::reports::{
     export_scan_report, get_report_applications, get_report_closed_cves, get_report_cves,
     get_report_errors, get_report_hosts, get_report_operating_systems, get_report_ports,
-    get_report_tls_certificates, get_report_vulns, get_scan_report,
+    get_report_tls_certificates, get_report_vulns, get_scan_report, GetScanReportRequest,
 };
 use gvm_gmp::commands::system::get_timezones;
 use gvm_gmp::commands::tasks::create_agent_group_task;
@@ -893,8 +893,8 @@ impl<C: GvmConnection> GmpClient<C> {
         scan_report_id: &EntityId,
         opts: GetScanReportOpts,
     ) -> Result<GetScanReportResponse, GvmError> {
-        let response = self.send(get_scan_report(scan_report_id, opts)).await?;
-        GetScanReportResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetScanReportRequest::new(scan_report_id.clone(), opts))
+            .await
     }
 
     /// Get one structured vulnerability report without typed response parsing.

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -73,12 +73,13 @@ use gvm_gmp::commands::report_formats::{
     GetReportFormatsOpts, ReportFormatOpts,
 };
 use gvm_gmp::commands::reports::{
-    get_audit_report, get_audit_report_hosts, get_report_applications, get_report_closed_cves,
-    get_report_cves, get_report_errors, get_report_export, get_report_export_with_opts,
-    get_report_hosts, get_report_operating_systems, get_report_ports, get_report_tls_certificates,
-    get_report_vulnerabilities, get_report_vulns, get_reports, import_report, ExportScanReportOpts,
-    ExportScanReportRequest, GetAuditReportHostsOpts, GetAuditReportOpts, GetReportDetailsOpts,
-    GetReportExportOpts, GetReportsOpts, ImportReportOpts,
+    import_report, ExportScanReportOpts, ExportScanReportRequest, GetAuditReportHostsOpts,
+    GetAuditReportHostsRequest, GetAuditReportOpts, GetAuditReportRequest,
+    GetReportApplicationsRequest, GetReportClosedCvesRequest, GetReportCvesRequest,
+    GetReportDetailsOpts, GetReportErrorsRequest, GetReportExportOpts, GetReportExportRequest,
+    GetReportHostsRequest, GetReportOperatingSystemsRequest, GetReportPortsRequest,
+    GetReportTlsCertificatesRequest, GetReportVulnsRequest, GetReportsOpts, GetReportsRequest,
+    ImportReportOpts,
 };
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
@@ -956,8 +957,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         audit_report_id: &EntityId,
         opts: GetAuditReportOpts,
     ) -> Result<GetAuditReportResponse, GvmError> {
-        let response = self.send(get_audit_report(audit_report_id, opts)).await?;
-        GetAuditReportResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAuditReportRequest::new(audit_report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_audit_report_hosts` request and return typed host summaries.
@@ -969,8 +970,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetAuditReportHostsOpts,
     ) -> Result<GetAuditReportHostsResponse, GvmError> {
-        let response = self.send(get_audit_report_hosts(report_id, opts)).await?;
-        GetAuditReportHostsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAuditReportHostsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_reports` request and return a typed [`GetReportsResponse`].
@@ -981,8 +982,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetReportsOpts,
     ) -> Result<GetReportsResponse, GvmError> {
-        let response = self.send(get_reports(opts)).await?;
-        GetReportsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportsRequest::new(opts)).await
     }
 
     /// Queue or reuse an asynchronous scan-report export and return its typed
@@ -1012,8 +1012,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportVulnsResponse, GvmError> {
-        let response = self.send(get_report_vulns(report_id, opts)).await?;
-        GetReportVulnsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportVulnsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_vulns` request using python-gvm's descriptive helper
@@ -1026,10 +1026,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportVulnsResponse, GvmError> {
-        let response = self
-            .send(get_report_vulnerabilities(report_id, opts))
-            .await?;
-        GetReportVulnsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportVulnsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_tls_certificates` request and return a typed [`GetReportTlsCertificatesResponse`].
@@ -1041,10 +1039,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportTlsCertificatesResponse, GvmError> {
-        let response = self
-            .send(get_report_tls_certificates(report_id, opts))
-            .await?;
-        GetReportTlsCertificatesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportTlsCertificatesRequest::new(
+            report_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `get_report_hosts` request and return a typed
@@ -1060,8 +1059,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportHostsResponse, GvmError> {
-        let response = self.send(get_report_hosts(report_id, opts)).await?;
-        GetReportHostsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportHostsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_ports` request and return a typed
@@ -1077,8 +1076,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportPortsResponse, GvmError> {
-        let response = self.send(get_report_ports(report_id, opts)).await?;
-        GetReportPortsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportPortsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_applications` request and return a typed
@@ -1094,8 +1093,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportApplicationsResponse, GvmError> {
-        let response = self.send(get_report_applications(report_id, opts)).await?;
-        GetReportApplicationsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportApplicationsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_operating_systems` request and return a typed
@@ -1111,10 +1110,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportOperatingSystemsResponse, GvmError> {
-        let response = self
-            .send(get_report_operating_systems(report_id, opts))
-            .await?;
-        GetReportOperatingSystemsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportOperatingSystemsRequest::new(
+            report_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `get_report_cves` request and return a typed
@@ -1130,8 +1130,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportCvesResponse, GvmError> {
-        let response = self.send(get_report_cves(report_id, opts)).await?;
-        GetReportCvesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportCvesRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_errors` request and return a typed [`GetReportErrorsResponse`].
@@ -1143,8 +1143,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportErrorsResponse, GvmError> {
-        let response = self.send(get_report_errors(report_id, opts)).await?;
-        GetReportErrorsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportErrorsRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_report_closed_cves` request and return a typed [`GetReportClosedCvesResponse`].
@@ -1156,8 +1156,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportDetailsOpts,
     ) -> Result<GetReportClosedCvesResponse, GvmError> {
-        let response = self.send(get_report_closed_cves(report_id, opts)).await?;
-        GetReportClosedCvesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportClosedCvesRequest::new(report_id.clone(), opts))
+            .await
     }
 
     /// Send a `get_reports` export request and return a typed [`ReportExport`].
@@ -1169,10 +1169,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         report_format_id: &EntityId,
     ) -> Result<ReportExport, GvmError> {
-        let response = self
-            .send(get_report_export(report_id, report_format_id))
-            .await?;
-        ReportExport::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportExportRequest::new(
+            report_id.clone(),
+            GetReportExportOpts::new(report_format_id.clone()),
+        ))
+        .await
     }
 
     /// Send a `get_reports` export request with export options and return a typed [`ReportExport`].
@@ -1184,10 +1185,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         report_id: &EntityId,
         opts: GetReportExportOpts,
     ) -> Result<ReportExport, GvmError> {
-        let response = self
-            .send(get_report_export_with_opts(report_id, opts))
-            .await?;
-        ReportExport::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetReportExportRequest::new(report_id.clone(), opts))
+            .await
     }
 
     // ── Results ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -25,7 +25,10 @@ use gvm_gmp::commands::permissions::{GetPermissionsOpts, PermissionOpts};
 use gvm_gmp::commands::port_lists::{GetPortListsOpts, PortListOpts};
 use gvm_gmp::commands::report_configs::GetReportConfigsOpts;
 use gvm_gmp::commands::report_formats::{GetReportFormatsOpts, ReportFormatOpts};
-use gvm_gmp::commands::reports::GetReportsOpts;
+use gvm_gmp::commands::reports::{
+    GetReportDetailsOpts, GetReportExportRequest, GetReportVulnsRequest, GetReportsOpts,
+    GetReportsRequest,
+};
 use gvm_gmp::commands::results::GetResultsOpts;
 use gvm_gmp::commands::roles::{GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::GetScanConfigsOpts;
@@ -229,6 +232,87 @@ async fn generic_execute_decodes_the_requests_associated_response() {
 
     assert_eq!(response.status, 200);
     assert!(response.items.is_empty());
+}
+
+#[tokio::test]
+async fn semantic_report_export_executes_binary_and_nested_xml_codecs() {
+    let cases = [
+        (
+            r#"<get_reports_response status="200" status_text="OK"><report extension="bin" content_type="application/octet-stream">AP8B/g==</report></get_reports_response>"#,
+            vec![0, 255, 1, 254],
+        ),
+        (
+            r#"<get_reports_response status="200" status_text="OK"><report extension="xml" content_type="text/xml"><report id="report-1"><results><result id="one"/><result id="two"/></results></report></report></get_reports_response>"#,
+            br#"<report id="report-1"><results><result id="one"/><result id="two"/></results></report>"#.to_vec(),
+        ),
+    ];
+
+    for (fixture, expected) in cases {
+        let Some(server) = fixture_server(MockVersion::V22_8, &[("get_reports", fixture)]).await
+        else {
+            return;
+        };
+        let mut client = client(&server).await;
+        server.clear_history();
+
+        let export = client
+            .execute(GetReportExportRequest::new(
+                id("report-1"),
+                GetReportExportOpts::new(id("format-1")),
+            ))
+            .await
+            .expect("associated irregular export response decodes");
+
+        assert_eq!(export.bytes, expected);
+        assert_eq!(server.command_history().len(), 1);
+        server.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn semantic_report_requests_execute_large_and_mixed_repeated_responses() {
+    const REPORTS: usize = 2_000;
+    let mut large_fixture = String::from(r#"<get_reports_response status="200" status_text="OK">"#);
+    for index in 0..REPORTS {
+        large_fixture.push_str(&format!(
+            r#"<report id="report-{index}"><name>Report {index}</name></report>"#
+        ));
+    }
+    large_fixture.push_str(&format!(
+        "<report_count>{REPORTS}<filtered>{REPORTS}</filtered></report_count></get_reports_response>"
+    ));
+    let overrides = [("get_reports", large_fixture.as_str())];
+    let Some(server) = fixture_server(MockVersion::V22_8, &overrides).await else {
+        return;
+    };
+    let mut large_client = client(&server).await;
+
+    let reports = large_client
+        .execute(GetReportsRequest::default())
+        .await
+        .expect("large associated report response decodes");
+    assert_eq!(reports.items.len(), REPORTS);
+    server.shutdown().await;
+
+    let mixed_fixture = r#"<get_report_vulns_response status="200" status_text="OK"><vulns><vuln id="one"><name>First</name></vuln><vulnerability id="two"><name>Second</name></vulnerability><vuln id="three"><name>Third</name></vuln></vulns><report_vuln_count>3<filtered>3</filtered></report_vuln_count></get_report_vulns_response>"#;
+    let Some(server) =
+        fixture_server(MockVersion::V22_8, &[("get_report_vulns", mixed_fixture)]).await
+    else {
+        return;
+    };
+    let mut mixed_client = client(&server).await;
+
+    let vulnerabilities = mixed_client
+        .execute(GetReportVulnsRequest::new(
+            id("report-1"),
+            GetReportDetailsOpts::default(),
+        ))
+        .await
+        .expect("mixed repeated response decodes");
+    assert_eq!(vulnerabilities.items.len(), 3);
+    assert_eq!(vulnerabilities.items[1].id.as_deref(), Some("three"));
+    assert_eq!(vulnerabilities.items[2].id.as_deref(), Some("two"));
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -10,7 +10,13 @@ use crate::common::{
     add_filter_attrs, add_optional_id_element, bool_str, set_optional_bool_attr,
     validate_single_xml_document,
 };
-use crate::responses::{ExportScanReportResponse, ParseError};
+use crate::responses::{
+    ExportScanReportResponse, GetAuditReportHostsResponse, GetAuditReportResponse,
+    GetReportApplicationsResponse, GetReportClosedCvesResponse, GetReportCvesResponse,
+    GetReportErrorsResponse, GetReportHostsResponse, GetReportOperatingSystemsResponse,
+    GetReportPortsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
+    GetReportsResponse, GetScanReportResponse, ParseError, ReportExport,
+};
 use crate::types::EntityId;
 use crate::GmpRequest;
 
@@ -114,6 +120,272 @@ pub struct ExportScanReportOpts {
     /// Whether result tags are included.
     pub result_tags: Option<bool>,
 }
+
+/// Semantic request for listing reports.
+#[derive(Debug, Clone, Default)]
+pub struct GetReportsRequest {
+    opts: GetReportsOpts,
+}
+
+impl GetReportsRequest {
+    /// Create a report-list request.
+    #[must_use]
+    pub fn new(opts: GetReportsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetReportsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_reports(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetReportsRequest {
+    type Response = GetReportsResponse;
+}
+
+/// Semantic request for one detailed report.
+#[derive(Debug, Clone)]
+pub struct GetReportRequest {
+    report_id: EntityId,
+}
+
+impl GetReportRequest {
+    /// Create a detailed single-report request.
+    #[must_use]
+    pub fn new(report_id: EntityId) -> Self {
+        Self { report_id }
+    }
+}
+
+impl Request for GetReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_report(&self.report_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetReportRequest {
+    type Response = GetReportsResponse;
+}
+
+/// Semantic request for listing audit reports.
+#[derive(Debug, Clone, Default)]
+pub struct GetAuditReportsRequest {
+    opts: GetReportsOpts,
+}
+
+impl GetAuditReportsRequest {
+    /// Create an audit-report list request.
+    #[must_use]
+    pub fn new(opts: GetReportsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetAuditReportsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_audit_reports(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAuditReportsRequest {
+    type Response = GetReportsResponse;
+}
+
+/// Semantic request for one structured vulnerability report.
+#[derive(Debug, Clone)]
+pub struct GetScanReportRequest {
+    scan_report_id: EntityId,
+    opts: GetScanReportOpts,
+}
+
+impl GetScanReportRequest {
+    /// Create a structured vulnerability-report request.
+    #[must_use]
+    pub fn new(scan_report_id: EntityId, opts: GetScanReportOpts) -> Self {
+        Self {
+            scan_report_id,
+            opts,
+        }
+    }
+}
+
+impl Request for GetScanReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scan_report(&self.scan_report_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScanReportRequest {
+    type Response = GetScanReportResponse;
+}
+
+/// Semantic request for one structured audit report.
+#[derive(Debug, Clone)]
+pub struct GetAuditReportRequest {
+    audit_report_id: EntityId,
+    opts: GetAuditReportOpts,
+}
+
+impl GetAuditReportRequest {
+    /// Create a structured audit-report request.
+    #[must_use]
+    pub fn new(audit_report_id: EntityId, opts: GetAuditReportOpts) -> Self {
+        Self {
+            audit_report_id,
+            opts,
+        }
+    }
+}
+
+impl Request for GetAuditReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_audit_report(&self.audit_report_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAuditReportRequest {
+    type Response = GetAuditReportResponse;
+}
+
+/// Semantic request for structured audit-report host summaries.
+#[derive(Debug, Clone)]
+pub struct GetAuditReportHostsRequest {
+    report_id: EntityId,
+    opts: GetAuditReportHostsOpts,
+}
+
+impl GetAuditReportHostsRequest {
+    /// Create an audit-report host request.
+    #[must_use]
+    pub fn new(report_id: EntityId, opts: GetAuditReportHostsOpts) -> Self {
+        Self { report_id, opts }
+    }
+}
+
+impl Request for GetAuditReportHostsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_audit_report_hosts(&self.report_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAuditReportHostsRequest {
+    type Response = GetAuditReportHostsResponse;
+}
+
+/// Semantic request for a synchronous report-format export.
+#[derive(Debug, Clone)]
+pub struct GetReportExportRequest {
+    report_id: EntityId,
+    opts: GetReportExportOpts,
+}
+
+impl GetReportExportRequest {
+    /// Create a synchronous report-format export request.
+    #[must_use]
+    pub fn new(report_id: EntityId, opts: GetReportExportOpts) -> Self {
+        Self { report_id, opts }
+    }
+}
+
+impl Request for GetReportExportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_report_export_with_opts(&self.report_id, self.opts.clone()).to_bytes()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some("get_report_export")
+    }
+}
+
+impl GmpRequest for GetReportExportRequest {
+    type Response = ReportExport;
+}
+
+macro_rules! report_detail_request {
+    ($request:ident, $response:ty, $builder:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            report_id: EntityId,
+            opts: GetReportDetailsOpts,
+        }
+
+        impl $request {
+            /// Create the structured report-subresource request.
+            #[must_use]
+            pub fn new(report_id: EntityId, opts: GetReportDetailsOpts) -> Self {
+                Self { report_id, opts }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(&self.report_id, self.opts.clone()).to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = $response;
+        }
+    };
+}
+
+report_detail_request!(
+    GetReportHostsRequest,
+    GetReportHostsResponse,
+    get_report_hosts,
+    "Semantic request for report host summaries."
+);
+report_detail_request!(
+    GetReportPortsRequest,
+    GetReportPortsResponse,
+    get_report_ports,
+    "Semantic request for report port summaries."
+);
+report_detail_request!(
+    GetReportApplicationsRequest,
+    GetReportApplicationsResponse,
+    get_report_applications,
+    "Semantic request for report application summaries."
+);
+report_detail_request!(
+    GetReportOperatingSystemsRequest,
+    GetReportOperatingSystemsResponse,
+    get_report_operating_systems,
+    "Semantic request for report operating-system summaries."
+);
+report_detail_request!(
+    GetReportCvesRequest,
+    GetReportCvesResponse,
+    get_report_cves,
+    "Semantic request for report CVE summaries."
+);
+report_detail_request!(
+    GetReportVulnsRequest,
+    GetReportVulnsResponse,
+    get_report_vulns,
+    "Semantic request for report vulnerability summaries."
+);
+report_detail_request!(
+    GetReportTlsCertificatesRequest,
+    GetReportTlsCertificatesResponse,
+    get_report_tls_certificates,
+    "Semantic request for report TLS-certificate summaries."
+);
+report_detail_request!(
+    GetReportErrorsRequest,
+    GetReportErrorsResponse,
+    get_report_errors,
+    "Semantic request for report errors."
+);
+report_detail_request!(
+    GetReportClosedCvesRequest,
+    GetReportClosedCvesResponse,
+    get_report_closed_cves,
+    "Semantic request for report closed-CVE summaries."
+);
 
 /// Semantic request for queuing or reusing an asynchronous report export.
 #[derive(Debug, Clone)]
@@ -467,6 +739,7 @@ pub fn get_report_closed_cves(report_id: &EntityId, opts: GetReportDetailsOpts) 
 mod tests {
     use super::*;
     use crate::common::xml;
+    use crate::GmpResponse;
 
     fn id(value: &str) -> EntityId {
         EntityId::new(value).expect("valid id")
@@ -539,6 +812,126 @@ mod tests {
             semantic.to_bytes(),
             br#"<export_scan_report config_id="config-1" filter="severity&gt;5" format_id="format-1" ignore_pagination="1" lean="0" notes_details="1" overrides_details="0" report_id="report-1" result_tags="1"/>"#
         );
+    }
+
+    fn assert_associated_response<R, T>()
+    where
+        R: GmpRequest<Response = T>,
+        T: GmpResponse,
+    {
+    }
+
+    #[test]
+    fn semantic_report_requests_have_fixed_response_types() {
+        assert_associated_response::<GetReportsRequest, GetReportsResponse>();
+        assert_associated_response::<GetReportRequest, GetReportsResponse>();
+        assert_associated_response::<GetAuditReportsRequest, GetReportsResponse>();
+        assert_associated_response::<GetScanReportRequest, GetScanReportResponse>();
+        assert_associated_response::<GetAuditReportRequest, GetAuditReportResponse>();
+        assert_associated_response::<GetAuditReportHostsRequest, GetAuditReportHostsResponse>();
+        assert_associated_response::<GetReportExportRequest, ReportExport>();
+        assert_associated_response::<GetReportHostsRequest, GetReportHostsResponse>();
+        assert_associated_response::<GetReportPortsRequest, GetReportPortsResponse>();
+        assert_associated_response::<GetReportApplicationsRequest, GetReportApplicationsResponse>();
+        assert_associated_response::<
+            GetReportOperatingSystemsRequest,
+            GetReportOperatingSystemsResponse,
+        >();
+        assert_associated_response::<GetReportCvesRequest, GetReportCvesResponse>();
+        assert_associated_response::<GetReportVulnsRequest, GetReportVulnsResponse>();
+        assert_associated_response::<
+            GetReportTlsCertificatesRequest,
+            GetReportTlsCertificatesResponse,
+        >();
+        assert_associated_response::<GetReportErrorsRequest, GetReportErrorsResponse>();
+        assert_associated_response::<GetReportClosedCvesRequest, GetReportClosedCvesResponse>();
+        assert_associated_response::<ExportScanReportRequest, ExportScanReportResponse>();
+    }
+
+    #[test]
+    fn semantic_report_requests_match_legacy_builder_bytes() {
+        let report_id = id("report-1");
+        let list_opts = GetReportsOpts {
+            filter_string: Some("severity>5".into()),
+            details: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(
+            GetReportsRequest::new(list_opts.clone()).to_bytes(),
+            get_reports(list_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            GetReportRequest::new(report_id.clone()).to_bytes(),
+            get_report(&report_id).to_bytes()
+        );
+        assert_eq!(
+            GetAuditReportsRequest::new(list_opts.clone()).to_bytes(),
+            get_audit_reports(list_opts).to_bytes()
+        );
+
+        let scan_opts = GetScanReportOpts {
+            filter_string: Some("levels=chml".into()),
+            filter_id: Some(id("filter-1")),
+        };
+        assert_eq!(
+            GetScanReportRequest::new(report_id.clone(), scan_opts.clone()).to_bytes(),
+            get_scan_report(&report_id, scan_opts).to_bytes()
+        );
+        let audit_opts = GetAuditReportOpts {
+            filter_string: Some("compliance_levels=yniu".into()),
+            filter_id: Some(id("filter-2")),
+        };
+        assert_eq!(
+            GetAuditReportRequest::new(report_id.clone(), audit_opts.clone()).to_bytes(),
+            get_audit_report(&report_id, audit_opts).to_bytes()
+        );
+        let audit_hosts_opts = GetAuditReportHostsOpts {
+            filter_string: Some("rows=25".into()),
+            filter_id: None,
+            lean: Some(true),
+            details: Some(false),
+        };
+        assert_eq!(
+            GetAuditReportHostsRequest::new(report_id.clone(), audit_hosts_opts.clone()).to_bytes(),
+            get_audit_report_hosts(&report_id, audit_hosts_opts).to_bytes()
+        );
+
+        let mut export_opts = GetReportExportOpts::new(id("format-1"));
+        export_opts.report_config_id = Some(id("config-1"));
+        export_opts.ignore_pagination = Some(false);
+        let export = GetReportExportRequest::new(report_id.clone(), export_opts.clone());
+        assert_eq!(
+            export.to_bytes(),
+            get_report_export_with_opts(&report_id, export_opts).to_bytes()
+        );
+        assert_eq!(export.semantic_command_name(), Some("get_report_export"));
+
+        let detail_opts = GetReportDetailsOpts {
+            filter_string: Some("rows=10".into()),
+            filter_id: Some(id("filter-3")),
+            ignore_pagination: Some(true),
+            details: Some(false),
+        };
+        macro_rules! assert_detail_bytes {
+            ($request:ident, $builder:ident) => {
+                assert_eq!(
+                    $request::new(report_id.clone(), detail_opts.clone()).to_bytes(),
+                    $builder(&report_id, detail_opts.clone()).to_bytes()
+                );
+            };
+        }
+        assert_detail_bytes!(GetReportHostsRequest, get_report_hosts);
+        assert_detail_bytes!(GetReportPortsRequest, get_report_ports);
+        assert_detail_bytes!(GetReportApplicationsRequest, get_report_applications);
+        assert_detail_bytes!(
+            GetReportOperatingSystemsRequest,
+            get_report_operating_systems
+        );
+        assert_detail_bytes!(GetReportCvesRequest, get_report_cves);
+        assert_detail_bytes!(GetReportVulnsRequest, get_report_vulns);
+        assert_detail_bytes!(GetReportTlsCertificatesRequest, get_report_tls_certificates);
+        assert_detail_bytes!(GetReportErrorsRequest, get_report_errors);
+        assert_detail_bytes!(GetReportClosedCvesRequest, get_report_closed_cves);
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/audit_report.rs
+++ b/crates/gvm-gmp/src/responses/audit_report.rs
@@ -9,7 +9,7 @@ use crate::responses::common::{
     count_info, optional_u32, parse_bool, parse_document, parse_entity_id, parse_entity_meta,
     parse_i32, parse_u32, status_from_response, CountInfo, EntityMeta, ParseError, XmlNode,
 };
-use crate::EntityId;
+use crate::{EntityId, GmpResponse, GmpVersion};
 
 /// An open compliance value used by audit reports and host summaries.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -262,6 +262,12 @@ impl GetAuditReportResponse {
     }
 }
 
+impl GmpResponse for GetAuditReportResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl AuditReport {
     fn from_node(node: &XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
@@ -314,6 +320,12 @@ impl GetAuditReportHostsResponse {
             page: parse_page(&root, "audit_report_hosts")?,
             counts: count_info(&root, "audit_report_host_count")?,
         })
+    }
+}
+
+impl GmpResponse for GetAuditReportHostsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -418,6 +418,32 @@ impl GmpResponse for ExportScanReportResponse {
     }
 }
 
+macro_rules! impl_report_gmp_response {
+    ($($response:ty),+ $(,)?) => {
+        $(
+            impl GmpResponse for $response {
+                fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+                    Self::from_response(response)
+                }
+            }
+        )+
+    };
+}
+
+impl_report_gmp_response!(
+    GetReportsResponse,
+    GetReportVulnsResponse,
+    GetReportTlsCertificatesResponse,
+    GetReportErrorsResponse,
+    GetReportClosedCvesResponse,
+    GetReportHostsResponse,
+    GetReportPortsResponse,
+    GetReportApplicationsResponse,
+    GetReportOperatingSystemsResponse,
+    GetReportCvesResponse,
+    ReportExport,
+);
+
 impl ReportVulnerability {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         let nvt = node.child("nvt");
@@ -902,6 +928,28 @@ mod tests {
     }
 
     #[test]
+    fn associated_decoder_handles_large_repeated_report_response() {
+        const REPORTS: usize = 10_000;
+        let mut xml = String::from(r#"<get_reports_response status="200" status_text="OK">"#);
+        for index in 0..REPORTS {
+            xml.push_str(&format!(
+                r#"<report id="report-{index}"><name>Report {index}</name><report><scan_start>2026-09-01T00:00:00Z</scan_start><result_count><full>1</full><filtered>1</filtered></result_count></report></report>"#
+            ));
+        }
+        xml.push_str(&format!(
+            "<report_count>{REPORTS}<filtered>{REPORTS}</filtered></report_count></get_reports_response>"
+        ));
+
+        let response = Response::new(xml.into_bytes());
+        let parsed = <GetReportsResponse as GmpResponse>::decode(&response, GmpVersion(22, 8))
+            .expect("large associated response decodes");
+
+        assert_eq!(parsed.items.len(), REPORTS);
+        assert_eq!(parsed.counts.total, Some(REPORTS as u32));
+        assert_eq!(parsed.items[REPORTS - 1].meta.id.as_str(), "report-9999");
+    }
+
+    #[test]
     fn parses_empty_reports() {
         let response = Response::from(
             r#"<get_reports_response status="200" status_text="OK"><report_count>0<filtered>0</filtered></report_count></get_reports_response>"#,
@@ -1316,6 +1364,36 @@ mod tests {
         assert_eq!(export.bytes, b"Hello PDF");
         assert_eq!(export.content_type.as_deref(), Some("application/pdf"));
         assert_eq!(export.extension.as_deref(), Some("pdf"));
+    }
+
+    #[test]
+    fn associated_decoder_preserves_arbitrary_binary_export_bytes() {
+        let response = Response::from(
+            r#"<get_reports_response status="200" status_text="OK"><report extension="bin" content_type="application/octet-stream">AP8B/g==</report></get_reports_response>"#,
+        );
+
+        let export = <ReportExport as GmpResponse>::decode(&response, GmpVersion(22, 8))
+            .expect("binary export decodes");
+
+        assert_eq!(export.bytes, [0, 255, 1, 254]);
+        assert_eq!(
+            export.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+    }
+
+    #[test]
+    fn associated_decoder_accepts_mixed_repeated_vulnerability_elements() {
+        let response = Response::from(
+            r#"<get_report_vulns_response status="200" status_text="OK"><vulns><vuln id="one"><name>First</name></vuln><vulnerability id="two"><name>Second</name></vulnerability><vuln id="three"><name>Third</name></vuln></vulns><report_vuln_count>3<filtered>3</filtered></report_vuln_count></get_report_vulns_response>"#,
+        );
+
+        let parsed = <GetReportVulnsResponse as GmpResponse>::decode(&response, GmpVersion(22, 8))
+            .expect("mixed repeated vulnerability elements decode");
+
+        assert_eq!(parsed.items.len(), 3);
+        assert_eq!(parsed.items[1].id.as_deref(), Some("three"));
+        assert_eq!(parsed.items[2].name.as_deref(), Some("Second"));
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/scan_report.rs
+++ b/crates/gvm-gmp/src/responses/scan_report.rs
@@ -14,6 +14,7 @@ use crate::responses::common::{
     CountInfo, EntityMeta, ParseError, XmlNode,
 };
 use crate::responses::report::{Severity, SeverityCount};
+use crate::{GmpResponse, GmpVersion};
 
 /// Full and filtered result counts from a structured vulnerability report.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -80,6 +81,12 @@ impl GetScanReportResponse {
             page: parse_page(&root, "scan_report")?,
             counts: count_info(&root, "scan_report_count")?,
         })
+    }
+}
+
+impl GmpResponse for GetScanReportResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -43,6 +43,17 @@ methods remain additive wrappers over generic typed execution. Scan
 configurations remain a separate later batch because they include larger and
 more specialized command surfaces.
 
+The irregular-report Phase 3 batch, tracked by
+[`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report
+list/detail, structured scan and audit reports, audit hosts, nine structured
+report drill-downs, and synchronous report-format export. Existing explicit
+parsers remain authoritative for binary/base64 exports, nested XML exports,
+mixed/repeated response elements, and large bounded responses. Existing typed
+helpers delegate to generic execution, while raw builders and versioned/raw
+helpers remain supported. Version policy stays explicit: audit operations are
+22.7+, scan/drill-down/synchronous-export operations are 22.8+, and
+`export_scan_report` still requires positive help discovery.
+
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|
 | `gvm-protocol` | ✅ Implemented | ~2,330 | 67 | XML command builder, response parser, streaming reader |

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -123,5 +123,50 @@ not need Serde derives. A request whose encoding genuinely differs by GMP
 version must make that distinction explicit in the GMP layer; transport code is
 not the place for command-specific branching.
 
+## Irregular report codecs and version policy
+
+The Phase 3 report family demonstrates that `GmpResponse` is a codec contract,
+not a Serde constraint. Report list/detail responses, structured scan and audit
+reports, report drill-downs, and both export styles all use `execute` while
+retaining their existing explicit parsers:
+
+```rust
+use gvm_gmp::commands::reports::{
+    GetReportExportOpts, GetReportExportRequest, GetReportVulnsRequest,
+};
+
+let export = client
+    .execute(GetReportExportRequest::new(
+        report_id.clone(),
+        GetReportExportOpts::new(report_format_id),
+    ))
+    .await?;
+
+let vulnerabilities = client
+    .execute(GetReportVulnsRequest::new(report_id, Default::default()))
+    .await?;
+```
+
+`ReportExport` accepts base64-encoded arbitrary bytes and the nested XML export
+shape. Structured report parsers retain mixed/repeated element handling and
+large responses remain subject to the same bounded transport frame limit as raw
+execution. No report parser requires `DeserializeOwned`, and the entire response
+is still returned as the request's associated type.
+
+Report command availability is intentionally not inferred from the XML root
+alone:
+
+- structured audit reports and audit-report hosts require GMP 22.7;
+- structured scan reports, report drill-downs, and synchronous report-format
+  export require GMP 22.8;
+- synchronous export uses `<get_reports ...>` on the wire but declares the
+  semantic capability `get_report_export`;
+- asynchronous `export_scan_report` was added without a distinct GMP version
+  and therefore continues to require positive XML-help discovery.
+
+These checks run before transmission through the same `send` path used by raw
+and ordinary typed requests. The retained raw builders and helpers remain
+available when callers need unmodeled report details.
+
 See [ADR 0001](adr/0001-typed-request-response-execution.md) for ownership,
 compatibility, error, and security decisions.


### PR DESCRIPTION
## What Problem This Solves

Phase 3 of #523 requires typed execution for irregular report operations without forcing binary, mixed-content, repeated-element, large, or version-dependent responses through a blanket deserializer. The report family still mixed semantic client wrappers with direct builder/send/parser plumbing.

## Why This Change Was Made

This change adds semantic request/response associations for report list/detail, structured scan and audit reports, audit hosts, all existing report drilldowns, and synchronous report export. Existing command builders and explicit response codecs remain the wire-format source of truth, preserving compatibility while making `GmpClient::execute` the common execution path.

Synchronous export retains the semantic `get_report_export` capability even though the GMP wire root is `get_reports`, so the existing GMP 22.8 gate is preserved. Raw/custom execution remains available for extensions.

## User Impact

- Existing public builders, wrappers, response types, and wire bytes remain compatible.
- Typed execution now covers report list/detail, structured scan/audit subresources, nine drilldowns, synchronous export, and the existing asynchronous export flow.
- Explicit codecs continue to support arbitrary binary exports, nested XML exports, mixed aliases, repeated elements, and large bounded response frames.
- No semver update is required for `gvm-gmp` or `gvm-client`.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo deny check`
- `cargo audit` (no vulnerabilities; existing allowed yanked transitive warning only)
- `cargo machete`
- `cargo vet`
- `make coverage-policy-test`
- `cargo semver-checks check-release --package gvm-gmp --baseline-rev origin/next`
- `cargo semver-checks check-release --package gvm-client --baseline-rev origin/next`

Fixes #546
Advances #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
