### PR TITLE
refactor(client): type system discovery execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ and the GMP 22.8 agent, agent-group, and integration-configuration families use
 the same execution contract, including binary/base64 support bundles. Generic
 configuration and port-list/port-range lifecycles are also fully migrated, and
 report-configuration, report-format, and TLS-certificate lifecycles are fully
-covered:
+covered. Read-only system discovery is covered as well, including aggregates,
+features, feeds, settings, timezones, help, system reports, generic information,
+preferences, resource names, vulnerabilities, license status, and authentication
+description:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -13,7 +13,7 @@
 //! validation, including non-2xx status detection.
 
 use gvm_connection::GvmConnection;
-use gvm_gmp::commands::aggregates::{get_aggregates_request, GetAggregatesRequestOpts};
+use gvm_gmp::commands::aggregates::{GetAggregatesRequest, GetAggregatesRequestOpts};
 use gvm_gmp::commands::alerts::{
     AlertOpts, CloneAlertRequest, CreateAlertRequest, DeleteAlertRequest, GetAlertRequest,
     GetAlertsOpts, GetAlertsRequest, ModifyAlertRequest, TestAlertRequest, TriggerAlertOpts,
@@ -36,8 +36,8 @@ use gvm_gmp::commands::credentials::{
     ModifyCredentialOpts, ModifyCredentialRequest, ModifyCredentialStoreCredentialOpts,
     ModifyCredentialStoreCredentialRequest, VerifyCredentialStoreRequest,
 };
-use gvm_gmp::commands::features::get_features;
-use gvm_gmp::commands::feed::{get_feed, get_feeds};
+use gvm_gmp::commands::features::GetFeaturesRequest;
+use gvm_gmp::commands::feed::{GetFeedRequest, GetFeedsRequest};
 use gvm_gmp::commands::filters::{
     CloneFilterRequest, CreateFilterRequest, DeleteFilterRequest, FilterOpts, GetFilterRequest,
     GetFiltersOpts, GetFiltersRequest, ModifyFilterRequest,
@@ -46,7 +46,7 @@ use gvm_gmp::commands::groups::{
     CloneGroupRequest, CreateGroupRequest, DeleteGroupRequest, GetGroupRequest, GetGroupsOpts,
     GetGroupsRequest, GroupOpts, ModifyGroupRequest,
 };
-use gvm_gmp::commands::help::{help, help_with_mode, HelpMode};
+use gvm_gmp::commands::help::{HelpMode, HelpRequest, HelpWithModeRequest};
 use gvm_gmp::commands::hosts::{
     CreateHostRequest, DeleteHostRequest, GetHostRequest, GetHostsOpts, GetHostsRequest, HostOpts,
     ModifyHostRequest,
@@ -135,11 +135,11 @@ use gvm_gmp::commands::secinfo::{
     GetOperatingSystemsRequest, GetSecInfoOpts, GetVulnerabilitiesRequest,
 };
 use gvm_gmp::commands::system::{
-    describe_auth, get_settings, get_timezones, get_vulnerability as get_vulnerability_cmd,
-    get_vulns, modify_auth, modify_license_with_opts, run_wizard_with_opts, FilteredGetOpts,
-    ModifyLicenseOpts, RunWizardOpts,
+    modify_auth, modify_license_with_opts, run_wizard_with_opts, DescribeAuthRequest,
+    FilteredGetOpts, GetSettingsRequest, GetTimezonesRequest, GetVulnerabilityRequest,
+    GetVulnsRequest, ModifyLicenseOpts, RunWizardOpts,
 };
-use gvm_gmp::commands::system_reports::{get_system_reports, GetSystemReportsOpts};
+use gvm_gmp::commands::system_reports::{GetSystemReportsOpts, GetSystemReportsRequest};
 use gvm_gmp::commands::tags::{
     CloneTagRequest, CreateTagRequest, DeleteTagRequest, GetTagRequest, GetTagsOpts,
     GetTagsRequest, ModifyTagRequest, TagOpts,
@@ -1563,8 +1563,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_feeds(&mut self) -> Result<GetFeedsResponse, GvmError> {
-        let response = self.send(get_feeds()).await?;
-        GetFeedsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetFeedsRequest::new()).await
     }
 
     /// Send a type-filtered `get_feeds` request and return a typed response.
@@ -1572,8 +1571,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_feed(&mut self, feed_type: FeedType) -> Result<GetFeedsResponse, GvmError> {
-        let response = self.send(get_feed(feed_type)).await?;
-        GetFeedsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetFeedRequest::new(feed_type)).await
     }
 
     /// Send a `get_timezones` request and return a typed [`GetTimezonesResponse`].
@@ -1581,8 +1579,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_timezones(&mut self) -> Result<GetTimezonesResponse, GvmError> {
-        let response = self.send(get_timezones()).await?;
-        GetTimezonesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetTimezonesRequest::new()).await
     }
 
     /// Send a `get_credential_stores` request and return a typed [`GetCredentialStoresResponse`].
@@ -1853,8 +1850,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: FilteredGetOpts,
     ) -> Result<GetVulnerabilitiesResponse, GvmError> {
-        let response = self.send(get_vulns(opts)).await?;
-        GetVulnerabilitiesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetVulnsRequest::new(opts)).await
     }
 
     /// Send a `get_vulns` request for a single vulnerability and return a typed
@@ -1866,8 +1862,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         vulnerability_id: &str,
     ) -> Result<GetVulnerabilitiesResponse, GvmError> {
-        let response = self.send(get_vulnerability_cmd(vulnerability_id)).await?;
-        GetVulnerabilitiesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetVulnerabilityRequest::new(vulnerability_id))
+            .await
     }
 
     // ── Alerts ────────────────────────────────────────────────────────────────
