### PR TITLE
docs(journal): add 2026-09-04 update

### DIFF
--- a/journal/2026-09-04.md
+++ b/journal/2026-09-04.md
@@ -1,0 +1,12 @@
+# 2026-09-04 — Typed Execution Advances Across Assets, Targets, and System Operations
+
+## Typed Execution Track
+- Pull requests [#565](https://github.com/greenbone-hive/rust-gvm/pull/565), [#569](https://github.com/greenbone-hive/rust-gvm/pull/569), [#570](https://github.com/greenbone-hive/rust-gvm/pull/570), and [#571](https://github.com/greenbone-hive/rust-gvm/pull/571) merged typed execution for NVT and SecInfo queries, assets and results, alternate targets, and agent and integration operations into `next`.
+- The corresponding focused issues [#563](https://github.com/greenbone-hive/rust-gvm/issues/563), [#566](https://github.com/greenbone-hive/rust-gvm/issues/566), [#567](https://github.com/greenbone-hive/rust-gvm/issues/567), and [#568](https://github.com/greenbone-hive/rust-gvm/issues/568) closed with those deliveries.
+
+## Next Work
+- Pull requests [#577](https://github.com/greenbone-hive/rust-gvm/pull/577), [#578](https://github.com/greenbone-hive/rust-gvm/pull/578), and [#579](https://github.com/greenbone-hive/rust-gvm/pull/579) opened to extend typed execution across report configuration, report formats and TLS certificates, generic configurations and port lists, and the remaining report mutations.
+- Pull requests [#580](https://github.com/greenbone-hive/rust-gvm/pull/580) and [#581](https://github.com/greenbone-hive/rust-gvm/pull/581) opened for system discovery and system administration operations.
+
+## Validation State
+- All five newly opened pull requests are mergeable and their CI and Security checks are green.


### PR DESCRIPTION
## Summary

- record typed-execution merges for NVT/SecInfo, assets/results, alternate targets, and agent/integration operations
- capture the five new green follow-up pull requests for remaining report and system operations
