### PR TITLE
refactor(client): type system administration execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ report-configuration, report-format, and TLS-certificate lifecycles are fully
 covered. Read-only system discovery is covered as well, including aggregates,
 features, feeds, settings, timezones, help, system reports, generic information,
 preferences, resource names, vulnerabilities, license status, and authentication
-description:
+description. System
+authentication, license, and wizard mutations plus user-setting list, detail,
+and modification operations are also statically associated while retaining
+their existing builders and redaction guarantees:
 
 ```rust
 use gvm_gmp::commands::targets::{GetTargetsOpts, GetTargetsRequest};

--- a/crates/gvm-client/src/typed.rs
+++ b/crates/gvm-client/src/typed.rs
@@ -135,9 +135,9 @@ use gvm_gmp::commands::secinfo::{
     GetOperatingSystemsRequest, GetSecInfoOpts, GetVulnerabilitiesRequest,
 };
 use gvm_gmp::commands::system::{
-    modify_auth, modify_license_with_opts, run_wizard_with_opts, DescribeAuthRequest,
-    FilteredGetOpts, GetSettingsRequest, GetTimezonesRequest, GetVulnerabilityRequest,
-    GetVulnsRequest, ModifyLicenseOpts, RunWizardOpts,
+    DescribeAuthRequest, FilteredGetOpts, GetSettingsRequest, GetTimezonesRequest,
+    GetVulnerabilityRequest, GetVulnsRequest, ModifyAuthRequest, ModifyLicenseOpts,
+    ModifyLicenseWithOptsRequest, RunWizardOpts, RunWizardWithOptsRequest,
 };
 use gvm_gmp::commands::system_reports::{GetSystemReportsOpts, GetSystemReportsRequest};
 use gvm_gmp::commands::tags::{
@@ -3452,10 +3452,11 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         group_name: &str,
         auth_conf_settings: &[(String, String)],
     ) -> Result<ModifyAuthResponse, GvmError> {
-        let response = self
-            .send(modify_auth(group_name, auth_conf_settings))
-            .await?;
-        ModifyAuthResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyAuthRequest::new(
+            group_name,
+            auth_conf_settings.iter().cloned(),
+        ))
+        .await
     }
 
     /// Upload a base64-encoded license file and return a typed
@@ -3468,8 +3469,8 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         file: &str,
         opts: ModifyLicenseOpts,
     ) -> Result<ModifyLicenseResponse, GvmError> {
-        let response = self.send(modify_license_with_opts(file, opts)).await?;
-        ModifyLicenseResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(ModifyLicenseWithOptsRequest::new(file, opts))
+            .await
     }
 
     /// Run a gvmd wizard and return its typed response envelope.
@@ -3482,8 +3483,12 @@ impl<C: GvmConnection + Send> GmpClient<C> {
         params: &[(String, String)],
         opts: RunWizardOpts,
     ) -> Result<RunWizardResponse, GvmError> {
-        let response = self.send(run_wizard_with_opts(name, params, opts)).await?;
-        RunWizardResponse::from_response(&response).map_err(GvmError::Parse)
+        self.execute(RunWizardWithOptsRequest::new(
+            name,
+            params.iter().cloned(),
+            opts,
+        ))
+        .await
     }
 }
 

--- a/crates/gvm-client/tests/typed_facade_coverage.rs
+++ b/crates/gvm-client/tests/typed_facade_coverage.rs
@@ -68,7 +68,11 @@ use gvm_gmp::commands::scanners::{
 };
 use gvm_gmp::commands::schedules::{GetSchedulesOpts, ScheduleOpts};
 use gvm_gmp::commands::secinfo::{GenericInfoType, GetInfoListOpts, GetSecInfoOpts};
-use gvm_gmp::commands::system::FilteredGetOpts;
+use gvm_gmp::commands::system::{
+    FilteredGetOpts, ModifyAuthRequest, ModifyLicenseOpts, ModifyLicenseRequest,
+    ModifyLicenseWithOptsRequest, ModifySettingRequest, RunWizardOpts, RunWizardRequest,
+    RunWizardWithOptsRequest,
+};
 use gvm_gmp::commands::system_reports::GetSystemReportsOpts;
 use gvm_gmp::commands::tags::{GetTagsOpts, TagOpts};
 use gvm_gmp::commands::targets::{
@@ -83,6 +87,10 @@ use gvm_gmp::commands::tasks::{
 };
 use gvm_gmp::commands::tickets::{CreateTicketOpts, GetTicketsOpts, TicketOpenNote};
 use gvm_gmp::commands::tls_certificates::{GetTlsCertificatesOpts, TlsCertificateOpts};
+use gvm_gmp::commands::user_settings::{
+    GetUserSettingRequest, GetUserSettingsOpts, GetUserSettingsRequest, ModifyUserSettingOpts,
+    ModifyUserSettingRequest,
+};
 use gvm_gmp::commands::users::{GetUsersOpts, ModifyUserOpts, UserOpts};
 use gvm_gmp::responses::{ActionResponse, ParseError};
 use gvm_gmp::types::{CollectionUpdate, EntityId, GmpVersion, ScalarUpdate};
@@ -94,6 +102,28 @@ use gvm_mock_server::{GmpVersion as MockVersion, MockGmpServer, ServerMode};
 use gvm_protocol::Request;
 
 const CREATED_ID: &str = "11111111-1111-1111-1111-111111111111";
+const SYSTEM_ADMIN_OVERRIDES: &[(&str, &str)] = &[
+    (
+        "modify_auth",
+        r#"<modify_auth_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "modify_license",
+        r#"<modify_license_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "modify_setting",
+        r#"<modify_setting_response status="200" status_text="OK"/>"#,
+    ),
+    (
+        "run_wizard",
+        r#"<run_wizard_response status="202" status_text="OK, request submitted"><response><start_task_response status="202" status_text="OK"/></response></run_wizard_response>"#,
+    ),
+    (
+        "get_settings",
+        r#"<get_settings_response status="200" status_text="OK"><setting id="setting-1"><name>timezone</name><value>UTC</value></setting></get_settings_response>"#,
+    ),
+];
 const TASK_LIFECYCLE_OVERRIDES: &[(&str, &str)] = &[
     (
         "get_tasks",
@@ -623,6 +653,132 @@ macro_rules! create_response {
             r#" status="201" status_text="OK" id="11111111-1111-1111-1111-111111111111"/>"#
         )
     };
+}
+
+#[tokio::test]
+async fn system_admin_and_user_setting_requests_execute_over_unix_transport() {
+    let Some(server) = fixture_server(MockVersion::V22_8, SYSTEM_ADMIN_OVERRIDES).await else {
+        return;
+    };
+    let mut client = client(&server).await;
+    server.clear_history();
+
+    let auth_settings = vec![("password".into(), "auth-secret".into())];
+    assert_typed_success!(
+        client.execute(ModifyAuthRequest::new("method:ldap_connect", auth_settings))
+    );
+    assert_typed_success!(client.execute(ModifyLicenseRequest::new("license-secret")));
+    assert_typed_success!(client.execute(ModifyLicenseWithOptsRequest::new(
+        "license-secret",
+        ModifyLicenseOpts {
+            allow_empty: Some(false),
+        }
+    )));
+
+    let setting_id = id("setting-1");
+    assert_typed_success!(client.execute(ModifySettingRequest::new(
+        setting_id.clone(),
+        "Europe/Berlin"
+    )));
+
+    let wizard = client
+        .execute(RunWizardRequest::new(
+            "quick_first_scan",
+            [("hosts".into(), "localhost".into())],
+        ))
+        .await
+        .expect("default wizard request should parse");
+    assert_eq!(wizard.status, 202);
+    let wizard_with_opts = client
+        .execute(RunWizardWithOptsRequest::new(
+            "quick_first_scan",
+            [("hosts".into(), "localhost".into())],
+            RunWizardOpts {
+                mode: Some("step".into()),
+                read_only: Some(false),
+            },
+        ))
+        .await
+        .expect("option-bearing wizard request should parse");
+    assert_eq!(wizard_with_opts.status, 202);
+
+    let settings = client
+        .execute(GetUserSettingsRequest::new(GetUserSettingsOpts::default()))
+        .await
+        .expect("user-setting list should parse");
+    assert_eq!(settings.settings.len(), 1);
+    let setting = client
+        .execute(GetUserSettingRequest::new(setting_id.clone()))
+        .await
+        .expect("single user setting should parse");
+    assert_eq!(setting.settings[0].id, setting_id);
+    assert_typed_success!(client.execute(ModifyUserSettingRequest::new(
+        id("setting-1"),
+        ModifyUserSettingOpts {
+            value: "Europe/Berlin".into(),
+        }
+    )));
+
+    let commands = server
+        .command_history()
+        .iter()
+        .map(|record| record.command_name().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands,
+        [
+            "modify_auth",
+            "modify_license",
+            "modify_license",
+            "modify_setting",
+            "run_wizard",
+            "run_wizard",
+            "get_settings",
+            "get_settings",
+            "modify_setting",
+        ]
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn system_admin_execution_preserves_status_and_user_setting_parse_context() {
+    let Some(server) = fixture_server(
+        MockVersion::V22_8,
+        &[
+            (
+                "modify_auth",
+                r#"<modify_auth_response status="409" status_text="authentication conflict"/>"#,
+            ),
+            (
+                "get_settings",
+                r#"<get_settings_response status="200" status_text="OK"><setting><name>timezone</name></setting></get_settings_response>"#,
+            ),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    let mut client = client(&server).await;
+
+    assert_server_error!(
+        client.execute(ModifyAuthRequest::new(
+            "method:ldap_connect",
+            [("enable".into(), "true".into())]
+        )),
+        409,
+        "authentication conflict"
+    );
+    let parse_error = client
+        .execute(GetUserSettingRequest::new(id("setting-1")))
+        .await
+        .expect_err("missing user-setting id should fail");
+    assert!(matches!(
+        parse_error,
+        GvmError::Parse(ParseError::MissingElement(field)) if field == "setting.id"
+    ));
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/gvm-gmp/src/commands/system.rs
+++ b/crates/gvm-gmp/src/commands/system.rs
@@ -11,7 +11,8 @@ use crate::enums::{AggregateStatistic, FeedType, HelpFormat, InfoType, ResourceT
 use crate::responses::{
     ActionResponse, DescribeAuthResponse, GetAggregatesResponse, GetFeedsResponse, GetInfoResponse,
     GetResourceNamesResponse, GetScanConfigPreferencesResponse, GetSettingsResponse,
-    GetTimezonesResponse, GetVulnerabilitiesResponse, HelpResponse,
+    GetTimezonesResponse, GetVulnerabilitiesResponse, HelpResponse, ModifyAuthResponse,
+    ModifyLicenseResponse, RunWizardResponse,
 };
 use crate::types::EntityId;
 use crate::GmpRequest;
@@ -97,6 +98,237 @@ pub struct RunWizardOpts {
     pub mode: Option<String>,
     /// Whether gvmd may only run a wizard marked as read-only.
     pub read_only: Option<bool>,
+}
+
+/// Semantic request for modifying a named authentication group.
+#[derive(Clone)]
+pub struct ModifyAuthRequest {
+    group_name: String,
+    auth_conf_settings: Vec<(String, String)>,
+}
+
+impl std::fmt::Debug for ModifyAuthRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifyAuthRequest")
+            .field("group_name", &self.group_name)
+            .field("auth_conf_settings", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ModifyAuthRequest {
+    /// Create an authentication-configuration modification request.
+    #[must_use]
+    pub fn new(
+        group_name: impl Into<String>,
+        auth_conf_settings: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        Self {
+            group_name: group_name.into(),
+            auth_conf_settings: auth_conf_settings.into_iter().collect(),
+        }
+    }
+}
+
+impl Request for ModifyAuthRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_auth(&self.group_name, &self.auth_conf_settings).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyAuthRequest {
+    type Response = ModifyAuthResponse;
+}
+
+/// Semantic request backed by [`modify_license`].
+#[derive(Clone)]
+pub struct ModifyLicenseRequest {
+    file: String,
+}
+
+impl std::fmt::Debug for ModifyLicenseRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifyLicenseRequest")
+            .field("file", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ModifyLicenseRequest {
+    /// Create a license modification with default options.
+    #[must_use]
+    pub fn new(file: impl Into<String>) -> Self {
+        Self { file: file.into() }
+    }
+}
+
+impl Request for ModifyLicenseRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_license(&self.file).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyLicenseRequest {
+    type Response = ModifyLicenseResponse;
+}
+
+/// Semantic request backed by [`modify_license_with_opts`].
+#[derive(Clone)]
+pub struct ModifyLicenseWithOptsRequest {
+    file: String,
+    opts: ModifyLicenseOpts,
+}
+
+impl std::fmt::Debug for ModifyLicenseWithOptsRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifyLicenseWithOptsRequest")
+            .field("file", &"<redacted>")
+            .field("allow_empty", &self.opts.allow_empty)
+            .finish()
+    }
+}
+
+impl ModifyLicenseWithOptsRequest {
+    /// Create a license modification with explicit options.
+    #[must_use]
+    pub fn new(file: impl Into<String>, opts: ModifyLicenseOpts) -> Self {
+        Self {
+            file: file.into(),
+            opts,
+        }
+    }
+}
+
+impl Request for ModifyLicenseWithOptsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_license_with_opts(&self.file, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyLicenseWithOptsRequest {
+    type Response = ModifyLicenseResponse;
+}
+
+/// Semantic compatibility request backed by [`modify_setting`].
+#[derive(Clone)]
+pub struct ModifySettingRequest {
+    setting_id: EntityId,
+    value: String,
+}
+
+impl std::fmt::Debug for ModifySettingRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifySettingRequest")
+            .field("setting_id", &self.setting_id)
+            .field("value", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ModifySettingRequest {
+    /// Create a system-module user-setting modification request.
+    #[must_use]
+    pub fn new(setting_id: EntityId, value: impl Into<String>) -> Self {
+        Self {
+            setting_id,
+            value: value.into(),
+        }
+    }
+}
+
+impl Request for ModifySettingRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_setting(&self.setting_id, &self.value).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifySettingRequest {
+    type Response = crate::responses::ModifyUserSettingResponse;
+}
+
+/// Semantic request backed by [`run_wizard`].
+#[derive(Clone)]
+pub struct RunWizardRequest {
+    name: String,
+    params: Vec<(String, String)>,
+}
+
+impl std::fmt::Debug for RunWizardRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RunWizardRequest")
+            .field("name", &self.name)
+            .field("params", &"<redacted>")
+            .finish()
+    }
+}
+
+impl RunWizardRequest {
+    /// Create a wizard request with default options.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        params: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            params: params.into_iter().collect(),
+        }
+    }
+}
+
+impl Request for RunWizardRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        run_wizard(&self.name, &self.params).to_bytes()
+    }
+}
+
+impl GmpRequest for RunWizardRequest {
+    type Response = RunWizardResponse;
+}
+
+/// Semantic request backed by [`run_wizard_with_opts`].
+#[derive(Clone)]
+pub struct RunWizardWithOptsRequest {
+    name: String,
+    params: Vec<(String, String)>,
+    opts: RunWizardOpts,
+}
+
+impl std::fmt::Debug for RunWizardWithOptsRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RunWizardWithOptsRequest")
+            .field("name", &self.name)
+            .field("params", &"<redacted>")
+            .field("mode", &self.opts.mode)
+            .field("read_only", &self.opts.read_only)
+            .finish()
+    }
+}
+
+impl RunWizardWithOptsRequest {
+    /// Create a wizard request with explicit options.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        params: impl IntoIterator<Item = (String, String)>,
+        opts: RunWizardOpts,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            params: params.into_iter().collect(),
+            opts,
+        }
+    }
+}
+
+impl Request for RunWizardWithOptsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        run_wizard_with_opts(&self.name, &self.params, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for RunWizardWithOptsRequest {
+    type Response = RunWizardResponse;
 }
 
 /// Semantic compatibility request for the system-module [`help`] builder.
@@ -761,5 +993,119 @@ mod tests {
             )),
             "<run_wizard read_only=\"1\"><mode>step</mode><name>quick</name><params/></run_wizard>"
         );
+    }
+
+    #[test]
+    fn semantic_system_admin_requests_preserve_builder_bytes_and_associations() {
+        fn auth<R: GmpRequest<Response = ModifyAuthResponse>>(_: &R) {}
+        fn license<R: GmpRequest<Response = ModifyLicenseResponse>>(_: &R) {}
+        fn setting<R: GmpRequest<Response = crate::responses::ModifyUserSettingResponse>>(_: &R) {}
+        fn wizard<R: GmpRequest<Response = RunWizardResponse>>(_: &R) {}
+
+        let settings = vec![("enable".into(), "auth-secret".into())];
+        let auth_request = ModifyAuthRequest::new("method:ldap_connect", settings.clone());
+        assert_eq!(
+            auth_request.to_bytes(),
+            modify_auth("method:ldap_connect", &settings).to_bytes()
+        );
+        auth(&auth_request);
+
+        let license_request = ModifyLicenseRequest::new("license-secret");
+        assert_eq!(
+            license_request.to_bytes(),
+            modify_license("license-secret").to_bytes()
+        );
+        license(&license_request);
+
+        let license_opts = ModifyLicenseOpts {
+            allow_empty: Some(false),
+        };
+        let license_with_opts =
+            ModifyLicenseWithOptsRequest::new("license-secret", license_opts.clone());
+        assert_eq!(
+            license_with_opts.to_bytes(),
+            modify_license_with_opts("license-secret", license_opts).to_bytes()
+        );
+        license(&license_with_opts);
+
+        let setting_id = id("setting-1");
+        let setting_request = ModifySettingRequest::new(setting_id.clone(), "setting-secret");
+        assert_eq!(
+            setting_request.to_bytes(),
+            modify_setting(&setting_id, "setting-secret").to_bytes()
+        );
+        setting(&setting_request);
+
+        let params = vec![("hosts".into(), "wizard-secret".into())];
+        let wizard_request = RunWizardRequest::new("quick_first_scan", params.clone());
+        assert_eq!(
+            wizard_request.to_bytes(),
+            run_wizard("quick_first_scan", &params).to_bytes()
+        );
+        wizard(&wizard_request);
+
+        let wizard_opts = RunWizardOpts {
+            mode: Some("step".into()),
+            read_only: Some(false),
+        };
+        let wizard_with_opts =
+            RunWizardWithOptsRequest::new("quick_first_scan", params.clone(), wizard_opts.clone());
+        assert_eq!(
+            wizard_with_opts.to_bytes(),
+            run_wizard_with_opts("quick_first_scan", &params, wizard_opts).to_bytes()
+        );
+        wizard(&wizard_with_opts);
+    }
+
+    #[test]
+    fn semantic_system_admin_debug_redacts_values() {
+        let auth = format!(
+            "{:?}",
+            ModifyAuthRequest::new(
+                "method:ldap_connect",
+                [("password".into(), "auth-secret".into())]
+            )
+        );
+        let license = format!("{:?}", ModifyLicenseRequest::new("license-secret"));
+        let license_with_opts = format!(
+            "{:?}",
+            ModifyLicenseWithOptsRequest::new(
+                "license-secret",
+                ModifyLicenseOpts {
+                    allow_empty: Some(false),
+                }
+            )
+        );
+        let setting = format!(
+            "{:?}",
+            ModifySettingRequest::new(id("setting-1"), "setting-secret")
+        );
+        let wizard = format!(
+            "{:?}",
+            RunWizardRequest::new(
+                "quick_first_scan",
+                [("hosts".into(), "wizard-secret".into())]
+            )
+        );
+        let wizard_with_opts = format!(
+            "{:?}",
+            RunWizardWithOptsRequest::new(
+                "quick_first_scan",
+                [("hosts".into(), "wizard-secret".into())],
+                RunWizardOpts::default(),
+            )
+        );
+
+        for (debug, secret) in [
+            (&auth, "auth-secret"),
+            (&license, "license-secret"),
+            (&license_with_opts, "license-secret"),
+            (&setting, "setting-secret"),
+            (&wizard, "wizard-secret"),
+            (&wizard_with_opts, "wizard-secret"),
+        ] {
+            assert!(debug.contains("<redacted>"));
+            assert!(!debug.contains(secret));
+        }
     }
 }

--- a/crates/gvm-gmp/src/commands/user_settings.rs
+++ b/crates/gvm-gmp/src/commands/user_settings.rs
@@ -4,10 +4,12 @@
 //! User-setting command builders.
 
 use base64::Engine as _;
-use gvm_protocol::XmlCommand;
+use gvm_protocol::{Request, XmlCommand};
 
 use crate::common::add_filter_attrs;
+use crate::responses::{GetUserSettingsResponse, ModifyUserSettingResponse};
 use crate::types::EntityId;
+use crate::GmpRequest;
 
 /// Options for `get_settings` requests.
 #[derive(Debug, Clone, Default)]
@@ -23,6 +25,88 @@ pub struct GetUserSettingsOpts {
 pub struct ModifyUserSettingOpts {
     /// UTF-8 setting value to apply; the builder Base64-encodes it for GMP.
     pub value: String,
+}
+
+/// Semantic request for listing user settings.
+#[derive(Debug, Clone, Default)]
+pub struct GetUserSettingsRequest {
+    opts: GetUserSettingsOpts,
+}
+
+impl GetUserSettingsRequest {
+    /// Create a user-setting list request.
+    #[must_use]
+    pub fn new(opts: GetUserSettingsOpts) -> Self {
+        Self { opts }
+    }
+}
+
+impl Request for GetUserSettingsRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_user_settings(self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for GetUserSettingsRequest {
+    type Response = GetUserSettingsResponse;
+}
+
+/// Semantic request for one user setting.
+#[derive(Debug, Clone)]
+pub struct GetUserSettingRequest {
+    setting_id: EntityId,
+}
+
+impl GetUserSettingRequest {
+    /// Create a detailed single-setting request.
+    #[must_use]
+    pub fn new(setting_id: EntityId) -> Self {
+        Self { setting_id }
+    }
+}
+
+impl Request for GetUserSettingRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        get_user_setting(&self.setting_id).to_bytes()
+    }
+}
+
+impl GmpRequest for GetUserSettingRequest {
+    type Response = GetUserSettingsResponse;
+}
+
+/// Semantic request for modifying a user setting.
+#[derive(Clone)]
+pub struct ModifyUserSettingRequest {
+    setting_id: EntityId,
+    opts: ModifyUserSettingOpts,
+}
+
+impl std::fmt::Debug for ModifyUserSettingRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModifyUserSettingRequest")
+            .field("setting_id", &self.setting_id)
+            .field("value", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ModifyUserSettingRequest {
+    /// Create a user-setting modification request.
+    #[must_use]
+    pub fn new(setting_id: EntityId, opts: ModifyUserSettingOpts) -> Self {
+        Self { setting_id, opts }
+    }
+}
+
+impl Request for ModifyUserSettingRequest {
+    fn to_bytes(&self) -> Vec<u8> {
+        modify_user_setting(&self.setting_id, self.opts.clone()).to_bytes()
+    }
+}
+
+impl GmpRequest for ModifyUserSettingRequest {
+    type Response = ModifyUserSettingResponse;
 }
 
 /// Build a `get_settings` request.
@@ -50,12 +134,17 @@ pub fn modify_user_setting(id: &EntityId, opts: ModifyUserSettingOpts) -> XmlCom
 
 #[cfg(test)]
 mod tests {
+    use gvm_protocol::Request;
+
     use crate::commands::user_settings::{
-        get_user_setting, get_user_settings, modify_user_setting, GetUserSettingsOpts,
-        ModifyUserSettingOpts,
+        get_user_setting, get_user_settings, modify_user_setting, GetUserSettingRequest,
+        GetUserSettingsOpts, GetUserSettingsRequest, ModifyUserSettingOpts,
+        ModifyUserSettingRequest,
     };
     use crate::common::xml;
+    use crate::responses::{GetUserSettingsResponse, ModifyUserSettingResponse};
     use crate::types::EntityId;
+    use crate::GmpRequest;
 
     fn id(value: &str) -> EntityId {
         EntityId::new(value).expect("valid id")
@@ -83,5 +172,49 @@ mod tests {
             )),
             "<modify_setting setting_id=\"s1\"><value>VVRD</value></modify_setting>"
         );
+    }
+
+    #[test]
+    fn semantic_user_setting_requests_preserve_builder_bytes_and_associations() {
+        fn get<R: GmpRequest<Response = GetUserSettingsResponse>>(_: &R) {}
+        fn modify<R: GmpRequest<Response = ModifyUserSettingResponse>>(_: &R) {}
+
+        let get_opts = GetUserSettingsOpts {
+            filter: Some("name=timezone".into()),
+            filter_id: Some(id("filter-1")),
+        };
+        let list = GetUserSettingsRequest::new(get_opts.clone());
+        assert_eq!(list.to_bytes(), get_user_settings(get_opts).to_bytes());
+        get(&list);
+
+        let setting_id = id("setting-1");
+        let detail = GetUserSettingRequest::new(setting_id.clone());
+        assert_eq!(detail.to_bytes(), get_user_setting(&setting_id).to_bytes());
+        get(&detail);
+
+        let modify_opts = ModifyUserSettingOpts {
+            value: "setting-secret".into(),
+        };
+        let modification = ModifyUserSettingRequest::new(setting_id.clone(), modify_opts.clone());
+        assert_eq!(
+            modification.to_bytes(),
+            modify_user_setting(&setting_id, modify_opts).to_bytes()
+        );
+        modify(&modification);
+    }
+
+    #[test]
+    fn semantic_user_setting_debug_redacts_value() {
+        let debug = format!(
+            "{:?}",
+            ModifyUserSettingRequest::new(
+                id("setting-1"),
+                ModifyUserSettingOpts {
+                    value: "setting-secret".into(),
+                }
+            )
+        );
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("setting-secret"));
     }
 }

--- a/crates/gvm-gmp/src/responses/system.rs
+++ b/crates/gvm-gmp/src/responses/system.rs
@@ -297,8 +297,8 @@ impl_gmp_response!(
     GetTimezonesResponse,
     HelpResponse,
     DescribeAuthResponse,
+    RunWizardResponse,
 );
-
 fn extract_wizard_response_xml(data: &[u8]) -> Result<Option<Vec<u8>>, ParseError> {
     let text = std::str::from_utf8(data)?;
     let mut reader = Reader::from_str(text);

--- a/crates/gvm-gmp/src/responses/user_settings.rs
+++ b/crates/gvm-gmp/src/responses/user_settings.rs
@@ -7,6 +7,7 @@ use gvm_protocol::Response;
 
 use crate::responses::common::{parse_document, status_from_response, ParseError, XmlNode};
 use crate::types::EntityId;
+use crate::{GmpResponse, GmpVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -72,6 +73,12 @@ impl GetUserSettingsResponse {
     }
 }
 
+impl GmpResponse for GetUserSettingsResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
+    }
+}
+
 impl ModifyUserSettingResponse {
     pub fn from_response(response: &Response) -> Result<Self, ParseError> {
         let (status, status_text) = status_from_response(response)?;
@@ -80,6 +87,12 @@ impl ModifyUserSettingResponse {
             status,
             status_text,
         })
+    }
+}
+
+impl GmpResponse for ModifyUserSettingResponse {
+    fn decode(response: &Response, _version: GmpVersion) -> Result<Self, ParseError> {
+        Self::from_response(response)
     }
 }
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-Last updated: 2026-09-03
+Last updated: 2026-09-04
 
 ## Support Direction
 
@@ -176,6 +176,17 @@ remain byte-identical delegations to their established builders. All 12 existing
 typed-returning facade helpers delegate through `execute`; `get_features`
 retains its GMP 22.6 gate and `get_timezones` its GMP 22.8 gate before
 transmission. Existing raw builders and compatibility APIs remain supported.
+
+The system-administration Phase 3 batch, tracked by
+[`#575`](https://github.com/greenbone-hive/rust-gvm/issues/575), migrates all
+nine public authentication, license, wizard, and user-setting builder shapes to
+semantic typed execution. The default and option-bearing compatibility forms
+remain distinct request types over the existing byte-identical encoders, and
+the system-module `modify_setting` wrapper continues to share the canonical
+user-setting encoding. Existing authentication, license, and wizard typed
+helpers now delegate to `execute`. Semantic request diagnostics redact auth
+configuration values, license payloads, wizard parameter values, and
+user-setting values; raw builders and custom execution remain supported.
 
 The irregular-report Phase 3 batch, tracked by
 [`#546`](https://github.com/greenbone-hive/rust-gvm/issues/546), migrates report

--- a/docs/typed-execution.md
+++ b/docs/typed-execution.md
@@ -156,6 +156,24 @@ Support-bundle responses continue to decode base64 content into binary bytes
 and validate declared sizes. OIDC client secrets remain redacted from
 semantic-request diagnostics and wire tracing.
 
+## System administration and user settings
+
+The system administration slice represents all six public mutation builders:
+authentication configuration, default and option-bearing license updates, the
+system-module setting compatibility wrapper, and default and option-bearing
+wizard execution. The three user-setting builders cover list, detail, and
+modification. Every request delegates to its established builder, so XML bytes,
+base64 setting encoding, option semantics, identifiers, status handling, and
+specialized wizard response parsing remain unchanged.
+
+The system-module `ModifySettingRequest` and user-setting-module
+`ModifyUserSettingRequest` are distinct semantic values over the same canonical
+encoder. Authentication, license, and wizard convenience helpers use
+`execute`; the user-setting requests are available directly through generic
+execution without adding another facade. `Debug` output redacts authentication
+setting values, license files, wizard parameter values, and user-setting
+values, matching the wire-trace boundary's secret handling.
+
 Audit list, detail, create, clone, modify, delete, start, stop, and resume
 requests likewise remain audit-scoped types even where their wire command is a
 task command. This keeps compile-time intent explicit without duplicating XML

--- a/docs/typed-facade-coverage.md
+++ b/docs/typed-facade-coverage.md
@@ -17,6 +17,9 @@ Coverage is organized by behavior family:
 
 - discovery/list and administration helpers use table-driven fixture
   responses and assert typed results plus command history;
+- system authentication, license, and wizard helpers execute through their
+  semantic requests, while the complete nine-request administration and
+  user-setting inventory is exercised over a live Unix transport;
 - create helpers use a shared response table and assert typed create IDs;
 - report export exercises both the simple and options XML shapes;
 - generic assets, host and operating-system aliases, and result queries assert


### PR DESCRIPTION
## Summary

- add distinct semantic request values for all six system-administration builder forms and all three user-setting builders
- associate each request with its established response codec and migrate the existing authentication, license, and wizard facades to `execute`
- preserve the existing XML encoders, options, identifiers, status/parse behavior, and raw compatibility APIs while redacting all sensitive mutation values from request diagnostics
- document the completed system-administration typed-execution slice

## Acceptance mapping

- **Nine builders:** `ModifyAuthRequest`, both license requests, `ModifySettingRequest`, both wizard requests, and user-setting list/detail/modify requests delegate byte-for-byte to the existing builders.
- **Three facades:** `modify_auth`, `modify_license`, and `run_wizard` are thin generic-execution wrappers without public signature changes.
- **Compatibility:** compile-time response associations reuse the existing action, wizard, and user-setting models; no transport, framing, option, or raw/custom API changes are introduced.
- **Redaction:** manual `Debug` implementations hide authentication setting values, license payloads, wizard parameter values, and user-setting values.
- **Coverage:** exact-byte/association/redaction unit tests and live Unix success, complete command-inventory, server-error, parse-context, and facade-inventory tests cover the scoped surface.
- **Documentation:** README, implementation status, typed-execution guide, and facade-coverage guide describe the new slice.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --workspace --all-features --no-deps`
- `cargo deny check`, `cargo audit`, `cargo vet`, and `cargo machete`
- Python SBOM policy tests and controlled coverage-threshold regression
- pinned python-gvm Unix, TLS, and mutual-TLS interoperability
- additive `cargo semver-checks` against exact `origin/next` for all workspace crates

Full local llvm-cov was intentionally serialized out of this parallel delivery queue; the protected GitHub Coverage job is authoritative. The local Cargo Geiger binary requires a newer GLIBC than this host, so the protected GitHub Security job is authoritative for the unchanged-dependency unsafe gate.

Closes #575

Agent: Thoth
Model: openai/gpt-5.6-sol
Thinking: high