@@ -3385,10 +3381,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         resource_type: &str,
         opts: GetAggregatesRequestOpts,
     ) -> Result<GetAggregatesResponse, GvmError> {
-        let response = self
-            .send(get_aggregates_request(resource_type, opts))
-            .await?;
-        GetAggregatesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetAggregatesRequest::new(resource_type, opts))
+            .await
     }
 
     /// Send a `get_features` request and return a typed
@@ -3400,8 +3394,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_features_parsed(&mut self) -> Result<GetFeaturesResponse, GvmError> {
-        let response = self.send(get_features()).await?;
-        GetFeaturesResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetFeaturesRequest::new()).await
     }
 
     /// Send a `get_settings` request and return a typed [`GetSettingsResponse`].
@@ -3409,8 +3402,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_settings(&mut self) -> Result<GetSettingsResponse, GvmError> {
-        let response = self.send(get_settings(FilteredGetOpts::default())).await?;
-        GetSettingsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetSettingsRequest::default()).await
     }
 
     /// Send a `get_system_reports` request and return typed report metadata and payloads.
@@ -3421,8 +3413,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         &mut self,
         opts: GetSystemReportsOpts,
     ) -> Result<GetSystemReportsResponse, GvmError> {
-        let response = self.send(get_system_reports(opts)).await?;
-        GetSystemReportsResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(GetSystemReportsRequest::new(opts)).await
     }
 
     /// Send a `help` request and return a typed [`HelpResponse`].
@@ -3430,8 +3421,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_help(&mut self) -> Result<HelpResponse, GvmError> {
-        let response = self.send(help(None)).await?;
-        HelpResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(HelpRequest::new(None)).await
     }
 
     /// Send a `help` request for an explicit response mode.
@@ -3439,8 +3429,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn get_help_with_mode(&mut self, mode: HelpMode) -> Result<HelpResponse, GvmError> {
-        let response = self.send(help_with_mode(mode)).await?;
-        HelpResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(HelpWithModeRequest::new(mode)).await
     }
 
     /// Send a `describe_auth` request and return a typed [`DescribeAuthResponse`].
