### PR TITLE
refactor(client): type agent and integration execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,9 @@ lifecycles, scan-config, policy, and credential-store operations, alerts and
 schedules, filters, tags, notes, overrides, trashcan recovery, user, group,
 role, and permission lifecycles, plus irregular report retrieval, drill-down,
 and export operations and the complete NVT/SecInfo query surface. Generic
-assets, host and operating-system asset lifecycles, and result list/detail
-queries use the same execution contract:
+assets, host and operating-system asset lifecycles, result list/detail queries,
+and the GMP 22.8 agent, agent-group, and integration-configuration families use
+the same execution contract, including binary/base64 support bundles:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/lib.rs
+++ b/crates/gvm-client/src/lib.rs
@@ -24,12 +24,13 @@ use std::sync::Arc;
 
 use gvm_connection::GvmConnection;
 use gvm_gmp::commands::agent_groups::{
-    clone_agent_group, create_agent_group, delete_agent_group, get_agent_group, get_agent_groups,
-    modify_agent_group,
+    CloneAgentGroupRequest, CreateAgentGroupRequest, DeleteAgentGroupRequest, GetAgentGroupRequest,
+    GetAgentGroupsRequest, ModifyAgentGroupRequest,
 };
 use gvm_gmp::commands::agents::{
-    delete_agent, get_agent, get_agent_installer_instruction, get_agent_support_bundle, get_agents,
-    modify_agent, modify_agent_control_scan_config, sync_agents,
+    DeleteAgentRequest, GetAgentInstallerInstructionRequest, GetAgentRequest,
+    GetAgentSupportBundleRequest, GetAgentsRequest, ModifyAgentControlScanConfigRequest,
+    ModifyAgentRequest, SyncAgentsRequest,
 };
 use gvm_gmp::commands::credentials::{
     create_credential_store_credential, get_credential_store, get_credential_stores,
@@ -498,8 +499,7 @@ impl<C: GvmConnection> GmpClient<C> {
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
     pub async fn get_agents(&mut self, opts: GetAgentsOpts) -> Result<GetAgentsResponse, GvmError> {
-        let response = self.call(get_agents(opts)).await?;
-        GetAgentsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentsRequest::new(opts)).await
     }
 
     /// Get a single agent.
@@ -508,8 +508,7 @@ impl<C: GvmConnection> GmpClient<C> {
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
     pub async fn get_agent(&mut self, agent_id: &EntityId) -> Result<GetAgentsResponse, GvmError> {
-        let response = self.call(get_agent(agent_id)).await?;
-        GetAgentsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentRequest::new(agent_id.clone())).await
     }
 
     /// Modify one or more agents.
@@ -522,8 +521,8 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_ids: &[EntityId],
         opts: ModifyAgentOpts,
     ) -> Result<ModifyAgentResponse, GvmError> {
-        let response = self.call(modify_agent(agent_ids, opts)).await?;
-        ModifyAgentResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyAgentRequest::new(agent_ids.to_vec(), opts))
+            .await
     }
 
     /// Delete one or more agents.
@@ -535,8 +534,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_ids: &[EntityId],
     ) -> Result<DeleteAgentResponse, GvmError> {
-        let response = self.call(delete_agent(agent_ids)).await?;
-        DeleteAgentResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteAgentRequest::new(agent_ids.to_vec()))
+            .await
     }
 
     /// Synchronize agents.
@@ -545,8 +544,7 @@ impl<C: GvmConnection> GmpClient<C> {
     /// Returns an error if the server does not support the command, the transport fails,
     /// parsing fails, or the server returns a non-success status.
     pub async fn sync_agents(&mut self) -> Result<SyncAgentsResponse, GvmError> {
-        let response = self.call(sync_agents()).await?;
-        SyncAgentsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(SyncAgentsRequest::new()).await
     }
 
     /// Modify the agent-control scan configuration defaults.
@@ -559,10 +557,11 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_control_id: &EntityId,
         opts: ModifyAgentControlScanConfigOpts,
     ) -> Result<ModifyAgentControlScanConfigResponse, GvmError> {
-        let response = self
-            .call(modify_agent_control_scan_config(agent_control_id, opts))
-            .await?;
-        ModifyAgentControlScanConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyAgentControlScanConfigRequest::new(
+            agent_control_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     /// Get agent installer instructions.
@@ -576,12 +575,12 @@ impl<C: GvmConnection> GmpClient<C> {
         language: AgentInstallerLanguage,
         origin_url: &str,
     ) -> Result<GetAgentInstallerInstructionResponse, GvmError> {
-        let response = self
-            .call(get_agent_installer_instruction(
-                scanner_id, language, origin_url,
-            ))
-            .await?;
-        GetAgentInstallerInstructionResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentInstallerInstructionRequest::new(
+            scanner_id.clone(),
+            language,
+            origin_url,
+        ))
+        .await
     }
 
     /// Get an agent support bundle.
@@ -594,10 +593,8 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_uuid: &EntityId,
         days: Option<u32>,
     ) -> Result<GetAgentSupportBundleResponse, GvmError> {
-        let response = self
-            .call(get_agent_support_bundle(agent_uuid, days))
-            .await?;
-        GetAgentSupportBundleResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentSupportBundleRequest::new(agent_uuid.clone(), days))
+            .await
     }
 
     /// Create an agent group.
@@ -612,15 +609,13 @@ impl<C: GvmConnection> GmpClient<C> {
         scheduler_cron_time: &str,
         opts: CreateAgentGroupOpts,
     ) -> Result<CreateAgentGroupResponse, GvmError> {
-        let response = self
-            .call(create_agent_group(
-                name,
-                agent_ids,
-                scheduler_cron_time,
-                opts,
-            ))
-            .await?;
-        CreateAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CreateAgentGroupRequest::new(
+            name,
+            agent_ids.to_vec(),
+            scheduler_cron_time,
+            opts,
+        ))
+        .await
     }
 
     /// Clone an agent group.
