### PR TITLE
refactor(client): type credential-store execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ println!("Raw XML: {} bytes", response.data().len());
 The `next` Technology Preview lane also exposes semantic request values whose
 response type is selected at compile time. Migrated families cover version
 negotiation, authentication, target/task/credential/scanner lifecycles,
-scan-config and policy operations, and irregular report retrieval, drill-down,
-and export operations:
+scan-config, policy, and credential-store operations, and irregular report
+retrieval, drill-down, and export operations:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -427,21 +427,6 @@ impl<C: GvmConnection> GmpClient<C> {
         })
     }
 
-    pub(crate) fn ensure_semantic_command_supported(
-        &self,
-        command_name: &str,
-    ) -> Result<(), GvmError> {
-        if self.command_supported_with_discovery(command_name) {
-            return Ok(());
-        }
-
-        Err(GvmError::UnsupportedCommand {
-            command: command_name.to_string(),
-            version: self.version,
-            required: self.command_requirement(command_name),
-        })
-    }
-
     fn command_supported_with_discovery(&self, command_name: &str) -> bool {
         let Some(capability) = gvm_gmp::capabilities::command_capability(command_name) else {
             return version::command_supported(command_name, self.version);
@@ -2514,10 +2499,6 @@ mod tests {
             GvmError::UnsupportedCommand { command, .. }
                 if command == "modify_credential_store_credential"
         ));
-        assert!(client
-            .ensure_semantic_command_supported("modify_credential_store_credential")
-            .is_err());
-
         let client = GmpClient {
             connection: ScriptedConnection::new(std::iter::empty::<&str>()),
             version: GmpVersion(22, 8),
@@ -2531,8 +2512,11 @@ mod tests {
             )
             .expect("credential-store modify is available in 22.8");
         client
-            .ensure_semantic_command_supported("modify_credential_store_credential")
-            .expect("semantic helper is available in 22.8");
+            .ensure_command_supported(
+                b"<modify_credential credential_id=\"credential-1\"/>",
+                Some("modify_credential_store_credential"),
+            )
+            .expect("semantic request metadata is available in 22.8");
     }
 
     #[tokio::test]

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -27,11 +27,11 @@ use gvm_gmp::commands::configs::{
     GetConfigOpts, GetConfigsOpts, ModifyConfigOpts,
 };
 use gvm_gmp::commands::credentials::{
-    create_credential_store_credential, get_credential_store, get_credential_stores,
-    get_credential_stores_with_opts, modify_credential_store_credential, verify_credential_store,
-    CreateCredentialRequest, CredentialOpts, CredentialStoreCredentialOpts,
-    DeleteCredentialRequest, GetCredentialStoresOpts, GetCredentialsOpts, GetCredentialsRequest,
+    CreateCredentialRequest, CreateCredentialStoreCredentialRequest, CredentialOpts,
+    CredentialStoreCredentialOpts, DeleteCredentialRequest, GetCredentialStoreRequest,
+    GetCredentialStoresOpts, GetCredentialStoresRequest, GetCredentialsOpts, GetCredentialsRequest,
     ModifyCredentialOpts, ModifyCredentialRequest, ModifyCredentialStoreCredentialOpts,
+    ModifyCredentialStoreCredentialRequest, VerifyCredentialStoreRequest,
 };
 use gvm_gmp::commands::features::get_features;
 use gvm_gmp::commands::feed::{get_feed, get_feeds};
@@ -1232,8 +1232,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_credential_stores(&mut self) -> Result<GetCredentialStoresResponse, GvmError> {
-        let response = self.send(get_credential_stores()).await?;
-        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetCredentialStoresRequest::default()).await
     }
 
     /// Send a `verify_credential_store` request and return a typed
@@ -1245,10 +1244,10 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         credential_store_id: &EntityId,
     ) -> Result<VerifyCredentialStoreResponse, GvmError> {
-        let response = self
-            .send(verify_credential_store(credential_store_id))
-            .await?;
-        VerifyCredentialStoreResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(VerifyCredentialStoreRequest::new(
+            credential_store_id.clone(),
+        ))
+        .await
     }
 
     /// Send a filtered `get_credential_stores` request and return a typed
