### PR TITLE
refactor(client): type scan-config and policy execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,9 @@ println!("Raw XML: {} bytes", response.data().len());
 
 The `next` Technology Preview lane also exposes semantic request values whose
 response type is selected at compile time. Migrated families cover version
-negotiation, authentication, target/task/credential/scanner lifecycles, and
-irregular report retrieval, drill-down, and export operations:
+negotiation, authentication, target/task/credential/scanner lifecycles,
+scan-config and policy operations, and irregular report retrieval, drill-down,
+and export operations:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -84,10 +84,11 @@ use gvm_gmp::commands::reports::{
 use gvm_gmp::commands::results::{get_results, GetResultsOpts};
 use gvm_gmp::commands::roles::{create_role, get_roles, GetRolesOpts, RoleOpts};
 use gvm_gmp::commands::scan_configs::{
-    clone_scan_config, create_scan_config, delete_scan_config, get_policies, get_policy,
-    get_scan_config, get_scan_configs, import_policy, modify_policy_set_comment,
-    modify_policy_set_name, modify_scan_config, modify_scan_config_set_comment,
-    modify_scan_config_set_name, sync_config, ConfigOpts, GetPolicyOpts, GetScanConfigsOpts,
+    CloneScanConfigRequest, ConfigOpts, CreateScanConfigRequest, DeleteScanConfigRequest,
+    GetPoliciesRequest, GetPolicyOpts, GetPolicyRequest, GetScanConfigRequest, GetScanConfigsOpts,
+    GetScanConfigsRequest, ImportPolicyRequest, ImportScanConfigRequest,
+    ModifyPolicySetCommentRequest, ModifyPolicySetNameRequest, ModifyScanConfigRequest,
+    ModifyScanConfigSetCommentRequest, ModifyScanConfigSetNameRequest, SyncConfigRequest,
 };
 use gvm_gmp::commands::scanners::{
     CloneScannerRequest, CreateScannerRequest, DeleteScannerRequest, GetScannerRequest,
@@ -464,8 +465,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetScanConfigsOpts,
     ) -> Result<GetScanConfigsResponse, GvmError> {
-        let response = self.send(get_scan_configs(opts)).await?;
-        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetScanConfigsRequest::new(opts)).await
     }
 
     /// Send a `create_scan_config` request and return a typed [`CreateScanConfigResponse`].
@@ -478,8 +478,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         base_id: Option<&EntityId>,
         opts: ConfigOpts,
     ) -> Result<CreateScanConfigResponse, GvmError> {
-        let response = self.send(create_scan_config(name, base_id, opts)).await?;
-        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateScanConfigRequest::new(name, base_id.cloned(), opts))
+            .await
     }
 
     /// Send a `create_config` request that imports scan-config XML and return a
@@ -492,9 +492,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         scan_config_xml: &str,
     ) -> Result<CreateScanConfigResponse, GvmError> {
-        let request = gvm_gmp::commands::scan_configs::import_scan_config(scan_config_xml)?;
-        let response = self.send(request).await?;
-        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ImportScanConfigRequest::new(scan_config_xml)?)
+            .await
     }
 
     /// Send a `get_scan_config` request and return a typed [`GetScanConfigsResponse`].
@@ -505,8 +504,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         config_id: &EntityId,
     ) -> Result<GetScanConfigsResponse, GvmError> {
-        let response = self.send(get_scan_config(config_id)).await?;
-        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetScanConfigRequest::new(config_id.clone()))
+            .await
     }
 
     /// Send a policy-scoped `get_configs` request and return a typed
@@ -518,8 +517,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetScanConfigsOpts,
     ) -> Result<GetScanConfigsResponse, GvmError> {
-        let response = self.send(get_policies(opts)).await?;
-        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetPoliciesRequest::new(opts)).await
     }
 
     /// Send a `get_configs` request for a single policy and return a typed
@@ -532,8 +530,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         policy_id: &EntityId,
         opts: GetPolicyOpts,
     ) -> Result<GetScanConfigsResponse, GvmError> {
-        let response = self.send(get_policy(policy_id, opts)).await?;
-        GetScanConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetPolicyRequest::new(policy_id.clone(), opts))
+            .await
     }
 
     /// Send a `create_config` request that imports policy XML and return a
@@ -546,9 +544,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         policy_xml: &str,
     ) -> Result<CreateScanConfigResponse, GvmError> {
-        let request = import_policy(policy_xml)?;
-        let response = self.send(request).await?;
-        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ImportPolicyRequest::new(policy_xml)?).await
     }
 
     /// Send a `modify_scan_config` request and return a typed [`ModifyScanConfigResponse`].
@@ -560,8 +556,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         config_id: &EntityId,
         opts: ConfigOpts,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
-        let response = self.send(modify_scan_config(config_id, opts)).await?;
-        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyScanConfigRequest::new(config_id.clone(), opts))
+            .await
     }
 
     /// Send a `modify_config` request to set a scan-config name and return a
@@ -574,10 +570,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         config_id: &EntityId,
         name: &str,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
-        let response = self
-            .send(modify_scan_config_set_name(config_id, name))
-            .await?;
-        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyScanConfigSetNameRequest::new(config_id.clone(), name))
+            .await
     }
 
     /// Send a `modify_config` request to set or clear a scan-config comment and
@@ -590,10 +584,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         config_id: &EntityId,
         comment: Option<&str>,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
-        let response = self
-            .send(modify_scan_config_set_comment(config_id, comment))
-            .await?;
-        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyScanConfigSetCommentRequest::new(
+            config_id.clone(),
+            comment.map(str::to_string),
+        ))
+        .await
     }
 
     /// Send a `modify_config` request to set a policy name and return a typed
@@ -606,8 +601,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         policy_id: &EntityId,
         name: &str,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
