### PR TITLE
refactor(client): type alternate target execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,12 @@ println!("Raw XML: {} bytes", response.data().len());
 
 The `next` Technology Preview lane also exposes semantic request values whose
 response type is selected at compile time. Migrated families cover version
-negotiation, authentication, standard and specialized task variants,
-target/credential/scanner lifecycles, scan-config, policy, and credential-store
-operations, alerts and schedules, filters, tags, notes, overrides, trashcan
-recovery, user, group, role, and permission lifecycles, plus irregular report
-retrieval, drill-down, and export operations and the complete NVT/SecInfo query
-surface:
+negotiation, authentication, standard and specialized task variants, standard,
+OCI-image, and web-application target lifecycles, credential/scanner
+lifecycles, scan-config, policy, and credential-store operations, alerts and
+schedules, filters, tags, notes, overrides, trashcan recovery, user, group,
+role, and permission lifecycles, plus irregular report retrieval, drill-down,
+and export operations and the complete NVT/SecInfo query surface:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -63,9 +63,9 @@ use gvm_gmp::commands::nvts::{
     GetScanConfigNvtsRequest,
 };
 use gvm_gmp::commands::oci_image_targets::{
-    clone_oci_image_target, create_oci_image_target, delete_oci_image_target, get_oci_image_target,
-    get_oci_image_targets, modify_oci_image_target, CreateOciImageTargetOpts,
-    GetOciImageTargetsOpts, ModifyOciImageTargetOpts,
+    CloneOciImageTargetRequest, CreateOciImageTargetOpts, CreateOciImageTargetRequest,
+    DeleteOciImageTargetRequest, GetOciImageTargetRequest, GetOciImageTargetsOpts,
+    GetOciImageTargetsRequest, ModifyOciImageTargetOpts, ModifyOciImageTargetRequest,
 };
 use gvm_gmp::commands::operating_systems::{
     get_operating_system, get_operating_systems, GetOperatingSystemsOpts,
@@ -164,9 +164,10 @@ use gvm_gmp::commands::users::{
 };
 use gvm_gmp::commands::version::GetVersionRequest;
 use gvm_gmp::commands::web_application_targets::{
-    clone_web_application_target, create_web_application_target, delete_web_application_target,
-    get_web_application_target, get_web_application_targets, modify_web_application_target,
-    CreateWebApplicationTargetOpts, GetWebApplicationTargetsOpts, ModifyWebApplicationTargetOpts,
+    CloneWebApplicationTargetRequest, CreateWebApplicationTargetOpts,
+    CreateWebApplicationTargetRequest, DeleteWebApplicationTargetRequest,
+    GetWebApplicationTargetRequest, GetWebApplicationTargetsOpts, GetWebApplicationTargetsRequest,
+    ModifyWebApplicationTargetOpts, ModifyWebApplicationTargetRequest,
 };
 use gvm_gmp::responses::{
     ActionResponse, AuthenticateResponse, CreateAlertResponse, CreateAssetResponse,
@@ -314,10 +315,12 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         image_references: &[String],
         opts: CreateOciImageTargetOpts,
     ) -> Result<CreateOciImageTargetResponse, GvmError> {
-        let response = self
-            .send(create_oci_image_target(name, image_references, opts))
-            .await?;
-        CreateOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateOciImageTargetRequest::new(
+            name,
+            image_references.to_vec(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `clone_oci_image_target` request and return a typed
@@ -329,10 +332,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         oci_image_target_id: &EntityId,
     ) -> Result<CreateOciImageTargetResponse, GvmError> {
-        let response = self
-            .send(clone_oci_image_target(oci_image_target_id))
-            .await?;
-        CreateOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CloneOciImageTargetRequest::new(oci_image_target_id.clone()))
+            .await
     }
 
     /// Send a `get_oci_image_targets` request for one target and return a typed
@@ -345,10 +346,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         oci_image_target_id: &EntityId,
         tasks: Option<bool>,
     ) -> Result<GetOciImageTargetsResponse, GvmError> {
-        let response = self
-            .send(get_oci_image_target(oci_image_target_id, tasks))
-            .await?;
-        GetOciImageTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetOciImageTargetRequest::new(
+            oci_image_target_id.clone(),
+            tasks,
+        ))
+        .await
     }
 
     /// Send a `get_oci_image_targets` request and return a typed
@@ -360,8 +362,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetOciImageTargetsOpts,
     ) -> Result<GetOciImageTargetsResponse, GvmError> {
-        let response = self.send(get_oci_image_targets(opts)).await?;
-        GetOciImageTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetOciImageTargetsRequest::new(opts)).await
     }
 
     /// Send a `modify_oci_image_target` request and return a typed