@@ -1260,8 +1259,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetCredentialStoresOpts,
     ) -> Result<GetCredentialStoresResponse, GvmError> {
-        let response = self.send(get_credential_stores_with_opts(opts)).await?;
-        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetCredentialStoresRequest::new(opts)).await
     }
 
     /// Send a single-store `get_credential_stores` request and return a typed
@@ -1274,10 +1272,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         credential_store_id: &EntityId,
         details: Option<bool>,
     ) -> Result<GetCredentialStoresResponse, GvmError> {
-        let response = self
-            .send(get_credential_store(credential_store_id, details))
-            .await?;
-        GetCredentialStoresResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetCredentialStoreRequest::new(
+            credential_store_id.clone(),
+            details,
+        ))
+        .await
     }
 
     // ── NVTs ──────────────────────────────────────────────────────────────────
@@ -1548,16 +1547,14 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         host_identifier: &str,
         opts: CredentialStoreCredentialOpts,
     ) -> Result<CreateCredentialResponse, GvmError> {
-        let response = self
-            .send(create_credential_store_credential(
-                name,
-                credential_type,
-                vault_id,
-                host_identifier,
-                opts,
-            ))
-            .await?;
-        CreateCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateCredentialStoreCredentialRequest::new(
+            name,
+            credential_type,
+            vault_id,
+            host_identifier,
+            opts,
+        ))
+        .await
     }
 
     /// Send a credential-store-backed `modify_credential` request and return a