@@ -632,8 +627,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_group_id: &EntityId,
     ) -> Result<CloneAgentGroupResponse, GvmError> {
-        let response = self.call(clone_agent_group(agent_group_id)).await?;
-        CloneAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(CloneAgentGroupRequest::new(agent_group_id.clone()))
+            .await
     }
 
     /// Get a single agent group.
@@ -645,8 +640,8 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         agent_group_id: &EntityId,
     ) -> Result<GetAgentGroupsResponse, GvmError> {
-        let response = self.call(get_agent_group(agent_group_id)).await?;
-        GetAgentGroupsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentGroupRequest::new(agent_group_id.clone()))
+            .await
     }
 
     /// List agent groups.
@@ -658,8 +653,7 @@ impl<C: GvmConnection> GmpClient<C> {
         &mut self,
         opts: GetAgentGroupsOpts,
     ) -> Result<GetAgentGroupsResponse, GvmError> {
-        let response = self.call(get_agent_groups(opts)).await?;
-        GetAgentGroupsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAgentGroupsRequest::new(opts)).await
     }
 
     /// Modify an agent group.
@@ -673,14 +667,12 @@ impl<C: GvmConnection> GmpClient<C> {
         scheduler_cron_time: &str,
         opts: ModifyAgentGroupOpts,
     ) -> Result<ModifyAgentGroupResponse, GvmError> {
-        let response = self
-            .call(modify_agent_group(
-                agent_group_id,
-                scheduler_cron_time,
-                opts,
-            ))
-            .await?;
-        ModifyAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyAgentGroupRequest::new(
+            agent_group_id.clone(),
+            scheduler_cron_time,
+            opts,
+        ))
+        .await
     }
 
     /// Delete an agent group.
@@ -693,10 +685,11 @@ impl<C: GvmConnection> GmpClient<C> {
         agent_group_id: &EntityId,
         ultimate: bool,
     ) -> Result<DeleteAgentGroupResponse, GvmError> {
-        let response = self
-            .call(delete_agent_group(agent_group_id, ultimate))
-            .await?;
-        DeleteAgentGroupResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DeleteAgentGroupRequest::new(
+            agent_group_id.clone(),
+            ultimate,
+        ))
+        .await
     }
 
     /// Create an OCI image target.

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -53,8 +53,8 @@ use gvm_gmp::commands::hosts::{
     ModifyHostRequest,
 };
 use gvm_gmp::commands::integration_configs::{
-    get_integration_config, get_integration_configs, modify_integration_config,
-    GetIntegrationConfigsOpts, ModifyIntegrationConfigOpts,
+    GetIntegrationConfigRequest, GetIntegrationConfigsOpts, GetIntegrationConfigsRequest,
+    ModifyIntegrationConfigOpts, ModifyIntegrationConfigRequest,
 };
 use gvm_gmp::commands::notes::{
     CloneNoteRequest, CreateNoteRequest, DeleteNoteRequest, GetNoteRequest, GetNotesOpts,
@@ -2743,10 +2743,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         integration_config_id: &EntityId,
         details: Option<bool>,
     ) -> Result<GetIntegrationConfigsResponse, GvmError> {
-        let response = self
-            .send(get_integration_config(integration_config_id, details))
-            .await?;
-        GetIntegrationConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetIntegrationConfigRequest::new(
+            integration_config_id.clone(),
+            details,
+        ))
+        .await
     }
 
     /// Send a `get_integration_configs` request and return a typed response.
@@ -2760,8 +2761,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetIntegrationConfigsOpts,
     ) -> Result<GetIntegrationConfigsResponse, GvmError> {
-        let response = self.send(get_integration_configs(opts)).await?;
-        GetIntegrationConfigsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetIntegrationConfigsRequest::new(opts)).await
     }
 
     /// Send a `modify_integration_config` request and return a typed response.
@@ -2776,10 +2776,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         integration_config_id: &EntityId,
         opts: ModifyIntegrationConfigOpts,
     ) -> Result<ModifyIntegrationConfigResponse, GvmError> {
-        let response = self
-            .send(modify_integration_config(integration_config_id, opts))
-            .await?;
-        ModifyIntegrationConfigResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyIntegrationConfigRequest::new(
+            integration_config_id.clone(),
+            opts,
+        ))
+        .await
     }
 
     // ── Assets ──────────────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -11,6 +11,16 @@ use gvm_client::{
 };
 use gvm_client::{GmpClient, GvmError};
 use gvm_connection::UnixSocketConnection;