-        let response = self.send(modify_policy_set_name(policy_id, name)).await?;
-        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyPolicySetNameRequest::new(policy_id.clone(), name))
+            .await
     }
 
     /// Send a `modify_config` request to set or clear a policy comment and
@@ -620,10 +615,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         policy_id: &EntityId,
         comment: Option<&str>,
     ) -> Result<ModifyScanConfigResponse, GvmError> {
-        let response = self
-            .send(modify_policy_set_comment(policy_id, comment))
-            .await?;
-        ModifyScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyPolicySetCommentRequest::new(
+            policy_id.clone(),
+            comment.map(str::to_string),
+        ))
+        .await
     }
 
     /// Send a `delete_scan_config` request and return a typed [`DeleteScanConfigResponse`].
@@ -635,8 +631,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         config_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteScanConfigResponse, GvmError> {
-        let response = self.send(delete_scan_config(config_id, ultimate)).await?;
-        DeleteScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteScanConfigRequest::new(config_id.clone(), ultimate))
+            .await
     }
 
     /// Send a `clone_scan_config` request and return a typed [`CreateScanConfigResponse`].
@@ -647,8 +643,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         config_id: &EntityId,
     ) -> Result<CreateScanConfigResponse, GvmError> {
-        let response = self.send(clone_scan_config(config_id)).await?;
-        CreateScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CloneScanConfigRequest::new(config_id.clone()))
+            .await
     }
 
     /// Send the global `sync_config` request and return a typed