@@ -1570,11 +1567,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         credential_id: &EntityId,
         opts: ModifyCredentialStoreCredentialOpts,
     ) -> Result<ModifyCredentialResponse, GvmError> {
-        self.ensure_semantic_command_supported("modify_credential_store_credential")?;
-        let response = self
-            .send(modify_credential_store_credential(credential_id, opts))
-            .await?;
-        ModifyCredentialResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyCredentialStoreCredentialRequest::new(
+            credential_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     // ── Filters ───────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/client_integration.rs
+++ b/crates/gvm-client/tests/client_integration.rs
@@ -30,7 +30,7 @@ use gvm_gmp::commands::credentials::{
     modify_credential_store_credential, CredentialOpts, CredentialStorePreference,
     ModifyCredentialOpts,
     ModifyCredentialStoreCredentialOpts as GmpModifyCredentialStoreCredentialOpts,
-    ModifyCredentialStoreOpts,
+    ModifyCredentialStoreOpts, ModifyCredentialStoreRequest,
 };
 use gvm_gmp::commands::help::HelpMode;
 use gvm_gmp::commands::nvts::{
@@ -2665,12 +2665,34 @@ async fn typed_verify_credential_store_uses_next_command_shape() {
         .expect("verify_credential_store should parse");
     assert_eq!(response.status, 200);
 
+    let response = client
+        .execute(ModifyCredentialStoreRequest::new(
+            credential_store_id.clone(),
+            ModifyCredentialStoreOpts {
+                active: Some(true),
+                host: Some("store.example".into()),
+                preferences: vec![CredentialStorePreference {
+                    name: "token".into(),
+                    value: "secret".into(),
+                }],
+                ..Default::default()
+            },
+        ))
+        .await
+        .expect("modify_credential_store should parse");
+    assert_eq!(response.status, 200);
+
     let history = server.command_history();
-    assert_eq!(history.len(), 1);
+    assert_eq!(history.len(), 2);
     assert_eq!(history[0].command_name(), "verify_credential_store");
     assert_eq!(
         std::str::from_utf8(history[0].raw_xml()).expect("valid UTF-8 command"),
         "<verify_credential_store credential_store_id=\"credential-store-1\"/>"
+    );
+    assert_eq!(history[1].command_name(), "modify_credential_store");
+    assert_eq!(
+        std::str::from_utf8(history[1].raw_xml()).expect("valid UTF-8 command"),
+        "<modify_credential_store credential_store_id=\"credential-store-1\"><active>1</active><host>store.example</host><preferences><preference><name>token</name><value>secret</value></preference></preferences></modify_credential_store>"
     );
 
     server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/credentials.rs
+++ b/crates/gvm-gmp/src/commands/credentials.rs
@@ -13,8 +13,9 @@ use crate::enums::{
     SnmpPrivacyAlgorithm,
 };
 use crate::responses::{
-    CreateCredentialResponse, DeleteCredentialResponse, GetCredentialsResponse,
-    ModifyCredentialResponse,
+    CreateCredentialResponse, DeleteCredentialResponse, GetCredentialStoresResponse,
+    GetCredentialsResponse, ModifyCredentialResponse, ModifyCredentialStoreResponse,
+    VerifyCredentialStoreResponse,
 };
 use crate::types::EntityId;
 use crate::GmpRequest;
@@ -422,6 +423,198 @@ pub struct ModifyCredentialStoreCredentialOpts {
     pub vault_id: Option<String>,
     /// Optional host identifier.
     pub host_identifier: Option<String>,
+}
+
+/// Semantic request for listing or filtering credential stores.
+#[derive(Debug, Clone, Default)]
+pub struct GetCredentialStoresRequest {
+    opts: GetCredentialStoresOpts,
+}
+
+impl GetCredentialStoresRequest {
+    /// Create a credential-store list request.
+    #[must_use]
+    pub fn new(opts: GetCredentialStoresOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetCredentialStoresRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_credential_stores_with_opts(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetCredentialStoresRequest {
+    type Response = GetCredentialStoresResponse;
+}
+
+/// Semantic request for one credential store.
+#[derive(Debug, Clone)]
+pub struct GetCredentialStoreRequest {
+    credential_store_id: EntityId,
+    details: Option<bool>,
+}
+
+impl GetCredentialStoreRequest {
+    /// Create a single credential-store request.
+    #[must_use]
+    pub fn new(credential_store_id: EntityId, details: Option<bool>) -> Self {
+        Self {
+            credential_store_id,
+            details,
+        }
+    }
+}
+
+impl Request for GetCredentialStoreRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_credential_store(&self.credential_store_id, self.details).to_bytes()
+    }
+}
+
+impl GmpRequest for GetCredentialStoreRequest {
+    type Response = GetCredentialStoresResponse;
+}
+
+/// Semantic request for verifying a credential store.
+#[derive(Debug, Clone)]
+pub struct VerifyCredentialStoreRequest {
+    credential_store_id: EntityId,
+}
+
+impl VerifyCredentialStoreRequest {
+    /// Create a credential-store verification request.
+    #[must_use]
+    pub fn new(credential_store_id: EntityId) -> Self {
+        Self {
+            credential_store_id,
+        }
+    }
+}
+
+impl Request for VerifyCredentialStoreRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        verify_credential_store(&self.credential_store_id).to_bytes()
+    }
+}
+
+impl GmpRequest for VerifyCredentialStoreRequest {
+    type Response = VerifyCredentialStoreResponse;
+}
+
+/// Semantic request for modifying a credential store.
+///
+/// This type intentionally omits `Debug`: preference values can contain
+/// secrets and must not gain a new formatting path through typed execution.
+#[derive(Clone)]
+pub struct ModifyCredentialStoreRequest {
+    credential_store_id: EntityId,
+    opts: ModifyCredentialStoreOpts,
+}
+
+impl ModifyCredentialStoreRequest {
+    /// Create a credential-store modification request.
+    #[must_use]
+    pub fn new(credential_store_id: EntityId, opts: ModifyCredentialStoreOpts) -> Self {
+        Self {
+            credential_store_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyCredentialStoreRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_credential_store(&self.credential_store_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyCredentialStoreRequest {
+    type Response = ModifyCredentialStoreResponse;
+}
+
+/// Semantic request for creating a credential-store-backed credential.
+#[derive(Debug, Clone)]
+pub struct CreateCredentialStoreCredentialRequest {
+    name: String,
+    credential_type: CredentialStoreCredentialType,
+    vault_id: String,
+    host_identifier: String,
+    opts: CredentialStoreCredentialOpts,
+}
+
+impl CreateCredentialStoreCredentialRequest {
+    /// Create a credential-store-backed credential request.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        credential_type: CredentialStoreCredentialType,
+        vault_id: impl Into<String>,
+        host_identifier: impl Into<String>,
+        opts: CredentialStoreCredentialOpts,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            credential_type,
+            vault_id: vault_id.into(),
+            host_identifier: host_identifier.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for CreateCredentialStoreCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_credential_store_credential(
+            &self.name,
+            self.credential_type,
+            &self.vault_id,
+            &self.host_identifier,
+            self.opts.clone(),
+        )
+        .to_bytes()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some("create_credential_store_credential")
+    }
+}
+
+impl GmpRequest for CreateCredentialStoreCredentialRequest {
+    type Response = CreateCredentialResponse;
+}
+
+/// Semantic request for modifying a credential-store-backed credential.
+#[derive(Debug, Clone)]
+pub struct ModifyCredentialStoreCredentialRequest {
+    credential_id: EntityId,
+    opts: ModifyCredentialStoreCredentialOpts,
+}
+
+impl ModifyCredentialStoreCredentialRequest {
+    /// Create a credential-store-backed credential modification request.
+    #[must_use]
+    pub fn new(credential_id: EntityId, opts: ModifyCredentialStoreCredentialOpts) -> Self {
+        Self {
+            credential_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyCredentialStoreCredentialRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_credential_store_credential(&self.credential_id, self.opts.clone()).to_bytes()
+    }
+
+    fn semantic_command_name(&self) -> Option<&'static str> {
+        Some("modify_credential_store_credential")
+    }
+}
+
+impl GmpRequest for ModifyCredentialStoreCredentialRequest {
+    type Response = ModifyCredentialResponse;
 }
 
 struct SemanticCommand {
@@ -916,6 +1109,137 @@ mod tests {
             credential_id,
             false,
         ));
+    }
+
+    #[test]
+    fn semantic_credential_store_requests_match_existing_builders_and_aliases() {
+        let store_id = id("store-1");
+        let credential_id = id("credential-1");
+        let get_opts = GetCredentialStoresOpts {
+            filter_string: Some("name=store".into()),
+            filter_id: Some(id("filter-1")),
+            details: Some(true),
+        };
+        let modify_store_opts = ModifyCredentialStoreOpts {
+            active: Some(true),
+            host: Some("store.example".into()),
+            path: Some("/vault".into()),
+            port: Some(8200),
+            comment: Some("primary".into()),
+            preferences: vec![CredentialStorePreference {
+                name: "token".into(),
+                value: "secret".into(),
+            }],
+        };
+        let create_opts = CredentialStoreCredentialOpts {
+            comment: Some("stored credential".into()),
+            credential_store_id: Some(store_id.clone()),
+        };
+        let modify_credential_opts = ModifyCredentialStoreCredentialOpts {
+            name: Some("renamed".into()),
+            comment: Some("stored credential".into()),
+            credential_store_id: Some(store_id.clone()),
+            vault_id: Some("vault-2".into()),
+            host_identifier: Some("host-2".into()),
+        };
+
+        assert_eq!(
+            GetCredentialStoresRequest::default().to_bytes(),
+            get_credential_stores().to_bytes()
+        );
+        assert_eq!(
+            GetCredentialStoresRequest::new(get_opts.clone()).to_bytes(),
+            get_credential_stores_with_opts(get_opts).to_bytes()
+        );
+        assert_eq!(
+            GetCredentialStoreRequest::new(store_id.clone(), Some(true)).to_bytes(),
+            get_credential_store(&store_id, Some(true)).to_bytes()
+        );
+        assert_eq!(
+            VerifyCredentialStoreRequest::new(store_id.clone()).to_bytes(),
+            verify_credential_store(&store_id).to_bytes()
+        );
+        assert_eq!(
+            ModifyCredentialStoreRequest::new(store_id.clone(), modify_store_opts.clone())
+                .to_bytes(),
+            modify_credential_store(&store_id, modify_store_opts).to_bytes()
+        );
+
+        let create = CreateCredentialStoreCredentialRequest::new(
+            "credential",
+            CredentialStoreCredentialType::UsernamePassword,
+            "vault-1",
+            "host-1",
+            create_opts.clone(),
+        );
+        assert_eq!(
+            create.to_bytes(),
+            create_credential_store_credential(
+                "credential",
+                CredentialStoreCredentialType::UsernamePassword,
+                "vault-1",
+                "host-1",
+                create_opts,
+            )
+            .to_bytes()
+        );
+        assert_eq!(
+            create.semantic_command_name(),
+            Some("create_credential_store_credential")
+        );
+
+        let modify = ModifyCredentialStoreCredentialRequest::new(
+            credential_id.clone(),
+            modify_credential_opts.clone(),
+        );
+        assert_eq!(
+            modify.to_bytes(),
+            modify_credential_store_credential(&credential_id, modify_credential_opts).to_bytes()
+        );
+        assert_eq!(
+            modify.semantic_command_name(),
+            Some("modify_credential_store_credential")
+        );
+    }
+
+    #[test]
+    fn semantic_credential_store_requests_have_expected_response_associations() {
+        fn assert_response<R, T>(_: &R)
+        where
+            R: GmpRequest<Response = T>,
+            T: crate::GmpResponse,
+        {
+        }
+
+        let store_id = id("store-1");
+        let credential_id = id("credential-1");
+        assert_response::<_, GetCredentialStoresResponse>(&GetCredentialStoresRequest::default());
+        assert_response::<_, GetCredentialStoresResponse>(&GetCredentialStoreRequest::new(
+            store_id.clone(),
+            Some(true),
+        ));
+        assert_response::<_, VerifyCredentialStoreResponse>(&VerifyCredentialStoreRequest::new(
+            store_id.clone(),
+        ));
+        assert_response::<_, ModifyCredentialStoreResponse>(&ModifyCredentialStoreRequest::new(
+            store_id,
+            ModifyCredentialStoreOpts::default(),
+        ));
+        assert_response::<_, CreateCredentialResponse>(
+            &CreateCredentialStoreCredentialRequest::new(
+                "credential",
+                CredentialStoreCredentialType::UsernamePassword,
+                "vault-1",
+                "host-1",
+                CredentialStoreCredentialOpts::default(),
+            ),
+        );
+        assert_response::<_, ModifyCredentialResponse>(
+            &ModifyCredentialStoreCredentialRequest::new(
+                credential_id,
+                ModifyCredentialStoreCredentialOpts::default(),
+            ),
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/credential.rs
+++ b/crates/gvm-gmp/src/responses/credential.rs
@@ -256,6 +256,12 @@ impl GetCredentialStoresResponse {
     }
 }
 
+impl GmpResponse for GetCredentialStoresResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateCredentialResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -280,6 +286,8 @@ impl GmpResponse for CreateCredentialResponse {
 }
 
 pub type VerifyCredentialStoreResponse = ActionResponse;
+
+pub type ModifyCredentialStoreResponse = ActionResponse;
 
 pub type ModifyCredentialResponse = ActionResponse;
 pub type DeleteCredentialResponse = ActionResponse;

--- a/crates/gvm-gmp/src/responses/mod.rs
+++ b/crates/gvm-gmp/src/responses/mod.rs
@@ -93,7 +93,7 @@ pub use config::{
 pub use credential::{
     CreateCredentialResponse, Credential, CredentialKind, CredentialStore,
     DeleteCredentialResponse, GetCredentialStoresResponse, GetCredentialsResponse,
-    ModifyCredentialResponse, VerifyCredentialStoreResponse,
+    ModifyCredentialResponse, ModifyCredentialStoreResponse, VerifyCredentialStoreResponse,
 };
 pub use features::{Feature, GetFeaturesResponse};
 pub use feed::{Feed, GetFeedsResponse};

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -35,6 +35,16 @@ typed execution. Credential-store operations stay separate because their
 vault, preference, semantic-alias, and version-policy shapes require a focused
 follow-up.
 
+The credential-store Phase 2 batch, tracked by
+[`#551`](https://github.com/greenbone-hive/rust-gvm/issues/551), migrates store
+list/filter/detail, verification and preference-bearing modification, plus
+store-backed credential creation and modification. Existing builders remain
+the byte-compatible encoders. The generic `create_credential` and
+`modify_credential` wire roots retain explicit credential-store semantic names,
+so their GMP 22.8 gates run before transmission; existing facade methods now
+delegate to generic execution. Preference values retain wire-trace redaction,
+and raw/custom execution remains supported.
+
 The scanner-focused Phase 2 batch, tracked by
 [`#542`](https://github.com/greenbone-hive/rust-gvm/issues/542), migrates the
 scanner list/get/create/clone/modify/delete/verify lifecycle. Scanner builders

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -123,6 +123,39 @@ not need Serde derives. A request whose encoding genuinely differs by GMP
 version must make that distinction explicit in the GMP layer; transport code is
 not the place for command-specific branching.
 
+## Credential stores and semantic aliases
+
+Credential stores are available from GMP 22.8. Their list, detail,
+verification, and preference-bearing modification requests use dedicated wire
+roots. Store-backed credentials instead reuse `create_credential` and
+`modify_credential`, so their semantic request values explicitly identify the
+newer operation before sending:
+
+```rust
+use gvm_gmp::commands::credentials::{
+    CreateCredentialStoreCredentialRequest, CredentialStoreCredentialOpts,
+};
+use gvm_gmp::CredentialStoreCredentialType;
+
+let credential = client
+    .execute(CreateCredentialStoreCredentialRequest::new(
+        "production vault credential",
+        CredentialStoreCredentialType::UsernamePassword,
+        "vault-entry-1",
+        "host-1",
+        CredentialStoreCredentialOpts::default(),
+    ))
+    .await?;
+```
+
+This preserves the `create_credential_store_credential` and
+`modify_credential_store_credential` capability gates even though those names
+do not appear as XML roots. A client negotiated below GMP 22.8 rejects them
+before transport. Existing builders remain authoritative for vault and host
+fields, store preferences keep the existing wire-trace redaction, and the
+preference-bearing semantic request deliberately provides no `Debug`
+representation that could expose its values.
+
 ## Irregular report codecs and version policy
 
 The Phase 3 report family demonstrates that `GmpResponse` is a codec contract,


### PR DESCRIPTION
## What Problem This Solves

Phase 2 of #523 requires typed execution for credential-store operations without losing vault/preference semantics or the GMP 22.8 gates hidden behind generic credential wire roots. The family still mixed typed facade methods with direct builder/send/parser plumbing, and `modify_credential_store` had no statically associated response.

## Why This Change Was Made

This change adds semantic requests for store list/filter/detail, verification, preference-bearing modification, and credential-store-backed credential creation/modification. Existing builders remain the byte encoders. The store-backed request types explicitly preserve `create_credential_store_credential` and `modify_credential_store_credential` as semantic command names even though their XML roots are `create_credential` and `modify_credential`.

The existing facade methods are now thin `GmpClient::execute` wrappers, and the obsolete private one-off semantic gate is removed in favor of the common request metadata path. The preference-bearing request deliberately has no `Debug` implementation that could expose values.

## User Impact

- Typed execution now covers the complete existing credential-store surface.
- GMP 22.7 and earlier still reject store-backed generic credential shapes before transmission.
- Existing builders, facade signatures, raw `send`/`call`, exact XML, status/parse context, and wire-trace redaction remain compatible.
- Documentation now explains vault/preference behavior and semantic aliases.
- No semver update is required for `gvm-gmp` or `gvm-client`.

## Evidence

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- Rust 1.86 `cargo check --workspace --all-features` and `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- warning-free workspace rustdoc
- `cargo deny check`, `cargo audit`, `cargo machete`, and `cargo vet`
- coverage policy regression test and measured 96.46% workspace line coverage
- pinned Python-GVM Unix, TLS, and mutual-TLS integration
- additive semver checks for `gvm-gmp` and `gvm-client` against `origin/next` and `v0.6.0`

Fixes #551
Advances #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