+use gvm_gmp::commands::agent_groups::{
+    CloneAgentGroupRequest, CreateAgentGroupOpts, CreateAgentGroupRequest, DeleteAgentGroupRequest,
+    GetAgentGroupRequest, GetAgentGroupsRequest, ModifyAgentGroupOpts, ModifyAgentGroupRequest,
+};
+use gvm_gmp::commands::agents::{
+    AgentInstallerLanguage, DeleteAgentRequest, GetAgentInstallerInstructionRequest,
+    GetAgentRequest, GetAgentSupportBundleRequest, GetAgentsRequest,
+    ModifyAgentControlScanConfigOpts, ModifyAgentControlScanConfigRequest, ModifyAgentOpts,
+    ModifyAgentRequest, SyncAgentsRequest,
+};
 use gvm_gmp::commands::alerts::{AlertOpts, GetAlertsOpts, TriggerAlertOpts};
 use gvm_gmp::commands::assets::{
     AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
@@ -23,6 +33,10 @@ use gvm_gmp::commands::credentials::{
 use gvm_gmp::commands::filters::{FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{GetGroupsOpts, GroupOpts};
 use gvm_gmp::commands::hosts::{GetHostsOpts, HostOpts};
+use gvm_gmp::commands::integration_configs::{
+    GetIntegrationConfigRequest, GetIntegrationConfigsRequest, ModifyIntegrationConfigOpts,
+    ModifyIntegrationConfigRequest,
+};
 use gvm_gmp::commands::notes::{GetNotesOpts, ModifyNoteOpts, NoteOpts};
 use gvm_gmp::commands::nvts::{GetNvtPreferencesOpts, GetNvtsOpts};
 use gvm_gmp::commands::operating_systems::GetOperatingSystemsOpts;
@@ -2737,6 +2751,7 @@ async fn generic_execute_preserves_server_status_and_parse_error_context() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn distinct_registry_and_semantic_version_gates_fail_before_transport_send() {
     let Some(v225_server) = fixture_server(MockVersion::V22_5, &[]).await else {
         return;
@@ -2778,6 +2793,134 @@ async fn distinct_registry_and_semantic_version_gates_fail_before_transport_send
     v227_server.clear_history();
     let report_id = id(CREATED_ID);
     let format_id = id("33333333-3333-3333-3333-333333333333");
+
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentsRequest::default()),
+        "get_agents",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentRequest::new(id("agent-1"))),
+        "get_agents",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(ModifyAgentRequest::new(
+            vec![id("agent-1")],
+            ModifyAgentOpts::default(),
+        )),
+        "modify_agent",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(DeleteAgentRequest::new(vec![id("agent-1")])),
+        "delete_agent",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(SyncAgentsRequest::new()),
+        "sync_agents",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(ModifyAgentControlScanConfigRequest::new(
+            id("scanner-1"),
+            ModifyAgentControlScanConfigOpts::default(),
+        )),
+        "modify_agent_control_scan_config",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentInstallerInstructionRequest::new(
+            id("scanner-1"),
+            AgentInstallerLanguage::En,
+            "https://gvmd.example",
+        )),
+        "get_agent_installer_instruction",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentSupportBundleRequest::new(id("agent-1"), Some(7))),
+        "get_agent_support_bundle",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(CreateAgentGroupRequest::new(
+            "group",
+            vec![id("agent-1")],
+            "0 */5 * * *",
+            CreateAgentGroupOpts::default(),
+        )),
+        "create_agent_group",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(CloneAgentGroupRequest::new(id("group-1"))),
+        "create_agent_group",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentGroupsRequest::default()),
+        "get_agent_groups",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetAgentGroupRequest::new(id("group-1"))),
+        "get_agent_groups",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(ModifyAgentGroupRequest::new(
+            id("group-1"),
+            "0 */5 * * *",
+            ModifyAgentGroupOpts::default(),
+        )),
+        "modify_agent_group",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(DeleteAgentGroupRequest::new(id("group-1"), false)),
+        "delete_agent_group",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetIntegrationConfigsRequest::default()),
+        "get_integration_configs",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(GetIntegrationConfigRequest::new(
+            id("integration-1"),
+            Some(true),
+        )),
+        "get_integration_configs",
+        GmpVersion(22, 7),
+        "22.8"
+    );
+    assert_unsupported_command!(
+        v227_client.execute(ModifyIntegrationConfigRequest::new(
+            id("integration-1"),
+            ModifyIntegrationConfigOpts::default(),
+        )),
+        "modify_integration_config",
+        GmpVersion(22, 7),
+        "22.8"
+    );
 
     let export_error = v227_client
         .get_report_export(&report_id, &format_id)