@@ -657,8 +653,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn sync_config(&mut self) -> Result<SyncConfigResponse, GvmError> {
-        let response = self.send(sync_config()).await?;
-        SyncConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(SyncConfigRequest::new()).await
     }
 
     /// Send the global `sync_config` request and return a typed

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -44,8 +44,8 @@ use gvm_gmp::commands::reports::{
 };
 use gvm_gmp::commands::roles::RoleOpts;
 use gvm_gmp::commands::scan_configs::{
-    create_policy, get_policies, get_scan_config_preference, get_scan_config_preferences,
-    ConfigOpts, GetPolicyOpts, GetScanConfigPreferencesOpts, GetScanConfigsOpts,
+    create_policy, get_policies, ConfigOpts, GetPolicyOpts, GetScanConfigPreferenceRequest,
+    GetScanConfigPreferencesOpts, GetScanConfigPreferencesRequest, GetScanConfigsOpts,
 };
 use gvm_gmp::commands::scanners::ScannerOpts;
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
@@ -3056,24 +3056,25 @@ async fn preference_getters_send_expected_mock_server_commands() {
         .expect("authenticate should succeed");
     server.clear_history();
 
-    let responses = [
+    let opts = GetScanConfigPreferencesOpts {
+        nvt_oid: Some("1.3.6.1".into()),
+        config_id: Some(EntityId::new("config-1").expect("valid id")),
+    };
+    let typed_responses = [
         client
-            .call(get_scan_config_preferences(GetScanConfigPreferencesOpts {
-                nvt_oid: Some("1.3.6.1".into()),
-                config_id: Some(EntityId::new("config-1").expect("valid id")),
-            }))
+            .execute(GetScanConfigPreferencesRequest::new(opts.clone()))
             .await
             .expect("scan-config preferences request should succeed"),
         client
-            .call(get_scan_config_preference(
-                "timeout",
-                GetScanConfigPreferencesOpts {
-                    nvt_oid: Some("1.3.6.1".into()),
-                    config_id: Some(EntityId::new("config-1").expect("valid id")),
-                },
-            ))
+            .execute(GetScanConfigPreferenceRequest::new("timeout", opts))
             .await
             .expect("scan-config preference request should succeed"),
+    ];
+    assert!(typed_responses
+        .iter()
+        .all(|response| response.status == 200 && response.items.is_empty()));
+
+    let responses = [
         client
             .call(get_nvt_preferences(GetNvtPreferencesOpts {
                 nvt_oid: Some("1.3.6.1".into()),

--- a/crates/gvm-gmp/src/commands/scan_configs.rs
+++ b/crates/gvm-gmp/src/commands/scan_configs.rs
@@ -15,8 +15,12 @@ use crate::commands::configs::{
 };
 use crate::commands::usage_type::UsageType;
 use crate::common::bool_str;
-use crate::responses::ParseError;
+use crate::responses::{
+    CreateScanConfigResponse, DeleteScanConfigResponse, GetScanConfigPreferencesResponse,
+    GetScanConfigsResponse, ModifyScanConfigResponse, ParseError, SyncConfigResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for scan-configuration create and modify requests.
 #[derive(Debug, Clone, Default)]
@@ -66,6 +70,745 @@ pub struct GetPolicyOpts {
     /// Whether to include audits using this policy.
     pub audits: Option<bool>,
 }
+
+/// Semantic request for listing scan configurations.
+#[derive(Debug, Clone, Default)]
+pub struct GetScanConfigsRequest {
+    opts: GetScanConfigsOpts,
+}
+
+impl GetScanConfigsRequest {
+    /// Create a scan-configuration list request.
+    #[must_use]
+    pub fn new(opts: GetScanConfigsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetScanConfigsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scan_configs(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScanConfigsRequest {
+    type Response = GetScanConfigsResponse;
+}
+
+/// Semantic request for one detailed scan configuration.
+#[derive(Debug, Clone)]
+pub struct GetScanConfigRequest {
+    config_id: EntityId,
+}
+
+impl GetScanConfigRequest {
+    /// Create a detailed single scan-configuration request.
+    #[must_use]
+    pub fn new(config_id: EntityId) -> Self {
+        Self { config_id }
+    }
+}
+
+impl Request for GetScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scan_config(&self.config_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScanConfigRequest {
+    type Response = GetScanConfigsResponse;
+}
+
+/// Semantic request for creating a scan configuration.
+#[derive(Debug, Clone)]
+pub struct CreateScanConfigRequest {
+    name: String,
+    base_id: Option<EntityId>,
+    opts: ConfigOpts,
+}
+
+impl CreateScanConfigRequest {
+    /// Create a scan-configuration creation request.
+    #[must_use]
+    pub fn new(name: impl Into<String>, base_id: Option<EntityId>, opts: ConfigOpts) -> Self {
+        Self {
+            name: name.into(),
+            base_id,
+            opts,
+        }
+    }
+}
+
+impl Request for CreateScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_scan_config(&self.name, self.base_id.as_ref(), self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateScanConfigRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for cloning a scan configuration.
+#[derive(Debug, Clone)]
+pub struct CloneScanConfigRequest {
+    config_id: EntityId,
+}
+
+impl CloneScanConfigRequest {
+    /// Create a scan-configuration clone request.
+    #[must_use]
+    pub fn new(config_id: EntityId) -> Self {
+        Self { config_id }
+    }
+}
+
+impl Request for CloneScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_scan_config(&self.config_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneScanConfigRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for importing scan-configuration XML.
+#[derive(Debug, Clone)]
+pub struct ImportScanConfigRequest {
+    bytes: Vec<u8>,
+}
+
+impl ImportScanConfigRequest {
+    /// Validate import XML and create a scan-configuration import request.
+    ///
+    /// # Errors
+    /// Returns an error under the same conditions as [`import_scan_config`].
+    pub fn new(scan_config_xml: &str) -> Result<Self, ParseError> {
+        Ok(Self {
+            bytes: import_scan_config(scan_config_xml)?.to_bytes(),
+        })
+    }
+}
+
+impl Request for ImportScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+impl GmpRequest for ImportScanConfigRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for modifying a scan configuration.
+#[derive(Debug, Clone)]
+pub struct ModifyScanConfigRequest {
+    config_id: EntityId,
+    opts: ConfigOpts,
+}
+
+impl ModifyScanConfigRequest {
+    /// Create a scan-configuration modification request.
+    #[must_use]
+    pub fn new(config_id: EntityId, opts: ConfigOpts) -> Self {
+        Self { config_id, opts }
+    }
+}
+
+impl Request for ModifyScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_scan_config(&self.config_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyScanConfigRequest {
+    type Response = ModifyScanConfigResponse;
+}
+
+/// Semantic request for deleting a scan configuration.
+#[derive(Debug, Clone)]
+pub struct DeleteScanConfigRequest {
+    config_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteScanConfigRequest {
+    /// Create a scan-configuration deletion request.
+    #[must_use]
+    pub fn new(config_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            config_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_scan_config(&self.config_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteScanConfigRequest {
+    type Response = DeleteScanConfigResponse;
+}
+
+/// Semantic request for globally synchronizing configurations.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SyncConfigRequest;
+
+impl SyncConfigRequest {
+    /// Create a global configuration synchronization request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for SyncConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        sync_config().to_bytes()
+    }
+}
+
+impl GmpRequest for SyncConfigRequest {
+    type Response = SyncConfigResponse;
+}
+
+/// Semantic request for listing policies.
+#[derive(Debug, Clone, Default)]
+pub struct GetPoliciesRequest {
+    opts: GetScanConfigsOpts,
+}
+
+impl GetPoliciesRequest {
+    /// Create a policy list request.
+    #[must_use]
+    pub fn new(opts: GetScanConfigsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetPoliciesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_policies(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetPoliciesRequest {
+    type Response = GetScanConfigsResponse;
+}
+
+/// Semantic request for one detailed policy.
+#[derive(Debug, Clone)]
+pub struct GetPolicyRequest {
+    policy_id: EntityId,
+    opts: GetPolicyOpts,
+}
+
+impl GetPolicyRequest {
+    /// Create a detailed single-policy request.
+    #[must_use]
+    pub fn new(policy_id: EntityId, opts: GetPolicyOpts) -> Self {
+        Self { policy_id, opts }
+    }
+}
+
+impl Request for GetPolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_policy(&self.policy_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetPolicyRequest {
+    type Response = GetScanConfigsResponse;
+}
+
+/// Semantic request for creating a policy.
+#[derive(Debug, Clone)]
+pub struct CreatePolicyRequest {
+    name: String,
+    opts: ConfigOpts,
+}
+
+impl CreatePolicyRequest {
+    /// Create a policy creation request.
+    #[must_use]
+    pub fn new(name: impl Into<String>, opts: ConfigOpts) -> Self {
+        Self {
+            name: name.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for CreatePolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_policy(&self.name, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreatePolicyRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for cloning a policy.
+#[derive(Debug, Clone)]
+pub struct ClonePolicyRequest {
+    policy_id: EntityId,
+}
+
+impl ClonePolicyRequest {
+    /// Create a policy clone request.
+    #[must_use]
+    pub fn new(policy_id: EntityId) -> Self {
+        Self { policy_id }
+    }
+}
+
+impl Request for ClonePolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_policy(&self.policy_id).to_bytes()
+    }
+}
+
+impl GmpRequest for ClonePolicyRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for importing policy XML.
+#[derive(Debug, Clone)]
+pub struct ImportPolicyRequest {
+    bytes: Vec<u8>,
+}
+
+impl ImportPolicyRequest {
+    /// Validate import XML and create a policy import request.
+    ///
+    /// # Errors
+    /// Returns an error under the same conditions as [`import_policy`].
+    pub fn new(policy_xml: &str) -> Result<Self, ParseError> {
+        Ok(Self {
+            bytes: import_policy(policy_xml)?.to_bytes(),
+        })
+    }
+}
+
+impl Request for ImportPolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+impl GmpRequest for ImportPolicyRequest {
+    type Response = CreateScanConfigResponse;
+}
+
+/// Semantic request for modifying a policy.
+#[derive(Debug, Clone)]
+pub struct ModifyPolicyRequest {
+    policy_id: EntityId,
+    opts: ConfigOpts,
+}
+
+impl ModifyPolicyRequest {
+    /// Create a policy modification request.
+    #[must_use]
+    pub fn new(policy_id: EntityId, opts: ConfigOpts) -> Self {
+        Self { policy_id, opts }
+    }
+}
+
+impl Request for ModifyPolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_policy(&self.policy_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyPolicyRequest {
+    type Response = ModifyScanConfigResponse;
+}
+
+/// Semantic request for deleting a policy.
+#[derive(Debug, Clone)]
+pub struct DeletePolicyRequest {
+    policy_id: EntityId,
+}
+
+impl DeletePolicyRequest {
+    /// Create a policy deletion request.
+    #[must_use]
+    pub fn new(policy_id: EntityId) -> Self {
+        Self { policy_id }
+    }
+}
+
+impl Request for DeletePolicyRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_policy(&self.policy_id).to_bytes()
+    }
+}
+
+impl GmpRequest for DeletePolicyRequest {
+    type Response = DeleteScanConfigResponse;
+}
+
+/// Semantic request for scan-configuration preferences.
+#[derive(Debug, Clone, Default)]
+pub struct GetScanConfigPreferencesRequest {
+    opts: GetScanConfigPreferencesOpts,
+}
+
+impl GetScanConfigPreferencesRequest {
+    /// Create a scan-configuration preference list request.
+    #[must_use]
+    pub fn new(opts: GetScanConfigPreferencesOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetScanConfigPreferencesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scan_config_preferences(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScanConfigPreferencesRequest {
+    type Response = GetScanConfigPreferencesResponse;
+}
+
+/// Semantic request for one scan-configuration preference.
+#[derive(Debug, Clone)]
+pub struct GetScanConfigPreferenceRequest {
+    name: String,
+    opts: GetScanConfigPreferencesOpts,
+}
+
+impl GetScanConfigPreferenceRequest {
+    /// Create a single scan-configuration preference request.
+    #[must_use]
+    pub fn new(name: impl Into<String>, opts: GetScanConfigPreferencesOpts) -> Self {
+        Self {
+            name: name.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for GetScanConfigPreferenceRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_scan_config_preference(&self.name, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetScanConfigPreferenceRequest {
+    type Response = GetScanConfigPreferencesResponse;
+}
+
+macro_rules! define_nvt_preference_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            name: String,
+            nvt_oid: String,
+            value: Option<String>,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(
+                resource_id: EntityId,
+                name: impl Into<String>,
+                nvt_oid: impl Into<String>,
+                value: Option<String>,
+            ) -> Self {
+                Self {
+                    resource_id,
+                    name: name.into(),
+                    nvt_oid: nvt_oid.into(),
+                    value,
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(
+                    &self.resource_id,
+                    &self.name,
+                    &self.nvt_oid,
+                    self.value.as_deref(),
+                )
+                .to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+macro_rules! define_scanner_preference_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            name: String,
+            value: Option<String>,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(
+                resource_id: EntityId,
+                name: impl Into<String>,
+                value: Option<String>,
+            ) -> Self {
+                Self {
+                    resource_id,
+                    name: name.into(),
+                    value,
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(&self.resource_id, &self.name, self.value.as_deref()).to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+macro_rules! define_nvt_selection_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            family: String,
+            nvt_oids: Vec<String>,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(
+                resource_id: EntityId,
+                family: impl Into<String>,
+                nvt_oids: Vec<String>,
+            ) -> Self {
+                Self {
+                    resource_id,
+                    family: family.into(),
+                    nvt_oids,
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(&self.resource_id, &self.family, &self.nvt_oids).to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+macro_rules! define_family_selection_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            families: Vec<NvtFamilySelection>,
+            auto_add_new_families: bool,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(
+                resource_id: EntityId,
+                families: Vec<NvtFamilySelection>,
+                auto_add_new_families: bool,
+            ) -> Self {
+                Self {
+                    resource_id,
+                    families,
+                    auto_add_new_families,
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(
+                    &self.resource_id,
+                    &self.families,
+                    self.auto_add_new_families,
+                )
+                .to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+macro_rules! define_name_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            name: String,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(resource_id: EntityId, name: impl Into<String>) -> Self {
+                Self {
+                    resource_id,
+                    name: name.into(),
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(&self.resource_id, &self.name).to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+macro_rules! define_comment_request {
+    ($request:ident, $builder:ident, $request_doc:literal, $new_doc:literal) => {
+        #[doc = $request_doc]
+        #[derive(Debug, Clone)]
+        pub struct $request {
+            resource_id: EntityId,
+            comment: Option<String>,
+        }
+
+        impl $request {
+            #[doc = $new_doc]
+            #[must_use]
+            pub fn new(resource_id: EntityId, comment: Option<String>) -> Self {
+                Self {
+                    resource_id,
+                    comment,
+                }
+            }
+        }
+
+        impl Request for $request {
+            fn to_bytes(&self) -> Vec<u8> {
+                $builder(&self.resource_id, self.comment.as_deref()).to_bytes()
+            }
+        }
+
+        impl GmpRequest for $request {
+            type Response = ModifyScanConfigResponse;
+        }
+    };
+}
+
+define_nvt_preference_request!(
+    ModifyScanConfigSetNvtPreferenceRequest,
+    modify_scan_config_set_nvt_preference,
+    "Semantic request for setting or deleting a scan-config NVT preference.",
+    "Create a scan-config NVT-preference mutation request."
+);
+define_scanner_preference_request!(
+    ModifyScanConfigSetScannerPreferenceRequest,
+    modify_scan_config_set_scanner_preference,
+    "Semantic request for setting or deleting a scan-config scanner preference.",
+    "Create a scan-config scanner-preference mutation request."
+);
+define_nvt_selection_request!(
+    ModifyScanConfigSetNvtSelectionRequest,
+    modify_scan_config_set_nvt_selection,
+    "Semantic request for replacing a scan-config NVT selection.",
+    "Create a scan-config NVT-selection mutation request."
+);
+define_family_selection_request!(
+    ModifyScanConfigSetFamilySelectionRequest,
+    modify_scan_config_set_family_selection,
+    "Semantic request for replacing a scan-config family selection.",
+    "Create a scan-config family-selection mutation request."
+);
+define_name_request!(
+    ModifyScanConfigSetNameRequest,
+    modify_scan_config_set_name,
+    "Semantic request for setting a scan-configuration name.",
+    "Create a scan-configuration name mutation request."
+);
+define_comment_request!(
+    ModifyScanConfigSetCommentRequest,
+    modify_scan_config_set_comment,
+    "Semantic request for setting or clearing a scan-configuration comment.",
+    "Create a scan-configuration comment mutation request."
+);
+
+define_nvt_preference_request!(
+    ModifyPolicySetNvtPreferenceRequest,
+    modify_policy_set_nvt_preference,
+    "Semantic request for setting or deleting a policy NVT preference.",
+    "Create a policy NVT-preference mutation request."
+);
+define_scanner_preference_request!(
+    ModifyPolicySetScannerPreferenceRequest,
+    modify_policy_set_scanner_preference,
+    "Semantic request for setting or deleting a policy scanner preference.",
+    "Create a policy scanner-preference mutation request."
+);
+define_nvt_selection_request!(
+    ModifyPolicySetNvtSelectionRequest,
+    modify_policy_set_nvt_selection,
+    "Semantic request for replacing a policy NVT selection.",
+    "Create a policy NVT-selection mutation request."
+);
+define_family_selection_request!(
+    ModifyPolicySetFamilySelectionRequest,
+    modify_policy_set_family_selection,
+    "Semantic request for replacing a policy family selection.",
+    "Create a policy family-selection mutation request."
+);
+define_name_request!(
+    ModifyPolicySetNameRequest,
+    modify_policy_set_name,
+    "Semantic request for setting a policy name.",
+    "Create a policy name mutation request."
+);
+define_comment_request!(
+    ModifyPolicySetCommentRequest,
+    modify_policy_set_comment,
+    "Semantic request for setting or clearing a policy comment.",
+    "Create a policy comment mutation request."
+);
 
 /// Build a clone request for an existing scan config.
 #[must_use]
@@ -793,5 +1536,285 @@ mod tests {
             xml(clone_policy(&id("p1"))),
             "<create_config><copy>p1</copy></create_config>"
         );
+    }
+
+    #[test]
+    fn semantic_scan_config_and_policy_requests_match_builders() {
+        let config_id = id("config-1");
+        let base_id = id("base-1");
+        let list_opts = GetScanConfigsOpts {
+            filter_string: Some("name=example".into()),
+            details: Some(true),
+            ..Default::default()
+        };
+        let config_opts = ConfigOpts {
+            comment: Some("comment".into()),
+            usage_type: Some("custom".into()),
+        };
+        let policy_opts = GetPolicyOpts { audits: Some(true) };
+        let import_xml = "<get_configs_response><config id=\"config-1\"/></get_configs_response>";
+
+        assert_eq!(
+            GetScanConfigsRequest::new(list_opts.clone()).to_bytes(),
+            get_scan_configs(list_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            GetScanConfigRequest::new(config_id.clone()).to_bytes(),
+            get_scan_config(&config_id).to_bytes()
+        );
+        assert_eq!(
+            CreateScanConfigRequest::new("config", Some(base_id.clone()), config_opts.clone())
+                .to_bytes(),
+            create_scan_config("config", Some(&base_id), config_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            CloneScanConfigRequest::new(config_id.clone()).to_bytes(),
+            clone_scan_config(&config_id).to_bytes()
+        );
+        assert_eq!(
+            ImportScanConfigRequest::new(import_xml)
+                .expect("valid import")
+                .to_bytes(),
+            import_scan_config(import_xml)
+                .expect("valid import")
+                .to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigRequest::new(config_id.clone(), config_opts.clone()).to_bytes(),
+            modify_scan_config(&config_id, config_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            DeleteScanConfigRequest::new(config_id.clone(), true).to_bytes(),
+            delete_scan_config(&config_id, true).to_bytes()
+        );
+        assert_eq!(
+            SyncConfigRequest::new().to_bytes(),
+            sync_config().to_bytes()
+        );
+
+        assert_eq!(
+            GetPoliciesRequest::new(list_opts.clone()).to_bytes(),
+            get_policies(list_opts).to_bytes()
+        );
+        assert_eq!(
+            GetPolicyRequest::new(config_id.clone(), policy_opts.clone()).to_bytes(),
+            get_policy(&config_id, policy_opts).to_bytes()
+        );
+        assert_eq!(
+            CreatePolicyRequest::new("policy", config_opts.clone()).to_bytes(),
+            create_policy("policy", config_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            ClonePolicyRequest::new(config_id.clone()).to_bytes(),
+            clone_policy(&config_id).to_bytes()
+        );
+        assert_eq!(
+            ImportPolicyRequest::new(import_xml)
+                .expect("valid import")
+                .to_bytes(),
+            import_policy(import_xml).expect("valid import").to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicyRequest::new(config_id.clone(), config_opts.clone()).to_bytes(),
+            modify_policy(&config_id, config_opts).to_bytes()
+        );
+        assert_eq!(
+            DeletePolicyRequest::new(config_id.clone()).to_bytes(),
+            delete_policy(&config_id).to_bytes()
+        );
+
+        assert!(ImportScanConfigRequest::new("<invalid/>").is_err());
+        assert!(ImportPolicyRequest::new("<invalid/>").is_err());
+    }
+
+    #[test]
+    fn semantic_preference_and_selection_requests_match_builders() {
+        let resource_id = id("config-1");
+        let preference_opts = GetScanConfigPreferencesOpts {
+            nvt_oid: Some("1.3.6.1".into()),
+            config_id: Some(resource_id.clone()),
+        };
+        let nvt_oids = vec!["1.3.6.1".into(), "1.3.6.2".into()];
+        let families = vec![NvtFamilySelection {
+            name: "General".into(),
+            growing: true,
+            all: false,
+        }];
+
+        assert_eq!(
+            GetScanConfigPreferencesRequest::new(preference_opts.clone()).to_bytes(),
+            get_scan_config_preferences(preference_opts.clone()).to_bytes()
+        );
+        assert_eq!(
+            GetScanConfigPreferenceRequest::new("timeout", preference_opts.clone()).to_bytes(),
+            get_scan_config_preference("timeout", preference_opts).to_bytes()
+        );
+
+        assert_eq!(
+            ModifyScanConfigSetNvtPreferenceRequest::new(
+                resource_id.clone(),
+                "timeout",
+                "1.3.6.1",
+                Some("30".into())
+            )
+            .to_bytes(),
+            modify_scan_config_set_nvt_preference(&resource_id, "timeout", "1.3.6.1", Some("30"))
+                .to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigSetScannerPreferenceRequest::new(
+                resource_id.clone(),
+                "max_checks",
+                None
+            )
+            .to_bytes(),
+            modify_scan_config_set_scanner_preference(&resource_id, "max_checks", None).to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigSetNvtSelectionRequest::new(
+                resource_id.clone(),
+                "General",
+                nvt_oids.clone()
+            )
+            .to_bytes(),
+            modify_scan_config_set_nvt_selection(&resource_id, "General", &nvt_oids).to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigSetFamilySelectionRequest::new(
+                resource_id.clone(),
+                families.clone(),
+                true
+            )
+            .to_bytes(),
+            modify_scan_config_set_family_selection(&resource_id, &families, true).to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigSetNameRequest::new(resource_id.clone(), "renamed").to_bytes(),
+            modify_scan_config_set_name(&resource_id, "renamed").to_bytes()
+        );
+        assert_eq!(
+            ModifyScanConfigSetCommentRequest::new(resource_id.clone(), None).to_bytes(),
+            modify_scan_config_set_comment(&resource_id, None).to_bytes()
+        );
+    }
+
+    #[test]
+    fn semantic_policy_preference_and_selection_requests_match_builders() {
+        let resource_id = id("policy-1");
+        let nvt_oids = vec!["1.3.6.1".into(), "1.3.6.2".into()];
+        let families = vec![NvtFamilySelection {
+            name: "General".into(),
+            growing: true,
+            all: false,
+        }];
+
+        assert_eq!(
+            ModifyPolicySetNvtPreferenceRequest::new(
+                resource_id.clone(),
+                "timeout",
+                "1.3.6.1",
+                Some("30".into())
+            )
+            .to_bytes(),
+            modify_policy_set_nvt_preference(&resource_id, "timeout", "1.3.6.1", Some("30"))
+                .to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicySetScannerPreferenceRequest::new(resource_id.clone(), "max_checks", None)
+                .to_bytes(),
+            modify_policy_set_scanner_preference(&resource_id, "max_checks", None).to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicySetNvtSelectionRequest::new(
+                resource_id.clone(),
+                "General",
+                nvt_oids.clone()
+            )
+            .to_bytes(),
+            modify_policy_set_nvt_selection(&resource_id, "General", &nvt_oids).to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicySetFamilySelectionRequest::new(
+                resource_id.clone(),
+                families.clone(),
+                false
+            )
+            .to_bytes(),
+            modify_policy_set_family_selection(&resource_id, &families, false).to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicySetNameRequest::new(resource_id.clone(), "renamed").to_bytes(),
+            modify_policy_set_name(&resource_id, "renamed").to_bytes()
+        );
+        assert_eq!(
+            ModifyPolicySetCommentRequest::new(resource_id.clone(), Some("comment".into()))
+                .to_bytes(),
+            modify_policy_set_comment(&resource_id, Some("comment")).to_bytes()
+        );
+    }
+
+    #[test]
+    fn semantic_scan_config_requests_have_expected_response_associations() {
+        fn assert_response<R, T>(_: &R)
+        where
+            R: GmpRequest<Response = T>,
+            T: crate::GmpResponse,
+        {
+        }
+
+        let resource_id = id("config-1");
+        assert_response::<_, GetScanConfigsResponse>(&GetScanConfigsRequest::default());
+        assert_response::<_, GetScanConfigsResponse>(&GetScanConfigRequest::new(
+            resource_id.clone(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(&CreateScanConfigRequest::new(
+            "config",
+            None,
+            ConfigOpts::default(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(&CloneScanConfigRequest::new(
+            resource_id.clone(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(
+            &ImportScanConfigRequest::new("<get_configs_response/>").expect("valid import"),
+        );
+        assert_response::<_, ModifyScanConfigResponse>(&ModifyScanConfigRequest::new(
+            resource_id.clone(),
+            ConfigOpts::default(),
+        ));
+        assert_response::<_, DeleteScanConfigResponse>(&DeleteScanConfigRequest::new(
+            resource_id.clone(),
+            false,
+        ));
+        assert_response::<_, SyncConfigResponse>(&SyncConfigRequest::new());
+        assert_response::<_, GetScanConfigPreferencesResponse>(
+            &GetScanConfigPreferencesRequest::default(),
+        );
+        assert_response::<_, GetScanConfigPreferencesResponse>(
+            &GetScanConfigPreferenceRequest::new(
+                "timeout",
+                GetScanConfigPreferencesOpts::default(),
+            ),
+        );
+        assert_response::<_, GetScanConfigsResponse>(&GetPoliciesRequest::default());
+        assert_response::<_, GetScanConfigsResponse>(&GetPolicyRequest::new(
+            resource_id.clone(),
+            GetPolicyOpts::default(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(&CreatePolicyRequest::new(
+            "policy",
+            ConfigOpts::default(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(&ClonePolicyRequest::new(
+            resource_id.clone(),
+        ));
+        assert_response::<_, CreateScanConfigResponse>(
+            &ImportPolicyRequest::new("<get_configs_response/>").expect("valid import"),
+        );
+        assert_response::<_, ModifyScanConfigResponse>(&ModifyPolicyRequest::new(
+            resource_id.clone(),
+            ConfigOpts::default(),
+        ));
+        assert_response::<_, DeleteScanConfigResponse>(&DeletePolicyRequest::new(resource_id));
     }
 }

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -153,8 +153,9 @@ pub use role::{
     CreateRoleResponse, DeleteRoleResponse, GetRolesResponse, ModifyRoleResponse, Role,
 };
 pub use scan_config::{
-    CreateScanConfigResponse, DeleteScanConfigResponse, GetScanConfigsResponse,
-    ModifyScanConfigResponse, ScanConfig, SyncConfigResponse,
+    CreateScanConfigResponse, DeleteScanConfigResponse, GetScanConfigPreferencesResponse,
+    GetScanConfigsResponse, ModifyScanConfigResponse, ScanConfig, ScanConfigPreference,
+    ScanConfigPreferenceNvt, SyncConfigResponse,
 };
 pub use scan_report::{GetScanReportResponse, ScanReport, ScanReportResultCount};
 pub use scanner::{

--- a/crates/gvm-gmp/src/responses/scan_config.rs
+++ b/crates/gvm-gmp/src/responses/scan_config.rs
@@ -9,6 +9,7 @@ use crate::responses::common::{
     count_info, optional_u32, parse_document, parse_entity_id, parse_entity_meta,
     status_from_response, ActionResponse, CountInfo, EntityMeta, ParseError,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -40,6 +41,51 @@ pub struct CreateScanConfigResponse {
     pub id: crate::EntityId,
 }
 
+/// NVT metadata attached to a configured preference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScanConfigPreferenceNvt {
+    /// NVT object identifier.
+    pub oid: String,
+    /// Optional NVT name.
+    pub name: Option<String>,
+}
+
+/// A default or configured NVT/scanner preference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScanConfigPreference {
+    /// NVT metadata, present for configuration-scoped preference responses.
+    pub nvt: Option<ScanConfigPreferenceNvt>,
+    /// Preference name.
+    pub name: String,
+    /// Optional preference identifier.
+    pub id: Option<String>,
+    /// Optional preference type.
+    pub type_: Option<String>,
+    /// Optional configured or default value.
+    pub value: Option<String>,
+    /// Alternate allowed values in wire order.
+    pub alternatives: Vec<String>,
+    /// Optional default value.
+    pub default: Option<String>,
+}
+
+/// Typed response for `get_preferences` requests owned by scan configs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GetScanConfigPreferencesResponse {
+    /// GMP response status.
+    pub status: u16,
+    /// GMP response status text.
+    pub status_text: String,
+    /// Returned preferences in wire order.
+    pub items: Vec<ScanConfigPreference>,
+}
+
 impl ScanConfig {
     fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
         Ok(Self {
@@ -69,6 +115,12 @@ impl GetScanConfigsResponse {
     }
 }
 
+impl GmpResponse for GetScanConfigsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateScanConfigResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -83,6 +135,70 @@ impl CreateScanConfigResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateScanConfigResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
+impl ScanConfigPreference {
+    fn from_node(node: &crate::responses::common::XmlNode) -> Result<Self, ParseError> {
+        let nvt = node
+            .child("nvt")
+            .map(|nvt| {
+                let oid = nvt
+                    .attr("oid")
+                    .filter(|oid| !oid.is_empty())
+                    .ok_or_else(|| ParseError::MissingElement("preference.nvt.oid".to_string()))?;
+                Ok::<_, ParseError>(ScanConfigPreferenceNvt {
+                    oid: oid.to_string(),
+                    name: nvt.optional_child_text("name"),
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            nvt,
+            name: node
+                .required_child_text("name")
+                .map_err(|_| ParseError::MissingElement("preference.name".to_string()))?,
+            id: node.optional_child_text("id"),
+            type_: node.optional_child_text("type"),
+            value: node.child("value").map(|value| value.text.clone()),
+            alternatives: node
+                .children_named("alt")
+                .map(|alt| alt.text.clone())
+                .collect(),
+            default: node.child("default").map(|default| default.text.clone()),
+        })
+    }
+}
+
+impl GetScanConfigPreferencesResponse {
+    /// Parse a typed preference response.
+    ///
+    /// # Errors
+    /// Returns an error for a non-success status or malformed preference XML.
+    pub fn from_response(response: &Response) -> Result<Self, ParseError> {
+        let (status, status_text) = status_from_response(response)?;
+        let root = parse_document(response.data())?;
+        let items = root
+            .children_named("preference")
+            .map(ScanConfigPreference::from_node)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            status,
+            status_text,
+            items,
+        })
+    }
+}
+
+impl GmpResponse for GetScanConfigPreferencesResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 
@@ -157,6 +273,57 @@ mod tests {
         let parsed = CreateScanConfigResponse::from_response(&response).expect("create parses");
 
         assert_eq!(parsed.id.as_str(), "cfg-1");
+    }
+
+    #[test]
+    fn parses_default_and_configured_preferences() {
+        let response = Response::from(
+            r#"<get_preferences_response status="200" status_text="OK">
+                <preference>
+                    <name>1.3.6.1:1:entry:Timeout :</name>
+                    <value>5</value>
+                    <alt>10</alt><alt>20</alt><default>5</default>
+                </preference>
+                <preference>
+                    <nvt oid="1.3.6.1"><name>Services</name></nvt>
+                    <id>1</id><name>Timeout :</name><type>entry</type><value></value>
+                </preference>
+            </get_preferences_response>"#,
+        );
+
+        let parsed =
+            GetScanConfigPreferencesResponse::from_response(&response).expect("preferences parse");
+        assert_eq!(parsed.items.len(), 2);
+        assert_eq!(parsed.items[0].value.as_deref(), Some("5"));
+        assert_eq!(parsed.items[0].alternatives, ["10", "20"]);
+        assert_eq!(parsed.items[0].default.as_deref(), Some("5"));
+        assert_eq!(
+            parsed.items[1].nvt.as_ref().map(|nvt| nvt.oid.as_str()),
+            Some("1.3.6.1")
+        );
+        assert_eq!(
+            parsed.items[1]
+                .nvt
+                .as_ref()
+                .and_then(|nvt| nvt.name.as_deref()),
+            Some("Services")
+        );
+        assert_eq!(parsed.items[1].value.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn rejects_preference_nvt_without_oid() {
+        let response = Response::from(
+            r#"<get_preferences_response status="200" status_text="OK">
+                <preference><nvt><name>Services</name></nvt><name>Timeout</name></preference>
+            </get_preferences_response>"#,
+        );
+
+        let error = GetScanConfigPreferencesResponse::from_response(&response)
+            .expect_err("missing NVT OID must fail");
+        assert!(
+            matches!(error, ParseError::MissingElement(field) if field == "preference.nvt.oid")
+        );
     }
 
     #[test]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-09-01
+Last updated: 2026-09-02
 
 ## Support Direction
 
@@ -42,6 +42,16 @@ remain the single byte-compatible encoders, and the existing convenience
 methods remain additive wrappers over generic typed execution. Scan
 configurations remain a separate later batch because they include larger and
 more specialized command surfaces.
+
+The scan-config/policy Phase 2 batch, tracked by
+[`#549`](https://github.com/greenbone-hive/rust-gvm/issues/549), migrates every
+operation owned by the scan-config command family: scan configurations and
+policies, import, preference retrieval and mutation, NVT/family selection, and
+global synchronization. The generic config builders remain the single encoder,
+import validation still happens before transmission, and a typed preference
+response preserves both default and configuration-scoped shapes. Existing
+convenience methods delegate to generic execution; raw builders, `send`, `call`,
+and the deprecated global-sync compatibility shim remain supported.
 
 The irregular-report Phase 3 batch, tracked by
 [`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -168,5 +168,47 @@ These checks run before transmission through the same `send` path used by raw
 and ordinary typed requests. The retained raw builders and helpers remain
 available when callers need unmodeled report details.
 
+## Scan configurations, policies, and preferences
+
+Scan configurations and policies demonstrate semantic typed requests layered
+over shared generic wire commands. Their requests continue to delegate to the
+existing `get_configs`, `create_config`, `modify_config`, and `delete_config`
+builders, so usage-type scoping, import XML validation, preference base64
+encoding, selection ordering, and exact bytes remain unchanged:
+
+```rust
+use gvm_gmp::commands::scan_configs::{
+    GetScanConfigPreferencesOpts, GetScanConfigPreferencesRequest,
+    ModifyScanConfigSetNvtPreferenceRequest,
+};
+
+let preferences = client
+    .execute(GetScanConfigPreferencesRequest::new(
+        GetScanConfigPreferencesOpts {
+            config_id: Some(config_id.clone()),
+            ..Default::default()
+        },
+    ))
+    .await?;
+
+client
+    .execute(ModifyScanConfigSetNvtPreferenceRequest::new(
+        config_id,
+        "Network connection timeout :",
+        "1.3.6.1.4.1.25623.1.0.10330",
+        Some("30".into()),
+    ))
+    .await?;
+```
+
+`GetScanConfigPreferencesResponse` preserves both GMP response shapes: default
+preferences encode the NVT/type in the preference name, while config-scoped
+preferences expose separate NVT metadata, identifier, type, configured value,
+alternate values, and default value. Empty values remain distinguishable from
+missing values. Passing `None` to a preference-mutation request retains the
+existing delete/fallback encoding. Import request constructors validate their
+XML before they can be executed, and `SyncConfigRequest` remains global and
+parameterless.
+
 See [ADR 0001](adr/0001-typed-request-response-execution.md) for ownership,
 compatibility, error, and security decisions.


### PR DESCRIPTION
## What Problem This Solves

Phase 2 of #523 requires typed execution for scan configurations and policies while preserving their shared generic config encoders, import validation, preference semantics, and compatibility helpers. This command family still mixed semantic client wrappers with direct builder/send/parser plumbing and had no typed preference response.

## Why This Change Was Made

This change adds concrete `GmpRequest` values for every public operation owned by `commands::scan_configs`: scan-config and policy lifecycle, import, preference retrieval and mutation, NVT/family selection, and global synchronization. Every request delegates to the existing builder so exact wire bytes and validation behavior remain the source of truth.

It also adds a typed preference response that preserves both default and configuration-scoped GMP shapes, including the distinction between missing and explicitly empty values. Existing scan-config/policy convenience methods are now thin `GmpClient::execute` wrappers.

## User Impact

- Typed execution now covers all 29 public scan-config/policy operations.
- Existing builders, convenience signatures, raw `send`/`call`, and the deprecated global-sync shim remain supported.
- Import XML is still validated before transmission; preference encoding and selection order are unchanged.
- README, implementation status, and typed-execution guidance document the new surface.
- No semver update is required for `gvm-gmp` or `gvm-client`.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- Rust 1.86 `cargo check --workspace --all-features` and `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- warning-free workspace rustdoc
- `cargo deny check`, `cargo audit`, `cargo machete`, and `cargo vet`
- coverage policy regression test and measured 96.50% workspace line coverage
- pinned Python-GVM Unix, TLS, and mutual-TLS integration
- additive semver checks for `gvm-gmp` and `gvm-client` against `origin/next` and `v0.6.0`

Fixes #549
Advances #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
