### PR TITLE
docs: add journal entry for 2026-09-02

### DIFF
--- a/journal/2026-09-02.md
+++ b/journal/2026-09-02.md
@@ -1,0 +1,9 @@
+# 2026-09-02 — Typed Execution Expands Across Scanners, Credentials, and Reports
+
+## Typed Execution Track
+- Pull requests [#543](https://github.com/greenbone-hive/rust-gvm/pull/543) and [#545](https://github.com/greenbone-hive/rust-gvm/pull/545) merged typed scanner and core credential lifecycle operations into `next`, preserving existing builders, helpers, and wire formats while binding each request to its response type.
+- Pull request [#547](https://github.com/greenbone-hive/rust-gvm/pull/547) merged typed execution for irregular report operations, including report detail, scan and audit subresources, drilldowns, and synchronous export without forcing binary or mixed-content responses through a generic deserializer.
+- Issues [#542](https://github.com/greenbone-hive/rust-gvm/issues/542), [#544](https://github.com/greenbone-hive/rust-gvm/issues/544), and [#546](https://github.com/greenbone-hive/rust-gvm/issues/546) closed with the three deliveries, advancing parent issue [#523](https://github.com/greenbone-hive/rust-gvm/issues/523).
+
+## Validation State
+- CI and Security are green on the latest `next` commit after all three merges.


### PR DESCRIPTION
## Summary

- document typed scanner, credential, and report execution merges
- record closure of the associated migration issues
- capture the green validation state on `next`
