### PR TITLE
docs: add journal entry for 2026-09-03

### DIFF
--- a/journal/2026-09-03.md
+++ b/journal/2026-09-03.md
@@ -1,0 +1,12 @@
+# 2026-09-03 — Typed Execution Covers the Remaining Management Families
+
+## Typed Execution Track
+- Pull requests [#550](https://github.com/greenbone-hive/rust-gvm/pull/550), [#552](https://github.com/greenbone-hive/rust-gvm/pull/552), and [#554](https://github.com/greenbone-hive/rust-gvm/pull/554) merged typed execution for scan configurations and policies, credential stores, and deferred task variants into `next`.
+- Pull requests [#556](https://github.com/greenbone-hive/rust-gvm/pull/556), [#558](https://github.com/greenbone-hive/rust-gvm/pull/558), [#560](https://github.com/greenbone-hive/rust-gvm/pull/560), and [#562](https://github.com/greenbone-hive/rust-gvm/pull/562) extended the migration across alerts and schedules, filters, tags and trashcan operations, notes and overrides, and identity and permission operations.
+- The corresponding focused issues [#549](https://github.com/greenbone-hive/rust-gvm/issues/549), [#551](https://github.com/greenbone-hive/rust-gvm/issues/551), [#553](https://github.com/greenbone-hive/rust-gvm/issues/553), [#555](https://github.com/greenbone-hive/rust-gvm/issues/555), [#557](https://github.com/greenbone-hive/rust-gvm/issues/557), [#559](https://github.com/greenbone-hive/rust-gvm/issues/559), and [#561](https://github.com/greenbone-hive/rust-gvm/issues/561) closed with those deliveries.
+
+## Next Work
+- Issue [#563](https://github.com/greenbone-hive/rust-gvm/issues/563) opened to carry the typed request/response migration into all public NVT and SecInfo query builders, including list, detail, scan-config-scoped, and specialized security-information helpers.
+
+## Validation State
+- CI and Security are green on the latest `next` commit after the seven merges; the transient Security failure on [#558](https://github.com/greenbone-hive/rust-gvm/pull/558) recovered on subsequent merges.


### PR DESCRIPTION
## Summary

- document seven typed-execution merges into `next`
- record the next NVT and SecInfo migration issue
- capture the current green validation state
