### PR TITLE
refactor(client): type remaining report mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ OCI-image, and web-application target lifecycles, credential/scanner
 lifecycles, scan-config, policy, and credential-store operations, alerts and
 schedules, filters, tags, notes, overrides, trashcan recovery, user, group,
 role, and permission lifecycles, plus irregular report retrieval, drill-down,
-and export operations and the complete NVT/SecInfo query surface. Generic
+export, create, import, and delete operations and the complete NVT/SecInfo query
+surface. Generic
 assets, host and operating-system asset lifecycles, result list/detail queries,
 and the GMP 22.8 agent, agent-group, and integration-configuration families use
 the same execution contract, including binary/base64 support bundles. Generic

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -99,13 +99,13 @@ use gvm_gmp::commands::report_formats::{
     VerifyReportFormatRequest,
 };
 use gvm_gmp::commands::reports::{
-    import_report, ExportScanReportOpts, ExportScanReportRequest, GetAuditReportHostsOpts,
+    ExportScanReportOpts, ExportScanReportRequest, GetAuditReportHostsOpts,
     GetAuditReportHostsRequest, GetAuditReportOpts, GetAuditReportRequest,
     GetReportApplicationsRequest, GetReportClosedCvesRequest, GetReportCvesRequest,
     GetReportDetailsOpts, GetReportErrorsRequest, GetReportExportOpts, GetReportExportRequest,
     GetReportHostsRequest, GetReportOperatingSystemsRequest, GetReportPortsRequest,
     GetReportTlsCertificatesRequest, GetReportVulnsRequest, GetReportsOpts, GetReportsRequest,
-    ImportReportOpts,
+    ImportReportOpts, ImportReportRequest,
 };
 use gvm_gmp::commands::results::{GetResultRequest, GetResultsOpts, GetResultsRequest};
 use gvm_gmp::commands::roles::{
@@ -3262,9 +3262,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         task_id: &EntityId,
         opts: ImportReportOpts,
     ) -> Result<CreateReportResponse, GvmError> {
-        let request = import_report(report_xml, task_id, opts)?;
-        let response = self.send(request).await?;
-        CreateReportResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ImportReportRequest::new(report_xml, task_id, opts)?)
+            .await
     }
 
     // ── Report Configs ────────────────────────────────────────────────────────

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -53,8 +53,9 @@ use gvm_gmp::commands::report_configs::{
 };
 use gvm_gmp::commands::report_formats::{GetReportFormatsOpts, ReportFormatOpts};
 use gvm_gmp::commands::reports::{
+    CreateReportOpts, CreateReportRequest, DeleteAuditReportRequest, DeleteReportRequest,
     GetReportDetailsOpts, GetReportExportRequest, GetReportVulnsRequest, GetReportsOpts,
-    GetReportsRequest,
+    GetReportsRequest, ImportReportOpts, ImportReportRequest,
 };
 use gvm_gmp::commands::results::GetResultsOpts;
 use gvm_gmp::commands::roles::{GetRolesOpts, RoleOpts};