@@ -374,10 +375,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         oci_image_target_id: &EntityId,
         opts: ModifyOciImageTargetOpts,
     ) -> Result<ModifyOciImageTargetResponse, GvmError> {
-        let response = self
-            .send(modify_oci_image_target(oci_image_target_id, opts))
-            .await?;
-        ModifyOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyOciImageTargetRequest::new(
+            oci_image_target_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `delete_oci_image_target` request and return a typed
@@ -390,10 +392,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         oci_image_target_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteOciImageTargetResponse, GvmError> {
-        let response = self
-            .send(delete_oci_image_target(oci_image_target_id, ultimate))
-            .await?;
-        DeleteOciImageTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteOciImageTargetRequest::new(
+            oci_image_target_id.clone(),
+            ultimate,
+        ))
+        .await
     }
 
     /// Send a `create_web_application_target` request and return a typed
@@ -407,10 +410,12 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         urls: &[String],
         opts: CreateWebApplicationTargetOpts,
     ) -> Result<CreateWebApplicationTargetResponse, GvmError> {
-        let response = self
-            .send(create_web_application_target(name, urls, opts))
-            .await?;
-        CreateWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateWebApplicationTargetRequest::new(
+            name,
+            urls.to_vec(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `clone_web_application_target` request and return a typed
@@ -422,10 +427,10 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         web_application_target_id: &EntityId,
     ) -> Result<CreateWebApplicationTargetResponse, GvmError> {
-        let response = self
-            .send(clone_web_application_target(web_application_target_id))
-            .await?;
-        CreateWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CloneWebApplicationTargetRequest::new(
+            web_application_target_id.clone(),
+        ))
+        .await
     }
 
     /// Send a `get_web_application_targets` request for one target and return a
@@ -438,10 +443,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         web_application_target_id: &EntityId,
         tasks: Option<bool>,
     ) -> Result<GetWebApplicationTargetsResponse, GvmError> {
-        let response = self
-            .send(get_web_application_target(web_application_target_id, tasks))
-            .await?;
-        GetWebApplicationTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetWebApplicationTargetRequest::new(
+            web_application_target_id.clone(),
+            tasks,
+        ))
+        .await
     }
 
     /// Send a `get_web_application_targets` request and return a typed
@@ -453,8 +459,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetWebApplicationTargetsOpts,
     ) -> Result<GetWebApplicationTargetsResponse, GvmError> {
-        let response = self.send(get_web_application_targets(opts)).await?;
-        GetWebApplicationTargetsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetWebApplicationTargetsRequest::new(opts))
+            .await
     }
 
     /// Send a `modify_web_application_target` request and return a typed
