### PR TITLE
docs(journal): add 2026-09-05 update

### DIFF
--- a/journal/2026-09-05.md
+++ b/journal/2026-09-05.md
@@ -1,0 +1,7 @@
+# 2026-09-05 — Config and Port-List Typed Execution Merges
+
+## Typed Execution Track
+- Pull request [#578](https://github.com/greenbone-hive/rust-gvm/pull/578) merged generic configuration, port-list, and port-range typed execution into `next`, preserving the established wire encoders while adding typed request/response associations and missing facade operations.
+
+## Action Required
+- The merge left follow-on pull requests [#577](https://github.com/greenbone-hive/rust-gvm/pull/577), [#579](https://github.com/greenbone-hive/rust-gvm/pull/579), [#580](https://github.com/greenbone-hive/rust-gvm/pull/580), and [#581](https://github.com/greenbone-hive/rust-gvm/pull/581) conflicting with `next`; each now needs a rebase before it can merge.


### PR DESCRIPTION
## Summary

- record the merge of typed configuration, port-list, and port-range execution
- flag the resulting conflicts on the four follow-on typed-execution pull requests