@@ -1349,6 +1350,126 @@ async fn semantic_report_requests_execute_large_and_mixed_repeated_responses() {
     assert_eq!(vulnerabilities.items[1].id.as_deref(), Some("three"));
     assert_eq!(vulnerabilities.items[2].id.as_deref(), Some("two"));
     server.shutdown().await;
+}
+
+#[tokio::test]
+async fn remaining_report_mutations_execute_with_fixed_response_associations() {
+    let overrides = [
+        (
+            "create_report",
+            r#"<create_report_response status="201" status_text="OK, resource created" id="11111111-1111-1111-1111-111111111111"/>"#,
+        ),
+        (
+            "delete_report",
+            r#"<delete_report_response status="200" status_text="OK"/>"#,
+        ),
+    ];
+    let Some(server) = fixture_server(MockVersion::V22_4, &overrides).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+    let task_id = id("22222222-2222-2222-2222-222222222222");
+    let report_id = id("33333333-3333-3333-3333-333333333333");
+
+    let created = client
+        .execute(CreateReportRequest::new(
+            task_id.clone(),
+            CreateReportOpts::default(),
+        ))
+        .await
+        .expect("report creation should decode");
+    assert_eq!(created.status, 201);
+
+    let imported = client
+        .execute(
+            ImportReportRequest::new(
+                r#"<report id="imported"><name>Imported</name></report>"#,
+                &task_id,
+                ImportReportOpts {
+                    in_assets: Some(true),
+                },
+            )
+            .expect("valid report XML"),
+        )
+        .await
+        .expect("report import should decode");
+    assert_eq!(imported.status, 201);
+
+    let deleted = client
+        .execute(DeleteReportRequest::new(report_id.clone(), true))
+        .await
+        .expect("report deletion should decode");
+    assert_eq!(deleted.status, 200);
+
+    let audit_deleted = client
+        .execute(DeleteAuditReportRequest::new(report_id))
+        .await
+        .expect("audit-report deletion should decode");
+    assert_eq!(audit_deleted.status, 200);
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 4);
+    assert_eq!(history[0].command_name(), "create_report");
+    assert_eq!(history[1].command_name(), "create_report");
+    assert_eq!(history[2].command_name(), "delete_report");
+    assert_eq!(history[3].command_name(), "delete_report");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn report_mutation_execution_preserves_server_status_and_parse_context() {
+    let Some(status_server) = fixture_server(
+        MockVersion::V22_4,
+        &[(
+            "create_report",
+            r#"<create_report_response status="503" status_text="backend unavailable"/>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut status_client = client(&status_server).await;
+    let status_error = status_client
+        .execute(CreateReportRequest::new(
+            id("22222222-2222-2222-2222-222222222222"),
+            CreateReportOpts::default(),
+        ))
+        .await
+        .expect_err("server status should fail");
+    assert!(matches!(
+        status_error,
+        GvmError::Parse(ParseError::ServerError { status: 503, message })
+            if message == "backend unavailable"
+    ));
+    status_server.shutdown().await;
+
+    let Some(malformed_server) = fixture_server(
+        MockVersion::V22_4,
+        &[(
+            "create_report",
+            r#"<create_report_response status="201" status_text="created"/>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut malformed_client = client(&malformed_server).await;
+    let malformed_error = malformed_client
+        .import_report(
+            r#"<report id="imported"><name>Imported</name></report>"#,
+            &id("22222222-2222-2222-2222-222222222222"),
+            ImportReportOpts::default(),
+        )
+        .await
+        .expect_err("missing response id should retain parse context");
+    assert!(matches!(
+        malformed_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "id"
+    ));
+    malformed_server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/gvm-gmp/src/commands/reports.rs
+++ b/crates/gvm-gmp/src/commands/reports.rs
@@ -11,11 +11,12 @@ use crate::common::{
     validate_single_xml_document,
 };
 use crate::responses::{
-    ExportScanReportResponse, GetAuditReportHostsResponse, GetAuditReportResponse,
-    GetReportApplicationsResponse, GetReportClosedCvesResponse, GetReportCvesResponse,
-    GetReportErrorsResponse, GetReportHostsResponse, GetReportOperatingSystemsResponse,
-    GetReportPortsResponse, GetReportTlsCertificatesResponse, GetReportVulnsResponse,
-    GetReportsResponse, GetScanReportResponse, ParseError, ReportExport,
+    CreateReportResponse, DeleteReportResponse, ExportScanReportResponse,
+    GetAuditReportHostsResponse, GetAuditReportResponse, GetReportApplicationsResponse,
+    GetReportClosedCvesResponse, GetReportCvesResponse, GetReportErrorsResponse,
+    GetReportHostsResponse, GetReportOperatingSystemsResponse, GetReportPortsResponse,
+    GetReportTlsCertificatesResponse, GetReportVulnsResponse, GetReportsResponse,
+    GetScanReportResponse, ParseError, ReportExport,
 };
 use crate::types::EntityId;
 use crate::GmpRequest;
@@ -36,6 +37,115 @@ pub struct CreateReportOpts {
 pub struct ImportReportOpts {
     /// Whether to import assets embedded in the report XML.
     pub in_assets: Option<bool>,
+}
+
+/// Semantic request for creating a report.
+#[derive(Debug, Clone)]
+pub struct CreateReportRequest {
+    task_id: EntityId,
+    opts: CreateReportOpts,
+}
+
+impl CreateReportRequest {
+    /// Create a report-creation request.
+    #[must_use]
+    pub fn new(task_id: EntityId, opts: CreateReportOpts) -> Self {
+        Self { task_id, opts }
+    }
+}
+
+impl Request for CreateReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        create_report(&self.task_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for CreateReportRequest {
+    type Response = CreateReportResponse;
+}
+
+/// Semantic request for importing report XML.
+#[derive(Debug, Clone)]
+pub struct ImportReportRequest {
+    bytes: Vec<u8>,
+}
+
+impl ImportReportRequest {
+    /// Validate report XML and create a report-import request.
+    ///
+    /// # Errors
+    /// Returns an error under the same conditions as [`import_report`].
+    pub fn new(
+        report_xml: &str,
+        task_id: &EntityId,
+        opts: ImportReportOpts,
+    ) -> Result<Self, ParseError> {
+        Ok(Self {
+            bytes: import_report(report_xml, task_id, opts)?.to_bytes(),
+        })
+    }
+}
+
+impl Request for ImportReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.bytes.clone()
+    }
+}
+
+impl GmpRequest for ImportReportRequest {
+    type Response = CreateReportResponse;
+}
+
+/// Semantic request for deleting a report.
+#[derive(Debug, Clone)]
+pub struct DeleteReportRequest {
+    report_id: EntityId,
+    ultimate: bool,
+}
+
+impl DeleteReportRequest {
+    /// Create a report-deletion request.
+    #[must_use]
+    pub fn new(report_id: EntityId, ultimate: bool) -> Self {
+        Self {
+            report_id,
+            ultimate,
+        }
+    }
+}
+
+impl Request for DeleteReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_report(&self.report_id, self.ultimate).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteReportRequest {
+    type Response = DeleteReportResponse;
+}
+
+/// Semantic request for deleting an audit report.
+#[derive(Debug, Clone)]
+pub struct DeleteAuditReportRequest {
+    report_id: EntityId,
+}
+
+impl DeleteAuditReportRequest {
+    /// Create an audit-report deletion request.
+    #[must_use]
+    pub fn new(report_id: EntityId) -> Self {
+        Self { report_id }
+    }
+}
+
+impl Request for DeleteAuditReportRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        delete_audit_report(&self.report_id).to_bytes()
+    }
+}
+
+impl GmpRequest for DeleteAuditReportRequest {
+    type Response = DeleteReportResponse;
 }
 
 /// Options for `get_reports` requests.
@@ -823,6 +933,10 @@ mod tests {
 
     #[test]
     fn semantic_report_requests_have_fixed_response_types() {
+        assert_associated_response::<CreateReportRequest, CreateReportResponse>();
+        assert_associated_response::<ImportReportRequest, CreateReportResponse>();
+        assert_associated_response::<DeleteReportRequest, DeleteReportResponse>();
+        assert_associated_response::<DeleteAuditReportRequest, DeleteReportResponse>();
         assert_associated_response::<GetReportsRequest, GetReportsResponse>();
         assert_associated_response::<GetReportRequest, GetReportsResponse>();
         assert_associated_response::<GetAuditReportsRequest, GetReportsResponse>();
@@ -846,6 +960,44 @@ mod tests {
         assert_associated_response::<GetReportErrorsRequest, GetReportErrorsResponse>();
         assert_associated_response::<GetReportClosedCvesRequest, GetReportClosedCvesResponse>();
         assert_associated_response::<ExportScanReportRequest, ExportScanReportResponse>();
+    }
+
+    #[test]
+    fn semantic_report_mutation_requests_match_legacy_builder_bytes() {
+        let task_id = id("task-1");
+        let create_opts = CreateReportOpts {
+            format_id: Some(id("format-1")),
+            filter_id: Some(id("filter-1")),
+            ignore_pagination: Some(true),
+        };
+        assert_eq!(
+            CreateReportRequest::new(task_id.clone(), create_opts.clone()).to_bytes(),
+            create_report(&task_id, create_opts).to_bytes()
+        );
+
+        let report_xml = r#"<report id="imported-report"><name>Imported</name></report>"#;
+        let import_opts = ImportReportOpts {
+            in_assets: Some(true),
+        };
+        assert_eq!(
+            ImportReportRequest::new(report_xml, &task_id, import_opts.clone())
+                .expect("valid report XML")
+                .to_bytes(),
+            import_report(report_xml, &task_id, import_opts)
+                .expect("valid report XML")
+                .to_bytes()
+        );
+        assert!(ImportReportRequest::new("<not-report/>", &task_id, Default::default()).is_err());
+
+        let report_id = id("report-1");
+        assert_eq!(
+            DeleteReportRequest::new(report_id.clone(), true).to_bytes(),
+            delete_report(&report_id, true).to_bytes()
+        );
+        assert_eq!(
+            DeleteAuditReportRequest::new(report_id.clone()).to_bytes(),
+            delete_audit_report(&report_id).to_bytes()
+        );
     }
 
     #[test]

--- a/crates/gvm-gmp/src/responses/report.rs
+++ b/crates/gvm-gmp/src/responses/report.rs
@@ -431,6 +431,7 @@ macro_rules! impl_report_gmp_response {
 }
 
 impl_report_gmp_response!(
+    CreateReportResponse,
     GetReportsResponse,
     GetReportVulnsResponse,
     GetReportTlsCertificatesResponse,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -177,6 +177,15 @@ helpers remain supported. Version policy stays explicit: audit operations are
 22.7+, scan/drill-down/synchronous-export operations are 22.8+, and
 `export_scan_report` still requires positive help discovery.
 
+The remaining report-mutation Phase 3 batch, tracked by
+[`#576`](https://github.com/greenbone-hive/rust-gvm/issues/576), adds semantic
+requests for report creation, XML import, deletion, and audit-report deletion.
+Create and import retain distinct Rust request types over their shared
+`create_report` wire root, while both deletion forms preserve the established
+`delete_report` encoding. The existing typed import helper now delegates to
+generic execution without changing validation, base64 payload handling,
+response parsing, or raw compatibility APIs.
+
 | Crate | Status | Lines | Tests | Description |
 |-------|--------|-------|-------|-------------|
 | `gvm-protocol` | ✅ Implemented | ~2,330 | 67 | XML command builder, response parser, streaming reader |

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -376,6 +376,16 @@ These checks run before transmission through the same `send` path used by raw
 and ordinary typed requests. The retained raw builders and helpers remain
 available when callers need unmodeled report details.
 
+## Report mutations
+
+Report creation and XML import use separate semantic request values even though
+both delegate to the existing `<create_report>` builders and decode the same
+typed create response. Import validation and payload encoding still happen in
+the legacy builder before transmission. Ordinary and audit-report deletion are
+likewise distinct semantic values over the established `<delete_report>` wire
+shape and action response. The `import_report` convenience method is a thin
+`execute` wrapper; raw builders and custom report XML remain supported.
+
 ## Scan configurations, policies, and preferences
 
 Scan configurations and policies demonstrate semantic typed requests layered

--- a/docs/typed-facade-coverage.md
+++ b/docs/typed-facade-coverage.md
@@ -25,6 +25,8 @@ Coverage is organized by behavior family:
   detail, lifecycle, and port-range semantic operations;
 - report configuration, report format, and TLS certificate coverage exercises
   all 23 existing builder shapes through fixed response associations;
+- report import exercises the semantic create response plus malformed-response
+  context, while direct execution covers create and both deletion intents;
 - server-status and malformed-payload cases assert typed error mapping;
 - the 22.6 registry gate, 22.8 registry gate, and 22.8 semantic-command gates
   are exercised through typed methods.


### PR DESCRIPTION
## Summary

- add typed create, import, delete, and audit-delete report requests
- route the existing `GmpClient::import_report` facade through typed execution
- preserve exact GMP payload bytes, response IDs/statuses, mutation semantics, and parse/error context
- document report-mutation typed execution and facade coverage

## Acceptance coverage

- `CreateReportRequest -> CreateReportResponse`
- `ImportReportRequest -> CreateReportResponse`
- `DeleteReportRequest -> DeleteReportResponse`
- `DeleteAuditReportRequest -> DeleteReportResponse`
- exact-byte parity and compile-time response-association tests
- live Unix transport success, status-error, malformed-response context, and facade-inventory tests

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- Rust 1.86 workspace tests and all-feature checks
- `cargo deny check`, `cargo audit`, `cargo vet`, and `cargo machete`
- coverage policy tests
- Python-gvm 27.7.0 Unix, TLS, and mTLS compatibility tests
- semver checks against `origin/next` and `v0.6.0`

Closes #576

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