@@ -467,13 +473,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         web_application_target_id: &EntityId,
         opts: ModifyWebApplicationTargetOpts,
     ) -> Result<ModifyWebApplicationTargetResponse, GvmError> {
-        let response = self
-            .send(modify_web_application_target(
-                web_application_target_id,
-                opts,
-            ))
-            .await?;
-        ModifyWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyWebApplicationTargetRequest::new(
+            web_application_target_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     /// Send a `delete_web_application_target` request and return a typed
@@ -486,13 +490,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         web_application_target_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteWebApplicationTargetResponse, GvmError> {
-        let response = self
-            .send(delete_web_application_target(
-                web_application_target_id,
-                ultimate,
-            ))
-            .await?;
-        DeleteWebApplicationTargetResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteWebApplicationTargetRequest::new(
+            web_application_target_id.clone(),
+            ultimate,
+        ))
+        .await
     }
 
     // ── Scan Configs ──────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -5,7 +5,9 @@
 #![cfg(feature = "unix-socket-tests")]
 
 use gvm_client::{
-    ExportScanReportOpts, GetOciImageTargetsOpts, GetReportExportOpts, GetWebApplicationTargetsOpts,
+    CreateOciImageTargetOpts, CreateWebApplicationTargetOpts, ExportScanReportOpts,
+    GetOciImageTargetsOpts, GetReportExportOpts, GetWebApplicationTargetsOpts,
+    ModifyOciImageTargetOpts, ModifyWebApplicationTargetOpts,
 };
 use gvm_client::{GmpClient, GvmError};
 use gvm_connection::UnixSocketConnection;
@@ -39,7 +41,9 @@ use gvm_gmp::commands::scanners::{
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::{GenericInfoType, GetInfoListOpts, GetSecInfoOpts};
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
-use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest, ModifyTargetOpts};
+use gvm_gmp::commands::targets::{
+    CloneTargetRequest, GetTargetsOpts, GetTargetsRequest, ModifyTargetOpts,
+};
 use gvm_gmp::commands::tasks::{
     create_agent_group_task, create_container_image_task, create_oci_image_target_task,
     create_web_application_task, CloneTaskRequest, CreateAgentGroupTaskOpts,
@@ -294,6 +298,45 @@ const NVT_SECINFO_OVERRIDES: &[(&str, &str)] = &[
     (
         "get_info",
         r#"<get_info_response status="200" status_text="OK"><cert_bund_adv id="CB-1"><name>CERT</name></cert_bund_adv><cpe id="cpe:/a:example"><name>CPE</name></cpe><cve id="CVE-2026-0001"><name>CVE</name></cve><dfn_cert_adv id="DFN-1"><name>DFN</name></dfn_cert_adv><nvt oid="1.3.6.1"><name>NVT</name></nvt><ovaldef id="oval:example:def:1"><name>OVAL</name></ovaldef><os id="os-1"><name>OS</name></os><vuln id="vuln-1"><name>Vulnerability</name></vuln></get_info_response>"#,
+    ),
+];
+
+const ALTERNATE_TARGET_OVERRIDES: &[(&str, &str)] = &[
+    (
+        "create_target",
+        r#"<create_target_response status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#,
+    ),
+    (
+        "create_oci_image_target",
+        r#"<create_oci_image_target_response status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#,
+    ),
+    (
+        "get_oci_image_targets",
+        r#"<get_oci_image_targets_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "modify_oci_image_target",
+        r#"<modify_oci_image_target_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "delete_oci_image_target",
+        r#"<delete_oci_image_target_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "create_web_application_target",
+        r#"<create_web_application_target_response status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#,
+    ),
+    (
+        "get_web_application_targets",
+        r#"<get_web_application_targets_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "modify_web_application_target",
+        r#"<modify_web_application_target_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "delete_web_application_target",
+        r#"<delete_web_application_target_response status="200" status_text="OK"/>"#,
     ),
 ];
 
@@ -556,6 +599,110 @@ async fn nvt_and_secinfo_queries_execute_through_typed_facade() {
             "unexpected facade inventory for {command}"
         );
     }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn alternate_target_requests_execute_through_typed_facade() {
+    let Some(server) = fixture_server(MockVersion::V22_8, ALTERNATE_TARGET_OVERRIDES).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+    let target_id = id(CREATED_ID);
+
+    assert_create_success!(client.execute(CloneTargetRequest::new(target_id.clone())));
+
+    assert_create_success!(client.create_oci_image_target_parsed(
+        "oci",
+        &["registry.example/image:latest".into()],
+        CreateOciImageTargetOpts::default()
+    ));
+    assert_create_success!(client.clone_oci_image_target_parsed(&target_id));
+    assert_typed_success!(client.get_oci_image_target_parsed(&target_id, Some(true)));
+    assert_typed_success!(client.get_oci_image_targets_parsed(GetOciImageTargetsOpts::default()));
+    assert_typed_success!(
+        client.modify_oci_image_target_parsed(&target_id, ModifyOciImageTargetOpts::default())
+    );
+    assert_typed_success!(client.delete_oci_image_target_parsed(&target_id, false));
+
+    assert_create_success!(client.create_web_application_target_parsed(
+        "web",
+        &["https://example.com".into()],
+        CreateWebApplicationTargetOpts::default()
+    ));
+    assert_create_success!(client.clone_web_application_target_parsed(&target_id));
+    assert_typed_success!(client.get_web_application_target_parsed(&target_id, Some(true)));
+    assert_typed_success!(
+        client.get_web_application_targets_parsed(GetWebApplicationTargetsOpts::default())
+    );
+    assert_typed_success!(client.modify_web_application_target_parsed(
+        &target_id,
+        ModifyWebApplicationTargetOpts::default()
+    ));
+    assert_typed_success!(client.delete_web_application_target_parsed(&target_id, false));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 13);
+    for (command, expected_count) in [
+        ("create_target", 1),
+        ("create_oci_image_target", 2),
+        ("get_oci_image_targets", 2),
+        ("modify_oci_image_target", 1),
+        ("delete_oci_image_target", 1),
+        ("create_web_application_target", 2),
+        ("get_web_application_targets", 2),
+        ("modify_web_application_target", 1),
+        ("delete_web_application_target", 1),
+    ] {
+        assert_eq!(
+            history
+                .iter()
+                .filter(|record| record.command_name() == command)
+                .count(),
+            expected_count,
+            "unexpected semantic inventory for {command}"
+        );
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn alternate_target_facades_preserve_status_and_parse_context() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_8,
+        &[
+            (
+                "get_oci_image_targets",
+                r#"<get_oci_image_targets_response status="503" status_text="registry unavailable"/>"#,
+            ),
+            (
+                "create_web_application_target",
+                r#"<create_web_application_target_response status="201" status_text="OK"/>"#,
+            ),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+
+    assert_server_error!(
+        client.get_oci_image_target_parsed(&id("oci-1"), None),
+        503,
+        "registry unavailable"
+    );
+    let parse_error = client
+        .clone_web_application_target_parsed(&id("web-1"))
+        .await
+        .expect_err("missing cloned target id should fail");
+    assert!(matches!(
+        parse_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "id"
+    ));
 
     server.shutdown().await;
 }
@@ -2510,6 +2657,30 @@ async fn distinct_registry_and_semantic_version_gates_fail_before_transport_send
             version: GmpVersion(22, 7),
             required: "22.8",
         } if command == "get_oci_image_targets"
+    ));
+    let oci_clone_error = v227_client
+        .clone_oci_image_target_parsed(&id("oci-1"))
+        .await
+        .expect_err("22.8 OCI-image-target clone gate should reject 22.7");
+    assert!(matches!(
+        oci_clone_error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "create_oci_image_target"
+    ));
+    let web_clone_error = v227_client
+        .clone_web_application_target_parsed(&id("web-1"))
+        .await
+        .expect_err("22.8 web-application-target clone gate should reject 22.7");
+    assert!(matches!(
+        web_clone_error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "create_web_application_target"
     ));
     assert!(v227_server.command_history().is_empty());
     v227_server.shutdown().await;