--- a/crates/gvm-client/tests/versioned_client.rs
+++ b/crates/gvm-client/tests/versioned_client.rs
@@ -20,6 +20,7 @@ use gvm_gmp::commands::credentials::{create_credential, verify_credential_store,
 use gvm_gmp::commands::oci_image_targets::get_oci_image_targets;
 use gvm_gmp::commands::reports::{get_scan_report, GetScanReportOpts};
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};
+use gvm_gmp::responses::ParseError;
 use gvm_gmp::{EntityId, GmpVersion};
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 
@@ -613,7 +614,7 @@ async fn next_client_agent_groups_round_trip() {
         .expect_err("deleted agent group should not be found");
     assert!(matches!(
         error,
-        gvm_client::GvmError::Server { status: 404, .. }
+        GvmError::Parse(ParseError::ServerError { status: 404, .. })
     ));
 
     server.shutdown().await;
@@ -838,7 +839,7 @@ async fn next_client_agent_commands_round_trip() {
         .expect_err("unseeded agent should not be found");
     assert!(matches!(
         missing_agent,
-        GvmError::Server { status: 404, .. }
+        GvmError::Parse(ParseError::ServerError { status: 404, .. })
     ));
 
     let agent_ids = [id("00000000-0000-0000-0000-000000000002")];

--- a/crates/gvm-gmp/src/commands/agent_groups.rs
+++ b/crates/gvm-gmp/src/commands/agent_groups.rs
@@ -6,7 +6,12 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str, set_optional_bool_attr};
+use crate::responses::{
+    CloneAgentGroupResponse, CreateAgentGroupResponse, DeleteAgentGroupResponse,
+    GetAgentGroupsResponse, ModifyAgentGroupResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Optional fields for `create_agent_group` requests.
 #[derive(Debug, Clone, Default)]
@@ -35,6 +40,182 @@ pub struct ModifyAgentGroupOpts {
     pub comment: Option<String>,
     /// Optional agent ids to set for the group.
     pub agent_ids: Vec<EntityId>,
+}
+
+/// Semantic request for cloning an agent group.
+#[derive(Debug, Clone)]
+pub struct CloneAgentGroupRequest(EntityId);
+
+impl CloneAgentGroupRequest {
+    /// Create an agent-group clone request.
+    #[must_use]
+    pub fn new(agent_group_id: EntityId) -> Self {
+        Self(agent_group_id)
+    }
+}
+
+impl Request for CloneAgentGroupRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        clone_agent_group(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for CloneAgentGroupRequest {
+    type Response = CloneAgentGroupResponse;
+}
+
+/// Semantic request for creating an agent group.
+#[derive(Debug, Clone)]
+pub struct CreateAgentGroupRequest {
+    name: String,
+    agent_ids: Vec<EntityId>,
+    scheduler_cron_time: String,
+    opts: CreateAgentGroupOpts,
+}
+
+impl CreateAgentGroupRequest {
+    /// Create an agent-group creation request.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        agent_ids: Vec<EntityId>,
+        scheduler_cron_time: impl Into<String>,
+        opts: CreateAgentGroupOpts,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            agent_ids,
+            scheduler_cron_time: scheduler_cron_time.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for CreateAgentGroupRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_agent_group(
+            &self.name,
+            &self.agent_ids,
+            &self.scheduler_cron_time,
+            self.opts.clone(),
+        )
+        .to_bytes()
+    }
+}
+
+impl GmpRequest for CreateAgentGroupRequest {
+    type Response = CreateAgentGroupResponse;
+}
+
+/// Semantic request for listing agent groups.
+#[derive(Debug, Clone, Default)]
+pub struct GetAgentGroupsRequest(GetAgentGroupsOpts);
+
+impl GetAgentGroupsRequest {
+    /// Create an agent-group list request.
+    #[must_use]
+    pub fn new(opts: GetAgentGroupsOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetAgentGroupsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agent_groups(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentGroupsRequest {
+    type Response = GetAgentGroupsResponse;
+}
+
+/// Semantic request for one agent group.
+#[derive(Debug, Clone)]
+pub struct GetAgentGroupRequest(EntityId);
+
+impl GetAgentGroupRequest {
+    /// Create a single agent-group request.
+    #[must_use]
+    pub fn new(agent_group_id: EntityId) -> Self {
+        Self(agent_group_id)
+    }
+}
+
+impl Request for GetAgentGroupRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agent_group(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentGroupRequest {
+    type Response = GetAgentGroupsResponse;
+}
+
+/// Semantic request for modifying an agent group.
+#[derive(Debug, Clone)]
+pub struct ModifyAgentGroupRequest {
+    agent_group_id: EntityId,
+    scheduler_cron_time: String,
+    opts: ModifyAgentGroupOpts,
+}
+
+impl ModifyAgentGroupRequest {
+    /// Create an agent-group modification request.
+    #[must_use]
+    pub fn new(
+        agent_group_id: EntityId,
+        scheduler_cron_time: impl Into<String>,
+        opts: ModifyAgentGroupOpts,
+    ) -> Self {
+        Self {
+            agent_group_id,
+            scheduler_cron_time: scheduler_cron_time.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyAgentGroupRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_agent_group(
+            &self.agent_group_id,
+            &self.scheduler_cron_time,
+            self.opts.clone(),
+        )
+        .to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyAgentGroupRequest {
+    type Response = ModifyAgentGroupResponse;
+}
+
+/// Semantic request for deleting an agent group.
+#[derive(Debug, Clone)]
+pub struct DeleteAgentGroupRequest {
+    agent_group_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteAgentGroupRequest {
+    /// Create an agent-group deletion request.
+    #[must_use]
+    pub fn new(agent_group_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            agent_group_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteAgentGroupRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_agent_group(&self.agent_group_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteAgentGroupRequest {
+    type Response = DeleteAgentGroupResponse;
 }
 
 /// Build a clone request for an existing agent group.
@@ -119,6 +300,10 @@ fn add_agent_elements(cmd: &mut XmlCommand, agent_ids: &[EntityId]) {
 mod tests {
     use super::*;
     use crate::common::xml;
+    use crate::responses::{
+        CreateAgentGroupResponse, DeleteAgentGroupResponse, GetAgentGroupsResponse,
+        ModifyAgentGroupResponse,
+    };
 
     fn id(value: &str) -> EntityId {
         EntityId::new(value).expect("valid id")
@@ -176,6 +361,64 @@ mod tests {
         assert_eq!(
             xml(delete_agent_group(&id("group-1"), false)),
             "<delete_agent_group agent_group_id=\"group-1\" ultimate=\"0\"/>"
+        );
+    }
+
+    #[test]
+    fn semantic_requests_preserve_builder_bytes_and_response_associations() {
+        fn groups<R: GmpRequest<Response = GetAgentGroupsResponse>>(_: &R) {}
+        fn create<R: GmpRequest<Response = CreateAgentGroupResponse>>(_: &R) {}
+        fn modify<R: GmpRequest<Response = ModifyAgentGroupResponse>>(_: &R) {}
+        fn delete<R: GmpRequest<Response = DeleteAgentGroupResponse>>(_: &R) {}
+
+        let group_id = id("group-1");
+        let agent_ids = vec![id("agent-1"), id("agent-2")];
+        let create_opts = CreateAgentGroupOpts {
+            comment: Some("scheduled".into()),
+        };
+        let list_opts = GetAgentGroupsOpts {
+            filter_string: Some("name=agents".into()),
+            filter_id: Some(id("filter-1")),
+            trash: Some(true),
+        };
+        let modify_opts = ModifyAgentGroupOpts {
+            name: Some("updated".into()),
+            comment: Some("changed".into()),
+            agent_ids: vec![id("agent-3")],
+        };
+
+        let clone = CloneAgentGroupRequest::new(group_id.clone());
+        create(&clone);
+        assert_eq!(clone.to_bytes(), clone_agent_group(&group_id).to_bytes());
+        let create_request = CreateAgentGroupRequest::new(
+            "agents",
+            agent_ids.clone(),
+            "0 */5 * * *",
+            create_opts.clone(),
+        );
+        create(&create_request);
+        assert_eq!(
+            create_request.to_bytes(),
+            create_agent_group("agents", &agent_ids, "0 */5 * * *", create_opts).to_bytes()
+        );
+        let list = GetAgentGroupsRequest::new(list_opts.clone());
+        groups(&list);
+        assert_eq!(list.to_bytes(), get_agent_groups(list_opts).to_bytes());
+        let get = GetAgentGroupRequest::new(group_id.clone());
+        groups(&get);
+        assert_eq!(get.to_bytes(), get_agent_group(&group_id).to_bytes());
+        let modify_request =
+            ModifyAgentGroupRequest::new(group_id.clone(), "0 */10 * * *", modify_opts.clone());
+        modify(&modify_request);
+        assert_eq!(
+            modify_request.to_bytes(),
+            modify_agent_group(&group_id, "0 */10 * * *", modify_opts).to_bytes()
+        );
+        let delete_request = DeleteAgentGroupRequest::new(group_id.clone(), true);
+        delete(&delete_request);
+        assert_eq!(
+            delete_request.to_bytes(),
+            delete_agent_group(&group_id, true).to_bytes()
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/agents.rs
+++ b/crates/gvm-gmp/src/commands/agents.rs
@@ -6,7 +6,13 @@
 use gvm_protocol::{xml_command::XmlElement, Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, add_text_element, bool_str};
+use crate::responses::{
+    DeleteAgentResponse, GetAgentInstallerInstructionResponse, GetAgentSupportBundleResponse,
+    GetAgentsResponse, ModifyAgentControlScanConfigResponse, ModifyAgentResponse,
+    SyncAgentsResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Supported agent installer instruction languages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,6 +114,207 @@ pub struct ModifyAgentControlScanConfigOpts {
     pub agent_defaults: Option<AgentConfigOpts>,
     /// Default update-to-latest value for controlled agents.
     pub update_to_latest: Option<bool>,
+}
+
+/// Semantic request for listing agents.
+#[derive(Debug, Clone, Default)]
+pub struct GetAgentsRequest(GetAgentsOpts);
+
+impl GetAgentsRequest {
+    /// Create an agent-list request.
+    #[must_use]
+    pub fn new(opts: GetAgentsOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetAgentsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agents(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentsRequest {
+    type Response = GetAgentsResponse;
+}
+
+/// Semantic request for one agent.
+#[derive(Debug, Clone)]
+pub struct GetAgentRequest(EntityId);
+
+impl GetAgentRequest {
+    /// Create a single-agent request.
+    #[must_use]
+    pub fn new(agent_id: EntityId) -> Self {
+        Self(agent_id)
+    }
+}
+
+impl Request for GetAgentRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agent(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentRequest {
+    type Response = GetAgentsResponse;
+}
+
+/// Semantic request for modifying agents.
+#[derive(Debug, Clone)]
+pub struct ModifyAgentRequest {
+    agent_ids: Vec<EntityId>,
+    opts: ModifyAgentOpts,
+}
+
+impl ModifyAgentRequest {
+    /// Create an agent-modification request.
+    #[must_use]
+    pub fn new(agent_ids: Vec<EntityId>, opts: ModifyAgentOpts) -> Self {
+        Self { agent_ids, opts }
+    }
+}
+
+impl Request for ModifyAgentRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_agent(&self.agent_ids, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyAgentRequest {
+    type Response = ModifyAgentResponse;
+}
+
+/// Semantic request for deleting agents.
+#[derive(Debug, Clone)]
+pub struct DeleteAgentRequest(Vec<EntityId>);
+
+impl DeleteAgentRequest {
+    /// Create an agent-deletion request.
+    #[must_use]
+    pub fn new(agent_ids: Vec<EntityId>) -> Self {
+        Self(agent_ids)
+    }
+}
+
+impl Request for DeleteAgentRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_agent(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteAgentRequest {
+    type Response = DeleteAgentResponse;
+}
+
+/// Semantic request for synchronizing agents.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SyncAgentsRequest;
+
+impl SyncAgentsRequest {
+    /// Create an agent-synchronization request.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for SyncAgentsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        sync_agents().to_bytes()
+    }
+}
+
+impl GmpRequest for SyncAgentsRequest {
+    type Response = SyncAgentsResponse;
+}
+
+/// Semantic request for modifying agent-control defaults.
+#[derive(Debug, Clone)]
+pub struct ModifyAgentControlScanConfigRequest {
+    agent_control_id: EntityId,
+    opts: ModifyAgentControlScanConfigOpts,
+}
+
+impl ModifyAgentControlScanConfigRequest {
+    /// Create an agent-control defaults request.
+    #[must_use]
+    pub fn new(agent_control_id: EntityId, opts: ModifyAgentControlScanConfigOpts) -> Self {
+        Self {
+            agent_control_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyAgentControlScanConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_agent_control_scan_config(&self.agent_control_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyAgentControlScanConfigRequest {
+    type Response = ModifyAgentControlScanConfigResponse;
+}
+
+/// Semantic request for agent installer instructions.
+#[derive(Debug, Clone)]
+pub struct GetAgentInstallerInstructionRequest {
+    scanner_id: EntityId,
+    language: AgentInstallerLanguage,
+    origin_url: String,
+}
+
+impl GetAgentInstallerInstructionRequest {
+    /// Create an installer-instruction request.
+    #[must_use]
+    pub fn new(
+        scanner_id: EntityId,
+        language: AgentInstallerLanguage,
+        origin_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            scanner_id,
+            language,
+            origin_url: origin_url.into(),
+        }
+    }
+}
+
+impl Request for GetAgentInstallerInstructionRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agent_installer_instruction(&self.scanner_id, self.language, &self.origin_url)
+            .to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentInstallerInstructionRequest {
+    type Response = GetAgentInstallerInstructionResponse;
+}
+
+/// Semantic request for an agent support bundle.
+#[derive(Debug, Clone)]
+pub struct GetAgentSupportBundleRequest {
+    agent_uuid: EntityId,
+    days: Option<u32>,
+}
+
+impl GetAgentSupportBundleRequest {
+    /// Create a support-bundle request.
+    #[must_use]
+    pub fn new(agent_uuid: EntityId, days: Option<u32>) -> Self {
+        Self { agent_uuid, days }
+    }
+}
+
+impl Request for GetAgentSupportBundleRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_agent_support_bundle(&self.agent_uuid, self.days).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAgentSupportBundleRequest {
+    type Response = GetAgentSupportBundleResponse;
 }
 
 /// Build a `get_agents` request.
@@ -274,6 +481,11 @@ fn add_u32_child(parent: &mut XmlElement, name: &str, value: Option<u32>) {
 mod tests {
     use super::*;
     use crate::common::xml;
+    use crate::responses::{
+        DeleteAgentResponse, GetAgentInstallerInstructionResponse, GetAgentSupportBundleResponse,
+        GetAgentsResponse, ModifyAgentControlScanConfigResponse, ModifyAgentResponse,
+        SyncAgentsResponse,
+    };
 
     fn id(value: &str) -> EntityId {
         EntityId::new(value).expect("valid id")
@@ -368,6 +580,84 @@ mod tests {
         assert_eq!(
             xml(get_agent_support_bundle(&id("agent-1"), None)),
             "<get_agent_support_bundle agent_uuid=\"agent-1\"/>"
+        );
+    }
+
+    #[test]
+    fn semantic_requests_preserve_builder_bytes_and_response_associations() {
+        fn agents<R: GmpRequest<Response = GetAgentsResponse>>(_: &R) {}
+        fn modify<R: GmpRequest<Response = ModifyAgentResponse>>(_: &R) {}
+        fn delete<R: GmpRequest<Response = DeleteAgentResponse>>(_: &R) {}
+        fn sync<R: GmpRequest<Response = SyncAgentsResponse>>(_: &R) {}
+        fn control<R: GmpRequest<Response = ModifyAgentControlScanConfigResponse>>(_: &R) {}
+        fn instruction<R: GmpRequest<Response = GetAgentInstallerInstructionResponse>>(_: &R) {}
+        fn bundle<R: GmpRequest<Response = GetAgentSupportBundleResponse>>(_: &R) {}
+
+        let agent_id = id("agent-1");
+        let agent_ids = vec![agent_id.clone(), id("agent-2")];
+        let list_opts = GetAgentsOpts {
+            filter_string: Some("scanner=agent-controller".into()),
+            filter_id: Some(id("filter-1")),
+        };
+        let modify_opts = ModifyAgentOpts {
+            authorized: Some(true),
+            update_to_latest: Some(false),
+            comment: Some("managed".into()),
+            config: Some(sample_config()),
+        };
+        let control_opts = ModifyAgentControlScanConfigOpts {
+            agent_defaults: Some(sample_config()),
+            update_to_latest: Some(true),
+        };
+
+        let list = GetAgentsRequest::new(list_opts.clone());
+        agents(&list);
+        assert_eq!(list.to_bytes(), get_agents(list_opts).to_bytes());
+        let get = GetAgentRequest::new(agent_id.clone());
+        agents(&get);
+        assert_eq!(get.to_bytes(), get_agent(&agent_id).to_bytes());
+        let modify_request = ModifyAgentRequest::new(agent_ids.clone(), modify_opts.clone());
+        modify(&modify_request);
+        assert_eq!(
+            modify_request.to_bytes(),
+            modify_agent(&agent_ids, modify_opts).to_bytes()
+        );
+        let delete_request = DeleteAgentRequest::new(agent_ids.clone());
+        delete(&delete_request);
+        assert_eq!(
+            delete_request.to_bytes(),
+            delete_agent(&agent_ids).to_bytes()
+        );
+        let sync_request = SyncAgentsRequest::new();
+        sync(&sync_request);
+        assert_eq!(sync_request.to_bytes(), sync_agents().to_bytes());
+        let control_request =
+            ModifyAgentControlScanConfigRequest::new(agent_id.clone(), control_opts.clone());
+        control(&control_request);
+        assert_eq!(
+            control_request.to_bytes(),
+            modify_agent_control_scan_config(&agent_id, control_opts).to_bytes()
+        );
+        let instruction_request = GetAgentInstallerInstructionRequest::new(
+            agent_id.clone(),
+            AgentInstallerLanguage::De,
+            "https://gvmd.example",
+        );
+        instruction(&instruction_request);
+        assert_eq!(
+            instruction_request.to_bytes(),
+            get_agent_installer_instruction(
+                &agent_id,
+                AgentInstallerLanguage::De,
+                "https://gvmd.example",
+            )
+            .to_bytes()
+        );
+        let bundle_request = GetAgentSupportBundleRequest::new(agent_id.clone(), Some(14));
+        bundle(&bundle_request);
+        assert_eq!(
+            bundle_request.to_bytes(),
+            get_agent_support_bundle(&agent_id, Some(14)).to_bytes()
         );
     }
 }

--- a/crates/gvm-gmp/src/commands/integration_configs.rs
+++ b/crates/gvm-gmp/src/commands/integration_configs.rs
@@ -6,7 +6,9 @@
 use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::{add_filter_attrs, set_optional_bool_attr};
+use crate::responses::{GetIntegrationConfigsResponse, ModifyIntegrationConfigResponse};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Options for `get_integration_configs` requests.
 #[derive(Debug, Clone, Default)]
@@ -34,6 +36,110 @@ pub struct ModifyIntegrationConfigOpts {
     pub oidc_provider_client_id: Option<String>,
     /// Optional OIDC provider client secret.
     pub oidc_provider_client_secret: Option<String>,
+}
+
+/// Semantic request for listing integration configurations.
+#[derive(Debug, Clone, Default)]
+pub struct GetIntegrationConfigsRequest(GetIntegrationConfigsOpts);
+
+impl GetIntegrationConfigsRequest {
+    /// Create an integration-configuration list request.
+    #[must_use]
+    pub fn new(opts: GetIntegrationConfigsOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetIntegrationConfigsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_integration_configs(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetIntegrationConfigsRequest {
+    type Response = GetIntegrationConfigsResponse;
+}
+
+/// Semantic request for one integration configuration.
+#[derive(Debug, Clone)]
+pub struct GetIntegrationConfigRequest {
+    integration_config_id: EntityId,
+    details: Option<bool>,
+}
+
+impl GetIntegrationConfigRequest {
+    /// Create a single integration-configuration request.
+    #[must_use]
+    pub fn new(integration_config_id: EntityId, details: Option<bool>) -> Self {
+        Self {
+            integration_config_id,
+            details,
+        }
+    }
+}
+
+impl Request for GetIntegrationConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_integration_config(&self.integration_config_id, self.details).to_bytes()
+    }
+}
+
+impl GmpRequest for GetIntegrationConfigRequest {
+    type Response = GetIntegrationConfigsResponse;
+}
+
+/// Semantic request for modifying an integration configuration.
+#[derive(Clone)]
+pub struct ModifyIntegrationConfigRequest {
+    integration_config_id: EntityId,
+    opts: ModifyIntegrationConfigOpts,
+}
+
+impl std::fmt::Debug for ModifyIntegrationConfigRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifyIntegrationConfigRequest")
+            .field("integration_config_id", &self.integration_config_id)
+            .field("service_url", &self.opts.service_url)
+            .field(
+                "service_cacert",
+                &self.opts.service_cacert.as_ref().map(|_| "<redacted>"),
+            )
+            .field("oidc_provider_url", &self.opts.oidc_provider_url)
+            .field(
+                "oidc_provider_client_id",
+                &self.opts.oidc_provider_client_id,
+            )
+            .field(
+                "oidc_provider_client_secret",
+                &self
+                    .opts
+                    .oidc_provider_client_secret
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl ModifyIntegrationConfigRequest {
+    /// Create an integration-configuration modification request.
+    #[must_use]
+    pub fn new(integration_config_id: EntityId, opts: ModifyIntegrationConfigOpts) -> Self {
+        Self {
+            integration_config_id,
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyIntegrationConfigRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_integration_config(&self.integration_config_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyIntegrationConfigRequest {
+    type Response = ModifyIntegrationConfigResponse;
 }
 
 /// Build a `get_integration_configs` request.
@@ -95,6 +201,7 @@ pub fn modify_integration_config(
 mod tests {
     use super::*;
     use crate::common::xml;
+    use crate::responses::{GetIntegrationConfigsResponse, ModifyIntegrationConfigResponse};
 
     fn id(value: &str) -> EntityId {
         EntityId::new(value).expect("valid id")
@@ -134,5 +241,48 @@ mod tests {
             xml(modify_integration_config(&id("ic1"), Default::default())),
             "<modify_integration_config uuid=\"ic1\"><service><url></url><cacert></cacert></service><oidc><url></url><client><id></id><secret></secret></client></oidc></modify_integration_config>"
         );
+    }
+
+    #[test]
+    fn semantic_requests_preserve_builder_bytes_and_response_associations() {
+        fn get<R: GmpRequest<Response = GetIntegrationConfigsResponse>>(_: &R) {}
+        fn modify<R: GmpRequest<Response = ModifyIntegrationConfigResponse>>(_: &R) {}
+
+        let config_id = id("ic1");
+        let get_opts = GetIntegrationConfigsOpts {
+            filter_string: Some("name=demo".into()),
+            filter_id: Some(id("f1")),
+        };
+        let modify_opts = ModifyIntegrationConfigOpts {
+            service_url: Some("https://service.example".into()),
+            service_cacert: Some("CERT".into()),
+            oidc_provider_url: Some("https://oidc.example".into()),
+            oidc_provider_client_id: Some("client-id".into()),
+            oidc_provider_client_secret: Some("client-secret".into()),
+        };
+
+        let list = GetIntegrationConfigsRequest::new(get_opts.clone());
+        get(&list);
+        assert_eq!(
+            list.to_bytes(),
+            get_integration_configs(get_opts).to_bytes()
+        );
+        let single = GetIntegrationConfigRequest::new(config_id.clone(), Some(true));
+        get(&single);
+        assert_eq!(
+            single.to_bytes(),
+            get_integration_config(&config_id, Some(true)).to_bytes()
+        );
+        let modify_request =
+            ModifyIntegrationConfigRequest::new(config_id.clone(), modify_opts.clone());
+        modify(&modify_request);
+        assert_eq!(
+            modify_request.to_bytes(),
+            modify_integration_config(&config_id, modify_opts).to_bytes()
+        );
+        let debug = format!("{modify_request:?}");
+        assert!(!debug.contains("CERT"));
+        assert!(!debug.contains("client-secret"));
+        assert!(debug.contains("<redacted>"));
     }
 }

--- a/crates/gvm-gmp/src/responses/agent.rs
+++ b/crates/gvm-gmp/src/responses/agent.rs
@@ -10,6 +10,7 @@ use crate::responses::common::{
     count_info, optional_u32, parse_bool, parse_document, parse_entity_meta, parse_named_entity,
     status_from_response, ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -234,6 +235,12 @@ impl GetAgentsResponse {
     }
 }
 
+impl GmpResponse for GetAgentsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl GetAgentInstallerInstructionResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -244,6 +251,12 @@ impl GetAgentInstallerInstructionResponse {
             language: root.required_child_text("language")?,
             instruction: root.required_child_text("instruction")?,
         })
+    }
+}
+
+impl GmpResponse for GetAgentInstallerInstructionResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 
@@ -259,6 +272,12 @@ impl GetAgentSupportBundleResponse {
             status_text,
             file: AgentSupportBundle::from_node(file)?,
         })
+    }
+}
+
+impl GmpResponse for GetAgentSupportBundleResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/agent_group.rs
+++ b/crates/gvm-gmp/src/responses/agent_group.rs
@@ -9,6 +9,7 @@ use crate::responses::common::{
     count_info, parse_document, parse_entity_id, parse_entity_meta, status_from_response,
     ActionResponse, CountInfo, EntityMeta, NamedEntity, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -65,6 +66,12 @@ impl GetAgentGroupsResponse {
     }
 }
 
+impl GmpResponse for GetAgentGroupsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl CreateAgentGroupResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -79,6 +86,12 @@ impl CreateAgentGroupResponse {
             status_text,
             id,
         })
+    }
+}
+
+impl GmpResponse for CreateAgentGroupResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/integration_config.rs
+++ b/crates/gvm-gmp/src/responses/integration_config.rs
@@ -9,6 +9,7 @@ use crate::responses::common::{
     count_info, parse_document, parse_entity_meta, status_from_response, ActionResponse, CountInfo,
     EntityMeta, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -94,6 +95,12 @@ impl GetIntegrationConfigsResponse {
             items,
             counts: count_info(&root, "integration_config_count")?,
         })
+    }
+}
+
+impl GmpResponse for GetIntegrationConfigsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -139,6 +139,16 @@ retain their GMP 22.8 gates while standard target cloning remains baseline.
 All twelve existing `_parsed` facade helpers now delegate to `execute`;
 builders and raw/custom execution remain supported.
 
+The agent-and-integration Phase 3 batch, tracked by
+[`#568`](https://github.com/greenbone-hive/rust-gvm/issues/568), migrates all 17
+public agent, agent-group, and integration-configuration builders to semantic
+typed execution. Existing agent and agent-group typed helpers and the parsed
+integration helpers now delegate to `execute`, while the raw integration
+methods, builders, and response models remain supported. All requests preserve
+their GMP 22.8 pre-send gate, and installer instructions, identifier
+collections, integration secrets, and binary/base64 support bundles retain
+their established wire and decoding behavior.
+
 The irregular-report Phase 3 batch, tracked by
 [`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report
 list/detail, structured scan and audit reports, audit hosts, nine structured

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -141,6 +141,21 @@ passed to `send` or `call`, so the compatibility escape hatch cannot bypass the
 same gate. Import/container and move requests retain their established baseline
 behavior.
 
+## Agents and integration configurations
+
+All agent, agent-group, and integration-configuration commands require GMP
+22.8. Their semantic requests delegate to the existing builders, so filters,
+identifier collections, scheduler values, nested agent defaults, and complete
+integration replacements remain byte-for-byte compatible. The typed agent and
+agent-group facade methods and the parsed integration helpers now use
+`execute`; the raw integration methods remain available for callers that need
+the unmodeled response.
+
+Agent installer instructions retain their language and origin metadata.
+Support-bundle responses continue to decode base64 content into binary bytes
+and validate declared sizes. OIDC client secrets remain redacted from
+semantic-request diagnostics and wire tracing.
+
 Audit list, detail, create, clone, modify, delete, start, stop, and resume
 requests likewise remain audit-scoped types even where their wire command is a
 task command. This keeps compile-time intent explicit without duplicating XML


### PR DESCRIPTION
## Problem

The remaining agent, agent-group, and integration-configuration facades bypassed the semantic request/response execution path. That left response associations, version gates, parse context, and facade inventory guarantees inconsistent with the already migrated command families.

## Changes

- add semantic request types and response associations for all 17 scoped builders;
- migrate 14 agent/agent-group helpers and three parsed integration helpers to `execute`;
- preserve existing builder bytes, GMP 22.8 gates, binary support-bundle behavior, and raw compatibility APIs;
- redact integration CA material and OIDC client secrets from request debug output;
- add byte-parity, association, version-gate, Unix success/error/parse, redaction, and facade-inventory coverage;
- update README and typed-execution/status documentation.

## User impact

The public APIs and wire protocol remain compatible. Typed callers now get the same compile-time response association, semantic command identity, gate enforcement, and contextual parse errors as the rest of the migrated facade.

## Evidence

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #568
Part of #523

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