@@ -3448,8 +3437,7 @@ impl<C: GvmConnection + Send> GmpClient<C> {
     /// # Errors
     /// Returns an error if the request fails or response parsing fails.
     pub async fn describe_auth(&mut self) -> Result<DescribeAuthResponse, GvmError> {
-        let response = self.send(describe_auth()).await?;
-        DescribeAuthResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(DescribeAuthRequest::new()).await
     }
 
     /// Modify a named authentication group and return a typed

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -21,6 +21,7 @@ use gvm_gmp::commands::agents::{
     ModifyAgentControlScanConfigOpts, ModifyAgentControlScanConfigRequest, ModifyAgentOpts,
     ModifyAgentRequest, SyncAgentsRequest,
 };
+use gvm_gmp::commands::aggregates::GetAggregatesRequestOpts;
 use gvm_gmp::commands::alerts::{AlertOpts, GetAlertsOpts, TriggerAlertOpts};
 use gvm_gmp::commands::assets::{
     AssetType, CreateAssetOpts, DeleteAssetOpts, GetAssetsOpts, ModifyAssetOpts,
@@ -36,6 +37,7 @@ use gvm_gmp::commands::credentials::{
 };
 use gvm_gmp::commands::filters::{FilterOpts, GetFiltersOpts};
 use gvm_gmp::commands::groups::{GetGroupsOpts, GroupOpts};
+use gvm_gmp::commands::help::HelpMode;
 use gvm_gmp::commands::hosts::{GetHostsOpts, HostOpts};
 use gvm_gmp::commands::integration_configs::{
     GetIntegrationConfigRequest, GetIntegrationConfigsRequest, ModifyIntegrationConfigOpts,
@@ -66,6 +68,8 @@ use gvm_gmp::commands::scanners::{
 };
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::{GenericInfoType, GetInfoListOpts, GetSecInfoOpts};
+use gvm_gmp::commands::system::FilteredGetOpts;
+use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{
     CloneTargetRequest, GetTargetsOpts, GetTargetsRequest, ModifyTargetOpts,
@@ -83,7 +87,7 @@ use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{ActionResponse, ParseError};
 use gvm_gmp::types::{CollectionUpdate, EntityId, GmpVersion, ScalarUpdate};
 use gvm_gmp::{
-    GmpRequest, PortRangeType, ScheduleDefinition, ScheduleInput, ScheduleRecurrence,
+    FeedType, GmpRequest, PortRangeType, ScheduleDefinition, ScheduleInput, ScheduleRecurrence,
     ScheduleTimestamp, ScheduleTimezone,
 };
 use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
@@ -484,6 +488,42 @@ const REPORT_CONFIG_FORMAT_TLS_OVERRIDES: &[(&str, &str)] = &[
     (
         "modify_tls_certificate",
         r#"<modify_tls_certificate_response status="200" status_text="OK"/>"#,
+    ),
+];
+
+const SYSTEM_DISCOVERY_OVERRIDES: &[(&str, &str)] = &[
+    (
+        "get_aggregates",
+        r#"<get_aggregates_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_features",
+        r#"<get_features_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_feeds",
+        r#"<get_feeds_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_timezones",
+        r#"<get_timezones_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_settings",
+        r#"<get_settings_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_system_reports",
+        r#"<get_system_reports_response status="200" status_text="OK"/>"#,
+    ),
+    ("help", r#"<help_response status="200" status_text="OK"/>"#),
+    (
+        "describe_auth",
+        r#"<describe_auth_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "get_vulns",
+        r#"<get_vulns_response status="200" status_text="OK"/>"#,
     ),
 ];
 
@@ -1043,6 +1083,53 @@ async fn generic_config_and_port_list_facades_cover_every_semantic_request() {
 }
 
 #[tokio::test]
+async fn system_discovery_queries_execute_through_typed_facade() {
+    let Some(server) = fixture_server(MockVersion::V22_8, SYSTEM_DISCOVERY_OVERRIDES).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+
+    assert_typed_success!(client.get_aggregates("task", GetAggregatesRequestOpts::default()));
+    assert_typed_success!(client.get_features_parsed());
+    assert_typed_success!(client.get_feeds());
+    assert_typed_success!(client.get_feed(FeedType::Nvt));
+    assert_typed_success!(client.get_timezones());
+    assert_typed_success!(client.get_settings());
+    assert_typed_success!(client.get_system_reports(GetSystemReportsOpts::default()));
+    assert_typed_success!(client.get_help());
+    assert_typed_success!(client.get_help_with_mode(HelpMode::BriefXml));
+    assert_typed_success!(client.describe_auth());
+    assert_typed_success!(client.get_vulnerabilities(FilteredGetOpts::default()));
+    assert_typed_success!(client.get_vulnerability("vuln-1"));
+
+    let history = server.command_history();
+    assert_eq!(history.len(), 12);
+    for (command, expected_count) in [
+        ("get_aggregates", 1),
+        ("get_features", 1),
+        ("get_feeds", 2),
+        ("get_timezones", 1),
+        ("get_settings", 1),
+        ("get_system_reports", 1),
+        ("help", 2),
+        ("describe_auth", 1),
+        ("get_vulns", 2),
+    ] {
+        assert_eq!(
+            history
+                .iter()
+                .filter(|record| record.command_name() == command)
+                .count(),
+            expected_count,
+            "unexpected facade inventory for {command}"
+        );
+    }
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn asset_and_result_facades_preserve_status_and_parse_context() {
     let Some(server) = fixture_server(
         MockVersion::V22_8,
@@ -1080,6 +1167,52 @@ async fn asset_and_result_facades_preserve_status_and_parse_context() {
         GvmError::Parse(ParseError::MissingElement(field)) if field == "result.id"
     ));
     server.shutdown().await;
+}
+
+#[tokio::test]
+async fn system_discovery_facades_preserve_status_and_parse_context() {
+    let Some(status_server) = fixture_server(
+        MockVersion::V22_8,
+        &[(
+            "get_system_reports",
+            r#"<get_system_reports_response status="503" status_text="metrics unavailable"/>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut status_client = client(&status_server).await;
+
+    assert_server_error!(
+        status_client.get_system_reports(GetSystemReportsOpts::default()),
+        503,
+        "metrics unavailable"
+    );
+    status_server.shutdown().await;
+
+    let Some(parse_server) = fixture_server(
+        MockVersion::V22_8,
+        &[(
+            "get_features",
+            r#"<get_features_response status="200" status_text="OK"><feature enabled="1"><name>ENABLE_AGENTS</name></feature></get_features_response>"#,
+        )],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut parse_client = client(&parse_server).await;
+    let parse_error = parse_client
+        .get_features_parsed()
+        .await
+        .expect_err("missing feature compiled-in state should fail");
+    assert!(matches!(
+        parse_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "feature.compiled_in"
+    ));
+
+    parse_server.shutdown().await;
 }
 
 #[tokio::test]
@@ -3387,6 +3520,18 @@ async fn distinct_registry_and_semantic_version_gates_fail_before_transport_send
             version: GmpVersion(22, 7),
             required: "22.8",
         } if command == "get_report_export"
+    ));
+    let timezones_error = v227_client
+        .get_timezones()
+        .await
+        .expect_err("22.8 timezone gate should reject 22.7");
+    assert!(matches!(
+        timezones_error,
+        GvmError::UnsupportedCommand {
+            command,
+            version: GmpVersion(22, 7),
+            required: "22.8",
+        } if command == "get_timezones"
     ));
     let oci_error = v227_client
         .get_oci_image_targets_parsed(GetOciImageTargetsOpts::default())

--- a/crates/gvm-gmp/src/commands/aggregates.rs
+++ b/crates/gvm-gmp/src/commands/aggregates.rs
@@ -3,11 +3,13 @@
 
 //! Aggregate command builders.
 
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
 
 use crate::commands::usage_type::UsageType;
 use crate::enums::SortOrder;
+use crate::responses::GetAggregatesResponse;
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Legacy options for `get_aggregates` requests.
 ///
@@ -121,6 +123,62 @@ pub struct GetAggregatesRequestOpts {
     pub mode: Option<AggregateMode>,
     /// Optional task or config usage type.
     pub usage_type: Option<UsageType>,
+}
+
+/// Semantic request for current gvmd aggregate discovery.
+#[derive(Debug, Clone)]
+pub struct GetAggregatesRequest {
+    resource_type: String,
+    opts: GetAggregatesRequestOpts,
+}
+
+impl GetAggregatesRequest {
+    /// Create a current aggregate-discovery request.
+    #[must_use]
+    pub fn new(resource_type: impl Into<String>, opts: GetAggregatesRequestOpts) -> Self {
+        Self {
+            resource_type: resource_type.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for GetAggregatesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_aggregates_request(&self.resource_type, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetAggregatesRequest {
+    type Response = GetAggregatesResponse;
+}
+
+/// Semantic compatibility request for the legacy aggregate wire shape.
+#[derive(Debug, Clone)]
+pub struct GetLegacyAggregatesRequest {
+    resource_type: String,
+    opts: GetAggregatesOpts,
+}
+
+impl GetLegacyAggregatesRequest {
+    /// Create a legacy aggregate-discovery request.
+    #[must_use]
+    pub fn new(resource_type: impl Into<String>, opts: GetAggregatesOpts) -> Self {
+        Self {
+            resource_type: resource_type.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for GetLegacyAggregatesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_aggregates(&self.resource_type, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetLegacyAggregatesRequest {
+    type Response = GetAggregatesResponse;
 }
 
 /// Build a current gvmd `get_aggregates` request.

--- a/crates/gvm-gmp/src/commands/features.rs
+++ b/crates/gvm-gmp/src/commands/features.rs
@@ -3,7 +3,32 @@
 
 //! Feature command builders.
 
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
+
+use crate::responses::GetFeaturesResponse;
+use crate::GmpRequest;
+
+/// Semantic request for discovering compiled and enabled gvmd features.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetFeaturesRequest;
+
+impl GetFeaturesRequest {
+    /// Create a feature-discovery request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for GetFeaturesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_features().to_bytes()
+    }
+}
+
+impl GmpRequest for GetFeaturesRequest {
+    type Response = GetFeaturesResponse;
+}
 
 /// Build a `get_features` request.
 #[must_use]

--- a/crates/gvm-gmp/src/commands/feed.rs
+++ b/crates/gvm-gmp/src/commands/feed.rs
@@ -3,9 +3,55 @@
 
 //! Feed command builders.
 
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
 
 use crate::enums::FeedType;
+use crate::responses::GetFeedsResponse;
+use crate::GmpRequest;
+
+/// Semantic request for listing every configured feed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetFeedsRequest;
+
+impl GetFeedsRequest {
+    /// Create an all-feeds request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for GetFeedsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_feeds().to_bytes()
+    }
+}
+
+impl GmpRequest for GetFeedsRequest {
+    type Response = GetFeedsResponse;
+}
+
+/// Semantic request for discovering one feed type.
+#[derive(Debug, Clone, Copy)]
+pub struct GetFeedRequest(FeedType);
+
+impl GetFeedRequest {
+    /// Create a type-filtered feed request.
+    #[must_use]
+    pub const fn new(feed_type: FeedType) -> Self {
+        Self(feed_type)
+    }
+}
+
+impl Request for GetFeedRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_feed(self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for GetFeedRequest {
+    type Response = GetFeedsResponse;
+}
 
 /// Build a `get_feeds` request.
 #[must_use]

--- a/crates/gvm-gmp/src/commands/help.rs
+++ b/crates/gvm-gmp/src/commands/help.rs
@@ -3,9 +3,11 @@
 
 //! Help command builders.
 
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
 
 use crate::enums::HelpFormat as SchemaFormat;
+use crate::responses::HelpResponse;
+use crate::GmpRequest;
 
 /// Supported help output formats.
 ///
@@ -43,6 +45,50 @@ pub enum HelpMode {
     BriefXml,
     /// Complete schema in the selected format.
     Schema(SchemaFormat),
+}
+
+/// Semantic compatibility request for [`help`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HelpRequest(Option<HelpFormat>);
+
+impl HelpRequest {
+    /// Create a compatibility help request.
+    #[must_use]
+    pub const fn new(format: Option<HelpFormat>) -> Self {
+        Self(format)
+    }
+}
+
+impl Request for HelpRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        help(self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for HelpRequest {
+    type Response = HelpResponse;
+}
+
+/// Semantic request for an explicit help response mode.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HelpWithModeRequest(HelpMode);
+
+impl HelpWithModeRequest {
+    /// Create an explicit-mode help request.
+    #[must_use]
+    pub const fn new(mode: HelpMode) -> Self {
+        Self(mode)
+    }
+}
+
+impl Request for HelpWithModeRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        help_with_mode(self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for HelpWithModeRequest {
+    type Response = HelpResponse;
 }
 
 /// Build a `help` request.

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -8,7 +8,13 @@ use gvm_protocol::{Request, XmlCommand};
 use crate::commands::user_settings::{modify_user_setting, ModifyUserSettingOpts};
 use crate::common::add_filter_attrs;
 use crate::enums::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceType, SortOrder};
+use crate::responses::{
+    ActionResponse, DescribeAuthResponse, GetAggregatesResponse, GetFeedsResponse, GetInfoResponse,
+    GetResourceNamesResponse, GetScanConfigPreferencesResponse, GetSettingsResponse,
+    GetTimezonesResponse, GetVulnerabilitiesResponse, HelpResponse,
+};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 pub use super::system_reports::{get_system_reports, GetSystemReportsOpts};
 
@@ -91,6 +97,320 @@ pub struct RunWizardOpts {
     pub mode: Option<String>,
     /// Whether gvmd may only run a wizard marked as read-only.
     pub read_only: Option<bool>,
+}
+
+/// Semantic compatibility request for the system-module [`help`] builder.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemHelpRequest(Option<HelpFormat>);
+
+impl SystemHelpRequest {
+    /// Create a system-module help request.
+    #[must_use]
+    pub const fn new(format: Option<HelpFormat>) -> Self {
+        Self(format)
+    }
+}
+
+impl Request for SystemHelpRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        help(self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for SystemHelpRequest {
+    type Response = HelpResponse;
+}
+
+/// Semantic compatibility request for the system-module [`get_feeds`] builder.
+#[derive(Debug, Clone, Default)]
+pub struct GetSystemFeedsRequest(GetFeedsOpts);
+
+impl GetSystemFeedsRequest {
+    /// Create a system-module feed request.
+    #[must_use]
+    pub fn new(opts: GetFeedsOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSystemFeedsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_feeds(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSystemFeedsRequest {
+    type Response = GetFeedsResponse;
+}
+
+/// Semantic request for filtered setting discovery.
+#[derive(Debug, Clone, Default)]
+pub struct GetSettingsRequest(FilteredGetOpts);
+
+impl GetSettingsRequest {
+    /// Create a filtered setting request.
+    #[must_use]
+    pub fn new(opts: FilteredGetOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSettingsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_settings(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSettingsRequest {
+    type Response = GetSettingsResponse;
+}
+
+/// Semantic request for timezone discovery.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetTimezonesRequest;
+
+impl GetTimezonesRequest {
+    /// Create a timezone-discovery request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for GetTimezonesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_timezones().to_bytes()
+    }
+}
+
+impl GmpRequest for GetTimezonesRequest {
+    type Response = GetTimezonesResponse;
+}
+
+/// Semantic compatibility request for the legacy system aggregate builder.
+#[derive(Debug, Clone, Default)]
+pub struct GetSystemAggregatesRequest(GetAggregatesOpts);
+
+impl GetSystemAggregatesRequest {
+    /// Create a legacy system aggregate request.
+    #[must_use]
+    pub fn new(opts: GetAggregatesOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSystemAggregatesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_aggregates(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSystemAggregatesRequest {
+    type Response = GetAggregatesResponse;
+}
+
+/// Semantic compatibility request for the system-module [`get_info`] builder.
+#[derive(Debug, Clone, Default)]
+pub struct GetSystemInfoRequest(GetInfoOpts);
+
+impl GetSystemInfoRequest {
+    /// Create a generic system information request.
+    #[must_use]
+    pub fn new(opts: GetInfoOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSystemInfoRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_info(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSystemInfoRequest {
+    type Response = GetInfoResponse;
+}
+
+/// Semantic compatibility request for the system-module preference builder.
+#[derive(Debug, Clone, Default)]
+pub struct GetSystemPreferencesRequest(FilteredGetOpts);
+
+impl GetSystemPreferencesRequest {
+    /// Create a filtered preference request.
+    #[must_use]
+    pub fn new(opts: FilteredGetOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSystemPreferencesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_preferences(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSystemPreferencesRequest {
+    type Response = GetScanConfigPreferencesResponse;
+}
+
+/// Semantic request for resource-name discovery.
+#[derive(Debug, Clone, Default)]
+pub struct GetResourceNamesRequest(GetResourceNamesOpts);
+
+impl GetResourceNamesRequest {
+    /// Create a resource-name list request.
+    #[must_use]
+    pub fn new(opts: GetResourceNamesOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetResourceNamesRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_resource_names(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetResourceNamesRequest {
+    type Response = GetResourceNamesResponse;
+}
+
+/// Semantic request for one resource name.
+#[derive(Debug, Clone)]
+pub struct GetResourceNameRequest {
+    resource_id: EntityId,
+    resource_type: ResourceType,
+}
+
+impl GetResourceNameRequest {
+    /// Create a single-resource name request.
+    #[must_use]
+    pub fn new(resource_id: EntityId, resource_type: ResourceType) -> Self {
+        Self {
+            resource_id,
+            resource_type,
+        }
+    }
+}
+
+impl Request for GetResourceNameRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_resource_name(&self.resource_id, self.resource_type).to_bytes()
+    }
+}
+
+impl GmpRequest for GetResourceNameRequest {
+    type Response = GetResourceNamesResponse;
+}
+
+/// Semantic request for vulnerability discovery.
+#[derive(Debug, Clone, Default)]
+pub struct GetVulnsRequest(FilteredGetOpts);
+
+impl GetVulnsRequest {
+    /// Create a vulnerability list request.
+    #[must_use]
+    pub fn new(opts: FilteredGetOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetVulnsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_vulns(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetVulnsRequest {
+    type Response = GetVulnerabilitiesResponse;
+}
+
+/// Semantic request for one vulnerability using [`get_vuln`].
+#[derive(Debug, Clone)]
+pub struct GetVulnRequest(String);
+
+impl GetVulnRequest {
+    /// Create a single-vulnerability request.
+    #[must_use]
+    pub fn new(vuln_id: impl Into<String>) -> Self {
+        Self(vuln_id.into())
+    }
+}
+
+impl Request for GetVulnRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_vuln(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for GetVulnRequest {
+    type Response = GetVulnerabilitiesResponse;
+}
+
+/// Semantic compatibility request for [`get_vulnerability`].
+#[derive(Debug, Clone)]
+pub struct GetVulnerabilityRequest(String);
+
+impl GetVulnerabilityRequest {
+    /// Create a descriptive-alias vulnerability request.
+    #[must_use]
+    pub fn new(vulnerability_id: impl Into<String>) -> Self {
+        Self(vulnerability_id.into())
+    }
+}
+
+impl Request for GetVulnerabilityRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_vulnerability(&self.0).to_bytes()
+    }
+}
+
+impl GmpRequest for GetVulnerabilityRequest {
+    type Response = GetVulnerabilitiesResponse;
+}
+
+/// Semantic request for license discovery.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GetLicenseRequest;
+
+impl GetLicenseRequest {
+    /// Create a license-discovery request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for GetLicenseRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_license().to_bytes()
+    }
+}
+
+impl GmpRequest for GetLicenseRequest {
+    type Response = ActionResponse;
+}
+
+/// Semantic request for authentication-configuration discovery.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DescribeAuthRequest;
+
+impl DescribeAuthRequest {
+    /// Create an authentication-description request.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Request for DescribeAuthRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        describe_auth().to_bytes()
+    }
+}
+
+impl GmpRequest for DescribeAuthRequest {
+    type Response = DescribeAuthResponse;
 }
 
 /// Build a `help` request.

--- a/crates/gvm-gmp/src/commands/system_reports.rs
+++ b/crates/gvm-gmp/src/commands/system_reports.rs
@@ -3,10 +3,12 @@
 
 //! System-report command builders.
 
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::bool_str;
+use crate::responses::GetSystemReportsResponse;
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Options for `get_system_reports` requests.
 #[derive(Debug, Clone, Default)]
@@ -23,6 +25,28 @@ pub struct GetSystemReportsOpts {
     pub brief: Option<bool>,
     /// Scanner from which to retrieve the report.
     pub slave_id: Option<EntityId>,
+}
+
+/// Semantic request for system-report discovery.
+#[derive(Debug, Clone, Default)]
+pub struct GetSystemReportsRequest(GetSystemReportsOpts);
+
+impl GetSystemReportsRequest {
+    /// Create a system-report request.
+    #[must_use]
+    pub fn new(opts: GetSystemReportsOpts) -> Self {
+        Self(opts)
+    }
+}
+
+impl Request for GetSystemReportsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_system_reports(self.0.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetSystemReportsRequest {
+    type Response = GetSystemReportsResponse;
 }
 
 /// Build a `get_system_reports` request.

--- a/crates/gvm-gmp/src/responses/aggregates.rs
+++ b/crates/gvm-gmp/src/responses/aggregates.rs
@@ -8,6 +8,7 @@ use gvm_protocol::Response;
 use crate::responses::common::{
     parse_document, parse_u32, status_from_response, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -353,6 +354,12 @@ impl GetAggregatesResponse {
             column_info,
             overall,
         })
+    }
+}
+
+impl GmpResponse for GetAggregatesResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/features.rs
+++ b/crates/gvm-gmp/src/responses/features.rs
@@ -8,6 +8,7 @@ use gvm_protocol::Response;
 use crate::responses::common::{
     parse_bool, parse_document, status_from_response, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -59,6 +60,12 @@ impl GetFeaturesResponse {
             status_text,
             features,
         })
+    }
+}
+
+impl GmpResponse for GetFeaturesResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/feed.rs
+++ b/crates/gvm-gmp/src/responses/feed.rs
@@ -8,6 +8,7 @@ use gvm_protocol::Response;
 use crate::responses::common::{
     count_info, parse_bool, parse_document, status_from_response, CountInfo, ParseError, XmlNode,
 };
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -87,6 +88,12 @@ impl GetFeedsResponse {
             feed_roles_set: optional_bool_child(&root, "feed_roles_set")?,
             feed_resources_access: optional_bool_child(&root, "feed_resources_access")?,
         })
+    }
+}
+
+impl GmpResponse for GetFeedsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/resource_names.rs
+++ b/crates/gvm-gmp/src/responses/resource_names.rs
@@ -7,6 +7,7 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{parse_document, status_from_response, ParseError, XmlNode};
 use crate::types::EntityId;
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -55,6 +56,12 @@ impl GetResourceNamesResponse {
             resource_type,
             items,
         })
+    }
+}
+
+impl GmpResponse for GetResourceNamesResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -10,7 +10,7 @@ use quick_xml::Reader;
 use crate::responses::common::{
     parse_document, parse_entity_id, status_from_response, ActionResponse, ParseError,
 };
-use crate::EntityId;
+use crate::{EntityId, GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -279,6 +279,25 @@ impl RunWizardResponse {
         })
     }
 }
+
+macro_rules! impl_gmp_response {
+    ($($response:ty),+ $(,)?) => {
+        $(
+            impl GmpResponse for $response {
+                fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+                    Self::from_response(response)
+                }
+            }
+        )+
+    };
+}
+
+impl_gmp_response!(
+    GetSettingsResponse,
+    GetTimezonesResponse,
+    HelpResponse,
+    DescribeAuthResponse,
+);
 
 fn extract_wizard_response_xml(data: &[u8]) -> Result<Option<Vec<u8>>, ParseError> {
     let text = std::str::from_utf8(data)?;

--- a/crates/gvm-gmp/src/responses/system_reports.rs
+++ b/crates/gvm-gmp/src/responses/system_reports.rs
@@ -6,6 +6,7 @@
 use gvm_protocol::Response;
 
 use crate::responses::common::{parse_document, status_from_response, ParseError, XmlNode};
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -83,6 +84,12 @@ impl GetSystemReportsResponse {
             status_text,
             reports,
         })
+    }
+}
+
+impl GmpResponse for GetSystemReportsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/crates/gvm-gmp/tests/test_system_discovery_execution.rs
+++ b/crates/gvm-gmp/tests/test_system_discovery_execution.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+
+#![allow(missing_docs, clippy::unwrap_used)]
+
+use gvm_gmp::commands::aggregates::{
+    get_aggregates as get_legacy_aggregates, get_aggregates_request, GetAggregatesOpts,
+    GetAggregatesRequest, GetAggregatesRequestOpts, GetLegacyAggregatesRequest,
+};
+use gvm_gmp::commands::features::{get_features, GetFeaturesRequest};
+use gvm_gmp::commands::feed::{get_feed, get_feeds, GetFeedRequest, GetFeedsRequest};
+use gvm_gmp::commands::help::{
+    help as help_command, help_with_mode, HelpFormat as CommandHelpFormat, HelpMode, HelpRequest,
+    HelpWithModeRequest,
+};
+use gvm_gmp::commands::system::{
+    describe_auth, get_aggregates, get_feeds as get_system_feeds, get_info, get_license,
+    get_preferences, get_resource_name, get_resource_names, get_settings, get_timezones, get_vuln,
+    get_vulnerability, get_vulns, DescribeAuthRequest, FilteredGetOpts,
+    GetAggregatesOpts as SystemAggregatesOpts, GetInfoOpts, GetLicenseRequest,
+    GetResourceNameRequest, GetResourceNamesOpts, GetResourceNamesRequest, GetSettingsRequest,
+    GetSystemAggregatesRequest, GetSystemFeedsRequest, GetSystemInfoRequest,
+    GetSystemPreferencesRequest, GetTimezonesRequest, GetVulnRequest, GetVulnerabilityRequest,
+    GetVulnsRequest, SystemHelpRequest,
+};
+use gvm_gmp::commands::system_reports::{
+    get_system_reports, GetSystemReportsOpts, GetSystemReportsRequest,
+};
+use gvm_gmp::responses::{
+    ActionResponse, DescribeAuthResponse, GetAggregatesResponse, GetFeaturesResponse,
+    GetFeedsResponse, GetInfoResponse, GetResourceNamesResponse, GetScanConfigPreferencesResponse,
+    GetSettingsResponse, GetSystemReportsResponse, GetTimezonesResponse,
+    GetVulnerabilitiesResponse, HelpResponse,
+};
+use gvm_gmp::{FeedType, GmpRequest, GmpResponse, HelpFormat, InfoType, ResourceType};
+use gvm_protocol::Request;
+
+fn assert_associated<R, T>(_: &R)
+where
+    R: GmpRequest<Response = T>,
+    T: GmpResponse,
+{
+}
+
+macro_rules! assert_request {
+    ($request:expr, $builder:expr, $response:ty) => {{
+        let request = $request;
+        assert_eq!(request.to_bytes(), $builder.to_bytes());
+        assert_associated::<_, $response>(&request);
+    }};
+}
+
+fn id(value: &str) -> gvm_gmp::EntityId {
+    gvm_gmp::EntityId::new(value).expect("valid test id")
+}
+
+fn assert_discovery_requests() {
+    let aggregate_opts = GetAggregatesRequestOpts {
+        filter_string: Some("rows=5".into()),
+        data_columns: vec!["severity".into()],
+        group_column: Some("status".into()),
+        ..Default::default()
+    };
+    assert_request!(
+        GetAggregatesRequest::new("task", aggregate_opts.clone()),
+        get_aggregates_request("task", aggregate_opts),
+        GetAggregatesResponse
+    );
+
+    let legacy_aggregate_opts = GetAggregatesOpts {
+        group_column: Some("status".into()),
+        filter: Some("rows=5".into()),
+        ..Default::default()
+    };
+    assert_request!(
+        GetLegacyAggregatesRequest::new("task", legacy_aggregate_opts.clone()),
+        get_legacy_aggregates("task", legacy_aggregate_opts),
+        GetAggregatesResponse
+    );
+
+    assert_request!(
+        GetFeaturesRequest::new(),
+        get_features(),
+        GetFeaturesResponse
+    );
+    assert_request!(GetFeedsRequest::new(), get_feeds(), GetFeedsResponse);
+    assert_request!(
+        GetFeedRequest::new(FeedType::Nvt),
+        get_feed(FeedType::Nvt),
+        GetFeedsResponse
+    );
+    assert_request!(
+        HelpRequest::new(Some(CommandHelpFormat::Brief)),
+        help_command(Some(CommandHelpFormat::Brief)),
+        HelpResponse
+    );
+    assert_request!(
+        HelpWithModeRequest::new(HelpMode::Schema(HelpFormat::Rnc)),
+        help_with_mode(HelpMode::Schema(HelpFormat::Rnc)),
+        HelpResponse
+    );
+
+    let report_opts = GetSystemReportsOpts {
+        name: Some("load".into()),
+        brief: Some(true),
+        ..Default::default()
+    };
+    assert_request!(
+        GetSystemReportsRequest::new(report_opts.clone()),
+        get_system_reports(report_opts),
+        GetSystemReportsResponse
+    );
+}
+
+fn assert_system_inventory_requests() {
+    assert_request!(
+        SystemHelpRequest::new(Some(HelpFormat::Xml)),
+        gvm_gmp::commands::system::help(Some(HelpFormat::Xml)),
+        HelpResponse
+    );
+
+    let system_feed_opts = gvm_gmp::commands::system::GetFeedsOpts {
+        feed_type: Some(FeedType::Scap),
+    };
+    assert_request!(
+        GetSystemFeedsRequest::new(system_feed_opts.clone()),
+        get_system_feeds(system_feed_opts),
+        GetFeedsResponse
+    );
+
+    let filtered = FilteredGetOpts {
+        filter_string: Some("name=example".into()),
+        filter_id: Some(id("filter-1")),
+    };
+    assert_request!(
+        GetSettingsRequest::new(filtered.clone()),
+        get_settings(filtered.clone()),
+        GetSettingsResponse
+    );
+    assert_request!(
+        GetTimezonesRequest::new(),
+        get_timezones(),
+        GetTimezonesResponse
+    );
+
+    let system_aggregate_opts = SystemAggregatesOpts {
+        data_column: Some("severity".into()),
+        group_column: Some("task_id".into()),
+        filter_string: Some("rows=5".into()),
+        ..Default::default()
+    };
+    assert_request!(
+        GetSystemAggregatesRequest::new(system_aggregate_opts.clone()),
+        get_aggregates(system_aggregate_opts),
+        GetAggregatesResponse
+    );
+
+    let info_opts = GetInfoOpts {
+        info_type: Some(InfoType::Cve),
+        info_id: Some(id("CVE-2026-0001")),
+        filter_string: Some("rows=1".into()),
+        ..Default::default()
+    };
+    assert_request!(
+        GetSystemInfoRequest::new(info_opts.clone()),
+        get_info(info_opts),
+        GetInfoResponse
+    );
+    assert_request!(
+        GetSystemPreferencesRequest::new(filtered.clone()),
+        get_preferences(filtered.clone()),
+        GetScanConfigPreferencesResponse
+    );
+}
+
+fn assert_system_resource_requests() {
+    let filtered = FilteredGetOpts {
+        filter_string: Some("name=example".into()),
+        filter_id: Some(id("filter-1")),
+    };
+    let resource_opts = GetResourceNamesOpts {
+        resource_type: Some(ResourceType::Task),
+        resource_id: Some(id("task-1")),
+        filter_string: Some("name=example".into()),
+        ..Default::default()
+    };
+    assert_request!(
+        GetResourceNamesRequest::new(resource_opts.clone()),
+        get_resource_names(resource_opts),
+        GetResourceNamesResponse
+    );
+    assert_request!(
+        GetResourceNameRequest::new(id("task-1"), ResourceType::Task),
+        get_resource_name(&id("task-1"), ResourceType::Task),
+        GetResourceNamesResponse
+    );
+
+    assert_request!(
+        GetVulnsRequest::new(filtered.clone()),
+        get_vulns(filtered),
+        GetVulnerabilitiesResponse
+    );
+    assert_request!(
+        GetVulnRequest::new("vuln-1"),
+        get_vuln("vuln-1"),
+        GetVulnerabilitiesResponse
+    );
+    assert_request!(
+        GetVulnerabilityRequest::new("vuln-1"),
+        get_vulnerability("vuln-1"),
+        GetVulnerabilitiesResponse
+    );
+    assert_eq!(
+        GetVulnRequest::new("vuln-1").to_bytes(),
+        GetVulnerabilityRequest::new("vuln-1").to_bytes()
+    );
+
+    assert_request!(GetLicenseRequest::new(), get_license(), ActionResponse);
+    assert_request!(
+        DescribeAuthRequest::new(),
+        describe_auth(),
+        DescribeAuthResponse
+    );
+}
+
+#[test]
+fn all_twenty_two_semantic_requests_preserve_builder_bytes_and_responses() {
+    assert_discovery_requests();
+    assert_system_inventory_requests();
+    assert_system_resource_requests();
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -166,6 +166,17 @@ certificate inputs retain their existing content and private-key encoding.
 Existing typed helpers delegate to `execute`, with additive detail and mutation
 helpers exposing only operations already supported by public builders.
 
+The system-discovery Phase 3 batch, tracked by
+[`#574`](https://github.com/greenbone-hive/rust-gvm/issues/574), migrates all 22
+public read-only builders across the aggregates, features, feed, help,
+system-report, and system compatibility modules. Current and legacy aggregate
+shapes, both feed and help representations, generic information and preference
+queries, resource-name list/detail requests, and both vulnerability aliases
+remain byte-identical delegations to their established builders. All 12 existing
+typed-returning facade helpers delegate through `execute`; `get_features`
+retains its GMP 22.6 gate and `get_timezones` its GMP 22.8 gate before
+transmission. Existing raw builders and compatibility APIs remain supported.
+
 The irregular-report Phase 3 batch, tracked by
 [`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report
 list/detail, structured scan and audit reports, audit hosts, nine structured

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -331,6 +331,29 @@ shapes. TLS certificates expose the same complete lifecycle without changing
 certificate or private-key payload encoding. All semantic requests delegate to
 the established builders, and raw compatibility APIs remain available.
 
+## Read-only system discovery
+
+The system-discovery family adds semantic requests for all 22 public builders
+owned by the aggregates, features, feed, help, system-report, and system
+compatibility modules. Each request delegates to its original builder, including
+both current and legacy aggregate forms, the optional-feed compatibility form,
+both help representations, resource-name list/detail requests, and the
+byte-identical `get_vuln`/`get_vulnerability` aliases.
+
+The associated response remains the established domain model. In particular,
+the compatibility `get_preferences` builder uses
+`GetScanConfigPreferencesResponse`, generic system `get_info` uses
+`GetInfoResponse`, and the payload-free `get_license` response uses
+`ActionResponse`. The 12 existing typed-returning convenience methods for
+aggregates, features, feeds, timezones, settings, system reports, help,
+authentication description, and vulnerabilities are thin `execute` wrappers.
+
+Version policy is unchanged. `GetFeaturesRequest` requires GMP 22.6 and
+`GetTimezonesRequest` requires GMP 22.8; generic execution checks those semantic
+command identities before writing to the transport. All other requests in this
+read-only slice retain their existing baseline gates. Raw builders, `send`, and
+`call` remain available without introducing another XML encoder.
+
 ## Irregular report codecs and version policy
 
 The Phase 3 report family demonstrates that `GmpResponse` is a codec contract,


### PR DESCRIPTION
## Summary

- add semantic request types and statically associated responses for all 22 read-only system-discovery builders
- route all 12 existing typed facade helpers through `GmpClient::execute` while retaining the current builders as the sole wire encoders
- preserve compatibility aliases, filters, pagination, identifiers, error behavior, and version gates
- document the completed typed-execution surface

## Acceptance mapping

- **22 builders:** exhaustive compile-enforced request inventory asserts exact builder-byte parity and response associations across aggregates, features, feed, help, system reports, and system reads
- **12 facade helpers:** inventory and live Unix tests cover every migrated helper and enforce thin `execute` delegation
- **pre-send gates:** feature discovery remains gated at GMP 22.6 and timezone discovery at GMP 22.8
- **behavior preservation:** tests cover aliases, filters, pagination, identifiers, successful parsing, server-status errors, and parse context
- **documentation:** README, status, and typed-execution guidance identify the completed surface

## Validation

- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `cargo deny check`
- `cargo audit`
- `cargo vet`
- `cargo machete`
- `make test-integration`
- `cargo semver-checks check-release --workspace --all-features --baseline-rev origin/next`

Coverage is left to the protected CI coverage job.

Closes #574

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