--- a/crates/gvm-gmp/src/commands/oci_image_targets.rs
+++ b/crates/gvm-gmp/src/commands/oci_image_targets.rs
@@ -8,7 +8,12 @@ use gvm_protocol::{Request, XmlCommand};
 use crate::common::{
     add_filter_attrs, add_optional_id_element, add_text_element, bool_str, set_optional_bool_attr,
 };
+use crate::responses::{
+    CreateOciImageTargetResponse, DeleteOciImageTargetResponse, GetOciImageTargetsResponse,
+    ModifyOciImageTargetResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for `create_oci_image_target` requests.
 #[derive(Debug, Clone, Default)]
@@ -43,6 +48,174 @@ pub struct ModifyOciImageTargetOpts {
     pub image_references: Vec<String>,
     /// Optional credential used for the target.
     pub credential_id: Option<EntityId>,
+}
+
+/// Semantic request for cloning an OCI image target.
+#[derive(Debug, Clone)]
+pub struct CloneOciImageTargetRequest {
+    oci_image_target_id: EntityId,
+}
+
+impl CloneOciImageTargetRequest {
+    /// Create an OCI-image-target clone request.
+    #[must_use]
+    pub fn new(oci_image_target_id: EntityId) -> Self {
+        Self {
+            oci_image_target_id,
+        }
+    }
+}
+
+impl Request for CloneOciImageTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_oci_image_target(&self.oci_image_target_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneOciImageTargetRequest {
+    type Response = CreateOciImageTargetResponse;
+}
+
+/// Semantic request for creating an OCI image target.
+#[derive(Debug, Clone)]
+pub struct CreateOciImageTargetRequest {
+    name: String,
+    image_references: Vec<String>,
+    opts: CreateOciImageTargetOpts,
+}
+
+impl CreateOciImageTargetRequest {
+    /// Create an OCI-image-target creation request.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        image_references: Vec<String>,
+        opts: CreateOciImageTargetOpts,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            image_references,
+            opts,
+        }
+    }
+}
+
+impl Request for CreateOciImageTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_oci_image_target(&self.name, &self.image_references, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateOciImageTargetRequest {
+    type Response = CreateOciImageTargetResponse;
+}
+
+/// Semantic request for listing OCI image targets.
+#[derive(Debug, Clone, Default)]
+pub struct GetOciImageTargetsRequest {
+    opts: GetOciImageTargetsOpts,
+}
+
+impl GetOciImageTargetsRequest {
+    /// Create an OCI-image-target list request.
+    #[must_use]
+    pub fn new(opts: GetOciImageTargetsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetOciImageTargetsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_oci_image_targets(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetOciImageTargetsRequest {
+    type Response = GetOciImageTargetsResponse;
+}
+
+/// Semantic request for one detailed OCI image target.
+#[derive(Debug, Clone)]
+pub struct GetOciImageTargetRequest {
+    oci_image_target_id: EntityId,
+    tasks: Option<bool>,
+}
+
+impl GetOciImageTargetRequest {
+    /// Create a detailed OCI-image-target request.
+    #[must_use]
+    pub fn new(oci_image_target_id: EntityId, tasks: Option<bool>) -> Self {
+        Self {
+            oci_image_target_id,
+            tasks,
+        }
+    }
+}
+
+impl Request for GetOciImageTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_oci_image_target(&self.oci_image_target_id, self.tasks).to_bytes()
+    }
+}
+
+impl GmpRequest for GetOciImageTargetRequest {
+    type Response = GetOciImageTargetsResponse;
+}
+
+/// Semantic request for modifying an OCI image target.
+#[derive(Debug, Clone)]
+pub struct ModifyOciImageTargetRequest {
+    oci_image_target_id: EntityId,
+    opts: ModifyOciImageTargetOpts,
+}
+
+impl ModifyOciImageTargetRequest {
+    /// Create an OCI-image-target modification request.
+    #[must_use]
+    pub fn new(oci_image_target_id: EntityId, opts: ModifyOciImageTargetOpts) -> Self {
+        Self {
+            oci_image_target_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyOciImageTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_oci_image_target(&self.oci_image_target_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyOciImageTargetRequest {
+    type Response = ModifyOciImageTargetResponse;
+}
+
+/// Semantic request for deleting an OCI image target.
+#[derive(Debug, Clone)]
+pub struct DeleteOciImageTargetRequest {
+    oci_image_target_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteOciImageTargetRequest {
+    /// Create an OCI-image-target deletion request.
+    #[must_use]
+    pub fn new(oci_image_target_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            oci_image_target_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteOciImageTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_oci_image_target(&self.oci_image_target_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteOciImageTargetRequest {
+    type Response = DeleteOciImageTargetResponse;
 }
 
 /// Build a clone request for an existing OCI image target.
@@ -182,5 +355,69 @@ mod tests {
             xml(delete_oci_image_target(&id("target-1"), true)),
             "<delete_oci_image_target oci_image_target_id=\"target-1\" ultimate=\"1\"/>"
         );
+    }
+
+    #[test]
+    fn semantic_requests_preserve_builder_bytes_and_response_associations() {
+        fn assert_response<R: GmpRequest<Response = T>, T: crate::GmpResponse>(_: &R) {}
+
+        let target_id = id("target-1");
+        let request = CloneOciImageTargetRequest::new(target_id.clone());
+        assert_eq!(
+            request.to_bytes(),
+            clone_oci_image_target(&target_id).to_bytes()
+        );
+        assert_response::<_, CreateOciImageTargetResponse>(&request);
+
+        let create_opts = CreateOciImageTargetOpts {
+            comment: Some("note".into()),
+            credential_id: Some(id("cred-1")),
+        };
+        let image_references = vec!["registry.example/image:1".into()];
+        let request =
+            CreateOciImageTargetRequest::new("oci", image_references.clone(), create_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            create_oci_image_target("oci", &image_references, create_opts).to_bytes()
+        );
+        assert_response::<_, CreateOciImageTargetResponse>(&request);
+
+        let get_opts = GetOciImageTargetsOpts {
+            filter_string: Some("name=oci".into()),
+            tasks: Some(true),
+            ..Default::default()
+        };
+        let request = GetOciImageTargetsRequest::new(get_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            get_oci_image_targets(get_opts).to_bytes()
+        );
+        assert_response::<_, GetOciImageTargetsResponse>(&request);
+
+        let request = GetOciImageTargetRequest::new(target_id.clone(), Some(false));
+        assert_eq!(
+            request.to_bytes(),
+            get_oci_image_target(&target_id, Some(false)).to_bytes()
+        );
+        assert_response::<_, GetOciImageTargetsResponse>(&request);
+
+        let modify_opts = ModifyOciImageTargetOpts {
+            name: Some("updated".into()),
+            image_references: vec!["registry.example/image:latest".into()],
+            ..Default::default()
+        };
+        let request = ModifyOciImageTargetRequest::new(target_id.clone(), modify_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            modify_oci_image_target(&target_id, modify_opts).to_bytes()
+        );
+        assert_response::<_, ModifyOciImageTargetResponse>(&request);
+
+        let request = DeleteOciImageTargetRequest::new(target_id.clone(), true);
+        assert_eq!(
+            request.to_bytes(),
+            delete_oci_image_target(&target_id, true).to_bytes()
+        );
+        assert_response::<_, DeleteOciImageTargetResponse>(&request);
     }
 }

--- a/crates/gvm-gmp/src/commands/targets.rs
+++ b/crates/gvm-gmp/src/commands/targets.rs
@@ -306,6 +306,30 @@ impl GmpRequest for DeleteTargetRequest {
     type Response = DeleteTargetResponse;
 }
 
+/// Semantic request for cloning a target.
+#[derive(Debug, Clone)]
+pub struct CloneTargetRequest {
+    target_id: EntityId,
+}
+
+impl CloneTargetRequest {
+    /// Create a target-clone request.
+    #[must_use]
+    pub fn new(target_id: EntityId) -> Self {
+        Self { target_id }
+    }
+}
+
+impl Request for CloneTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_target(&self.target_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneTargetRequest {
+    type Response = CreateTargetResponse;
+}
+
 /// Build a clone request for an existing target.
 #[must_use]
 pub fn clone_target(target_id: &EntityId) -> impl Request {
@@ -668,6 +692,8 @@ mod tests {
 
     #[test]
     fn semantic_target_requests_match_legacy_builder_bytes() {
+        fn assert_response<R: GmpRequest<Response = T>, T: crate::GmpResponse>(_: &R) {}
+
         let list_opts = GetTargetsOpts {
             filter_string: Some("name=production".into()),
             details: Some(true),
@@ -713,6 +739,10 @@ mod tests {
             DeleteTargetRequest::new(target_id.clone(), true).to_bytes(),
             delete_target(&target_id, true).to_bytes()
         );
+
+        let request = CloneTargetRequest::new(target_id.clone());
+        assert_eq!(request.to_bytes(), clone_target(&target_id).to_bytes());
+        assert_response::<_, CreateTargetResponse>(&request);
     }
 
     #[test]

--- a/crates/gvm-gmp/src/commands/web_application_targets.rs
+++ b/crates/gvm-gmp/src/commands/web_application_targets.rs
@@ -8,7 +8,12 @@ use gvm_protocol::{Request, XmlCommand};
 use crate::common::{
     add_filter_attrs, add_optional_id_element, add_text_element, bool_str, set_optional_bool_attr,
 };
+use crate::responses::{
+    CreateWebApplicationTargetResponse, DeleteWebApplicationTargetResponse,
+    GetWebApplicationTargetsResponse, ModifyWebApplicationTargetResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for `create_web_application_target` requests.
 #[derive(Debug, Clone, Default)]
@@ -47,6 +52,174 @@ pub struct ModifyWebApplicationTargetOpts {
     pub exclude_urls: Vec<String>,
     /// Optional credential used for the target.
     pub credential_id: Option<EntityId>,
+}
+
+/// Semantic request for cloning a web application target.
+#[derive(Debug, Clone)]
+pub struct CloneWebApplicationTargetRequest {
+    web_application_target_id: EntityId,
+}
+
+impl CloneWebApplicationTargetRequest {
+    /// Create a web-application-target clone request.
+    #[must_use]
+    pub fn new(web_application_target_id: EntityId) -> Self {
+        Self {
+            web_application_target_id,
+        }
+    }
+}
+
+impl Request for CloneWebApplicationTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_web_application_target(&self.web_application_target_id).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneWebApplicationTargetRequest {
+    type Response = CreateWebApplicationTargetResponse;
+}
+
+/// Semantic request for creating a web application target.
+#[derive(Debug, Clone)]
+pub struct CreateWebApplicationTargetRequest {
+    name: String,
+    urls: Vec<String>,
+    opts: CreateWebApplicationTargetOpts,
+}
+
+impl CreateWebApplicationTargetRequest {
+    /// Create a web-application-target creation request.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        urls: Vec<String>,
+        opts: CreateWebApplicationTargetOpts,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            urls,
+            opts,
+        }
+    }
+}
+
+impl Request for CreateWebApplicationTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_web_application_target(&self.name, &self.urls, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateWebApplicationTargetRequest {
+    type Response = CreateWebApplicationTargetResponse;
+}
+
+/// Semantic request for listing web application targets.
+#[derive(Debug, Clone, Default)]
+pub struct GetWebApplicationTargetsRequest {
+    opts: GetWebApplicationTargetsOpts,
+}
+
+impl GetWebApplicationTargetsRequest {
+    /// Create a web-application-target list request.
+    #[must_use]
+    pub fn new(opts: GetWebApplicationTargetsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetWebApplicationTargetsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_web_application_targets(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetWebApplicationTargetsRequest {
+    type Response = GetWebApplicationTargetsResponse;
+}
+
+/// Semantic request for one detailed web application target.
+#[derive(Debug, Clone)]
+pub struct GetWebApplicationTargetRequest {
+    web_application_target_id: EntityId,
+    tasks: Option<bool>,
+}
+
+impl GetWebApplicationTargetRequest {
+    /// Create a detailed web-application-target request.
+    #[must_use]
+    pub fn new(web_application_target_id: EntityId, tasks: Option<bool>) -> Self {
+        Self {
+            web_application_target_id,
+            tasks,
+        }
+    }
+}
+
+impl Request for GetWebApplicationTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_web_application_target(&self.web_application_target_id, self.tasks).to_bytes()
+    }
+}
+
+impl GmpRequest for GetWebApplicationTargetRequest {
+    type Response = GetWebApplicationTargetsResponse;
+}
+
+/// Semantic request for modifying a web application target.
+#[derive(Debug, Clone)]
+pub struct ModifyWebApplicationTargetRequest {
+    web_application_target_id: EntityId,
+    opts: ModifyWebApplicationTargetOpts,
+}
+
+impl ModifyWebApplicationTargetRequest {
+    /// Create a web-application-target modification request.
+    #[must_use]
+    pub fn new(web_application_target_id: EntityId, opts: ModifyWebApplicationTargetOpts) -> Self {
+        Self {
+            web_application_target_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyWebApplicationTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_web_application_target(&self.web_application_target_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyWebApplicationTargetRequest {
+    type Response = ModifyWebApplicationTargetResponse;
+}
+
+/// Semantic request for deleting a web application target.
+#[derive(Debug, Clone)]
+pub struct DeleteWebApplicationTargetRequest {
+    web_application_target_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteWebApplicationTargetRequest {
+    /// Create a web-application-target deletion request.
+    #[must_use]
+    pub fn new(web_application_target_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            web_application_target_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteWebApplicationTargetRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_web_application_target(&self.web_application_target_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteWebApplicationTargetRequest {
+    type Response = DeleteWebApplicationTargetResponse;
 }
 
 /// Build a clone request for an existing web application target.
@@ -204,5 +377,72 @@ mod tests {
             xml(delete_web_application_target(&id("target-1"), true)),
             "<delete_web_application_target ultimate=\"1\" web_application_target_id=\"target-1\"/>"
         );
+    }
+
+    #[test]
+    fn semantic_requests_preserve_builder_bytes_and_response_associations() {
+        fn assert_response<R: GmpRequest<Response = T>, T: crate::GmpResponse>(_: &R) {}
+
+        let target_id = id("target-1");
+        let request = CloneWebApplicationTargetRequest::new(target_id.clone());
+        assert_eq!(
+            request.to_bytes(),
+            clone_web_application_target(&target_id).to_bytes()
+        );
+        assert_response::<_, CreateWebApplicationTargetResponse>(&request);
+
+        let create_opts = CreateWebApplicationTargetOpts {
+            comment: Some("note".into()),
+            exclude_urls: vec!["https://example.com/logout".into()],
+            credential_id: Some(id("cred-1")),
+        };
+        let urls = vec!["https://example.com".into()];
+        let request =
+            CreateWebApplicationTargetRequest::new("web", urls.clone(), create_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            create_web_application_target("web", &urls, create_opts).to_bytes()
+        );
+        assert_response::<_, CreateWebApplicationTargetResponse>(&request);
+
+        let get_opts = GetWebApplicationTargetsOpts {
+            filter_string: Some("name=web".into()),
+            tasks: Some(true),
+            ..Default::default()
+        };
+        let request = GetWebApplicationTargetsRequest::new(get_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            get_web_application_targets(get_opts).to_bytes()
+        );
+        assert_response::<_, GetWebApplicationTargetsResponse>(&request);
+
+        let request = GetWebApplicationTargetRequest::new(target_id.clone(), Some(false));
+        assert_eq!(
+            request.to_bytes(),
+            get_web_application_target(&target_id, Some(false)).to_bytes()
+        );
+        assert_response::<_, GetWebApplicationTargetsResponse>(&request);
+
+        let modify_opts = ModifyWebApplicationTargetOpts {
+            name: Some("updated".into()),
+            urls: vec!["https://example.com/app".into()],
+            exclude_urls: vec!["https://example.com/logout".into()],
+            ..Default::default()
+        };
+        let request =
+            ModifyWebApplicationTargetRequest::new(target_id.clone(), modify_opts.clone());
+        assert_eq!(
+            request.to_bytes(),
+            modify_web_application_target(&target_id, modify_opts).to_bytes()
+        );
+        assert_response::<_, ModifyWebApplicationTargetResponse>(&request);
+
+        let request = DeleteWebApplicationTargetRequest::new(target_id.clone(), true);
+        assert_eq!(
+            request.to_bytes(),
+            delete_web_application_target(&target_id, true).to_bytes()
+        );
+        assert_response::<_, DeleteWebApplicationTargetResponse>(&request);
     }
 }

--- a/crates/gvm-gmp/src/responses/oci_image_target.rs
+++ b/crates/gvm-gmp/src/responses/oci_image_target.rs
@@ -10,6 +10,7 @@ use crate::responses::common::{
     parse_entity_ref, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
     ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -71,6 +72,12 @@ impl GetOciImageTargetsResponse {
     }
 }
 
+impl GmpResponse for GetOciImageTargetsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateOciImageTargetResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -85,6 +92,12 @@ impl CreateOciImageTargetResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateOciImageTargetResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/web_application_target.rs
+++ b/crates/gvm-gmp/src/responses/web_application_target.rs
@@ -10,6 +10,7 @@ use crate::responses::common::{
     parse_entity_ref, status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity,
     ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -76,6 +77,12 @@ impl GetWebApplicationTargetsResponse {
     }
 }
 
+impl GmpResponse for GetWebApplicationTargetsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateWebApplicationTargetResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -90,6 +97,12 @@ impl CreateWebApplicationTargetResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateWebApplicationTargetResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -14,7 +14,7 @@ The `next` Technology Preview lane now includes the first statically associated
 typed-execution slice. `GmpRequest` binds a semantic request to one
 `GmpResponse`, and `GmpClient::execute` preserves existing command gates,
 redacted tracing, parsing, and compatibility APIs. Version/authentication,
-target list/get/create/modify/delete, and asynchronous report export prove the
+target list/get/create/clone/modify/delete, and asynchronous report export prove the
 contract before family-by-family migration. See
 [ADR 0001](adr/0001-typed-request-response-execution.md) and the
 [typed-execution guide](typed-execution.md).
@@ -115,6 +115,17 @@ resource kinds, while CPE, CVE, advisory, operating-system, and vulnerability
 requests retain their specialized response codecs. Existing facade methods now
 delegate to `execute`; explicit SecInfo operating-system and vulnerability
 helper names avoid changing the distinct asset and legacy `get_vulns` APIs.
+
+The alternate-target Phase 2 batch, tracked by
+[`#567`](https://github.com/greenbone-hive/rust-gvm/issues/567), completes the
+existing target command boundary with the remaining standard target clone plus
+all OCI-image and web-application target list/detail/create/clone/modify/delete
+operations. Each operation has a distinct semantic request and delegates to its
+established public builder, preserving filters, relationship fields, mutation
+behavior, and exact XML bytes. The OCI-image and web-application families
+retain their GMP 22.8 gates while standard target cloning remains baseline.
+All twelve existing `_parsed` facade helpers now delegate to `execute`;
+builders and raw/custom execution remain supported.
 
 The irregular-report Phase 3 batch, tracked by
 [`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -258,6 +258,22 @@ SecInfo operating-system and vulnerability facades are named
 change the distinct `get_assets` and legacy `get_vulns` helper behavior. Raw
 builders and `send`/`call` remain available for callers that need complete XML.
 
+## Alternate target lifecycles
+
+The target command boundary includes a semantic `CloneTargetRequest` for the
+remaining standard target clone operation and complete list, detail, create,
+clone, modify, and delete request types for both OCI-image and web-application
+targets. Each request delegates to its existing builder, so filters, saved
+filter identifiers, trash and task flags, image/URL collections, credential
+relationships, ultimate deletion, and exact XML bytes remain unchanged.
+
+Standard target cloning retains the baseline `create_target` capability. The
+OCI-image and web-application request types keep their separate semantic intent
+and their existing GMP 22.8 command gates, including clone requests encoded by
+the respective creation command. All existing `_parsed` convenience methods
+for the two alternate-target families are thin `execute` wrappers. Raw builders
+and `send`/`call` remain available without introducing a second encoding path.
+
 ## Irregular report codecs and version policy
 
 The Phase 3 report family demonstrates that `GmpResponse` is a codec contract,


### PR DESCRIPTION
## What Problem This Solves

Standard target cloning and the OCI-image and web-application target lifecycles still required manual builder/parser pairing. Their twelve typed facade helpers used raw `send`, so their response association was not enforced by the generic execution contract from #523.

## Why This Change Was Made

This adds all 13 scoped semantic request types and binds each to its correct response while preserving the established builders as the only XML encoders. The alternate-target types keep explicit semantic identities and the existing GMP 22.8 gates before transmission.

## User Impact

- Standard target clone plus OCI-image and web-application target list/detail/create/clone/modify/delete can use `GmpClient::execute` safely.
- All twelve existing `_parsed` facade helpers now delegate through `execute`.
- Existing builders, raw compatibility APIs, response models, filters, relationships, validation, version policy, and wire bytes remain unchanged.

## Evidence

- Exact-byte and compile-time response-association coverage for all 13 semantic requests.
- Live Unix full-surface success, status, parse-context, pre-send version-gate, and facade-inventory coverage.
- Full `cargo test --workspace --all-features` passes.
- Strict all-target/all-feature workspace Clippy passes with warnings denied.
- Warning-free all-feature workspace rustdoc passes.
- Formatting and `git diff --check` pass.
- Signed commit: `303006c87e4e7a3989e77bc7080aa53253fc3c72`.

Fixes #567
Part of #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
